### PR TITLE
[codex] Upload APK when publishing releases

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,6 +1,8 @@
 name: Release APK
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version_name:
@@ -53,18 +55,34 @@ jobs:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          VERSION_NAME: ${{ inputs.version_name }}
+          VERSION_NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version_name }}
         run: |
+          VERSION_NAME="${VERSION_NAME#v}"
           export VERSION_CODE=$((1000 + GITHUB_RUN_NUMBER))
           chmod +x ./gradlew
           ./gradlew :app:assembleRelease
 
       - name: Prepare APK artifact
+        env:
+          VERSION_NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version_name }}
         run: |
+          VERSION_NAME="${VERSION_NAME#v}"
           mkdir -p release
-          cp app/build/outputs/apk/release/app-release.apk "release/EchoFlow-${{ inputs.version_name }}.apk"
+          cp app/build/outputs/apk/release/app-release.apk "release/EchoFlow-${VERSION_NAME}.apk"
+
+      - name: Upload APK to published release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION_NAME="${VERSION_NAME#v}"
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "release/EchoFlow-${VERSION_NAME}.apk" \
+            --clobber
 
       - name: Create GitHub release
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION_NAME: ${{ inputs.version_name }}
@@ -72,6 +90,7 @@ jobs:
           DRAFT: ${{ inputs.draft }}
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
+          VERSION_NAME="${VERSION_NAME#v}"
           args=()
           if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
           if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi


### PR DESCRIPTION
## What changed
- Update the `Release APK` workflow to also run when a GitHub Release is published.
- When someone uses GitHub's Releases page, the workflow builds the signed release APK and uploads it to that same release.
- Keep the existing manual workflow path that can create a release directly from Actions.

## Important behavior
GitHub will always add source code zip/tar.gz assets automatically. This change adds the APK asset alongside those generated source archives after the workflow completes.

## Validation
- Local signed release build passed: `./gradlew.bat :app:assembleRelease`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upload APK to GitHub Release when publishing releases
> - Adds a `release: [published]` trigger to [release-apk.yml](.github/workflows/release-apk.yml) so the workflow runs automatically when a GitHub Release is published.
> - Resolves `VERSION_NAME` from the release tag on release events, stripping any leading `v`, and falls back to the manual `inputs.version_name` for `workflow_dispatch` runs.
> - Uploads the built APK to the triggering GitHub Release via `gh release upload --clobber`, conditional on the release event.
> - Gates the existing "Create GitHub release" step to `workflow_dispatch` only to avoid duplicate release creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd566e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release workflow to trigger when publishing releases on GitHub, in addition to manual activation.
  * Improved version handling for APK builds, automatically deriving version information from release tags or manual input.
  * APK artifacts are now automatically uploaded to published GitHub releases, streamlining the release distribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->