### PR TITLE
[codex] Add manual signed APK releases

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,91 @@
+name: Release APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_name:
+        description: "Public release version, for example 2.0, 2.5, or 4.0"
+        required: true
+        default: "2.0"
+      release_notes:
+        description: "Optional release notes"
+        required: false
+        default: ""
+      draft:
+        description: "Create the GitHub release as a draft"
+        required: true
+        type: boolean
+        default: false
+      prerelease:
+        description: "Mark this as a prerelease"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-apk:
+    name: Build signed release APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          test -n "$KEYSTORE_BASE64"
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/upload-keystore.jks"
+
+      - name: Build release APK
+        env:
+          KEYSTORE_PATH: ${{ runner.temp }}/upload-keystore.jks
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          VERSION_NAME: ${{ inputs.version_name }}
+        run: |
+          export VERSION_CODE=$((1000 + GITHUB_RUN_NUMBER))
+          chmod +x ./gradlew
+          ./gradlew :app:assembleRelease
+
+      - name: Prepare APK artifact
+        run: |
+          mkdir -p release
+          cp app/build/outputs/apk/release/app-release.apk "release/EchoFlow-${{ inputs.version_name }}.apk"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION_NAME: ${{ inputs.version_name }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          args=()
+          if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
+          if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
+
+          if [ -n "$RELEASE_NOTES" ]; then
+            printf "%s\n" "$RELEASE_NOTES" > release-notes.md
+            notes_args=(--notes-file release-notes.md)
+          else
+            notes_args=(--generate-notes)
+          fi
+
+          gh release create "v${VERSION_NAME}" \
+            "release/EchoFlow-${VERSION_NAME}.apk" \
+            --title "EchoFlow ${VERSION_NAME}" \
+            --target "$GITHUB_SHA" \
+            "${notes_args[@]}" \
+            "${args[@]}"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "com.echoflow"
     minSdk = 24
     targetSdk = 36
-    versionCode = 1
-    versionName = "1.0"
+    versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
+    versionName = System.getenv("VERSION_NAME") ?: "1.0"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -31,7 +31,7 @@ android {
       val keystorePath = System.getenv("KEYSTORE_PATH") ?: "${rootDir}/my-upload-key.jks"
       storeFile = file(keystorePath)
       storePassword = System.getenv("STORE_PASSWORD")
-      keyAlias = "upload"
+      keyAlias = System.getenv("KEY_ALIAS") ?: "upload"
       keyPassword = System.getenv("KEY_PASSWORD")
     }
     create("debugConfig") {
@@ -44,6 +44,7 @@ android {
 
   buildTypes {
     release {
+      signingConfig = signingConfigs.getByName("release")
       isCrunchPngs = false
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")


### PR DESCRIPTION
## What changed
- Add a manual-only `Release APK` GitHub Actions workflow.
- Build a signed release APK using GitHub Secrets for the upload keystore.
- Let the release runner choose the public `version_name`, such as `2.0`, `2.5`, or `4.0`.
- Generate an increasing Android `versionCode` automatically from the workflow run number.
- Attach the APK to a GitHub Release named `EchoFlow <version>` with tag `v<version>`.

## Signing setup
The release keystore is not committed. The repository has these GitHub Secrets configured:
- `KEYSTORE_BASE64`
- `STORE_PASSWORD`
- `KEY_PASSWORD`
- `KEY_ALIAS`

## Trigger behavior
This workflow does not run on merge, push, or PR. It only runs when manually started from GitHub Actions.

## Validation
- Local signed release build passed with release signing env vars: `./gradlew.bat :app:assembleRelease`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual signed APK release workflow
> - Adds [release-apk.yml](.github/workflows/release-apk.yml), a `workflow_dispatch` GitHub Actions workflow that builds a signed release APK and publishes a GitHub Release with the APK attached.
> - Accepts `version_name`, `release_notes`, `draft`, and `prerelease` as inputs; derives `VERSION_CODE` from `GITHUB_RUN_NUMBER`.
> - Decodes a base64 keystore secret into a temporary JKS file at build time; `KEY_ALIAS` is now read from the environment in [app/build.gradle.kts](https://github.com/adityavardhansharma/EchoFlow/pull/15/files#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46).
> - Updates `versionCode` and `versionName` in `build.gradle.kts` to fall back to `1`/`"1.0"` when env vars are absent, and explicitly assigns the release signing config to the release build type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cd62c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated release workflow for building and publishing APK releases with customizable version numbers, release notes, and release type options
  * Updated build configuration to support environment variables for versioning and code signing parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->