### PR TITLE
Collapsible settings UI, Gemma 4/Qwen3 catalog, and local model recovery fixes

### DIFF
--- a/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
+++ b/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
@@ -1,0 +1,121 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+class HuggingFaceModelSearch {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val resultType = Types.newParameterizedType(List::class.java, HfModel::class.java)
+    private val resultAdapter = moshi.adapter<List<HfModel>>(resultType)
+
+    suspend fun search(query: String, hfToken: String?): List<CatalogEntry> = withContext(Dispatchers.IO) {
+        val cleanQuery = query.trim().ifEmpty { "qwen3 gemma" }
+        val url = "https://huggingface.co/api/models".toHttpUrl().newBuilder()
+            .addQueryParameter("author", "litert-community")
+            .addQueryParameter("search", cleanQuery)
+            .addQueryParameter("limit", "30")
+            .addQueryParameter("full", "true")
+            .build()
+
+        val request = Request.Builder().url(url)
+            .apply {
+                if (!hfToken.isNullOrBlank()) addHeader("Authorization", "Bearer ${hfToken.trim()}")
+            }
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception("Hugging Face search failed (HTTP ${response.code}).")
+            val body = response.body?.string().orEmpty()
+            val models = resultAdapter.fromJson(body).orEmpty()
+            models.mapNotNull { it.toCatalogEntry(hfToken) }
+                .distinctBy { it.id }
+                .sortedWith(compareBy<CatalogEntry> { it.approxSizeBytes <= 0L }.thenBy { it.approxSizeBytes })
+                .take(12)
+        }
+    }
+
+    private fun HfModel.toCatalogEntry(hfToken: String?): CatalogEntry? {
+        val repoId = modelId ?: id ?: return null
+        if (pipelineTag != null && pipelineTag != "text-generation") return null
+        val lowerTags = tags.orEmpty().map { it.lowercase(Locale.US) }
+        if (libraryName != "litert-lm" && "litertlm" !in lowerTags && "litert-lm" !in lowerTags) return null
+
+        val file = siblings.orEmpty()
+            .map { it.rfilename }
+            .filter { it.endsWith(".litertlm", ignoreCase = true) || it.endsWith(".task", ignoreCase = true) }
+            .filterNot { it.contains("mediatek", ignoreCase = true) || it.contains("qualcomm", ignoreCase = true) || it.contains("intel", ignoreCase = true) || it.contains("google_tensor", ignoreCase = true) }
+            .sortedWith(compareBy<String> { !it.contains("mixed_int4", ignoreCase = true) }
+                .thenBy { !it.endsWith(".litertlm", ignoreCase = true) }
+                .thenBy { it.length })
+            .firstOrNull() ?: return null
+
+        val size = resolveSize(repoId, file, hfToken).takeIf { it > 0L } ?: usedStorage ?: 0L
+        val requiresAuth = gated == true || gated is String
+        val family = repoId.substringAfterLast("/")
+        val slug = (repoId.substringAfter("/") + "-" + file.substringBeforeLast("."))
+            .lowercase(Locale.US)
+            .replace(Regex("[^a-z0-9]+"), "-")
+            .trim('-')
+
+        return CatalogEntry(
+            id = "local/hf-$slug",
+            name = family.replace('-', ' ').replace('_', ' '),
+            fileName = file.substringAfterLast("/"),
+            url = "https://huggingface.co/$repoId/resolve/main/$file",
+            approxSizeBytes = size,
+            requiresAuth = requiresAuth,
+            maxTokens = if (file.contains("4096")) 4096 else 2048,
+            description = "Hugging Face mobile bundle from $repoId. File: ${file.substringAfterLast("/")}"
+        )
+    }
+
+    private fun resolveSize(repoId: String, fileName: String, hfToken: String?): Long {
+        val request = Request.Builder()
+            .head()
+            .url("https://huggingface.co/$repoId/resolve/main/$fileName")
+            .apply {
+                if (!hfToken.isNullOrBlank()) addHeader("Authorization", "Bearer ${hfToken.trim()}")
+            }
+            .build()
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                response.header("X-Linked-Size")?.toLongOrNull()
+                    ?: response.header("Content-Length")?.toLongOrNull()
+                    ?: 0L
+            }
+        }.getOrDefault(0L)
+    }
+
+}
+
+private data class HfModel(
+    val id: String? = null,
+    val modelId: String? = null,
+    val gated: Any? = null,
+    val tags: List<String>? = null,
+    @Json(name = "pipeline_tag") val pipelineTag: String? = null,
+    @Json(name = "library_name") val libraryName: String? = null,
+    val siblings: List<HfSibling>? = null,
+    val usedStorage: Long? = null,
+)
+
+private data class HfSibling(
+    val rfilename: String,
+)

