### PR TITLE
[codex] Improve chat reasoning and settings flows

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -118,7 +118,8 @@ fun AdaptiveChatWorkspace(
     onSettingsClicked: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
-    val allConversations by chatViewModel.allThreads.collectAsState()
+    val allConversations by chatViewModel.filteredThreads.collectAsState()
+    val drawerSearchQuery by chatViewModel.drawerSearchQuery.collectAsState()
     val selectedThreadId by chatViewModel.currentChatThreadId.collectAsState()
 
     // Inspect screen boundaries for Tablet orientation check
@@ -140,7 +141,9 @@ fun AdaptiveChatWorkspace(
                         onNewChatClicked = { chatViewModel.startNewChat() },
                         onDeleteThread = { t -> chatViewModel.deleteThread(t) },
                         onRenameThread = { t, name -> chatViewModel.renameThread(t, name) },
-                        onSettingsClicked = onSettingsClicked
+                        onSettingsClicked = onSettingsClicked,
+                        searchQuery = drawerSearchQuery,
+                        onSearchQueryChange = chatViewModel::setDrawerSearchQuery
                     )
                 }
 
@@ -180,7 +183,9 @@ fun AdaptiveChatWorkspace(
                             onDeleteThread = { t -> chatViewModel.deleteThread(t) },
                             onRenameThread = { t, name -> chatViewModel.renameThread(t, name) },
                             onSettingsClicked = onSettingsClicked,
-                            onCloseDrawer = { scope.launch { mobileDrawerState.close() } }
+                            onCloseDrawer = { scope.launch { mobileDrawerState.close() } },
+                            searchQuery = drawerSearchQuery,
+                            onSearchQueryChange = chatViewModel::setDrawerSearchQuery
                         )
                     }
                 }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class],
-    version = 3, // v3: local_models table + chat_messages.toolEventsJson/citationsJson (MIGRATION_2_3)
+    version = 4, // v4: chat_messages.segmentsJson — ordered reply timeline (MIGRATION_3_4)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -38,6 +38,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN segmentsJson TEXT")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -45,7 +51,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4)
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -57,6 +57,18 @@ data class Citation(
     val url: String
 )
 
+/**
+ * One block of a finished reply, persisted in arrival order so the rendered timeline
+ * (reason → search → reason → search → answer) survives exactly as it streamed instead
+ * of being merged into "all reasoning, then all searches, then text".
+ */
+data class PersistedSegment(
+    val type: String, // "text" | "reasoning" | "search"
+    val text: String? = null,
+    val query: String? = null,
+    val sources: List<SearchSource>? = null
+)
+
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */
 object ToolEventJson {
     private val moshi: Moshi = Moshi.Builder()
@@ -71,6 +83,10 @@ object ToolEventJson {
         Types.newParameterizedType(List::class.java, Citation::class.java)
     )
 
+    private val segmentsAdapter: JsonAdapter<List<PersistedSegment>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, PersistedSegment::class.java)
+    )
+
     fun toolEventsToJson(events: List<ToolEvent>): String? =
         if (events.isEmpty()) null else toolEventsAdapter.toJson(events)
 
