### PR TITLE
feat: stream and display reasoning ("thinking") traces

### DIFF
--- a/app/src/main/java/com/example/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/data/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [ChatThread::class, ChatMessage::class, CustomModel::class],
-    version = 1,
+    version = 2, // v2: added ChatMessage.reasoning (destructive migration is enabled)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/example/data/Models.kt
+++ b/app/src/main/java/com/example/data/Models.kt
@@ -31,6 +31,7 @@ data class ChatMessage(
     val role: String, // "user", "assistant", "system"
     val content: String,
     val createdAt: Long,
+    val reasoning: String? = null, // reasoning/"thinking" trace for reasoning-capable models
     val localAttachmentUri: String? = null,
     val localAttachmentMimeType: String? = null,
     val localAttachmentName: String? = null

--- a/app/src/main/java/com/example/data/OpenRouterService.kt
+++ b/app/src/main/java/com/example/data/OpenRouterService.kt
@@ -19,6 +19,12 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.InputStream
 import java.util.concurrent.TimeUnit
 
+/** A piece of a streamed completion: either reasoning ("thinking") or final answer content. */
+sealed class StreamChunk {
+    data class Reasoning(val text: String) : StreamChunk()
+    data class Content(val text: String) : StreamChunk()
+}
+
 class OpenRouterService(private val context: Context) {
 
     private val client = OkHttpClient.Builder()
@@ -149,7 +155,7 @@ class OpenRouterService(private val context: Context) {
     /**
      * Run Streaming completions with flows.
      */
-    fun sendChatMessageStream(apiKey: String, model: String, history: List<ChatMessage>): Flow<String> = flow {
+    fun sendChatMessageStream(apiKey: String, model: String, history: List<ChatMessage>): Flow<StreamChunk> = flow {
         if (apiKey.isBlank()) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
@@ -158,7 +164,11 @@ class OpenRouterService(private val context: Context) {
         val requestMap = mapOf(
             "model" to model,
             "messages" to messagesPayload,
-            "stream" to true
+            "stream" to true,
+            // Ask OpenRouter to stream reasoning tokens for reasoning-capable models. Models that
+            // don't support it simply ignore this and never send a `reasoning` delta.
+            "include_reasoning" to true,
+            "reasoning" to mapOf("enabled" to true)
         )
 
         val jsonPayload = dynamicAdapter.toJson(requestMap)
@@ -202,9 +212,15 @@ class OpenRouterService(private val context: Context) {
                         val choices = map?.get("choices") as? List<*>
                         val choice = choices?.firstOrNull() as? Map<*, *>
                         val delta = choice?.get("delta") as? Map<*, *>
+                        // Reasoning tokens (different providers name the field differently).
+                        val reasoning = (delta?.get("reasoning") as? String)
+                            ?: (delta?.get("reasoning_content") as? String)
+                        if (!reasoning.isNullOrEmpty()) {
+                            emit(StreamChunk.Reasoning(reasoning))
+                        }
                         val content = delta?.get("content") as? String
                         if (!content.isNullOrEmpty()) {
-                            emit(content)
+                            emit(StreamChunk.Content(content))
                         }
                     } catch (e: Exception) {
                         // Resilient inline SSE fail ignores

--- a/app/src/main/java/com/example/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/example/ui/ChatViewModel.kt
@@ -54,6 +54,9 @@ class ChatViewModel(
     private val _activeStreamingBuffer = MutableStateFlow("")
     val activeStreamingBuffer: StateFlow<String> = _activeStreamingBuffer.asStateFlow()
 
+    private val _activeReasoningBuffer = MutableStateFlow("")
+    val activeReasoningBuffer: StateFlow<String> = _activeReasoningBuffer.asStateFlow()
+
     private val _apiProgressLoading = MutableStateFlow(false)
     val apiProgressLoading: StateFlow<Boolean> = _apiProgressLoading.asStateFlow()
 
@@ -198,15 +201,25 @@ class ChatViewModel(
             // Begin Streaming Assistant response
             _isStreaming.value = true
             _activeStreamingBuffer.value = ""
+            _activeReasoningBuffer.value = ""
             _apiProgressLoading.value = true // Show leading load before tokens stream
 
             var accumulatedResponse = ""
+            var accumulatedReasoning = ""
             try {
                 openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory)
                     .collect { chunk ->
                         _apiProgressLoading.value = false // Dismiss initial load as stream flows
-                        accumulatedResponse += chunk
-                        _activeStreamingBuffer.value = accumulatedResponse
+                        when (chunk) {
+                            is StreamChunk.Reasoning -> {
+                                accumulatedReasoning += chunk.text
+                                _activeReasoningBuffer.value = accumulatedReasoning
+                            }
+                            is StreamChunk.Content -> {
+                                accumulatedResponse += chunk.text
+                                _activeStreamingBuffer.value = accumulatedResponse
+                            }
+                        }
                     }
 
                 // If content streamed, write to local db
@@ -216,7 +229,8 @@ class ChatViewModel(
                         chatId = chatId,
                         role = "assistant",
                         content = accumulatedResponse,
-                        createdAt = System.currentTimeMillis()
+                        createdAt = System.currentTimeMillis(),
+                        reasoning = accumulatedReasoning.ifBlank { null }
                     )
                     messageDao.insertMessage(assistantMsg)
 
@@ -236,13 +250,15 @@ class ChatViewModel(
                         chatId = chatId,
                         role = "assistant",
                         content = "$accumulatedResponse\n\n*[Connection lost: ${e.message}]*",
-                        createdAt = System.currentTimeMillis()
+                        createdAt = System.currentTimeMillis(),
+                        reasoning = accumulatedReasoning.ifBlank { null }
                     )
                     messageDao.insertMessage(assistantMsg)
                 }
             } finally {
                 _isStreaming.value = false
                 _activeStreamingBuffer.value = ""
+                _activeReasoningBuffer.value = ""
                 _apiProgressLoading.value = false
             }
         }

--- a/app/src/main/java/com/example/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/example/ui/components/MarkdownText.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,53 +40,48 @@ fun MarkdownText(
     textColor: Color = MaterialTheme.colorScheme.onSurface,
     style: TextStyle = MaterialTheme.typography.bodyLarge
 ) {
+    // Parsing is memoized on `text`, and every block is a child composable that takes only stable
+    // String params — so Compose skips re-rendering unchanged blocks. During streaming this means
+    // only the final, still-growing block re-renders each frame (production-grade incremental MD).
+    val blocks = remember(text) { parseMarkdownBlocks(text) }
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        val blocks = parseMarkdownBlocks(text)
         for (block in blocks) {
             when (block) {
-                is MarkdownBlock.Header -> {
-                    Text(
-                        text = parseInlineStyles(block.text, textColor),
-                        style = when (block.level) {
-                            1 -> MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold, color = textColor)
-                            2 -> MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold, color = textColor)
-                            else -> MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold, color = textColor)
-                        },
-                        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
-                    )
-                }
-                is MarkdownBlock.CodeBlock -> {
-                    CodeBlockItem(code = block.code, language = block.language)
-                }
-                is MarkdownBlock.BulletItem -> {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
-                        verticalAlignment = Alignment.Top
-                    ) {
-                        Text(
-                            text = "• ",
-                            style = style.copy(fontWeight = FontWeight.Bold, color = textColor),
-                            modifier = Modifier.width(16.dp)
-                        )
-                        SelectionContainer {
-                            Text(
-                                text = parseInlineStyles(block.text, textColor),
-                                style = style.copy(color = textColor),
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-                    }
-                }
-                is MarkdownBlock.Paragraph -> {
-                    SelectionContainer {
-                        Text(
-                            text = parseInlineStyles(block.text, textColor),
-                            style = style.copy(color = textColor),
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                }
+                is MarkdownBlock.Header -> MdHeader(block.text, block.level, textColor)
+                is MarkdownBlock.CodeBlock -> CodeBlockItem(code = block.code, language = block.language)
+                is MarkdownBlock.BulletItem -> MdBullet(block.text, textColor, style)
+                is MarkdownBlock.Paragraph -> MdParagraph(block.text, textColor, style)
             }
+        }
+    }
+}
+
+@Composable
+private fun MdHeader(text: String, level: Int, color: Color) {
+    val annotated = remember(text, color) { parseInlineStyles(text, color) }
+    val base = when (level) {
+        1 -> MaterialTheme.typography.headlineMedium
+        2 -> MaterialTheme.typography.titleLarge
+        else -> MaterialTheme.typography.titleMedium
+    }
+    Text(annotated, style = base.copy(fontWeight = FontWeight.Bold, color = color), modifier = Modifier.padding(top = 4.dp, bottom = 2.dp))
+}
+
+@Composable
+private fun MdParagraph(text: String, color: Color, style: TextStyle) {
+    val annotated = remember(text, color) { parseInlineStyles(text, color) }
+    SelectionContainer {
+        Text(annotated, style = style.copy(color = color), modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+private fun MdBullet(text: String, color: Color, style: TextStyle) {
+    val annotated = remember(text, color) { parseInlineStyles(text, color) }
+    Row(modifier = Modifier.fillMaxWidth().padding(start = 8.dp), verticalAlignment = Alignment.Top) {
+        Text("• ", style = style.copy(fontWeight = FontWeight.Bold, color = color), modifier = Modifier.width(16.dp))
+        SelectionContainer {
+            Text(annotated, style = style.copy(color = color), modifier = Modifier.weight(1f))
         }
     }
 }

--- a/app/src/main/java/com/example/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/ChatScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -31,6 +33,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -69,6 +72,7 @@ fun ChatScreen(
     val messages by chatViewModel.currentMessages.collectAsState()
     val isStreaming by chatViewModel.isStreaming.collectAsState()
     val streamingBuffer by chatViewModel.activeStreamingBuffer.collectAsState()
+    val reasoningBuffer by chatViewModel.activeReasoningBuffer.collectAsState()
     val progressLoading by chatViewModel.apiProgressLoading.collectAsState()
     val errorMessage by chatViewModel.errorMessage.collectAsState()
 
@@ -111,11 +115,24 @@ fun ChatScreen(
     LaunchedEffect(atBottom, listState.isScrollInProgress) {
         if (listState.isScrollInProgress) autoFollow = atBottom
     }
-    // Snap (not animate) to the very bottom on new content while following — smooth, no fighting.
-    LaunchedEffect(messages.size, streamingBuffer, progressLoading) {
+    // Pin to bottom on discrete events (new message sent, thinking row appears).
+    LaunchedEffect(messages.size, progressLoading) {
         if (autoFollow) {
             val idx = listState.layoutInfo.totalItemsCount - 1
             if (idx >= 0) runCatching { listState.scrollToItem(idx, Int.MAX_VALUE) }
+        }
+    }
+    // While generating, keep the bottom pinned every frame so the smooth text reveal stays in view
+    // — but skip frames where the user is actively scrolling, so manual scroll-up isn't fought.
+    LaunchedEffect(autoFollow, isStreaming, progressLoading) {
+        if (autoFollow && (isStreaming || progressLoading)) {
+            while (true) {
+                withFrameNanos { it }
+                if (!listState.isScrollInProgress) {
+                    val idx = listState.layoutInfo.totalItemsCount - 1
+                    if (idx >= 0) runCatching { listState.scrollToItem(idx, Int.MAX_VALUE) }
+                }
+            }
         }
     }
 
@@ -155,10 +172,13 @@ fun ChatScreen(
                         items(messages, key = { it.id }) { msg ->
                             MessageBubble(msg) { clipboard.setText(AnnotatedString(msg.content)) }
                         }
-                        if (progressLoading && streamingBuffer.isEmpty()) item { ThinkingRow() }
-                        if (streamingBuffer.isNotEmpty()) item(key = "streaming") {
+                        if (progressLoading && streamingBuffer.isEmpty() && reasoningBuffer.isEmpty()) item { ThinkingRow() }
+                        if (streamingBuffer.isNotEmpty() || reasoningBuffer.isNotEmpty()) item(key = "streaming") {
                             MessageBubble(
-                                ChatMessage("streaming", "temp", "assistant", streamingBuffer, System.currentTimeMillis()),
+                                ChatMessage(
+                                    "streaming", "temp", "assistant", streamingBuffer, System.currentTimeMillis(),
+                                    reasoning = reasoningBuffer.ifBlank { null },
+                                ),
                                 streaming = true,
                             ) { clipboard.setText(AnnotatedString(streamingBuffer)) }
                         }
@@ -265,20 +285,23 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                 Text("AVS Chat", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
             }
             Spacer(Modifier.height(Spacing.s))
+
+            // Reasoning ("thinking") trace for reasoning-capable models.
+            val reasoningText = message.reasoning
+            if (!reasoningText.isNullOrBlank()) {
+                ReasoningSection(
+                    reasoning = reasoningText,
+                    active = streaming && message.content.isBlank(),
+                )
+                Spacer(Modifier.height(Spacing.s))
+            }
+
             message.localAttachmentUri?.let {
                 AsyncImage(it, null, Modifier.padding(bottom = Spacing.s).size(200.dp).clip(MaterialTheme.shapes.large), contentScale = ContentScale.Crop)
             }
             if (streaming) {
-                // While generating, render plain stable text so existing words never re-flow
-                // (no per-token markdown re-parse). Full markdown renders once the message lands.
-                SelectionContainer {
-                    Text(
-                        text = message.content,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+                // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
+                if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
             } else {
                 MarkdownText(text = message.content, modifier = Modifier.fillMaxWidth())
             }
@@ -289,6 +312,120 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                     modifier = Modifier.size(32.dp),
                     colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
                 ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp)) }
+            }
+        }
+    }
+}
+
+/**
+ * Smooth "typewriter" reveal, the way production AI apps (T3 Chat, Vercel v0, ChatGPT) do it:
+ * the network delivers text in bursts, but we reveal it at a steady, frame-synced cadence so it
+ * reads pleasantly instead of flickering in chunks. The pace is a gentle base speed plus a
+ * proportional catch-up, so it never lags far behind a fast model yet never feels rushed.
+ */
+@Composable
+private fun SmoothStreamingText(
+    text: String,
+    modifier: Modifier = Modifier,
+    markdown: Boolean = true,
+    style: androidx.compose.ui.text.TextStyle = MaterialTheme.typography.bodyLarge,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    val target by rememberUpdatedState(text)
+    var shown by remember { mutableStateOf(0) }
+    LaunchedEffect(Unit) {
+        var lastFrame = 0L
+        while (true) {
+            val frame = withFrameNanos { it }
+            val dt = if (lastFrame == 0L) 0f else (frame - lastFrame) / 1_000_000_000f
+            lastFrame = frame
+            val t = target
+            if (shown > t.length) shown = 0 // a new message started — restart the reveal
+            if (shown < t.length) {
+                val remaining = t.length - shown
+                // Steady, pleasant cadence that scales with backlog so the whole answer finishes a
+                // beat after the model (≈2s drain), never instant-dumping even at 1000+ tps.
+                val charsPerSec = (remaining / 2f).coerceIn(40f, 900f)
+                val add = (charsPerSec * dt).toInt().coerceAtLeast(1)
+                shown = (shown + add).coerceAtMost(t.length)
+            }
+        }
+    }
+    val revealed = target.take(shown)
+    if (markdown) {
+        // Live markdown while streaming. Because the text is revealed gradually (not in bursts),
+        // markdown spans complete one char at a time, so re-layout stays smooth like ChatGPT/Claude.
+        MarkdownText(text = revealed, modifier = modifier, textColor = color, style = style)
+    } else {
+        SelectionContainer { Text(text = revealed, style = style, color = color, modifier = modifier) }
+    }
+}
+
+/**
+ * Collapsible reasoning ("thinking") trace, styled like T3 Chat / Claude. Subtly tinted so it reads
+ * as meta-content. Auto-expands and streams while the model is reasoning, then auto-collapses once
+ * the answer begins; the user can expand/collapse at any time (collapsed by default once complete).
+ */
+@Composable
+private fun ReasoningSection(reasoning: String, active: Boolean) {
+    var userToggled by remember { mutableStateOf<Boolean?>(null) }
+    val expanded = userToggled ?: active
+    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "reasoning-chevron")
+    Surface(
+        onClick = { userToggled = !expanded },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Psychology, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.tertiary)
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    if (active) "Reasoning…" else "Reasoning",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (active) {
+                    Spacer(Modifier.width(Spacing.s))
+                    LoadingIndicator(color = MaterialTheme.colorScheme.tertiary, modifier = Modifier.size(18.dp))
+                }
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand",
+                    Modifier.size(20.dp).rotate(chevron),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            AnimatedVisibility(visible = expanded, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                if (active) {
+                    // Bounded, internally auto-scrolling panel so a fast reasoning stream can never
+                    // overflow / "break out" of the container — it scrolls within a fixed height.
+                    val sc = rememberScrollState()
+                    LaunchedEffect(sc.maxValue) { sc.scrollTo(sc.maxValue) }
+                    Box(
+                        Modifier
+                            .padding(top = Spacing.s)
+                            .fillMaxWidth()
+                            .heightIn(max = 190.dp)
+                            .verticalScroll(sc),
+                    ) {
+                        SmoothStreamingText(
+                            reasoning, Modifier.fillMaxWidth(),
+                            markdown = true,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else {
+                    Box(Modifier.padding(top = Spacing.s)) {
+                        MarkdownText(
+                            reasoning, Modifier.fillMaxWidth(),
+                            textColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/SettingsScreen.kt
@@ -84,7 +84,7 @@ fun SettingsScreen(
         },
     ) { pad ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(pad),
+            modifier = Modifier.fillMaxSize().padding(pad).imePadding(),
             contentPadding = PaddingValues(horizontal = Spacing.base, vertical = Spacing.s),
             verticalArrangement = Arrangement.spacedBy(Spacing.xl),
         ) {


### PR DESCRIPTION
## What changed

Adds end-to-end support for **reasoning ("thinking") traces** from reasoning-capable models on OpenRouter, on top of the existing Material 3 Expressive redesign.

- **`OpenRouterService`** — requests reasoning tokens (`include_reasoning` + `reasoning.enabled`) and now emits a typed `StreamChunk` (`Reasoning` / `Content`) so reasoning and answer deltas are handled separately. Reads both `reasoning` and `reasoning_content` delta fields to cover different providers. Models that don't support reasoning simply never send a reasoning delta.
- **`ChatMessage` / `AppDatabase`** — persists a nullable `reasoning` trace and bumps the Room schema to **v2** (destructive migration is already enabled).
- **`ChatViewModel`** — accumulates reasoning into a separate streaming buffer and stores it alongside the assistant message.
- **`ChatScreen`** — collapsible `ReasoningSection` that auto-expands while the model is reasoning and auto-collapses once the answer begins (user can toggle anytime), plus smoother streaming text rendering and a bounded auto-scrolling reasoning panel.

## Why

Reasoning models expose their intermediate thinking; surfacing it (T3 Chat / Claude style) gives users insight into how an answer was formed without cluttering the main message.

## Reviewer notes

- The Room version bump relies on **destructive migration** — existing local chat history will be cleared on upgrade. This matches the prior migration strategy in the project.
- Could not build/verify from CLI (no Gradle/SDK in this environment, per project constraints) — please confirm in Android Studio.
- `.idea/`, `.agents/`, and `skills-lock.json` were intentionally left out of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for AI reasoning and thinking output—now displays a collapsible "Reasoning" section in chat messages when the model provides it.
  * Improved streaming text reveal with smooth animation for better readability during live responses.

* **Bug Fixes**
  * Fixed keyboard padding in Settings screen for better spacing when on-screen keyboard appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream and display reasoning traces from AI models in the chat UI
> - Extends `OpenRouterService.sendChatMessageStream` to request reasoning tokens from providers (`include_reasoning=true`) and emit typed `StreamChunk.Reasoning` / `StreamChunk.Content` chunks.
> - Adds a `reasoning` field to `ChatMessage` (persisted as a new nullable DB column; bumps Room schema to version 2) and streams it live via a new `activeReasoningBuffer` StateFlow in `ChatViewModel`.
> - Introduces a collapsible `ReasoningSection` in `MessageBubble` that streams reasoning with `SmoothStreamingText` while active, then renders as static markdown when complete.
> - `SmoothStreamingText` reveals text at a frame-synchronized cadence to avoid bursty rendering during streaming.
> - Risk: Room schema version bump from 1 to 2 requires a migration path; existing installs without a migration will lose chat history on upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized efa9bb8. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->