--- a/app/src/main/java/com/echoflow/data/LocalLlmService.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmService.kt
@@ -58,7 +58,7 @@ class LocalLlmService(private val context: Context) {
         engine = null
         loadedPath = null
 
-        val maxTokens = LocalModelCatalog.maxTokensFor(model.id)
+        val maxTokens = LocalModelCatalog.maxTokensFor(model.id, model.fileName)
 
         fun options(backend: LlmInference.Backend) = LlmInference.LlmInferenceOptions.builder()
             .setModelPath(path)
@@ -161,7 +161,7 @@ class LocalLlmService(private val context: Context) {
                     if (prior.isNotEmpty()) {
                         // Replay older turns as one transcript chunk, trimming the oldest turns
                         // when they would crowd out room for the answer.
-                        val maxTokens = LocalModelCatalog.maxTokensFor(model.id)
+                        val maxTokens = LocalModelCatalog.maxTokensFor(model.id, model.fileName)
                         var turns = prior
                         var transcript = transcriptOf(turns)
                         while (turns.size > 1 &&

--- a/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
@@ -59,11 +59,53 @@ object LocalModelCatalog {
             requiresAuth = false,
             maxTokens = 4096,
             description = "Reasoning-tuned distill that thinks before answering, no login needed (~2.5 GB RAM)."
+        ),
+        CatalogEntry(
+            id = "local/gemma-4-e2b-it",
+            name = "Gemma 4 E2B",
+            fileName = "gemma-4-E2B-it.litertlm",
+            url = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
+            approxSizeBytes = 2_588_147_712L,
+            requiresAuth = false,
+            maxTokens = 4096,
+            description = "Latest Gemma generation with an effective 2B footprint. Strong quality on flagship phones, no login needed (~3.5 GB RAM)."
+        ),
+        CatalogEntry(
+            id = "local/qwen3-4b-instruct-2507",
+            name = "Qwen3 4B Instruct 2507",
+            fileName = "qwen3_4b_instruct_2507_mixed_int4.litertlm",
+            url = "https://huggingface.co/litert-community/Qwen3-4B-Instruct-2507/resolve/main/qwen3_4b_instruct_2507_mixed_int4.litertlm",
+            approxSizeBytes = 2_659_057_664L,
+            requiresAuth = false,
+            maxTokens = 4096,
+            description = "Newest Qwen3 instruct build (July 2025 refresh), mixed INT4, no login needed (~4 GB RAM)."
+        ),
+        CatalogEntry(
+            id = "local/gemma-4-e4b-it",
+            name = "Gemma 4 E4B",
+            fileName = "gemma-4-E4B-it.litertlm",
+            url = "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm",
+            approxSizeBytes = 3_659_530_240L,
+            requiresAuth = false,
+            maxTokens = 4096,
+            description = "Largest Gemma 4 mobile bundle — best answers, needs a high-end phone (~5 GB RAM), no login needed."
         )
     )
 
     fun entryById(id: String): CatalogEntry? = entries.firstOrNull { it.id == id }
 
-    /** Safe context budget for a model: catalog value, or a conservative default for imports. */
-    fun maxTokensFor(modelId: String): Int = entryById(modelId)?.maxTokens ?: 1280
+    private val ekvHint = Regex("ekv(\\d+)", RegexOption.IGNORE_CASE)
+
+    /**
+     * Safe context budget for a model. Catalog entries know their value; imported or
+     * recovered files fall back to hints in the file name (ekv kv-cache markers), then to
+     * a conservative default so we never exceed the kv-cache the file was exported with.
+     */
+    fun maxTokensFor(modelId: String, fileName: String? = null): Int {
+        entryById(modelId)?.let { return it.maxTokens }
+        val file = fileName ?: return 1280
+        entries.firstOrNull { it.fileName.equals(file, ignoreCase = true) }?.let { return it.maxTokens }
+        ekvHint.find(file)?.groupValues?.get(1)?.toIntOrNull()?.let { return it.coerceIn(512, 4096) }
+        return if (file.endsWith(".litertlm", ignoreCase = true)) 2048 else 1280
+    }
 }

--- a/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
@@ -28,7 +28,17 @@ object LocalModelCatalog {
             approxSizeBytes = 555L * 1024 * 1024,
             requiresAuth = true,
             maxTokens = 2048,
-            description = "Google's small instruction-tuned model. Fast on most phones (~1.5 GB RAM). Gated: accept the Gemma license on HuggingFace."
+            description = "Small Gemma instruction model. Fast on most phones; requires accepting the Gemma license on Hugging Face."
+        ),
+        CatalogEntry(
+            id = "local/qwen3-0.6b",
+            name = "Qwen3 0.6B",
+            fileName = "qwen3_0_6b_mixed_int4.litertlm",
+            url = "https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/qwen3_0_6b_mixed_int4.litertlm",
+            approxSizeBytes = 497_664_000L,
+            requiresAuth = false,
+            maxTokens = 2048,
+            description = "Tiny Qwen3 LiteRT-LM build for everyday phones. Mixed INT4, no login needed."
         ),
         CatalogEntry(
             id = "local/qwen2.5-1.5b-instruct",
@@ -49,16 +59,6 @@ object LocalModelCatalog {
             requiresAuth = false,
             maxTokens = 4096,
             description = "Reasoning-tuned distill that thinks before answering, no login needed (~2.5 GB RAM)."
-        ),
-        CatalogEntry(
-            id = "local/gemma-3n-e2b-it",
-            name = "Gemma 3n E2B",
-            fileName = "gemma-3n-E2B-it-int4.litertlm",
-            url = "https://huggingface.co/google/gemma-3n-E2B-it-litert-lm-preview/resolve/main/gemma-3n-E2B-it-int4.litertlm",
-            approxSizeBytes = 3100L * 1024 * 1024,
-            requiresAuth = true,
-            maxTokens = 4096,
-            description = "Google's strongest on-device model. Needs a high-end phone with ~5 GB free RAM. Gated: accept the Gemma license on HuggingFace."
         )
     )
 

--- a/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
+++ b/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
@@ -44,6 +44,7 @@ class ModelDownloadManager(
         .build()
 
     private val jobs = mutableMapOf<String, Job>()
+    private val activeDownloads = mutableMapOf<String, CatalogEntry>()
 
     private val _states = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
     val states: StateFlow<Map<String, DownloadState>> = _states.asStateFlow()
@@ -61,6 +62,7 @@ class ModelDownloadManager(
 
     fun download(entry: CatalogEntry, hfToken: String?) {
         if (jobs[entry.id]?.isActive == true) return
+        activeDownloads[entry.id] = entry
         setState(entry.id, DownloadState.Downloading(0, entry.approxSizeBytes))
 
         jobs[entry.id] = scope.launch {
@@ -122,11 +124,13 @@ class ModelDownloadManager(
                         )
                     )
                     setState(entry.id, DownloadState.Done)
+                    activeDownloads.remove(entry.id)
                 }
             } catch (e: Exception) {
                 partFile.delete()
                 if (e is kotlinx.coroutines.CancellationException) {
                     setState(entry.id, null)
+                    activeDownloads.remove(entry.id)
                     throw e
                 }
                 setState(entry.id, DownloadState.Failed(e.message ?: "Download failed."))
@@ -136,9 +140,10 @@ class ModelDownloadManager(
 
     fun cancel(entryId: String) {
         jobs.remove(entryId)?.cancel()
-        LocalModelCatalog.entryById(entryId)?.let {
+        (activeDownloads[entryId] ?: LocalModelCatalog.entryById(entryId))?.let {
             File(modelsDir, it.fileName + ".part").delete()
         }
+        activeDownloads.remove(entryId)
         setState(entryId, null)
     }
 
@@ -216,13 +221,42 @@ class ModelDownloadManager(
         setState(model.id, null)
     }
 
-    /** Drops DB rows whose file vanished and stray .part files from killed downloads. */
+    /** Reconciles app storage and DB after upgrades/reinstalls that keep files but lose rows. */
     suspend fun pruneOrphans() = withContext(Dispatchers.IO) {
-        localModelDao.getAllLocalModelsSync().forEach { model ->
+        val existingModels = localModelDao.getAllLocalModelsSync()
+        existingModels.forEach { model ->
             if (!fileFor(model).exists()) localModelDao.deleteLocalModel(model.id)
         }
+
         modelsDir.listFiles()?.forEach { file ->
-            if (file.name.endsWith(".part")) file.delete()
+            when {
+                file.name.endsWith(".part") -> file.delete()
+                file.isFile &&
+                    (file.name.endsWith(".task", ignoreCase = true) ||
+                        file.name.endsWith(".litertlm", ignoreCase = true)) -> {
+                    val catalogEntry = LocalModelCatalog.entries.firstOrNull { it.fileName == file.name }
+                    val safeId = catalogEntry?.id ?: "local/recovered-" + file.name.lowercase()
+                        .removeSuffix(".task")
+                        .removeSuffix(".litertlm")
+                        .replace(Regex("[^a-z0-9]+"), "-")
+                        .trim('-')
+                    val displayName = catalogEntry?.name ?: file.name
+                        .removeSuffix(".task")
+                        .removeSuffix(".litertlm")
+                        .replace('_', ' ')
+                        .replace('-', ' ')
+                    localModelDao.insertLocalModel(
+                        LocalModel(
+                            id = safeId,
+                            name = displayName,
+                            fileName = file.name,
+                            sizeBytes = file.length(),
+                            source = catalogEntry?.let { "curated" } ?: "recovered",
+                            addedAt = file.lastModified().takeIf { it > 0L } ?: System.currentTimeMillis()
+                        )
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
+++ b/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
@@ -221,16 +221,23 @@ class ModelDownloadManager(
         setState(model.id, null)
     }
 
-    /** Reconciles app storage and DB after upgrades/reinstalls that keep files but lose rows. */
+    /**
+     * Reconciles app storage and DB after upgrades or DB resets that keep files but lose
+     * rows: rows whose file vanished are dropped, and model files on disk with no row are
+     * re-adopted (matched back to catalog entries by file name when possible) so they show
+     * up as installed without re-downloading.
+     */
     suspend fun pruneOrphans() = withContext(Dispatchers.IO) {
         val existingModels = localModelDao.getAllLocalModelsSync()
-        existingModels.forEach { model ->
-            if (!fileFor(model).exists()) localModelDao.deleteLocalModel(model.id)
-        }
+        val (tracked, missing) = existingModels.partition { fileFor(it).exists() }
+        missing.forEach { localModelDao.deleteLocalModel(it.id) }
+        val trackedFileNames = tracked.map { it.fileName.lowercase() }.toSet()
 
         modelsDir.listFiles()?.forEach { file ->
             when {
                 file.name.endsWith(".part") -> file.delete()
+                // Already represented by a DB row — don't create a duplicate "recovered" entry.
+                file.name.lowercase() in trackedFileNames -> Unit
                 file.isFile &&
                     (file.name.endsWith(".task", ignoreCase = true) ||
                         file.name.endsWith(".litertlm", ignoreCase = true)) -> {

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.echoflow.data.CatalogEntry
 import com.echoflow.data.CustomModel
 import com.echoflow.data.CustomModelDao
 import com.echoflow.data.DownloadState
+import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelDao
 import com.echoflow.data.ModelDownloadManager
@@ -25,6 +26,7 @@ class SettingsViewModel(
     private val localModelDao: LocalModelDao,
     private val downloadManager: ModelDownloadManager
 ) : ViewModel() {
+    private val hfModelSearch = HuggingFaceModelSearch()
 
     val apiKey: StateFlow<String> = repository.apiKey
     val selectedModel: StateFlow<String> = repository.selectedModel
@@ -45,6 +47,18 @@ class SettingsViewModel(
 
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
+
+    private val _hfModelQuery = MutableStateFlow("qwen3")
+    val hfModelQuery: StateFlow<String> = _hfModelQuery.asStateFlow()
+
+    private val _hfSearchResults = MutableStateFlow<List<CatalogEntry>>(emptyList())
+    val hfSearchResults: StateFlow<List<CatalogEntry>> = _hfSearchResults.asStateFlow()
+
+    private val _hfSearchLoading = MutableStateFlow(false)
+    val hfSearchLoading: StateFlow<Boolean> = _hfSearchLoading.asStateFlow()
+
+    private val _hfSearchError = MutableStateFlow<String?>(null)
+    val hfSearchError: StateFlow<String?> = _hfSearchError.asStateFlow()
 
     val customModels: StateFlow<List<CustomModel>> = customModelDao.getAllCustomModels()
         .stateIn(
@@ -102,6 +116,27 @@ class SettingsViewModel(
 
     fun downloadModel(entry: CatalogEntry) {
         downloadManager.download(entry, repository.getHfAccessTokenDirect())
+    }
+
+    fun updateHfModelQuery(query: String) {
+        _hfModelQuery.value = query
+    }
+
+    fun searchHfModels() {
+        viewModelScope.launch {
+            _hfSearchLoading.value = true
+            _hfSearchError.value = null
+            try {
+                _hfSearchResults.value = hfModelSearch.search(
+                    query = _hfModelQuery.value,
+                    hfToken = repository.getHfAccessTokenDirect()
+                )
+            } catch (e: Exception) {
+                _hfSearchError.value = e.message ?: "Search failed."
+            } finally {
+                _hfSearchLoading.value = false
+            }
+        }
     }
 
     fun cancelDownload(entryId: String) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -97,6 +98,10 @@ fun SettingsScreen(
     val localModels by viewModel.localModels.collectAsState()
     val downloadStates by viewModel.downloadStates.collectAsState()
     val importError by viewModel.importError.collectAsState()
+    val hfModelQuery by viewModel.hfModelQuery.collectAsState()
+    val hfSearchResults by viewModel.hfSearchResults.collectAsState()
+    val hfSearchLoading by viewModel.hfSearchLoading.collectAsState()
+    val hfSearchError by viewModel.hfSearchError.collectAsState()
 
     var keyInput by remember(apiKey) { mutableStateOf(apiKey) }
     var keyVisible by remember { mutableStateOf(false) }
@@ -113,6 +118,7 @@ fun SettingsScreen(
     var searchKeyVisible by remember { mutableStateOf(false) }
     var hfTokenInput by remember(hfToken) { mutableStateOf(hfToken) }
     var hfTokenVisible by remember { mutableStateOf(false) }
+    var showHfModelSearch by remember { mutableStateOf(false) }
 
     val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         uri?.let { viewModel.importModel(it) }
@@ -361,12 +367,28 @@ fun SettingsScreen(
 
                             // Curated downloads
                             Spacer(Modifier.height(Spacing.l))
-                            Text(
-                                "Download a model",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(start = Spacing.xs, bottom = Spacing.m),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    "Download a model",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                FilledTonalButton(
+                                    onClick = {
+                                        showHfModelSearch = true
+                                        if (hfSearchResults.isEmpty()) viewModel.searchHfModels()
+                                    },
+                                    shape = CircleShape,
+                                ) {
+                                    Icon(Icons.Default.Search, null, Modifier.size(18.dp))
+                                    Spacer(Modifier.width(Spacing.s))
+                                    Text("Search")
+                                }
+                            }
                             Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
                                 LocalModelCatalog.entries.forEachIndexed { index, entry ->
                                     CatalogModelRow(
@@ -499,6 +521,23 @@ fun SettingsScreen(
 
             item { Spacer(Modifier.height(Spacing.xl)) }
         }
+    }
+
+    if (showHfModelSearch) {
+        HfModelSearchDialog(
+            query = hfModelQuery,
+            results = hfSearchResults,
+            loading = hfSearchLoading,
+            error = hfSearchError,
+            localModels = localModels,
+            downloadStates = downloadStates,
+            onQueryChange = viewModel::updateHfModelQuery,
+            onSearch = viewModel::searchHfModels,
+            onDownload = viewModel::downloadModel,
+            onCancel = viewModel::cancelDownload,
+            onRetry = viewModel::retryDownload,
+            onDismiss = { showHfModelSearch = false },
+        )
     }
 }
 
@@ -674,6 +713,93 @@ private fun CatalogModelRow(
             }
         }
     }
+}
+
+@Composable
+private fun HfModelSearchDialog(
+    query: String,
+    results: List<CatalogEntry>,
+    loading: Boolean,
+    error: String?,
+    localModels: List<LocalModel>,
+    downloadStates: Map<String, DownloadState>,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onDownload: (CatalogEntry) -> Unit,
+    onCancel: (String) -> Unit,
+    onRetry: (CatalogEntry) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+        title = { Text("Search mobile models") },
+        text = {
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = onQueryChange,
+                        singleLine = true,
+                        placeholder = { Text("Gemma 4, Qwen3...") },
+                        leadingIcon = { Icon(Icons.Default.Search, null) },
+                        shape = MaterialTheme.shapes.medium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Spacer(Modifier.width(Spacing.s))
+                    FilledTonalIconButton(onClick = onSearch, enabled = !loading) {
+                        Icon(Icons.Default.Search, "Search Hugging Face")
+                    }
+                }
+                Spacer(Modifier.height(Spacing.m))
+                Text(
+                    "Showing LiteRT-LM mobile bundles from Hugging Face that end in .litertlm or .task.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.m))
+                when {
+                    loading -> Box(
+                        modifier = Modifier.fillMaxWidth().height(120.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularWavyProgressIndicator()
+                    }
+                    error != null -> Text(
+                        error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    results.isEmpty() -> Text(
+                        "No mobile-ready LiteRT model bundles found for this search.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp),
+                        verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
+                    ) {
+                        items(results.size) { index ->
+                            val entry = results[index]
+                            CatalogModelRow(
+                                entry = entry,
+                                index = index,
+                                count = results.size,
+                                installed = localModels.any { it.id == entry.id },
+                                state = downloadStates[entry.id],
+                                onDownload = { onDownload(entry) },
+                                onCancel = { onCancel(entry.id) },
+                                onRetry = { onRetry(entry) },
+                            )
+                        }
+                    }
+                }
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -7,12 +7,26 @@ import android.text.format.Formatter
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -21,6 +35,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Language
@@ -35,15 +50,19 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DownloadState
@@ -120,11 +139,43 @@ fun SettingsScreen(
     var hfTokenVisible by remember { mutableStateOf(false) }
     var showHfModelSearch by remember { mutableStateOf(false) }
 
+    // Every section starts collapsed; the header row toggles it open.
+    var appearanceOpen by rememberSaveable { mutableStateOf(false) }
+    var apiOpen by rememberSaveable { mutableStateOf(false) }
+    var searchOpen by rememberSaveable { mutableStateOf(false) }
+    var localOpen by rememberSaveable { mutableStateOf(false) }
+    var modelsOpen by rememberSaveable { mutableStateOf(false) }
+
     val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         uri?.let { viewModel.importModel(it) }
     }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+    val themeLabel = when (darkMode) {
+        "light" -> "Light"
+        "dark" -> "Dark"
+        else -> "System"
+    }
+    val accentLabel = if (themeColor == "dynamic") "Wallpaper"
+    else accents.firstOrNull { it.id == themeColor }?.label ?: "Wallpaper"
+    val selectedProvider = searchProviders.firstOrNull { it.id == webSearchProvider }
+    val searchSubtitle = if (webSearchProvider == "off") "Off" else buildString {
+        append(selectedProvider?.label ?: webSearchProvider)
+        append(" · ")
+        append(
+            when (webSearchScope) {
+                "cloud" -> "Cloud models"
+                "local" -> "Local models"
+                else -> "All models"
+            }
+        )
+    }
+    val localSubtitle = when {
+        !localModelsEnabled -> "Off"
+        localModels.isEmpty() -> "On · No models installed yet"
+        else -> "On · ${localModels.size} installed"
+    }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -146,12 +197,19 @@ fun SettingsScreen(
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(pad).imePadding(),
             contentPadding = PaddingValues(horizontal = Spacing.base, vertical = Spacing.s),
-            verticalArrangement = Arrangement.spacedBy(Spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(Spacing.m),
         ) {
             // ── Appearance ────────────────────────────────────────────────────────────────
             item {
-                Column {
-                    SettingsSectionHeader(Icons.Default.Palette, "Appearance", MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onPrimaryContainer)
+                ExpandableSection(
+                    icon = Icons.Default.Palette,
+                    title = "Appearance",
+                    subtitle = "$themeLabel theme · $accentLabel accent",
+                    container = MaterialTheme.colorScheme.primaryContainer,
+                    onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                    expanded = appearanceOpen,
+                    onToggle = { appearanceOpen = !appearanceOpen },
+                ) {
                     SettingsCard {
                         Text("Theme", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
                         Spacer(Modifier.height(Spacing.m))
@@ -180,8 +238,15 @@ fun SettingsScreen(
 
             // ── OpenRouter API ────────────────────────────────────────────────────────────
             item {
-                Column {
-                    SettingsSectionHeader(Icons.Default.Key, "OpenRouter API", MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onSecondaryContainer)
+                ExpandableSection(
+                    icon = Icons.Default.Key,
+                    title = "OpenRouter API",
+                    subtitle = if (apiKey.isBlank()) "No key saved" else "API key saved",
+                    container = MaterialTheme.colorScheme.secondaryContainer,
+                    onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                    expanded = apiOpen,
+                    onToggle = { apiOpen = !apiOpen },
+                ) {
                     SettingsCard {
                         Text("API key", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
                         Spacer(Modifier.height(Spacing.s))
@@ -209,8 +274,15 @@ fun SettingsScreen(
 
             // ── Web search ────────────────────────────────────────────────────────────────
             item {
-                Column {
-                    SettingsSectionHeader(Icons.Default.Language, "Web search", MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onSecondaryContainer)
+                ExpandableSection(
+                    icon = Icons.Default.Language,
+                    title = "Web search",
+                    subtitle = searchSubtitle,
+                    container = MaterialTheme.colorScheme.secondaryContainer,
+                    onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                    expanded = searchOpen,
+                    onToggle = { searchOpen = !searchOpen },
+                ) {
                     Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
                         searchProviders.forEachIndexed { index, option ->
                             SearchProviderRow(
@@ -311,14 +383,21 @@ fun SettingsScreen(
 
             // ── Local models ──────────────────────────────────────────────────────────────
             item {
-                Column {
-                    SettingsSectionHeader(Icons.Default.PhoneAndroid, "Local models", MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer)
+                ExpandableSection(
+                    icon = Icons.Default.PhoneAndroid,
+                    title = "Local models",
+                    subtitle = localSubtitle,
+                    container = MaterialTheme.colorScheme.tertiaryContainer,
+                    onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                    expanded = localOpen,
+                    onToggle = { localOpen = !localOpen },
+                ) {
                     SettingsCard {
                         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                             Column(Modifier.weight(1f)) {
                                 Text("Run models on-device", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
                                 Text(
-                                    "Private, offline and free — powered by Google AI Edge",
+                                    "Private, offline and free — runs fully on your phone",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -336,7 +415,7 @@ fun SettingsScreen(
                                 Text("Hugging Face token", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
                                 Spacer(Modifier.height(Spacing.xs))
                                 Text(
-                                    "Only needed for license-gated models (Gemma). Accept the model " +
+                                    "Only needed for license-gated models (Gemma 3). Accept the model " +
                                         "license on huggingface.co, then create a read token under " +
                                         "Settings → Access Tokens.",
                                     style = MaterialTheme.typography.bodySmall,
@@ -416,7 +495,8 @@ fun SettingsScreen(
                                 Text("Import from file")
                             }
                             Text(
-                                "Pick a .task or .litertlm model file you've downloaded yourself.",
+                                "Pick a .task or .litertlm model file you've downloaded yourself. " +
+                                    "Models already on this phone are re-detected automatically.",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.padding(start = Spacing.xs, top = Spacing.s),
@@ -458,8 +538,16 @@ fun SettingsScreen(
 
             // ── Models ────────────────────────────────────────────────────────────────────
             item {
-                Column {
-                    SettingsSectionHeader(Icons.Default.Add, "Models", MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer)
+                ExpandableSection(
+                    icon = Icons.Default.Memory,
+                    title = "Models",
+                    subtitle = if (customModels.isEmpty()) "Add custom OpenRouter models"
+                    else "${customModels.size} custom model" + if (customModels.size == 1) "" else "s",
+                    container = MaterialTheme.colorScheme.tertiaryContainer,
+                    onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                    expanded = modelsOpen,
+                    onToggle = { modelsOpen = !modelsOpen },
+                ) {
                     SettingsCard {
                         Text("Add a custom model", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
                         Spacer(Modifier.height(Spacing.s))
@@ -484,13 +572,15 @@ fun SettingsScreen(
                             Icon(Icons.Default.Add, null, Modifier.size(18.dp)); Spacer(Modifier.width(Spacing.s)); Text("Add model")
                         }
                     }
-                }
-            }
 
-            if (customModels.isNotEmpty()) {
-                item {
-                    Column {
-                        SettingsSectionHeader(Icons.Default.Memory, "Your models", MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer)
+                    if (customModels.isNotEmpty()) {
+                        Spacer(Modifier.height(Spacing.l))
+                        Text(
+                            "Your models",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
+                        )
                         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
                             customModels.forEachIndexed { index, model ->
                                 Surface(
@@ -524,7 +614,7 @@ fun SettingsScreen(
     }
 
     if (showHfModelSearch) {
-        HfModelSearchDialog(
+        HfModelSearchSheet(
             query = hfModelQuery,
             results = hfSearchResults,
             loading = hfSearchLoading,
@@ -541,18 +631,74 @@ fun SettingsScreen(
     }
 }
 
+/**
+ * A collapsible settings section: the header is a tappable card showing a live summary of
+ * the section's state; tapping it expands the detail content with a smooth resize + fade.
+ */
 @Composable
-private fun SettingsSectionHeader(icon: ImageVector, title: String, container: Color, onContainer: Color) {
-    Row(
-        Modifier.padding(start = Spacing.xs, bottom = Spacing.m, top = Spacing.xs),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Box(
-            Modifier.size(34.dp).clip(RoundedPolygonShape(BrandShapes.avatarStart)).background(container),
-            contentAlignment = Alignment.Center,
-        ) { Icon(icon, null, Modifier.size(18.dp), tint = onContainer) }
-        Spacer(Modifier.width(Spacing.m))
-        Text(title, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onSurface)
+private fun ExpandableSection(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    container: Color,
+    onContainer: Color,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessMediumLow),
+        label = "sectionChevron",
+    )
+    Column {
+        Surface(
+            onClick = onToggle,
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                Modifier.padding(horizontal = Spacing.base, vertical = Spacing.base),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    Modifier.size(40.dp).clip(RoundedPolygonShape(BrandShapes.avatarStart)).background(container),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(icon, null, Modifier.size(20.dp), tint = onContainer) }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Icon(
+                    Icons.Default.ExpandMore,
+                    if (expanded) "Collapse $title" else "Expand $title",
+                    Modifier.rotate(chevronRotation),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically(
+                animationSpec = tween(320, easing = FastOutSlowInEasing),
+                expandFrom = Alignment.Top,
+            ) + fadeIn(tween(220, delayMillis = 80)),
+            exit = shrinkVertically(
+                animationSpec = tween(260, easing = FastOutSlowInEasing),
+                shrinkTowards = Alignment.Top,
+            ) + fadeOut(tween(120)),
+        ) {
+            Column(Modifier.padding(top = Spacing.m), content = content)
+        }
     }
 }
 
@@ -567,26 +713,56 @@ private fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
     }
 }
 
-/** Custom connected segmented control — the M3 Expressive replacement for segmented buttons. */
+/**
+ * Connected segmented control with a sliding thumb — the M3 Expressive replacement for
+ * segmented buttons. The thumb is inset evenly on all sides so it never touches the track.
+ */
 @Composable
 private fun SegmentedToggle(options: List<Pair<String, String>>, selected: String, onSelect: (String) -> Unit) {
-    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest, modifier = Modifier.fillMaxWidth()) {
-        Row(Modifier.padding(Spacing.xs), horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-            options.forEach { (value, label) ->
-                val isSel = value == selected
-                Surface(
-                    onClick = { onSelect(value) },
-                    shape = CircleShape,
-                    color = if (isSel) MaterialTheme.colorScheme.primary else Color.Transparent,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Text(
-                        label,
-                        style = MaterialTheme.typography.titleSmall,
-                        textAlign = TextAlign.Center,
-                        color = if (isSel) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.m),
+    val trackPadding = 5.dp
+    val segmentHeight = 44.dp
+    val selectedIndex = options.indexOfFirst { it.first == selected }.coerceAtLeast(0)
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        BoxWithConstraints(Modifier.padding(trackPadding)) {
+            val segmentWidth = maxWidth / options.size
+            val thumbOffset by animateDpAsState(
+                targetValue = segmentWidth * selectedIndex,
+                animationSpec = spring(dampingRatio = 0.85f, stiffness = Spring.StiffnessMediumLow),
+                label = "segmentThumb",
+            )
+            Box(
+                Modifier
+                    .offset(x = thumbOffset)
+                    .width(segmentWidth)
+                    .height(segmentHeight)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+            )
+            Row(Modifier.fillMaxWidth()) {
+                options.forEach { (value, label) ->
+                    val isSel = value == selected
+                    val textColor by animateColorAsState(
+                        targetValue = if (isSel) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        animationSpec = tween(200),
+                        label = "segmentText",
                     )
+                    Box(
+                        Modifier
+                            .weight(1f)
+                            .height(segmentHeight)
+                            .clip(CircleShape)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                            ) { onSelect(value) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(label, style = MaterialTheme.typography.titleSmall, textAlign = TextAlign.Center, color = textColor)
+                    }
                 }
             }
         }
@@ -715,8 +891,9 @@ private fun CatalogModelRow(
     }
 }
 
+/** Bottom-sheet redesign of the Hugging Face model search — replaces the cramped dialog. */
 @Composable
-private fun HfModelSearchDialog(
+private fun HfModelSearchSheet(
     query: String,
     results: List<CatalogEntry>,
     loading: Boolean,
@@ -730,56 +907,94 @@ private fun HfModelSearchDialog(
     onRetry: (CatalogEntry) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    AlertDialog(
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        confirmButton = {},
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
-        },
-        title = { Text("Search mobile models") },
-        text = {
-            Column {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    OutlinedTextField(
-                        value = query,
-                        onValueChange = onQueryChange,
-                        singleLine = true,
-                        placeholder = { Text("Gemma 4, Qwen3...") },
-                        leadingIcon = { Icon(Icons.Default.Search, null) },
-                        shape = MaterialTheme.shapes.medium,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Spacer(Modifier.width(Spacing.s))
-                    FilledTonalIconButton(onClick = onSearch, enabled = !loading) {
-                        Icon(Icons.Default.Search, "Search Hugging Face")
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.base)
+                .imePadding()
+                .navigationBarsPadding(),
+        ) {
+            Text("Search mobile models", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.xs))
+            Text(
+                "LiteRT-LM bundles from Hugging Face (.task / .litertlm) that run fully on-device.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.base))
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                placeholder = { Text("Gemma 4, Qwen3…") },
+                leadingIcon = { Icon(Icons.Default.Search, null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) { Icon(Icons.Default.Close, "Clear") }
                     }
-                }
-                Spacer(Modifier.height(Spacing.m))
-                Text(
-                    "Showing LiteRT-LM mobile bundles from Hugging Face that end in .litertlm or .task.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(Spacing.m))
+                },
+                shape = CircleShape,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.m))
+            Button(onClick = onSearch, enabled = !loading, shape = CircleShape, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.Search, null, Modifier.size(18.dp))
+                Spacer(Modifier.width(Spacing.s))
+                Text(if (loading) "Searching…" else "Search Hugging Face")
+            }
+            Spacer(Modifier.height(Spacing.base))
+            Box(Modifier.fillMaxWidth().heightIn(min = 160.dp)) {
                 when {
-                    loading -> Box(
-                        modifier = Modifier.fillMaxWidth().height(120.dp),
-                        contentAlignment = Alignment.Center,
+                    loading -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         CircularWavyProgressIndicator()
+                        Spacer(Modifier.height(Spacing.m))
+                        Text(
+                            "Searching Hugging Face…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
-                    error != null -> Text(
-                        error,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                    results.isEmpty() -> Text(
-                        "No mobile-ready LiteRT model bundles found for this search.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    error != null -> Surface(
+                        shape = MaterialTheme.shapes.large,
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.padding(Spacing.base),
+                        )
+                    }
+                    results.isEmpty() -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Icon(
+                            Icons.Default.Search, null,
+                            Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                        Text(
+                            "No mobile-ready model bundles found.\nTry “gemma”, “qwen” or “deepseek”.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                     else -> LazyColumn(
-                        modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp),
+                        modifier = Modifier.fillMaxWidth().heightIn(max = 440.dp),
                         verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
                     ) {
                         items(results.size) { index ->
@@ -798,8 +1013,9 @@ private fun HfModelSearchDialog(
                     }
                 }
             }
-        },
-    )
+            Spacer(Modifier.height(Spacing.xl))
+        }
+    }
 }
 
 @Composable
@@ -827,8 +1043,11 @@ private fun InstalledModelRow(
             Column(Modifier.weight(1f)) {
                 Text(model.name, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
                 Text(
-                    (if (model.source == "imported") "Imported · " else "Downloaded · ") +
-                        Formatter.formatShortFileSize(context, model.sizeBytes),
+                    when (model.source) {
+                        "imported" -> "Imported · "
+                        "recovered" -> "Found on device · "
+                        else -> "Downloaded · "
+                    } + Formatter.formatShortFileSize(context, model.sizeBytes),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
## What changed

### Settings UI
- Every settings section (Appearance, OpenRouter API, Web search, Local models, Models) is now a collapsible card, collapsed by default, with a smooth expand/shrink + fade animation and a spring-rotating chevron.
- Collapsed headers show a live summary line — Web search shows only the selected provider and scope (e.g. "Exa · Local models") until expanded; the provider list, Both/Cloud/Local toggle, and API key card live inside the expanded state.
- Segmented toggles (theme mode, search scope) redesigned with an animated sliding thumb inset evenly 5dp on all sides, fixing the pill touching the track edge.
- The Hugging Face model search dialog is now a bottom sheet with a proper search field (IME search action, clear button) and distinct loading/error/empty states.
- "Powered by Google AI Edge" wording removed from the on-device toggle.
- The stray "Your models" section was folded into the Models section.

### Local model catalog
- Added **Gemma 4 E2B** (2.59 GB) and **Gemma 4 E4B** (3.66 GB) — these litert-community bundles are **not license-gated**, unlike Gemma 3.
- Added **Qwen3 4B Instruct 2507** (2.66 GB). All URLs and exact byte sizes verified against the Hugging Face API on 2026-06-12. (Qwen3-1.7B has no LiteRT bundle.)

### Model recovery (DB reset / app update resilience)
- Fixed `pruneOrphans()` inserting a **duplicate "recovered" row on every app launch** for imported and search-downloaded models — it now skips files already tracked in Room.
- Models already on the phone are re-adopted into the DB at startup (matched back to catalog entries by file name), so after a DB reset or app update they show as Installed and appear in the model selector without re-downloading.
- Recovered/imported models now derive their context budget from kv-cache hints in the file name (`ekv4096` etc.) instead of a hardcoded 1280 cap.

## Notes for review
- Per project convention this was not built from the CLI — please verify in Android Studio. The riskiest area is the new `androidx.compose.animation` usage in `SettingsScreen.kt` (`ExpandableSection`, `SegmentedToggle`, `HfModelSearchSheet`).
- Model files live in `filesDir/models`, so they survive app updates and DB resets but not a full uninstall (Android wipes private storage); true uninstall-survival would need public storage + permissions and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible settings sections, Gemma 4/Qwen3 catalog entries, and local model recovery
> - Reworks the settings screen to use collapsible `ExpandableSection` headers with live subtitles summarizing current values for each group (Appearance, API keys, Local models, etc.).
> - Adds Qwen3 0.6B, Qwen3 4B Instruct 2507, Gemma 4 E2B, and Gemma 4 E4B to the curated model catalog; updates Gemma 2B metadata.
> - Adds a Hugging Face model search bottom sheet (`HfModelSearchSheet`) that queries the `litert-community` author on the HF API and shows up to 12 size-sorted results with download/cancel controls.
> - Expands `pruneOrphans` in `ModelDownloadManager` to auto-adopt untracked `.litertlm` files already on disk as 'recovered' models, matching catalog entries by filename where possible.
> - Updates `LocalModelCatalog.maxTokensFor` to accept an optional filename and infer context window size from `ekv\d+` patterns in filenames when no catalog entry matches.
> - Risk: orphan recovery silently re-inserts any matching on-disk file into the DB on next launch; manually sideloaded files with non-standard names will get generated IDs and a 2048-token default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c6032d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and browse Hugging Face models directly from the app
  * Added new models to catalog (Qwen3 0.6B, Gemma 4, Qwen3 4B Instruct)
  * Settings screen redesigned with collapsible sections for better organization

* **Bug Fixes**
  * Improved model token calculation accuracy
  * Enhanced recovery of previously downloaded models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->