@@ -82,4 +98,10 @@ object ToolEventJson {
 
     fun citationsFromJson(json: String?): List<Citation> =
         json?.let { runCatching { citationsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+
+    fun segmentsToJson(segments: List<PersistedSegment>): String? =
+        if (segments.isEmpty()) null else segmentsAdapter.toJson(segments)
+
+    fun segmentsFromJson(json: String?): List<PersistedSegment> =
+        json?.let { runCatching { segmentsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
 }

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -34,6 +34,10 @@ interface MessageDao {
 
     @Query("DELETE FROM chat_messages WHERE chatId = :chatId")
     suspend fun deleteMessagesForChat(chatId: String)
+
+    /** Chat ids whose message text matches the drawer search query. */
+    @Query("SELECT DISTINCT chatId FROM chat_messages WHERE content LIKE '%' || :query || '%'")
+    fun searchChatIdsByContent(query: String): Flow<List<String>>
 }
 
 @Dao

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -36,7 +36,8 @@ data class ChatMessage(
     val localAttachmentMimeType: String? = null,
     val localAttachmentName: String? = null,
     val toolEventsJson: String? = null, // JSON List<ToolEvent>: web searches the model ran for this answer
-    val citationsJson: String? = null // JSON List<Citation>: deduped sources backing this answer
+    val citationsJson: String? = null, // JSON List<Citation>: deduped sources backing this answer
+    val segmentsJson: String? = null // JSON List<PersistedSegment>: ordered reply timeline (reasoning/search/text interleaved)
 )
 
 @Entity(tableName = "custom_models")

--- a/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
@@ -1,0 +1,81 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/** One model from OpenRouter's public directory, normalized for the picker UI. */
+data class OpenRouterModelInfo(
+    val id: String, // "anthropic/claude-sonnet-4.6"
+    val name: String, // "Anthropic: Claude Sonnet 4.6"
+    val contextLength: Int?,
+    val promptPricePerM: Double?, // USD per 1M prompt tokens
+    val completionPricePerM: Double?, // USD per 1M completion tokens
+) {
+    val isFree: Boolean get() = (promptPricePerM ?: 0.0) == 0.0 && (completionPricePerM ?: 0.0) == 0.0
+}
+
+/**
+ * Fetches OpenRouter's public model directory (https://openrouter.ai/api/v1/models — no
+ * auth needed) once per process and serves it from memory, so the add-model search can
+ * filter the full list instantly as the user types.
+ */
+class OpenRouterModelDirectory {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val adapter = moshi.adapter(DirectoryResponse::class.java)
+
+    @Volatile
+    private var cache: List<OpenRouterModelInfo>? = null
+
+    suspend fun allModels(): List<OpenRouterModelInfo> = withContext(Dispatchers.IO) {
+        cache?.let { return@withContext it }
+
+        val request = Request.Builder().url("https://openrouter.ai/api/v1/models").build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw Exception("Could not load the model directory (HTTP ${response.code}).")
+            }
+            val body = response.body?.string().orEmpty()
+            val parsed = adapter.fromJson(body)?.data.orEmpty()
+            val models = parsed.mapNotNull { raw ->
+                val id = raw.id ?: return@mapNotNull null
+                OpenRouterModelInfo(
+                    id = id,
+                    name = raw.name ?: id,
+                    contextLength = raw.contextLength,
+                    promptPricePerM = raw.pricing?.prompt?.toDoubleOrNull()?.times(1_000_000),
+                    completionPricePerM = raw.pricing?.completion?.toDoubleOrNull()?.times(1_000_000),
+                )
+            }.sortedBy { it.name.lowercase() }
+            cache = models
+            models
+        }
+    }
+}
+
+private data class DirectoryResponse(val data: List<RawModel>? = null)
+
+private data class RawModel(
+    val id: String? = null,
+    val name: String? = null,
+    @Json(name = "context_length") val contextLength: Int? = null,
+    val pricing: RawPricing? = null,
+)
+
+private data class RawPricing(
+    val prompt: String? = null,
+    val completion: String? = null,
+)

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -88,6 +88,7 @@ object SystemPrompts {
         - Base time-sensitive claims on the search results, not on memory.
         - Cite sources inline as markdown links, e.g. ([Reuters](https://example.com/article)).
         - If results conflict, say so and present the most credible reading.
+        - Never append a "Sources" or "References" list at the end of the answer — the app already shows your sources separately.
         """.trimIndent()
 
     private fun cloudFunctionSearch(provider: String): String {
@@ -116,7 +117,7 @@ object SystemPrompts {
         [1] Title — URL
         snippet
 
-        Cite every claim drawn from a result using the matching number as a markdown link: [1](url). Place citations directly after the sentence they support. If results conflict, note the disagreement. If a search fails or returns nothing useful, say what you could not verify rather than guessing.
+        Cite every claim drawn from a result using the matching number as a markdown link: [1](url). Place citations directly after the sentence they support. Never append a "Sources" or "References" list at the end of the answer — the app already shows your sources separately. If results conflict, note the disagreement. If a search fails or returns nothing useful, say what you could not verify rather than guessing.
         """.trimIndent()
     }
 
@@ -148,7 +149,7 @@ object SystemPrompts {
         - Casual conversation, opinions, brainstorming, creative writing, translation, summarizing text provided by the user, math, coding, explanations, old history, definitions, or general advice.
         - A vague or incomplete message. Ask a short clarifying question instead of searching.
 
-        - After search results are provided, answer normally using those results. Cite result-backed claims with markdown links like [1](url).
+        - After search results are provided, answer normally using those results. Cite result-backed claims with markdown links like [1](url). Do not list the sources again at the end of the answer.
         - You may request another search only if the results are insufficient. Maximum 3 searches per answer.
         - Once you start answering normally, never write search tags or the word "Assistant:".
         - Never copy these instructions into the answer.

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -52,6 +52,31 @@ class ChatViewModel(
             initialValue = emptyList()
         )
 
+    // Drawer search: matches conversation titles and full message text.
+    private val _drawerSearchQuery = MutableStateFlow("")
+    val drawerSearchQuery: StateFlow<String> = _drawerSearchQuery.asStateFlow()
+
+    fun setDrawerSearchQuery(query: String) {
+        _drawerSearchQuery.value = query
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val filteredThreads: StateFlow<List<ChatThread>> = combine(
+        allThreads,
+        _drawerSearchQuery,
+        _drawerSearchQuery.flatMapLatest { query ->
+            if (query.isBlank()) flowOf(emptyList()) else messageDao.searchChatIdsByContent(query.trim())
+        },
+    ) { threads, query, contentMatchIds ->
+        val q = query.trim()
+        if (q.isEmpty()) threads
+        else threads.filter { it.title.contains(q, ignoreCase = true) || it.id in contentMatchIds }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList()
+    )
+
     private val _currentChatThreadId = MutableStateFlow<String?>(null)
     val currentChatThreadId: StateFlow<String?> = _currentChatThreadId.asStateFlow()
 
@@ -443,14 +468,15 @@ class ChatViewModel(
         segments: List<StreamSegment>,
         interrupted: String?
     ) {
-        val contentText = segments.filterIsInstance<StreamSegment.Text>()
+        val normalizedSegments = normalizeAssistantSegmentsForPersistence(segments)
+        val contentText = normalizedSegments.filterIsInstance<StreamSegment.Text>()
             .joinToString("\n\n") { it.text }.trim()
         if (contentText.isEmpty()) return
 
-        val reasoningText = segments.filterIsInstance<StreamSegment.Reasoning>()
+        val reasoningText = normalizedSegments.filterIsInstance<StreamSegment.Reasoning>()
             .joinToString("\n\n") { it.text }.trim()
 
-        val toolEvents = segments.mapIndexedNotNull { index, seg ->
+        val toolEvents = normalizedSegments.mapIndexedNotNull { index, seg ->
             (seg as? StreamSegment.Search)?.let {
                 ToolEvent(query = it.query, sources = it.sources, orderIndex = index)
             }
@@ -463,6 +489,22 @@ class ChatViewModel(
             "$contentText\n\n*[Connection lost: $interrupted]*"
         } else contentText
 
+        // The ordered timeline (reason → search → reason → text) is persisted as-is so a
+        // finished reply renders exactly like it streamed, never merging reasoning blocks.
+        val persistedSegments = normalizedSegments.mapNotNull { seg ->
+            when (seg) {
+                is StreamSegment.Reasoning -> seg.text.trim().takeIf { it.isNotEmpty() }
+                    ?.let { PersistedSegment(type = "reasoning", text = it) }
+                is StreamSegment.Search ->
+                    PersistedSegment(type = "search", query = seg.query, sources = seg.sources)
+                is StreamSegment.Text -> seg.text.trim().takeIf { it.isNotEmpty() }
+                    ?.let { PersistedSegment(type = "text", text = it) }
+            }
+        }.let { list ->
+            if (interrupted != null) list + PersistedSegment(type = "text", text = "*[Connection lost: $interrupted]*")
+            else list
+        }
+
         messageDao.insertMessage(
             ChatMessage(
                 id = UUID.randomUUID().toString(),
@@ -472,13 +514,63 @@ class ChatViewModel(
                 createdAt = System.currentTimeMillis(),
                 reasoning = reasoningText.ifBlank { null },
                 toolEventsJson = ToolEventJson.toolEventsToJson(toolEvents),
-                citationsJson = ToolEventJson.citationsToJson(citations)
+                citationsJson = ToolEventJson.citationsToJson(citations),
+                segmentsJson = ToolEventJson.segmentsToJson(persistedSegments)
             )
         )
 
         chatDao.getThreadById(chatId)?.let { currentT ->
             chatDao.updateThread(currentT.copy(updatedAt = System.currentTimeMillis()))
         }
+    }
+
+    /**
+     * Some OpenRouter/provider combinations (notably a few DeepSeek routes) can stream the
+     * visible answer through `reasoning` / `reasoning_content` and never send `content`.
+     * Without this guard the live answer disappears when streaming ends because there is no
+     * assistant content to persist. Preserve the timeline, but promote the final reasoning tail
+     * into normal text when it is the only answer-like material we received.
+     */
+    private fun normalizeAssistantSegmentsForPersistence(segments: List<StreamSegment>): List<StreamSegment> {
+        if (segments.any { it is StreamSegment.Text && it.text.isNotBlank() }) return segments
+
+        val lastReasoningIndex = segments.indexOfLast {
+            it is StreamSegment.Reasoning && it.text.isNotBlank()
+        }
+        if (lastReasoningIndex < 0) return segments
+
+        val normalized = segments.toMutableList()
+        val reasoning = normalized[lastReasoningIndex] as StreamSegment.Reasoning
+        val (remainingReasoning, answerText) = splitReasoningOnlyAnswer(reasoning.text)
+        val replacement = mutableListOf<StreamSegment>()
+        if (remainingReasoning.isNotBlank()) replacement.add(StreamSegment.Reasoning(remainingReasoning))
+        replacement.add(StreamSegment.Text(answerText))
+
+        normalized.removeAt(lastReasoningIndex)
+        normalized.addAll(lastReasoningIndex, replacement)
+        return normalized
+    }
+
+    private fun splitReasoningOnlyAnswer(text: String): Pair<String, String> {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return "" to ""
+
+        val thinkEnd = trimmed.lastIndexOf("</think>", ignoreCase = true)
+        if (thinkEnd >= 0) {
+            val answer = trimmed.substring(thinkEnd + "</think>".length).trim()
+            if (answer.isNotEmpty()) return trimmed.substring(0, thinkEnd + "</think>".length).trim() to answer
+        }
+
+        val marker = Regex(
+            pattern = "(?im)^\\s*(final\\s+answer|answer|response)\\s*:\\s*"
+        ).findAll(trimmed).lastOrNull()
+        if (marker != null) {
+            val answerStart = marker.range.last + 1
+            val answer = trimmed.substring(answerStart).trim()
+            if (answer.isNotEmpty()) return trimmed.substring(0, marker.range.first).trim() to answer
+        }
+
+        return "" to trimmed
     }
 
     // -------------------------------------------------------------------------------

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -12,8 +12,11 @@ import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelDao
 import com.echoflow.data.ModelDownloadManager
+import com.echoflow.data.OpenRouterModelDirectory
+import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.data.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,7 +51,9 @@ class SettingsViewModel(
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
 
-    private val _hfModelQuery = MutableStateFlow("qwen3")
+    // Starts empty on purpose: the search sheet must open idle, never replaying a stale
+    // query or kicking off a search by itself.
+    private val _hfModelQuery = MutableStateFlow("")
     val hfModelQuery: StateFlow<String> = _hfModelQuery.asStateFlow()
 
     private val _hfSearchResults = MutableStateFlow<List<CatalogEntry>>(emptyList())
@@ -59,6 +64,32 @@ class SettingsViewModel(
 
     private val _hfSearchError = MutableStateFlow<String?>(null)
     val hfSearchError: StateFlow<String?> = _hfSearchError.asStateFlow()
+
+    // OpenRouter model directory (add-cloud-model search)
+    private val orDirectory = OpenRouterModelDirectory()
+
+    private val _orAllModels = MutableStateFlow<List<OpenRouterModelInfo>>(emptyList())
+
+    private val _orModelQuery = MutableStateFlow("")
+    val orModelQuery: StateFlow<String> = _orModelQuery.asStateFlow()
+
+    private val _orDirectoryLoading = MutableStateFlow(false)
+    val orDirectoryLoading: StateFlow<Boolean> = _orDirectoryLoading.asStateFlow()
+
+    private val _orDirectoryError = MutableStateFlow<String?>(null)
+    val orDirectoryError: StateFlow<String?> = _orDirectoryError.asStateFlow()
+
+    /** Directory filtered live as the user types; capped so the sheet stays snappy. */
+    val orModelResults: StateFlow<List<OpenRouterModelInfo>> =
+        combine(_orAllModels, _orModelQuery) { all, query ->
+            val q = query.trim()
+            if (q.isEmpty()) all.take(40)
+            else all.filter { it.id.contains(q, true) || it.name.contains(q, true) }.take(60)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
 
     val customModels: StateFlow<List<CustomModel>> = customModelDao.getAllCustomModels()
         .stateIn(
@@ -135,6 +166,26 @@ class SettingsViewModel(
                 _hfSearchError.value = e.message ?: "Search failed."
             } finally {
                 _hfSearchLoading.value = false
+            }
+        }
+    }
+
+    fun updateOrModelQuery(query: String) {
+        _orModelQuery.value = query
+    }
+
+    /** Loads the OpenRouter directory once; safe to call every time the sheet opens. */
+    fun loadOpenRouterDirectory() {
+        if (_orAllModels.value.isNotEmpty() || _orDirectoryLoading.value) return
+        viewModelScope.launch {
+            _orDirectoryLoading.value = true
+            _orDirectoryError.value = null
+            try {
+                _orAllModels.value = orDirectory.allModels()
+            } catch (e: Exception) {
+                _orDirectoryError.value = e.message ?: "Could not load the model directory."
+            } finally {
+                _orDirectoryLoading.value = false
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
@@ -17,9 +17,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -28,6 +31,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
@@ -58,6 +65,8 @@ fun ChatDrawerContent(
     onRenameThread: (ChatThread, String) -> Unit,
     onSettingsClicked: () -> Unit,
     onCloseDrawer: (() -> Unit)? = null,
+    searchQuery: String = "",
+    onSearchQueryChange: ((String) -> Unit)? = null,
 ) {
     var threadToRename by remember { mutableStateOf<ChatThread?>(null) }
     var threadToDelete by remember { mutableStateOf<ChatThread?>(null) }
@@ -156,18 +165,42 @@ fun ChatDrawerContent(
             Text("New conversation", style = MaterialTheme.typography.titleSmall)
         }
 
-        Spacer(Modifier.height(Spacing.l))
-        SectionLabel("Recent")
+        // Search across every conversation — titles and message text.
+        if (onSearchQueryChange != null) {
+            Spacer(Modifier.height(Spacing.m))
+            DrawerSearchField(query = searchQuery, onQueryChange = onSearchQueryChange)
+        }
 
-        LazyColumn(Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-            items(allThreads, key = { it.id }) { thread ->
-                ThreadPill(
-                    thread = thread,
-                    selected = thread.id == currentThreadId,
-                    onClick = { onThreadSelected(thread.id); onCloseDrawer?.invoke() },
-                    onRename = { threadToRename = thread },
-                    onDelete = { threadToDelete = thread },
+        Spacer(Modifier.height(Spacing.l))
+        SectionLabel(if (searchQuery.isBlank()) "Recent" else "Results")
+
+        if (searchQuery.isNotBlank() && allThreads.isEmpty()) {
+            Column(
+                Modifier.weight(1f).fillMaxWidth().padding(top = Spacing.xl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Icon(
+                    Icons.Default.Search, null, Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                Spacer(Modifier.height(Spacing.s))
+                Text(
+                    "No conversations match “$searchQuery”",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                items(allThreads, key = { it.id }) { thread ->
+                    ThreadPill(
+                        thread = thread,
+                        selected = thread.id == currentThreadId,
+                        onClick = { onThreadSelected(thread.id); onCloseDrawer?.invoke() },
+                        onRename = { threadToRename = thread },
+                        onDelete = { threadToDelete = thread },
+                    )
+                }
             }
         }
 
@@ -223,6 +256,97 @@ fun ChatDrawerContent(
             )
         }
         Spacer(Modifier.height(Spacing.s))
+    }
+}
+
+/**
+ * Compact pill search field tuned for the drawer's dark surface.
+ *
+ * The text field only exists in the composition after the user taps the pill: drawers
+ * move focus into their content when they open, and a permanently-focusable field would
+ * grab that focus and pop the keyboard on every drawer swipe.
+ */
+@Composable
+private fun DrawerSearchField(query: String, onQueryChange: (String) -> Unit) {
+    var editing by remember { mutableStateOf(false) }
+    var hadFocus by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    Surface(
+        onClick = { editing = true },
+        shape = PillShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.heightIn(min = 48.dp).padding(horizontal = Spacing.base),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Search, null, Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.width(Spacing.m))
+            if (editing) {
+                BasicTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    decorationBox = { innerTextField ->
+                        Box(contentAlignment = Alignment.CenterStart) {
+                            if (query.isEmpty()) {
+                                Text(
+                                    "Search conversations",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester)
+                        .onFocusChanged { state ->
+                            if (state.isFocused) {
+                                hadFocus = true
+                            } else if (hadFocus) {
+                                // Leave edit mode when focus moves away (e.g. the drawer
+                                // closes) so reopening the drawer never re-grabs focus.
+                                editing = false
+                                hadFocus = false
+                            }
+                        },
+                )
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+            } else {
+                Text(
+                    query.ifEmpty { "Search conversations" },
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (query.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            if (query.isNotEmpty()) {
+                IconButton(
+                    onClick = {
+                        onQueryChange("")
+                        editing = false
+                    },
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        Icons.Default.Close, "Clear search", Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownText.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
@@ -427,12 +428,31 @@ private fun AnnotatedString.Builder.appendInline(text: String, linkColor: Color)
                     if (parenClose != -1) {
                         val label = text.substring(nextIdx + 1, labelEnd)
                         val url = text.substring(labelEnd + 2, parenClose)
-                        withLink(
-                            LinkAnnotation.Url(
-                                url,
-                                TextLinkStyles(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline))
-                            )
-                        ) { appendInline(label, linkColor) }
+                        if (isCitationLabel(label)) {
+                            // Numbered citation ([1](url)) — render as a tiny raised pill
+                            // in the accent color instead of a bare underlined "1".
+                            withLink(
+                                LinkAnnotation.Url(
+                                    url,
+                                    TextLinkStyles(
+                                        SpanStyle(
+                                            color = linkColor,
+                                            background = linkColor.copy(alpha = 0.14f),
+                                            fontWeight = FontWeight.SemiBold,
+                                            fontSize = 11.sp,
+                                            baselineShift = BaselineShift.Superscript,
+                                        )
+                                    )
+                                )
+                            ) { append(" $label ") }
+                        } else {
+                            withLink(
+                                LinkAnnotation.Url(
+                                    url,
+                                    TextLinkStyles(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline))
+                                )
+                            ) { appendInline(label, linkColor) }
+                        }
                         cursor = parenClose + 1
                     } else { append("["); cursor = nextIdx + 1 }
                 } else { append("["); cursor = nextIdx + 1 }
@@ -440,6 +460,10 @@ private fun AnnotatedString.Builder.appendInline(text: String, linkColor: Color)
         }
     }
 }
+
+/** A link label that is just a small number — the `[1](url)` citation convention. */
+private fun isCitationLabel(label: String): Boolean =
+    label.length in 1..3 && label.all { it.isDigit() }
 
 /** Index of a standalone `*` italic marker (not part of `**`, and opening a non-space run). */
 private fun indexOfItalic(text: String, from: Int): Int {

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -68,7 +68,6 @@ import com.echoflow.ui.components.MarkdownText
 import com.echoflow.ui.components.RichMarkdown
 import com.echoflow.ui.components.SearchActivityCard
 import com.echoflow.ui.components.SectionLabel
-import com.echoflow.ui.components.SourcesRow
 import com.echoflow.ui.theme.BrandShapes
 import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.Spacing
@@ -449,39 +448,55 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
             }
             Spacer(Modifier.height(Spacing.s))
 
-            // Reasoning ("thinking") trace for reasoning-capable models.
-            val reasoningText = message.reasoning
-            if (!reasoningText.isNullOrBlank()) {
-                ReasoningSection(
-                    reasoning = reasoningText,
-                    active = streaming && message.content.isBlank(),
-                )
-                Spacer(Modifier.height(Spacing.s))
-            }
-
-            // Web searches the model ran for this answer (persisted, collapsed).
-            val toolEvents = remember(message.id) { ToolEventJson.toolEventsFromJson(message.toolEventsJson) }
-            toolEvents.forEach { event ->
-                SearchActivityCard(query = event.query, sources = event.sources, active = false)
-                Spacer(Modifier.height(Spacing.s))
-            }
+            // Finished replies render their persisted timeline in arrival order, so
+            // reason → search → reason → search → answer keeps exactly the layout it
+            // streamed with instead of merging all reasoning into one block.
+            val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
 
             message.localAttachmentUri?.let {
                 AsyncImage(it, null, Modifier.padding(bottom = Spacing.s).size(200.dp).clip(MaterialTheme.shapes.large), contentScale = ContentScale.Crop)
             }
-            if (streaming) {
-                // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
-                if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
-            } else {
-                // World-class render for the finished message: tables, lists, highlighted code, etc.
-                RichMarkdown(message.content, Modifier.fillMaxWidth())
-            }
-            if (!streaming) {
-                val citations = remember(message.id) { ToolEventJson.citationsFromJson(message.citationsJson) }
-                if (citations.isNotEmpty()) {
-                    Spacer(Modifier.height(Spacing.m))
-                    SourcesRow(citations)
+
+            when {
+                streaming -> {
+                    // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
+                    if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
                 }
+                persistedSegments.isNotEmpty() -> {
+                    persistedSegments.forEachIndexed { index, segment ->
+                        when (segment.type) {
+                            "reasoning" -> {
+                                ReasoningSection(reasoning = segment.text.orEmpty(), active = false)
+                                Spacer(Modifier.height(Spacing.s))
+                            }
+                            "search" -> {
+                                SearchActivityCard(query = segment.query.orEmpty(), sources = segment.sources.orEmpty(), active = false)
+                                Spacer(Modifier.height(Spacing.s))
+                            }
+                            else -> {
+                                RichMarkdown(segment.text.orEmpty(), Modifier.fillMaxWidth())
+                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                            }
+                        }
+                    }
+                }
+                else -> {
+                    // Legacy messages saved before the timeline column existed.
+                    val reasoningText = message.reasoning
+                    if (!reasoningText.isNullOrBlank()) {
+                        ReasoningSection(reasoning = reasoningText, active = false)
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    val toolEvents = remember(message.id) { ToolEventJson.toolEventsFromJson(message.toolEventsJson) }
+                    toolEvents.forEach { event ->
+                        SearchActivityCard(query = event.query, sources = event.sources, active = false)
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    RichMarkdown(message.content, Modifier.fillMaxWidth())
+                }
+            }
+
+            if (!streaming) {
                 Spacer(Modifier.height(Spacing.xs))
                 FilledTonalIconButton(
                     onClick = onCopy,

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
@@ -33,22 +31,25 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
@@ -58,7 +59,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
@@ -76,13 +79,15 @@ import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DownloadState
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelCatalog
+import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.components.GroupedItemGap
-import com.echoflow.ui.components.SectionLabel
 import com.echoflow.ui.components.groupedItemShape
 import com.echoflow.ui.theme.BrandShapes
+import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberMorph
 
 private data class Accent(val id: String, val label: String, val swatch: Color)
 
@@ -110,10 +115,9 @@ private const val CatalogPreviewCount = 3
 
 private const val PageHome = "home"
 private const val PageAppearance = "appearance"
-private const val PageCloudApi = "cloud_api"
+private const val PageCloudModels = "cloud_models"
 private const val PageWebSearch = "web_search"
 private const val PageLocalModels = "local_models"
-private const val PageCustomModels = "custom_models"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -129,10 +133,10 @@ private fun sectionExit(): ExitTransition = shrinkVertically(
 ) + fadeOut(MaterialTheme.motionScheme.defaultEffectsSpec())
 
 /**
- * Settings is a hub-and-detail flow, like Android system settings: the home page lists
- * each area as a tappable row with a live summary, and every area opens its own focused
- * page. This keeps each screen flat — content sits directly on the surface instead of
- * cards nested in expanding cards.
+ * Settings is a hub-and-detail flow: four focused destinations, each opening its own
+ * page. Every page is built from the same visual system — a flexible large app bar,
+ * section headers, and grouped slabs sitting directly on the surface — so nothing nests
+ * cards inside cards.
  */
 @Composable
 fun SettingsScreen(
@@ -149,7 +153,6 @@ fun SettingsScreen(
         targetState = page,
         transitionSpec = {
             if (targetState == PageHome) {
-                // Popping back to the hub: hub slides in from the left.
                 (slideInHorizontally(spatial) { -it / 5 } + fadeIn(effects)) togetherWith
                     (slideOutHorizontally(spatial) { it / 5 } + fadeOut(effects))
             } else {
@@ -161,10 +164,9 @@ fun SettingsScreen(
     ) { current ->
         when (current) {
             PageAppearance -> AppearancePage(viewModel, onBack = { page = PageHome })
-            PageCloudApi -> CloudApiPage(viewModel, onBack = { page = PageHome })
+            PageCloudModels -> CloudModelsPage(viewModel, onBack = { page = PageHome })
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
-            PageCustomModels -> CustomModelsPage(viewModel, onBack = { page = PageHome })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -194,6 +196,12 @@ private fun SettingsHomePage(
     }
     val accentLabel = if (themeColor == "dynamic") "Wallpaper"
     else accents.firstOrNull { it.id == themeColor }?.label ?: "Wallpaper"
+
+    val cloudSubtitle = when {
+        apiKey.isBlank() -> "Add your OpenRouter key to get started"
+        customModels.isEmpty() -> "Key saved · default model only"
+        else -> "Key saved · ${customModels.size} model" + (if (customModels.size == 1) "" else "s") + " added"
+    }
     val searchSubtitle = if (webSearchProvider == "off") "Off" else buildString {
         append(searchProviders.firstOrNull { it.id == webSearchProvider }?.label ?: webSearchProvider)
         append(" · ")
@@ -211,67 +219,49 @@ private fun SettingsHomePage(
         else -> "On · ${localModels.size} installed"
     }
 
-    SettingsPageScaffold(title = "Settings", onBack = onBackClicked) {
-        SectionLabel("Personalize")
-        SettingsNavRow(
-            icon = Icons.Default.Palette,
-            polygon = BrandShapes.heroStart, // Sunny
-            title = "Appearance",
-            subtitle = "$themeLabel theme · $accentLabel accent",
-            container = MaterialTheme.colorScheme.primaryContainer,
-            onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-            index = 0, count = 1,
-            onClick = { onOpen(PageAppearance) },
-        )
-
-        Spacer(Modifier.height(Spacing.m))
-        SectionLabel("Cloud")
+    SettingsPageScaffold(title = "Settings", subtitle = "Make EchoFlow yours", onBack = onBackClicked) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
             SettingsNavRow(
-                icon = Icons.Default.Key,
-                polygon = MaterialShapes.Gem,
-                title = "OpenRouter API",
-                subtitle = if (apiKey.isBlank()) "No key saved" else "API key saved",
-                container = MaterialTheme.colorScheme.secondaryContainer,
-                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 0, count = 3,
-                onClick = { onOpen(PageCloudApi) },
+                icon = Icons.Default.Palette,
+                polygon = BrandShapes.heroStart, // Sunny
+                title = "Appearance",
+                subtitle = "$themeLabel theme · $accentLabel accent",
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 0, count = 4,
+                onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
                 icon = Icons.Default.Language,
+                polygon = MaterialShapes.Gem,
+                title = "Cloud models",
+                subtitle = cloudSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 1, count = 4,
+                onClick = { onOpen(PageCloudModels) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Search,
                 polygon = BrandShapes.avatarEnd, // Clover4Leaf
                 title = "Web search",
                 subtitle = searchSubtitle,
-                container = MaterialTheme.colorScheme.secondaryContainer,
-                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 3,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                index = 2, count = 4,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
-                icon = Icons.Default.Memory,
-                polygon = BrandShapes.heroEnd, // Cookie12Sided
-                title = "Custom models",
-                subtitle = if (customModels.isEmpty()) "Add OpenRouter model IDs"
-                else "${customModels.size} model" + if (customModels.size == 1) "" else "s",
-                container = MaterialTheme.colorScheme.secondaryContainer,
-                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 2, count = 3,
-                onClick = { onOpen(PageCustomModels) },
+                icon = Icons.Default.PhoneAndroid,
+                polygon = BrandShapes.avatarStart, // Cookie9Sided
+                title = "Local models",
+                subtitle = localSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 3, count = 4,
+                onClick = { onOpen(PageLocalModels) },
             )
         }
-
-        Spacer(Modifier.height(Spacing.m))
-        SectionLabel("On-device")
-        SettingsNavRow(
-            icon = Icons.Default.PhoneAndroid,
-            polygon = BrandShapes.avatarStart, // Cookie9Sided
-            title = "Local models",
-            subtitle = localSubtitle,
-            container = MaterialTheme.colorScheme.tertiaryContainer,
-            onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-            index = 0, count = 1,
-            onClick = { onOpen(PageLocalModels) },
-        )
     }
 }
 
@@ -295,16 +285,17 @@ private fun SettingsNavRow(
         modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
-            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.base),
+            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.l),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
-                Modifier.size(44.dp).clip(RoundedPolygonShape(polygon)).background(container),
+                Modifier.size(48.dp).clip(RoundedPolygonShape(polygon)).background(container),
                 contentAlignment = Alignment.Center,
-            ) { Icon(icon, null, Modifier.size(20.dp), tint = onContainer) }
+            ) { Icon(icon, null, Modifier.size(22.dp), tint = onContainer) }
             Spacer(Modifier.width(Spacing.base))
             Column(Modifier.weight(1f)) {
                 Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                Spacer(Modifier.height(2.dp))
                 Text(
                     subtitle,
                     style = MaterialTheme.typography.bodySmall,
@@ -322,7 +313,7 @@ private fun SettingsNavRow(
     }
 }
 
-// ── Detail pages ──────────────────────────────────────────────────────────────────────
+// ── Appearance ────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun AppearancePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
@@ -330,55 +321,111 @@ private fun AppearancePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val themeColor by viewModel.themeColor.collectAsState()
 
     SettingsPageScaffold(title = "Appearance", subtitle = "Theme & accent color", onBack = onBack) {
-        Text(
-            "Theme",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-        )
+        PageSection("Theme")
         ConnectedToggleRow(
             options = listOf("system" to "System", "light" to "Light", "dark" to "Dark"),
+            icons = listOf(Icons.Default.BrightnessAuto, Icons.Default.LightMode, Icons.Default.DarkMode),
             selected = darkMode,
             onSelect = viewModel::saveDarkMode,
         )
 
         Spacer(Modifier.height(Spacing.xl))
-        Text(
-            "Accent color",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-        )
+        PageSection("Accent color", "Wallpaper follows your Material You palette")
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(Spacing.base),
-            verticalArrangement = Arrangement.spacedBy(Spacing.base),
+            verticalArrangement = Arrangement.spacedBy(Spacing.l),
         ) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                WallpaperSwatch(selected = themeColor == "dynamic") { viewModel.saveThemeColor("dynamic") }
+                MorphSwatch(
+                    label = "Wallpaper",
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    idleIcon = Icons.Default.Palette,
+                    idleIconTint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    selected = themeColor == "dynamic",
+                ) { viewModel.saveThemeColor("dynamic") }
             }
             accents.forEach { accent ->
-                AccentSwatch(accent, selected = themeColor == accent.id) { viewModel.saveThemeColor(accent.id) }
+                MorphSwatch(
+                    label = accent.label,
+                    color = accent.swatch,
+                    idleIcon = null,
+                    idleIconTint = Color.White,
+                    selected = themeColor == accent.id,
+                ) { viewModel.saveThemeColor(accent.id) }
             }
         }
     }
 }
 
+/**
+ * Accent swatch with an Expressive selection state: the polygon morphs Cookie → Sunny
+ * with a spring, scales up slightly, and the check pops in.
+ */
 @Composable
-private fun CloudApiPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+private fun MorphSwatch(
+    label: String,
+    color: Color,
+    idleIcon: ImageVector?,
+    idleIconTint: Color,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val morph = rememberMorph(BrandShapes.avatarStart, BrandShapes.heroStart)
+    val progress by animateFloatAsState(
+        targetValue = if (selected) 1f else 0f,
+        animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+        label = "swatchMorph",
+    )
+    val swatchScale by animateFloatAsState(
+        targetValue = if (selected) 1.08f else 1f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "swatchScale",
+    )
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Surface(
+            onClick = onClick,
+            shape = MorphPolygonShape(morph, progress),
+            color = color,
+            modifier = Modifier.size(56.dp).scale(swatchScale),
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                when {
+                    selected -> Icon(
+                        Icons.Default.Check, "Selected",
+                        Modifier.size(24.dp).scale(progress),
+                        tint = idleIconTint,
+                    )
+                    idleIcon != null -> Icon(idleIcon, null, Modifier.size(22.dp), tint = idleIconTint)
+                }
+            }
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ── Cloud models (OpenRouter key + model list) ────────────────────────────────────────
+
+@Composable
+private fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val apiKey by viewModel.apiKey.collectAsState()
+    val customModels by viewModel.customModels.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orResults by viewModel.orModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
     var keyInput by remember(apiKey) { mutableStateOf(apiKey) }
     var keyVisible by remember { mutableStateOf(false) }
+    var showModelDirectory by remember { mutableStateOf(false) }
 
-    SettingsPageScaffold(title = "OpenRouter API", subtitle = "Cloud model access", onBack = onBack) {
-        SettingsCard {
-            Text("API key", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
-            Spacer(Modifier.height(Spacing.xs))
-            Text(
-                "Create a key at openrouter.ai → Keys. It unlocks every cloud model in the picker.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(Spacing.s))
+    SettingsPageScaffold(title = "Cloud models", subtitle = "OpenRouter key & model list", onBack = onBack) {
+        PageSection("API key", "One key from openrouter.ai unlocks every cloud model")
+        FormCard {
             OutlinedTextField(
                 value = keyInput,
                 onValueChange = { keyInput = it },
@@ -386,6 +433,7 @@ private fun CloudApiPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                 singleLine = true,
                 shape = MaterialTheme.shapes.medium,
                 visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                leadingIcon = { Icon(Icons.Default.Key, null) },
                 trailingIcon = {
                     IconButton(onClick = { keyVisible = !keyVisible }) {
                         Icon(if (keyVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility, if (keyVisible) "Hide" else "Show")
@@ -395,23 +443,316 @@ private fun CloudApiPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             )
             if (apiKey.isNotBlank()) {
                 Spacer(Modifier.height(Spacing.s))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.CheckCircle, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
-                    Spacer(Modifier.width(Spacing.xs))
-                    Text(
-                        "A key is saved on this device",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
+                SavedKeyBadge("A key is saved on this device")
             }
             Spacer(Modifier.height(Spacing.m))
             Button(onClick = { viewModel.saveApiKey(keyInput.trim()) }, shape = CircleShape, modifier = Modifier.fillMaxWidth()) {
                 Text("Save key")
             }
         }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Your models", "Live pricing and context windows from the directory")
+        Button(
+            onClick = {
+                showModelDirectory = true
+                viewModel.loadOpenRouterDirectory()
+            },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Search, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Browse the model directory")
+        }
+
+        Spacer(Modifier.height(Spacing.m))
+        if (customModels.isEmpty()) {
+            Surface(
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    Modifier.fillMaxWidth().padding(Spacing.xl),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(Icons.Default.Memory, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(
+                        "No models added yet.\nSearch the directory to build your model picker.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                customModels.forEachIndexed { index, model ->
+                    Surface(
+                        shape = groupedItemShape(index, customModels.size),
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Box(
+                                Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Gem)).background(MaterialTheme.colorScheme.secondaryContainer),
+                                contentAlignment = Alignment.Center,
+                            ) { Icon(Icons.Default.Memory, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
+                            Spacer(Modifier.width(Spacing.base))
+                            Column(Modifier.weight(1f)) {
+                                Text(model.name, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                                Text(
+                                    model.id,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            IconButton(onClick = { viewModel.deleteCustomModel(model.id) }) {
+                                Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showModelDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = customModels.map { it.id }.toSet(),
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> viewModel.addCustomModel(info.id, info.name.substringAfter(": ")) },
+            onRemove = viewModel::deleteCustomModel,
+            onDismiss = { showModelDirectory = false },
+        )
     }
 }
+
+/** Live OpenRouter directory: search-as-you-type with pricing and context windows. */
+@Composable
+private fun OpenRouterDirectorySheet(
+    query: String,
+    results: List<OpenRouterModelInfo>,
+    loading: Boolean,
+    error: String?,
+    addedIds: Set<String>,
+    onQueryChange: (String) -> Unit,
+    onRetry: () -> Unit,
+    onAdd: (OpenRouterModelInfo) -> Unit,
+    onRemove: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        // Full height from the moment it opens — the sheet must not jump taller when
+        // results stream in.
+        modifier = Modifier.fillMaxHeight(0.94f),
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = Spacing.base)
+                .imePadding()
+                .navigationBarsPadding(),
+        ) {
+            Text("Model directory", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.xs))
+            Text(
+                "Live from openrouter.ai — tap a model to add it to your picker.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.base))
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                placeholder = { Text("Claude, GPT, Gemini, DeepSeek…") },
+                leadingIcon = { Icon(Icons.Default.Search, null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) { Icon(Icons.Default.Close, "Clear") }
+                    }
+                },
+                shape = CircleShape,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.m))
+            Box(Modifier.fillMaxWidth().weight(1f)) {
+                when {
+                    loading -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        CircularWavyProgressIndicator()
+                        Spacer(Modifier.height(Spacing.m))
+                        Text(
+                            "Loading the directory…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    error != null -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.l),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(Modifier.height(Spacing.m))
+                        FilledTonalButton(onClick = onRetry, shape = CircleShape) {
+                            Icon(Icons.Default.Refresh, null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(Spacing.s))
+                            Text("Try again")
+                        }
+                    }
+                    results.isEmpty() -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Icon(Icons.Default.SearchOff, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Spacer(Modifier.height(Spacing.s))
+                        Text(
+                            "Nothing in the directory matches “$query”.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
+                    ) {
+                        items(results.size) { index ->
+                            val info = results[index]
+                            OrModelRow(
+                                info = info,
+                                index = index,
+                                count = results.size,
+                                added = info.id in addedIds,
+                                onAdd = { onAdd(info) },
+                                onRemove = { onRemove(info.id) },
+                            )
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(Spacing.xl))
+        }
+    }
+}
+
+@Composable
+private fun OrModelRow(
+    info: OpenRouterModelInfo,
+    index: Int,
+    count: Int,
+    added: Boolean,
+    onAdd: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Surface(
+        onClick = { if (added) onRemove() else onAdd() },
+        shape = groupedItemShape(index, count),
+        color = if (added) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.m, top = Spacing.m, bottom = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    info.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (added) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    info.id,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (added) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(Spacing.xs))
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    info.contextLength?.let { ctx ->
+                        InfoPill(text = formatContext(ctx), added = added)
+                    }
+                    InfoPill(text = formatPricing(info), added = added)
+                }
+            }
+            Spacer(Modifier.width(Spacing.s))
+            if (added) {
+                Icon(Icons.Default.CheckCircle, "Added", tint = MaterialTheme.colorScheme.primary)
+            } else {
+                FilledTonalIconButton(onClick = onAdd, modifier = Modifier.size(36.dp)) {
+                    Icon(Icons.Default.Add, "Add ${info.name}", Modifier.size(18.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoPill(text: String, added: Boolean) {
+    Surface(
+        shape = CircleShape,
+        color = if (added) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+        else MaterialTheme.colorScheme.surfaceContainerHighest,
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = if (added) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.s, vertical = 3.dp),
+        )
+    }
+}
+
+private fun formatContext(tokens: Int): String = when {
+    tokens >= 1_000_000 -> "%.1fM ctx".format(tokens / 1_000_000.0).replace(".0M", "M")
+    tokens >= 1_000 -> "${tokens / 1_000}K ctx"
+    else -> "$tokens ctx"
+}
+
+private fun formatPricing(info: OpenRouterModelInfo): String {
+    if (info.isFree) return "Free"
+    fun fmt(v: Double?): String? = v?.let {
+        when {
+            it >= 10 -> "$%.0f".format(it)
+            it >= 1 -> "$%.1f".format(it)
+            else -> "$%.2f".format(it)
+        }
+    }
+    val inP = fmt(info.promptPricePerM)
+    val outP = fmt(info.completionPricePerM)
+    return when {
+        inP != null && outP != null -> "$inP in · $outP out /M"
+        inP != null -> "$inP /M"
+        else -> "Pricing varies"
+    }
+}
+
+// ── Web search ────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
@@ -434,15 +775,10 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     var searchKeyVisible by remember { mutableStateOf(false) }
 
     SettingsPageScaffold(title = "Web search", subtitle = "Live answers for every model", onBack = onBack) {
-        Text(
-            "Provider",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-        )
+        PageSection("Provider")
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
             searchProviders.forEachIndexed { index, option ->
-                SearchProviderRow(
+                ProviderRow(
                     option = option,
                     index = index,
                     count = searchProviders.size,
@@ -455,18 +791,9 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
         AnimatedVisibility(visible = webSearchProvider != "off", enter = sectionEnter(), exit = sectionExit()) {
             Column {
                 Spacer(Modifier.height(Spacing.xl))
-                Text(
-                    "Use search with",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-                )
+                PageSection("Use search with")
                 ConnectedToggleRow(
-                    options = listOf(
-                        "both" to "Both",
-                        "cloud" to "Cloud",
-                        "local" to "Local"
-                    ),
+                    options = listOf("both" to "Both", "cloud" to "Cloud", "local" to "Local"),
                     selected = webSearchScope,
                     onSelect = viewModel::saveWebSearchScope,
                 )
@@ -485,15 +812,13 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
         AnimatedVisibility(visible = webSearchProvider == "openrouter", enter = sectionEnter(), exit = sectionExit()) {
             Column {
                 Spacer(Modifier.height(Spacing.m))
-                SettingsCard {
-                    Text("How OpenRouter search works", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                FormCard {
+                    Text("How it works", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
                     Spacer(Modifier.height(Spacing.s))
                     Text(
                         "Search runs server-side on OpenRouter: the model decides if and when " +
                             "to search — zero, one or several times per answer — and the cost is " +
-                            "billed through your OpenRouter account.\n\n" +
-                            "This only works with OpenRouter cloud models. For on-device models, " +
-                            "pick Exa, Parallel or Firecrawl instead.",
+                            "billed through your OpenRouter account.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -503,11 +828,13 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
         AnimatedVisibility(visible = webSearchProvider in setOf("exa", "parallel", "firecrawl"), enter = sectionEnter(), exit = sectionExit()) {
             Column {
-                Spacer(Modifier.height(Spacing.m))
-                SettingsCard {
-                    val providerLabel = searchProviders.firstOrNull { it.id == webSearchProvider }?.label ?: ""
-                    Text("$providerLabel API key", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
-                    Spacer(Modifier.height(Spacing.s))
+                Spacer(Modifier.height(Spacing.xl))
+                val providerLabel = searchProviders.firstOrNull { it.id == webSearchProvider }?.label ?: ""
+                PageSection(
+                    "$providerLabel API key",
+                    "Offered to every model — even on-device ones — as a search tool. Stored only on this phone.",
+                )
+                FormCard {
                     OutlinedTextField(
                         value = searchKeyInput,
                         onValueChange = { searchKeyDrafts[webSearchProvider] = it },
@@ -515,6 +842,7 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                         singleLine = true,
                         shape = MaterialTheme.shapes.medium,
                         visualTransformation = if (searchKeyVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                        leadingIcon = { Icon(Icons.Default.Key, null) },
                         trailingIcon = {
                             IconButton(onClick = { searchKeyVisible = !searchKeyVisible }) {
                                 Icon(if (searchKeyVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility, if (searchKeyVisible) "Hide" else "Show")
@@ -524,15 +852,7 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                     )
                     if (savedSearchKey.isNotBlank()) {
                         Spacer(Modifier.height(Spacing.s))
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.CheckCircle, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
-                            Spacer(Modifier.width(Spacing.xs))
-                            Text(
-                                "A $providerLabel key is saved on this device",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
+                        SavedKeyBadge("A $providerLabel key is saved on this device")
                     }
                     Spacer(Modifier.height(Spacing.m))
                     Button(
@@ -543,18 +863,83 @@ private fun WebSearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                         shape = CircleShape,
                         modifier = Modifier.fillMaxWidth(),
                     ) { Text("Save key") }
-                    Spacer(Modifier.height(Spacing.m))
-                    Text(
-                        "Offered to every model — including on-device ones — as a search tool " +
-                            "it can call while answering. The key is stored only on this device.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
                 }
             }
         }
     }
 }
+
+/** Provider choice with a shaped monogram badge; selected state fills with primary. */
+@Composable
+private fun ProviderRow(
+    option: SearchProviderOption,
+    index: Int,
+    count: Int,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    val badgeShapes = listOf(
+        MaterialShapes.Circle,
+        BrandShapes.heroEnd, // Cookie12Sided
+        BrandShapes.heroStart, // Sunny
+        BrandShapes.avatarEnd, // Clover4Leaf
+        BrandShapes.avatarStart, // Cookie9Sided
+    )
+    Surface(
+        onClick = onSelect,
+        shape = groupedItemShape(index, count),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .clip(RoundedPolygonShape(badgeShapes[index % badgeShapes.size]))
+                    .background(
+                        if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.surfaceContainerHighest
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (option.id == "off") {
+                    Icon(
+                        Icons.Default.SearchOff, null, Modifier.size(18.dp),
+                        tint = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Text(
+                        option.label.take(1),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.width(Spacing.base))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    option.label,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    option.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (selected) {
+                Spacer(Modifier.width(Spacing.s))
+                Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+// ── Local models ──────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
@@ -603,12 +988,7 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                 // Installed models — the thing you came for goes first.
                 if (localModels.isNotEmpty()) {
                     Spacer(Modifier.height(Spacing.xl))
-                    Text(
-                        "Installed",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-                    )
+                    PageSection("Installed")
                     Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
                         localModels.forEachIndexed { index, model ->
                             InstalledModelRow(
@@ -621,20 +1001,11 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                     }
                 }
 
-                // Get models: search + import side by side, then the curated list.
                 Spacer(Modifier.height(Spacing.xl))
-                Text(
-                    "Get models",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-                )
+                PageSection("Get models", "Curated picks below, or search all of Hugging Face")
                 Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
                     FilledTonalButton(
-                        onClick = {
-                            showHfModelSearch = true
-                            if (hfSearchResults.isEmpty()) viewModel.searchHfModels()
-                        },
+                        onClick = { showHfModelSearch = true },
                         shape = CircleShape,
                         modifier = Modifier.weight(1f),
                     ) {
@@ -702,26 +1073,29 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                             animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
                             label = "hfTokenChevron",
                         )
-                        Row(
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable { hfTokenOpen = !hfTokenOpen }
-                                .padding(Spacing.base),
-                            verticalAlignment = Alignment.CenterVertically,
+                        Surface(
+                            onClick = { hfTokenOpen = !hfTokenOpen },
+                            color = Color.Transparent,
+                            modifier = Modifier.fillMaxWidth(),
                         ) {
-                            Column(Modifier.weight(1f)) {
-                                Text("Hugging Face token", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
-                                Text(
-                                    if (hfToken.isBlank()) "Only needed for gated models like Gemma 3"
-                                    else "Token saved",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            Row(
+                                Modifier.padding(Spacing.base),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    Text("Hugging Face token", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                                    Text(
+                                        if (hfToken.isBlank()) "Only needed for gated models like Gemma 3"
+                                        else "Token saved",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Icon(
+                                    Icons.Default.ExpandMore, if (hfTokenOpen) "Collapse" else "Expand",
+                                    Modifier.rotate(tokenChevron), tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
-                            Icon(
-                                Icons.Default.ExpandMore, if (hfTokenOpen) "Collapse" else "Expand",
-                                Modifier.rotate(tokenChevron), tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
                         }
                         AnimatedVisibility(visible = hfTokenOpen, enter = sectionEnter(), exit = sectionExit()) {
                             Column(Modifier.padding(start = Spacing.base, end = Spacing.base, bottom = Spacing.base)) {
@@ -778,82 +1152,6 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     }
 }
 
-@Composable
-private fun CustomModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
-    val customModels by viewModel.customModels.collectAsState()
-    var modelId by remember { mutableStateOf("") }
-    var modelName by remember { mutableStateOf("") }
-
-    SettingsPageScaffold(title = "Custom models", subtitle = "Your OpenRouter model list", onBack = onBack) {
-        SettingsCard {
-            Text("Add a model", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
-            Spacer(Modifier.height(Spacing.xs))
-            Text(
-                "Any OpenRouter model ID works — e.g. anthropic/claude-sonnet-4.6",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(Spacing.s))
-            OutlinedTextField(
-                value = modelId, onValueChange = { modelId = it },
-                label = { Text("Model ID") }, singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                shape = MaterialTheme.shapes.medium, modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(Modifier.height(Spacing.s))
-            OutlinedTextField(
-                value = modelName, onValueChange = { modelName = it },
-                label = { Text("Display name") }, singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                shape = MaterialTheme.shapes.medium, modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(Modifier.height(Spacing.m))
-            FilledTonalButton(
-                onClick = {
-                    if (modelId.trim().isNotEmpty()) { viewModel.addCustomModel(modelId.trim(), modelName.trim()); modelId = ""; modelName = "" }
-                },
-                shape = CircleShape, modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.Default.Add, null, Modifier.size(18.dp)); Spacer(Modifier.width(Spacing.s)); Text("Add model")
-            }
-        }
-
-        if (customModels.isNotEmpty()) {
-            Spacer(Modifier.height(Spacing.l))
-            Text(
-                "Your models",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.m),
-            )
-            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
-                customModels.forEachIndexed { index, model ->
-                    Surface(
-                        shape = groupedItemShape(index, customModels.size),
-                        color = MaterialTheme.colorScheme.surfaceContainer,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Row(Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m), verticalAlignment = Alignment.CenterVertically) {
-                            Box(
-                                Modifier.size(40.dp).clip(RoundedPolygonShape(BrandShapes.avatarStart)).background(MaterialTheme.colorScheme.tertiaryContainer),
-                                contentAlignment = Alignment.Center,
-                            ) { Icon(Icons.Default.Memory, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer) }
-                            Spacer(Modifier.width(Spacing.base))
-                            Column(Modifier.weight(1f)) {
-                                Text(model.name, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
-                                Text(model.id, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            IconButton(onClick = { viewModel.deleteCustomModel(model.id) }) {
-                                Icon(Icons.Default.DeleteOutline, "Delete", tint = MaterialTheme.colorScheme.error)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 // ── Shared building blocks ────────────────────────────────────────────────────────────
 
 /**
@@ -901,8 +1199,24 @@ private fun SettingsPageScaffold(
     }
 }
 
+/** Section header used on every page: title plus optional supporting line. */
 @Composable
-private fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
+private fun PageSection(title: String, supporting: String? = null) {
+    Column(Modifier.padding(start = Spacing.xs, bottom = Spacing.m)) {
+        Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+        if (supporting != null) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                supporting,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FormCard(content: @Composable ColumnScope.() -> Unit) {
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surfaceContainer,
@@ -912,9 +1226,18 @@ private fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
     }
 }
 
+@Composable
+private fun SavedKeyBadge(text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(Icons.Default.CheckCircle, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
+        Spacer(Modifier.width(Spacing.xs))
+        Text(text, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+    }
+}
+
 /**
  * The M3 Expressive connected button group: ToggleButtons that share a slab and morph
- * shape on press/selection, replacing the old custom segmented pill.
+ * shape on press/selection.
  */
 @Composable
 private fun ConnectedToggleRow(
@@ -922,18 +1245,20 @@ private fun ConnectedToggleRow(
     selected: String,
     onSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
+    icons: List<ImageVector>? = null,
 ) {
     Row(
         modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
     ) {
         options.forEachIndexed { index, (value, label) ->
+            val checked = selected == value
             ToggleButton(
-                checked = selected == value,
+                checked = checked,
                 onCheckedChange = { if (it) onSelect(value) },
                 modifier = Modifier
                     .weight(1f)
-                    .height(48.dp)
+                    .height(52.dp)
                     .semantics { role = Role.RadioButton },
                 shapes = when (index) {
                     0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
@@ -941,10 +1266,11 @@ private fun ConnectedToggleRow(
                     else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
                 },
             ) {
-                if (selected == value) {
-                    Icon(Icons.Default.Check, null, Modifier.size(16.dp))
-                    Spacer(Modifier.width(Spacing.xs))
+                when {
+                    checked -> Icon(Icons.Default.Check, null, Modifier.size(16.dp))
+                    icons != null -> Icon(icons[index], null, Modifier.size(16.dp))
                 }
+                if (checked || icons != null) Spacer(Modifier.width(Spacing.xs))
                 Text(label, style = MaterialTheme.typography.titleSmall, maxLines = 1)
             }
         }
@@ -988,44 +1314,6 @@ private fun ShowMoreRow(
                 Modifier.size(18.dp).rotate(chevron),
                 tint = MaterialTheme.colorScheme.primary,
             )
-        }
-    }
-}
-
-@Composable
-private fun SearchProviderRow(
-    option: SearchProviderOption,
-    index: Int,
-    count: Int,
-    selected: Boolean,
-    onSelect: () -> Unit,
-) {
-    Surface(
-        onClick = onSelect,
-        shape = groupedItemShape(index, count),
-        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    option.label,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
-                )
-                Text(
-                    option.description,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (selected) {
-                Spacer(Modifier.width(Spacing.s))
-                Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
-            }
         }
     }
 }
@@ -1114,7 +1402,7 @@ private fun CatalogModelRow(
     }
 }
 
-/** Bottom-sheet Hugging Face model search. */
+/** Bottom-sheet Hugging Face model search. Opens idle — nothing runs until you search. */
 @Composable
 private fun HfModelSearchSheet(
     query: String,
@@ -1131,14 +1419,21 @@ private fun HfModelSearchSheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var hasSearched by remember { mutableStateOf(false) }
+    val runSearch = {
+        hasSearched = true
+        onSearch()
+    }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        // Full height from the start, matching the OpenRouter directory sheet.
+        modifier = Modifier.fillMaxHeight(0.94f),
     ) {
         Column(
             Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(horizontal = Spacing.base)
                 .imePadding()
                 .navigationBarsPadding(),
@@ -1164,17 +1459,17 @@ private fun HfModelSearchSheet(
                 },
                 shape = CircleShape,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+                keyboardActions = KeyboardActions(onSearch = { runSearch() }),
                 modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(Spacing.m))
-            Button(onClick = onSearch, enabled = !loading, shape = CircleShape, modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = runSearch, enabled = !loading, shape = CircleShape, modifier = Modifier.fillMaxWidth()) {
                 Icon(Icons.Default.Search, null, Modifier.size(18.dp))
                 Spacer(Modifier.width(Spacing.s))
                 Text(if (loading) "Searching…" else "Search Hugging Face")
             }
             Spacer(Modifier.height(Spacing.base))
-            Box(Modifier.fillMaxWidth().heightIn(min = 160.dp)) {
+            Box(Modifier.fillMaxWidth().weight(1f)) {
                 when {
                     loading -> Column(
                         Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
@@ -1200,24 +1495,34 @@ private fun HfModelSearchSheet(
                             modifier = Modifier.padding(Spacing.base),
                         )
                     }
+                    results.isEmpty() && !hasSearched -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Icon(Icons.Default.Search, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Spacer(Modifier.height(Spacing.s))
+                        Text(
+                            "Type a model name and search —\ntry “gemma”, “qwen” or “deepseek”.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                     results.isEmpty() -> Column(
                         Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        Icon(
-                            Icons.Default.Search, null,
-                            Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        Icon(Icons.Default.SearchOff, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                         Spacer(Modifier.height(Spacing.s))
                         Text(
-                            "No mobile-ready model bundles found.\nTry “gemma”, “qwen” or “deepseek”.",
+                            "No mobile-ready model bundles found.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center,
                         )
                     }
                     else -> LazyColumn(
-                        modifier = Modifier.fillMaxWidth().heightIn(max = 440.dp),
+                        modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
                     ) {
                         items(results.size) { index ->
@@ -1279,40 +1584,5 @@ private fun InstalledModelRow(
                 Icon(Icons.Default.DeleteOutline, "Delete", tint = MaterialTheme.colorScheme.error)
             }
         }
-    }
-}
-
-@Composable
-private fun AccentSwatch(accent: Accent, selected: Boolean, onClick: () -> Unit) {
-    val shape = RoundedPolygonShape(BrandShapes.avatarStart)
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            Modifier.size(52.dp).clip(shape).background(accent.swatch)
-                .then(if (selected) Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, shape) else Modifier)
-                .clickable(onClick = onClick),
-            contentAlignment = Alignment.Center,
-        ) { if (selected) Icon(Icons.Default.Check, null, tint = Color.White, modifier = Modifier.size(24.dp)) }
-        Spacer(Modifier.height(Spacing.xs))
-        Text(accent.label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-}
-
-@Composable
-private fun WallpaperSwatch(selected: Boolean, onClick: () -> Unit) {
-    val shape = RoundedPolygonShape(BrandShapes.heroStart)
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            Modifier.size(52.dp).clip(shape).background(MaterialTheme.colorScheme.primaryContainer)
-                .then(if (selected) Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, shape) else Modifier)
-                .clickable(onClick = onClick),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                if (selected) Icons.Default.Check else Icons.Default.Palette, "Wallpaper colors",
-                tint = MaterialTheme.colorScheme.onPrimaryContainer, modifier = Modifier.size(24.dp),
-            )
-        }
-        Spacer(Modifier.height(Spacing.xs))
-        Text("Wallpaper", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
     }
 }


### PR DESCRIPTION
## Summary
- improve chat reasoning/search persistence so DeepSeek/OpenRouter reasoning-only answers do not disappear after streaming
- add ordered assistant reply segments, citations/search persistence, and richer markdown rendering behavior
- refresh settings/model management flows, including OpenRouter model directory lookup and related UI updates
- update drawer/search and chat screen behavior around the new persisted timeline

## Validation
- `./gradlew.bat :app:compileDebugKotlin --console=plain --no-daemon`

## Notes
This is separated from the existing release-upload PR so the remaining chat/settings work can be reviewed independently.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve chat reasoning replay and settings flows with OpenRouter directory and drawer search
> - Finished chat messages now render an ordered timeline of reasoning, search, and text segments from a new `segmentsJson` column (DB v4 migration), replacing the previous merged-block approach; citations row is removed from the UI
> - Adds live drawer thread search filtered by title and message content via `filteredThreads` in `ChatViewModel`
> - Replaces `CloudApiPage`/`CustomModelsPage` with a new `CloudModelsPage` that includes a searchable OpenRouter model directory sheet for adding/removing models
> - Assistant replies streamed as reasoning-only are now persisted with visible content by promoting the final reasoning tail to a text segment
> - `HfModelSearchSheet` and the settings home are restructured: HF search no longer auto-triggers on open, and settings navigation consolidates to four rows with updated icons and morphing swatches
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab83d53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->