### PR TITLE
Add Deep Research mode (cloud)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
             android:name=".data.KeepAliveService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <service
+            android:name=".data.DeepResearchForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -1,10 +1,15 @@
 package com.echoflow
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -31,9 +36,20 @@ import com.echoflow.ui.theme.EchoFlowTheme
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+    private val notificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* best effort */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Android 13+ needs runtime POST_NOTIFICATIONS for the Deep Research / Data Agent
+        // foreground-service progress notification to appear in the status bar.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
 
         // 1. Initializing Local Repositories and SQLite Database
         val database = AppDatabase.getDatabase(application)

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -12,12 +12,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.filled.Settings
 import com.echoflow.data.AppDatabase
+import com.echoflow.data.DeepResearchForegroundService
 import com.echoflow.data.ModelDownloadManager
 import com.echoflow.data.SettingsRepository
 import com.echoflow.ui.ChatViewModel
@@ -38,6 +40,14 @@ class MainActivity : ComponentActivity() {
         val settingsRepo = SettingsRepository(applicationContext)
         val modelDownloadManager = ModelDownloadManager(applicationContext, database.localModelDao())
 
+        // Resume any Deep Research run that was interrupted by an app kill — but only spin
+        // up the service when there is actually something to resume (no idle notification).
+        lifecycleScope.launch {
+            if (database.researchRunDao().getInterrupted().isNotEmpty()) {
+                DeepResearchForegroundService.resume(applicationContext)
+            }
+        }
+
         setContent {
             // 2. Fetch ViewModels using our custom factory providers
             val settingsVm: SettingsViewModel = viewModel(
@@ -45,7 +55,8 @@ class MainActivity : ComponentActivity() {
                     settingsRepo,
                     database.customModelDao(),
                     database.localModelDao(),
-                    modelDownloadManager
+                    modelDownloadManager,
+                    database.deepResearchModelDao()
                 )
             )
 
@@ -55,7 +66,9 @@ class MainActivity : ComponentActivity() {
                     database.chatDao(),
                     database.messageDao(),
                     settingsRepo,
-                    database.localModelDao()
+                    database.localModelDao(),
+                    database.researchRunDao(),
+                    database.deepResearchModelDao()
                 )
             )
 

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -8,8 +8,11 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class],
-    version = 4, // v4: chat_messages.segmentsJson — ordered reply timeline (MIGRATION_3_4)
+    entities = [
+        ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
+        DeepResearchModel::class, ResearchRun::class
+    ],
+    version = 5, // v5: deep_research_models + research_runs tables (MIGRATION_4_5)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -17,6 +20,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun messageDao(): MessageDao
     abstract fun customModelDao(): CustomModelDao
     abstract fun localModelDao(): LocalModelDao
+    abstract fun deepResearchModelDao(): DeepResearchModelDao
+    abstract fun researchRunDao(): ResearchRunDao
 
     companion object {
         @Volatile
@@ -44,6 +49,43 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS deep_research_models (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "addedAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS research_runs (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "chatId TEXT NOT NULL, " +
+                        "topic TEXT NOT NULL, " +
+                        "engineId TEXT NOT NULL, " +
+                        "engineKind TEXT NOT NULL, " +
+                        "engineLabel TEXT NOT NULL, " +
+                        "searchProvider TEXT, " +
+                        "maxSearches INTEGER NOT NULL, " +
+                        "maxSources INTEGER NOT NULL, " +
+                        "providerJobId TEXT, " +
+                        "status TEXT NOT NULL, " +
+                        "phase TEXT, " +
+                        "progressDone INTEGER NOT NULL, " +
+                        "progressTotal INTEGER NOT NULL, " +
+                        "planJson TEXT, " +
+                        "sourcesJson TEXT, " +
+                        "report TEXT, " +
+                        "error TEXT, " +
+                        "assistantMessageId TEXT, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_research_runs_chatId ON research_runs (chatId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_research_runs_status ON research_runs (status)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -51,7 +93,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
         DeepResearchModel::class, ResearchRun::class
     ],
-    version = 5, // v5: deep_research_models + research_runs tables (MIGRATION_4_5)
+    version = 6, // v6: research_runs.level/costInfo/maxCredits — Exa Agent effort + Data Agent (MIGRATION_5_6)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -86,6 +86,14 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN level TEXT")
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN costInfo TEXT")
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN maxCredits INTEGER NOT NULL DEFAULT 2500")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -93,7 +101,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -59,6 +59,39 @@ interface CustomModelDao {
 }
 
 @Dao
+interface DeepResearchModelDao {
+    @Query("SELECT * FROM deep_research_models ORDER BY addedAt ASC")
+    fun getAll(): Flow<List<DeepResearchModel>>
+
+    @Query("SELECT * FROM deep_research_models ORDER BY addedAt ASC")
+    suspend fun getAllSync(): List<DeepResearchModel>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(model: DeepResearchModel)
+
+    @Query("DELETE FROM deep_research_models WHERE id = :modelId")
+    suspend fun delete(modelId: String)
+}
+
+@Dao
+interface ResearchRunDao {
+    @Query("SELECT * FROM research_runs WHERE chatId = :chatId AND status NOT IN ('completed','failed','cancelled') ORDER BY createdAt DESC LIMIT 1")
+    fun observeActiveForChat(chatId: String): Flow<ResearchRun?>
+
+    @Query("SELECT * FROM research_runs WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): ResearchRun?
+
+    @Query("SELECT * FROM research_runs WHERE status NOT IN ('completed','failed','cancelled')")
+    suspend fun getInterrupted(): List<ResearchRun>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(run: ResearchRun)
+
+    @Query("DELETE FROM research_runs WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
 interface LocalModelDao {
     @Query("SELECT * FROM local_models ORDER BY addedAt ASC")
     fun getAllLocalModels(): Flow<List<LocalModel>>

--- a/app/src/main/java/com/echoflow/data/DeepResearch.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearch.kt
@@ -55,6 +55,14 @@ object DeepResearchCatalog {
             description = "Deep search with enhanced reasoning — recommended",
         ),
         DrEngine(
+            id = "exa-agent",
+            name = "Exa Agent",
+            provider = "exa",
+            // Routed to the Exa Agent API (/agent/runs); depth is set by the effort pill.
+            providerModel = "agent",
+            description = "Autonomous agent — searches, reasons, sets its own depth",
+        ),
+        DrEngine(
             id = "parallel-pro",
             name = "Parallel · Pro",
             provider = "parallel",
@@ -82,23 +90,69 @@ object DeepResearchCatalog {
     /** True when [id] is one of the built-in provider-native engines. */
     fun isProviderEngine(id: String): Boolean = providerEngineById(id) != null
 
+    /** True when [id] is the Exa Agent engine (the only one that uses the effort pill). */
+    fun usesEffort(id: String): Boolean = id == "exa-agent"
+
     /** Which providers have at least one provider-native engine. */
     val knownProviders = setOf("exa", "parallel", "firecrawl")
 }
 
-/** Resolved, ready-to-run configuration for a single Deep Research request. */
+/** Exa Agent effort levels (cost/depth dial). "auto" lets Exa pick. */
+object ExaEffort {
+    val levels = listOf("auto", "low", "medium", "high", "xhigh")
+    const val DEFAULT = "auto"
+    fun label(level: String): String = when (level) {
+        "auto" -> "Auto"
+        "low" -> "Low"
+        "medium" -> "Medium"
+        "high" -> "High"
+        "xhigh" -> "X-High"
+        else -> level.replaceFirstChar { it.uppercase() }
+    }
+}
+
+/**
+ * Data Agent is a separate, opt-in mode (off by default) for *extracting* data from the web
+ * — distinct from Deep Research, which answers questions. It is Firecrawl-only, using the
+ * Firecrawl Agent (`/v2/agent`), which returns structured data shaped by the request.
+ */
+object DataAgentCatalog {
+    val engines: List<DrEngine> = listOf(
+        DrEngine(
+            id = "firecrawl-agent-mini",
+            name = "Firecrawl · Faster",
+            provider = "firecrawl",
+            providerModel = "spark-1-mini",
+            description = "Cheaper — good for straightforward extraction",
+        ),
+        DrEngine(
+            id = "firecrawl-agent-pro",
+            name = "Firecrawl · Accurate",
+            provider = "firecrawl",
+            providerModel = "spark-1-pro",
+            description = "Higher accuracy for complex, multi-site tasks",
+        ),
+    )
+
+    fun byId(id: String): DrEngine? = engines.firstOrNull { it.id == id }
+}
+
+/** Resolved, ready-to-run configuration for a single Deep Research / Data Agent request. */
 data class DeepResearchConfig(
     val engineId: String,
-    val engineKind: String, // "provider" | "agent"
+    val engineKind: String, // "provider" | "agent" | "data-agent"
     val engineLabel: String,
     /** provider kind: search provider that runs it. agent kind: the chat model id. */
     val provider: String,
-    /** provider kind: API model/processor token. */
+    /** provider kind: API model/processor token (e.g. Exa type, Parallel processor, Firecrawl model). */
     val providerModel: String,
     /** agent kind: search provider backing the tool (resolved from "auto"). */
     val searchProvider: String?,
+    /** Exa Agent effort ("auto".."xhigh"); null for engines that don't use it. */
+    val level: String? = null,
     val maxSearches: Int,
     val maxSources: Int,
+    val maxCredits: Int = 2500, // Data Agent spend cap (Firecrawl credits)
 )
 
 /** Moshi helpers for the JSON columns on [ResearchRun]. */

--- a/app/src/main/java/com/echoflow/data/DeepResearch.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearch.kt
@@ -1,0 +1,128 @@
+package com.echoflow.data
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+/**
+ * Deep Research is an opt-in, power-user mode separate from normal chat. Two execution
+ * kinds are supported:
+ *
+ *  - **provider** — a search provider (Exa / Parallel / Firecrawl) runs the whole research
+ *    on its own infrastructure and returns a finished report. EchoFlow just creates the
+ *    job and polls it.
+ *  - **agent** — a cloud chat model orchestrates: it plans sub-questions, EchoFlow runs
+ *    each search via [WebSearchService], then the model synthesizes a report. The user
+ *    adds these models separately from normal chat models.
+ *
+ * Provider-native engines appear in the Deep Research model picker as if they were models,
+ * but only when the matching provider API key is configured.
+ */
+data class DrEngine(
+    val id: String,
+    val name: String,
+    /** "exa" | "parallel" | "firecrawl" for provider engines; the model id for agent. */
+    val provider: String,
+    /** Provider-specific model/processor token sent to the API (provider kind only). */
+    val providerModel: String,
+    val description: String,
+)
+
+object DeepResearchCatalog {
+
+    /** Built-in provider-native engines, grouped by the key they require. */
+    val providerEngines: List<DrEngine> = listOf(
+        DrEngine(
+            id = "exa-deep-lite",
+            name = "Exa · Deep Lite",
+            provider = "exa",
+            providerModel = "deep-lite",
+            description = "Fast deep search with light synthesis",
+        ),
+        DrEngine(
+            id = "exa-deep",
+            name = "Exa · Deep",
+            provider = "exa",
+            providerModel = "deep",
+            description = "In-depth research with synthesis",
+        ),
+        DrEngine(
+            id = "exa-deep-reasoning",
+            name = "Exa · Deep Reasoning",
+            provider = "exa",
+            providerModel = "deep-reasoning",
+            description = "Deep search with enhanced reasoning — recommended",
+        ),
+        DrEngine(
+            id = "parallel-pro",
+            name = "Parallel · Pro",
+            provider = "parallel",
+            providerModel = "pro",
+            description = "Objective-driven deep web research",
+        ),
+        DrEngine(
+            id = "parallel-ultra",
+            name = "Parallel · Ultra",
+            provider = "parallel",
+            providerModel = "ultra",
+            description = "State-of-the-art accuracy, slowest and priciest",
+        ),
+        DrEngine(
+            id = "firecrawl-research",
+            name = "Firecrawl Research",
+            provider = "firecrawl",
+            providerModel = "firecrawl",
+            description = "Autonomous crawl + synthesis over full pages",
+        ),
+    )
+
+    fun providerEngineById(id: String): DrEngine? = providerEngines.firstOrNull { it.id == id }
+
+    /** True when [id] is one of the built-in provider-native engines. */
+    fun isProviderEngine(id: String): Boolean = providerEngineById(id) != null
+
+    /** Which providers have at least one provider-native engine. */
+    val knownProviders = setOf("exa", "parallel", "firecrawl")
+}
+
+/** Resolved, ready-to-run configuration for a single Deep Research request. */
+data class DeepResearchConfig(
+    val engineId: String,
+    val engineKind: String, // "provider" | "agent"
+    val engineLabel: String,
+    /** provider kind: search provider that runs it. agent kind: the chat model id. */
+    val provider: String,
+    /** provider kind: API model/processor token. */
+    val providerModel: String,
+    /** agent kind: search provider backing the tool (resolved from "auto"). */
+    val searchProvider: String?,
+    val maxSearches: Int,
+    val maxSources: Int,
+)
+
+/** Moshi helpers for the JSON columns on [ResearchRun]. */
+object ResearchJson {
+    private val moshi: Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val stepsAdapter: JsonAdapter<List<String>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, String::class.java)
+    )
+    private val sourcesAdapter: JsonAdapter<List<SearchSource>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, SearchSource::class.java)
+    )
+
+    fun stepsToJson(steps: List<String>): String? =
+        if (steps.isEmpty()) null else stepsAdapter.toJson(steps)
+
+    fun stepsFromJson(json: String?): List<String> =
+        json?.let { runCatching { stepsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+
+    fun sourcesToJson(sources: List<SearchSource>): String? =
+        if (sources.isEmpty()) null else sourcesAdapter.toJson(sources)
+
+    fun sourcesFromJson(json: String?): List<SearchSource> =
+        json?.let { runCatching { sourcesAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+}

--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -30,6 +30,13 @@ sealed class ResearchEvent {
 
     /** Final report markdown. */
     data class Report(val text: String) : ResearchEvent()
+
+    /** Final structured result (JSON string) from the Data Agent. */
+    data class Structured(val json: String) : ResearchEvent()
+
+    /** Live cost/credits meter text, e.g. "$0.12" or "84 credits". */
+    data class Cost(val label: String) : ResearchEvent()
+
     data class Failed(val message: String) : ResearchEvent()
 }
 
@@ -65,10 +72,10 @@ class DeepResearchEngine(
         existing: ResearchRun?,
     ): Flow<ResearchEvent> = flow {
         try {
-            if (config.engineKind == "provider") {
-                runProvider(config, topic, searchKey, existing)
-            } else {
-                runAgent(config, topic, openRouterKey, searchKey, existing)
+            when (config.engineKind) {
+                "provider" -> runProvider(config, topic, searchKey, existing)
+                "data-agent" -> runDataAgent(config, topic, searchKey, existing)
+                else -> runAgent(config, topic, openRouterKey, searchKey, existing)
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
@@ -91,12 +98,17 @@ class DeepResearchEngine(
         }
         emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Starting ${config.engineLabel}…"))
 
-        // Exa runs deep research synchronously in a single /search call (no job, no polling).
         if (config.provider == "exa") {
-            emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Researching with Exa…"))
-            val done = exaDeepSearch(apiKey, config.providerModel, topic, config.maxSources)
-            if (done.sources.isNotEmpty()) emit(ResearchEvent.Sources(done.sources))
-            emit(ResearchEvent.Report(done.report))
+            if (config.providerModel == "agent") {
+                // Exa Agent: async POST /agent/runs, depth set by `effort`.
+                runExaAgent(apiKey, config, topic, existing)
+            } else {
+                // Exa Deep Reasoning: a single synchronous /search call (no job, no polling).
+                emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Researching with Exa…"))
+                val done = exaDeepSearch(apiKey, config.providerModel, topic, config.maxSources)
+                if (done.sources.isNotEmpty()) emit(ResearchEvent.Sources(done.sources))
+                emit(ResearchEvent.Report(done.report))
+            }
             return
         }
 
@@ -275,6 +287,136 @@ class DeepResearchEngine(
         }
     }
 
+    // Exa Agent: async POST /agent/runs then poll GET /agent/runs/{id}. Depth = effort.
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.runExaAgent(
+        apiKey: String,
+        config: DeepResearchConfig,
+        topic: String,
+        existing: ResearchRun?,
+    ) {
+        val headers = mapOf("x-api-key" to apiKey, "Exa-Beta" to EXA_AGENT_BETA)
+        val jobId = existing?.providerJobId ?: run {
+            val created = post(
+                url = "https://api.exa.ai/agent/runs",
+                headers = headers,
+                body = mapOf("query" to topic, "effort" to (config.level ?: "auto")),
+                label = "Exa",
+            )
+            (created["id"] as? String) ?: throw Exception("Exa Agent did not return a run id.")
+        }
+        emit(ResearchEvent.ProviderJob(jobId))
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Exa agent is researching…"))
+
+        val deadline = System.currentTimeMillis() + 40 * 60 * 1000L
+        while (System.currentTimeMillis() < deadline) {
+            delay(POLL_INTERVAL_MS)
+            val json = get("https://api.exa.ai/agent/runs/$jobId", headers, "Exa")
+            (json["costDollars"] as? Double)?.let { emit(ResearchEvent.Cost("$" + "%.2f".format(it))) }
+            when ((json["status"] as? String).orEmpty()) {
+                "completed" -> {
+                    val output = json["output"] as? Map<*, *>
+                    val text = (output?.get("text") as? String).orEmpty()
+                    val structured = output?.get("structured")
+                    val report = when {
+                        text.isNotBlank() -> text
+                        structured != null -> anyAdapter.toJson(structured)
+                        else -> ""
+                    }
+                    val sources = collectSources(output?.get("grounding"))
+                    if (sources.isNotEmpty()) emit(ResearchEvent.Sources(sources))
+                    if (report.isBlank()) emit(ResearchEvent.Failed("Exa Agent returned an empty result."))
+                    else emit(ResearchEvent.Report(report))
+                    return
+                }
+                "failed", "cancelled", "canceled", "error" -> {
+                    emit(ResearchEvent.Failed("Exa Agent run failed."))
+                    return
+                }
+                else -> Unit
+            }
+        }
+        emit(ResearchEvent.Failed("Exa Agent timed out. Try a lower effort or a narrower question."))
+    }
+
+    // ── Data Agent (Firecrawl /v2/agent — structured extraction) ─────────────────────
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.runDataAgent(
+        config: DeepResearchConfig,
+        topic: String,
+        apiKey: String,
+        existing: ResearchRun?,
+    ) {
+        if (apiKey.isBlank()) {
+            emit(ResearchEvent.Failed("No Firecrawl API key — add one in Settings → Web search."))
+            return
+        }
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Starting the data agent…"))
+        val headers = mapOf("Authorization" to "Bearer $apiKey")
+        val jobId = existing?.providerJobId ?: run {
+            val created = post(
+                url = "https://api.firecrawl.dev/v2/agent",
+                headers = headers,
+                body = mapOf("prompt" to topic, "model" to config.providerModel, "maxCredits" to config.maxCredits),
+                label = "Firecrawl",
+            )
+            (created["id"] as? String) ?: ((created["data"] as? Map<*, *>)?.get("id") as? String)
+                ?: throw Exception("Firecrawl agent did not return a job id.")
+        }
+        emit(ResearchEvent.ProviderJob(jobId))
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Collecting data…"))
+
+        val deadline = System.currentTimeMillis() + 40 * 60 * 1000L
+        while (System.currentTimeMillis() < deadline) {
+            delay(POLL_INTERVAL_MS)
+            val json = get("https://api.firecrawl.dev/v2/agent/$jobId", headers, "Firecrawl")
+            (json["creditsUsed"] as? Double)?.let { emit(ResearchEvent.Cost("${it.toInt()} credits")) }
+            when ((json["status"] as? String).orEmpty()) {
+                "completed" -> {
+                    val data = json["data"]
+                    val sources = (collectSources(data) + collectSources(json["sources"])).distinctBy { it.url }
+                    if (sources.isNotEmpty()) emit(ResearchEvent.Sources(sources))
+                    when (data) {
+                        is String -> if (data.isBlank()) emit(ResearchEvent.Failed("The data agent returned no data.")) else emit(ResearchEvent.Report(data))
+                        null -> emit(ResearchEvent.Failed("The data agent returned no data."))
+                        else -> emit(ResearchEvent.Structured(anyAdapter.toJson(data)))
+                    }
+                    return
+                }
+                "failed", "cancelled", "error" -> {
+                    emit(ResearchEvent.Failed("The data agent failed."))
+                    return
+                }
+                else -> Unit
+            }
+        }
+        emit(ResearchEvent.Failed("The data agent timed out."))
+    }
+
+    /** Recursively pull any {url,title,…} objects out of an arbitrary JSON node (citations/sources). */
+    private fun collectSources(node: Any?): List<SearchSource> {
+        val out = mutableListOf<SearchSource>()
+        fun walk(n: Any?) {
+            when (n) {
+                is Map<*, *> -> {
+                    val url = n["url"] as? String
+                    if (url != null && url.startsWith("http")) {
+                        out.add(
+                            SearchSource(
+                                title = (n["title"] as? String).orEmpty().ifBlank { url },
+                                url = url,
+                                snippet = (n["snippet"] as? String) ?: (n["text"] as? String),
+                            )
+                        )
+                    }
+                    n.values.forEach { walk(it) }
+                }
+                is List<*> -> n.forEach { walk(it) }
+            }
+        }
+        walk(node)
+        return out.distinctBy { it.url }
+    }
+
     // ── Agentic (plan → search → synthesize) ─────────────────────────────────────────
 
     private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.runAgent(
@@ -399,5 +541,6 @@ class DeepResearchEngine(
 
     companion object {
         private const val POLL_INTERVAL_MS = 5000L
+        private const val EXA_AGENT_BETA = "agent-2026-05-07"
     }
 }

--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -164,6 +164,7 @@ class DeepResearchEngine(
                 "query" to topic,
                 "type" to type,
                 "numResults" to numResults.coerceIn(1, 100),
+                "systemPrompt" to SystemPrompts.exaResearchSystemPrompt(),
                 "outputSchema" to mapOf("type" to "text"),
                 "contents" to mapOf(
                     "highlights" to true,
@@ -299,7 +300,10 @@ class DeepResearchEngine(
             val created = post(
                 url = "https://api.exa.ai/agent/runs",
                 headers = headers,
-                body = mapOf("query" to topic, "effort" to (config.level ?: "auto")),
+                body = mapOf(
+                    "query" to topic + "\n\n" + SystemPrompts.exaResearchSystemPrompt(),
+                    "effort" to (config.level ?: "auto"),
+                ),
                 label = "Exa",
             )
             (created["id"] as? String) ?: throw Exception("Exa Agent did not return a run id.")
@@ -356,7 +360,11 @@ class DeepResearchEngine(
             val created = post(
                 url = "https://api.firecrawl.dev/v2/agent",
                 headers = headers,
-                body = mapOf("prompt" to topic, "model" to config.providerModel, "maxCredits" to config.maxCredits),
+                body = mapOf(
+                    "prompt" to topic + SystemPrompts.dataAgentPromptSuffix(),
+                    "model" to config.providerModel,
+                    "maxCredits" to config.maxCredits,
+                ),
                 label = "Firecrawl",
             )
             (created["id"] as? String) ?: ((created["data"] as? Map<*, *>)?.get("id") as? String)
@@ -492,12 +500,22 @@ class DeepResearchEngine(
         apiKey: String,
         topic: String,
         sources: List<SearchSource>,
-    ): String = openRouterService.complete(
-        apiKey = apiKey,
-        model = model,
-        systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
-        userPrompt = "Numbered search results:\n\n" + formatSearchResultsForModel(sources),
-    )
+    ): String {
+        // Cap what we feed the model: many chat models (especially free ones) have small
+        // context windows, so an un-trimmed 20×4000-char source dump 400s the request. We
+        // trim each snippet and bound the total so synthesis stays within budget.
+        val trimmed = sources.take(MAX_SYNTHESIS_SOURCES).map { src ->
+            src.copy(snippet = src.snippet?.take(MAX_SNIPPET_CHARS))
+        }
+        var block = formatSearchResultsForModel(trimmed)
+        if (block.length > MAX_SYNTHESIS_CHARS) block = block.take(MAX_SYNTHESIS_CHARS)
+        return openRouterService.complete(
+            apiKey = apiKey,
+            model = model,
+            systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
+            userPrompt = "Numbered search results:\n\n$block",
+        )
+    }
 
     private fun parsePlan(raw: String, max: Int): List<String> =
         raw.lineSequence()
@@ -542,5 +560,9 @@ class DeepResearchEngine(
     companion object {
         private const val POLL_INTERVAL_MS = 5000L
         private const val EXA_AGENT_BETA = "agent-2026-05-07"
+        // Synthesis context budget (chars) so small/free model context windows aren't exceeded.
+        private const val MAX_SYNTHESIS_SOURCES = 16
+        private const val MAX_SNIPPET_CHARS = 800
+        private const val MAX_SYNTHESIS_CHARS = 14000
     }
 }

--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -1,0 +1,403 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
+
+/** Progress/result events emitted by [DeepResearchEngine] for the service to persist. */
+sealed class ResearchEvent {
+    /** Provider-native job created — persist [jobId] so the run can resume by re-polling. */
+    data class ProviderJob(val jobId: String) : ResearchEvent()
+    data class Plan(val steps: List<String>) : ResearchEvent()
+    data class Phase(
+        val status: String,
+        val label: String,
+        val done: Int = 0,
+        val total: Int = 0,
+    ) : ResearchEvent()
+
+    /** Newly discovered sources to merge into the accumulated set. */
+    data class Sources(val sources: List<SearchSource>) : ResearchEvent()
+
+    /** Final report markdown. */
+    data class Report(val text: String) : ResearchEvent()
+    data class Failed(val message: String) : ResearchEvent()
+}
+
+/**
+ * Runs one Deep Research request and emits [ResearchEvent]s. Two paths:
+ *  - **provider**: create a job on Exa/Parallel/Firecrawl, then poll until it finishes.
+ *  - **agent**: plan sub-questions with a cloud chat model, run each search locally via
+ *    [WebSearchService], then synthesize a cited report with the same model.
+ *
+ * Stateless: all durable state lives in [ResearchRun]; the caller persists what we emit and
+ * can re-invoke with an [existing] run to resume.
+ */
+class DeepResearchEngine(
+    private val openRouterService: OpenRouterService,
+    private val webSearchService: WebSearchService,
+) {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(45, TimeUnit.SECONDS)
+        // Exa's deep-reasoning /search is synchronous and can take 12–40s (sometimes more),
+        // so the read timeout is generous.
+        .readTimeout(120, TimeUnit.SECONDS)
+        .writeTimeout(45, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val anyAdapter = moshi.adapter(Any::class.java)
+
+    fun run(
+        config: DeepResearchConfig,
+        topic: String,
+        openRouterKey: String,
+        searchKey: String,
+        existing: ResearchRun?,
+    ): Flow<ResearchEvent> = flow {
+        try {
+            if (config.engineKind == "provider") {
+                runProvider(config, topic, searchKey, existing)
+            } else {
+                runAgent(config, topic, openRouterKey, searchKey, existing)
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            emit(ResearchEvent.Failed(e.message ?: "Deep research failed."))
+        }
+    }.flowOn(Dispatchers.IO)
+
+    // ── Provider-native ──────────────────────────────────────────────────────────────
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.runProvider(
+        config: DeepResearchConfig,
+        topic: String,
+        apiKey: String,
+        existing: ResearchRun?,
+    ) {
+        if (apiKey.isBlank()) {
+            emit(ResearchEvent.Failed("No ${config.provider} API key — add one in Settings → Web search."))
+            return
+        }
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Starting ${config.engineLabel}…"))
+
+        // Exa runs deep research synchronously in a single /search call (no job, no polling).
+        if (config.provider == "exa") {
+            emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Researching with Exa…"))
+            val done = exaDeepSearch(apiKey, config.providerModel, topic, config.maxSources)
+            if (done.sources.isNotEmpty()) emit(ResearchEvent.Sources(done.sources))
+            emit(ResearchEvent.Report(done.report))
+            return
+        }
+
+        // Parallel and Firecrawl create a job, then we poll until it finishes.
+        val jobId = existing?.providerJobId ?: when (config.provider) {
+            "parallel" -> createParallel(apiKey, config.providerModel, topic)
+            "firecrawl" -> createFirecrawl(apiKey, topic, config.maxSources)
+            else -> throw Exception("Unknown research provider: ${config.provider}")
+        }
+        emit(ResearchEvent.ProviderJob(jobId))
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Researching the web…"))
+
+        // Poll until the provider finishes. Capped so a stuck job can't poll forever.
+        val deadline = System.currentTimeMillis() + 40 * 60 * 1000L
+        while (System.currentTimeMillis() < deadline) {
+            delay(POLL_INTERVAL_MS)
+            val result = when (config.provider) {
+                "parallel" -> pollParallel(apiKey, jobId)
+                else -> pollFirecrawl(apiKey, jobId)
+            }
+            when (result) {
+                is PollResult.Pending -> {
+                    result.label?.let { emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, it)) }
+                }
+                is PollResult.Done -> {
+                    if (result.sources.isNotEmpty()) emit(ResearchEvent.Sources(result.sources))
+                    emit(ResearchEvent.Report(result.report))
+                    return
+                }
+                is PollResult.Error -> {
+                    emit(ResearchEvent.Failed(result.message))
+                    return
+                }
+            }
+        }
+        emit(ResearchEvent.Failed("Research timed out. Try a narrower question or a faster engine."))
+    }
+
+    private sealed class PollResult {
+        data class Pending(val label: String?) : PollResult()
+        data class Done(val report: String, val sources: List<SearchSource>) : PollResult()
+        data class Error(val message: String) : PollResult()
+    }
+
+    // Exa deep research is a single synchronous POST /search with a deep `type`
+    // ("deep" | "deep-lite" | "deep-reasoning"). With outputSchema {type:"text"} the
+    // synthesized report comes back in output.content and the sources in results[].
+    private fun exaDeepSearch(apiKey: String, type: String, topic: String, numResults: Int): PollResult.Done {
+        val json = post(
+            url = "https://api.exa.ai/search",
+            headers = mapOf("x-api-key" to apiKey),
+            body = mapOf(
+                "query" to topic,
+                "type" to type,
+                "numResults" to numResults.coerceIn(1, 100),
+                "outputSchema" to mapOf("type" to "text"),
+                "contents" to mapOf(
+                    "highlights" to true,
+                    "text" to mapOf("maxCharacters" to 2000),
+                ),
+            ),
+            label = "Exa",
+        )
+        val output = json["output"] as? Map<*, *>
+        val report = when (val content = output?.get("content")) {
+            is String -> content
+            is Map<*, *> -> anyAdapter.toJson(content)
+            else -> ""
+        }
+        val sources = (json["results"] as? List<*>).orEmpty().mapNotNull { raw ->
+            val r = raw as? Map<*, *> ?: return@mapNotNull null
+            val url = r["url"] as? String ?: return@mapNotNull null
+            val snippet = (r["text"] as? String)?.take(2000)
+                ?: (r["highlights"] as? List<*>)?.filterIsInstance<String>()?.joinToString("\n")?.take(2000)
+                ?: (r["summary"] as? String)
+            SearchSource(
+                title = (r["title"] as? String).orEmpty().ifBlank { url },
+                url = url,
+                snippet = snippet,
+                publishedDate = r["publishedDate"] as? String,
+            )
+        }.distinctBy { it.url }
+        if (report.isBlank()) throw Exception("Exa returned an empty report.")
+        return PollResult.Done(report, sources)
+    }
+
+    // Parallel: POST /v1/tasks/runs then poll GET /v1/tasks/runs/{id}, then GET .../result
+    private fun createParallel(apiKey: String, processor: String, topic: String): String {
+        val json = post(
+            url = "https://api.parallel.ai/v1/tasks/runs",
+            headers = mapOf("x-api-key" to apiKey),
+            body = mapOf(
+                "input" to topic,
+                "processor" to processor,
+                "task_spec" to mapOf("output_schema" to mapOf("type" to "text")),
+            ),
+            label = "Parallel",
+        )
+        return (json["run_id"] as? String) ?: (json["id"] as? String)
+            ?: throw Exception("Parallel did not return a run id.")
+    }
+
+    private fun pollParallel(apiKey: String, id: String): PollResult {
+        val status = get("https://api.parallel.ai/v1/tasks/runs/$id", mapOf("x-api-key" to apiKey), "Parallel")
+        return when (val s = (status["status"] as? String).orEmpty()) {
+            "completed" -> {
+                val result = get("https://api.parallel.ai/v1/tasks/runs/$id/result", mapOf("x-api-key" to apiKey), "Parallel")
+                val output = result["output"] as? Map<*, *>
+                val content = output?.get("content")
+                val report = when (content) {
+                    is String -> content
+                    is Map<*, *> -> anyAdapter.toJson(content)
+                    else -> ""
+                }
+                val basis = (output?.get("basis") as? List<*>).orEmpty()
+                val sources = basis.flatMap { b ->
+                    val citations = ((b as? Map<*, *>)?.get("citations") as? List<*>).orEmpty()
+                    citations.mapNotNull { raw ->
+                        val c = raw as? Map<*, *> ?: return@mapNotNull null
+                        val url = c["url"] as? String ?: return@mapNotNull null
+                        SearchSource(
+                            title = (c["title"] as? String).orEmpty().ifBlank { url },
+                            url = url,
+                            snippet = (c["excerpts"] as? List<*>)?.filterIsInstance<String>()?.joinToString("\n")?.take(2000),
+                        )
+                    }
+                }.distinctBy { it.url }
+                if (report.isBlank()) PollResult.Error("Parallel returned an empty report.")
+                else PollResult.Done(report, sources)
+            }
+            "failed", "cancelled", "cancelling" -> PollResult.Error("Parallel research failed.")
+            else -> PollResult.Pending(if (s == "running") "Researching with Parallel…" else null)
+        }
+    }
+
+    // Firecrawl: POST /v1/deep-research then GET /v1/deep-research/{id}
+    private fun createFirecrawl(apiKey: String, topic: String, maxSources: Int): String {
+        val json = post(
+            url = "https://api.firecrawl.dev/v1/deep-research",
+            headers = mapOf("Authorization" to "Bearer $apiKey"),
+            body = mapOf(
+                "query" to topic,
+                "maxUrls" to maxSources.coerceIn(1, 120),
+                "maxDepth" to 5,
+                "timeLimit" to 270,
+            ),
+            label = "Firecrawl",
+        )
+        return (json["id"] as? String) ?: ((json["data"] as? Map<*, *>)?.get("id") as? String)
+            ?: throw Exception("Firecrawl did not return a job id.")
+    }
+
+    private fun pollFirecrawl(apiKey: String, id: String): PollResult {
+        val json = get("https://api.firecrawl.dev/v1/deep-research/$id", mapOf("Authorization" to "Bearer $apiKey"), "Firecrawl")
+        val data = json["data"] as? Map<*, *>
+        return when ((json["status"] as? String).orEmpty()) {
+            "completed" -> {
+                val report = (data?.get("finalAnalysis") as? String).orEmpty()
+                val sources = (data?.get("sources") as? List<*>).orEmpty().mapNotNull { raw ->
+                    val s = raw as? Map<*, *> ?: return@mapNotNull null
+                    val url = s["url"] as? String ?: return@mapNotNull null
+                    SearchSource(
+                        title = (s["title"] as? String).orEmpty().ifBlank { url },
+                        url = url,
+                        snippet = s["description"] as? String,
+                    )
+                }.distinctBy { it.url }
+                if (report.isBlank()) PollResult.Error("Firecrawl returned an empty report.")
+                else PollResult.Done(report, sources)
+            }
+            "failed", "cancelled", "error" -> PollResult.Error("Firecrawl research failed.")
+            else -> {
+                val depth = (data?.get("currentDepth") as? Double)?.toInt()
+                PollResult.Pending(depth?.let { "Crawling the web (depth $it)…" })
+            }
+        }
+    }
+
+    // ── Agentic (plan → search → synthesize) ─────────────────────────────────────────
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.runAgent(
+        config: DeepResearchConfig,
+        topic: String,
+        openRouterKey: String,
+        searchKey: String,
+        existing: ResearchRun?,
+    ) {
+        if (openRouterKey.isBlank()) {
+            emit(ResearchEvent.Failed("OpenRouter API key is missing — add it in Settings → Cloud models."))
+            return
+        }
+        val searchProvider = config.searchProvider
+        if (searchProvider.isNullOrBlank() || searchKey.isBlank()) {
+            emit(ResearchEvent.Failed("No search provider is configured for Deep Research. Add an Exa, Parallel or Firecrawl key in Settings → Web search."))
+            return
+        }
+
+        // Resume: if we already gathered sources for a plan, jump straight to synthesis.
+        val resumedSources = ResearchJson.sourcesFromJson(existing?.sourcesJson)
+        if (existing != null && resumedSources.isNotEmpty() && existing.report.isNullOrBlank()) {
+            emit(ResearchEvent.Phase(ResearchRun.STATUS_SYNTHESIZING, "Writing the report…"))
+            emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, resumedSources)))
+            return
+        }
+
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_PLANNING, "Planning the research…"))
+        val planRaw = openRouterService.complete(
+            apiKey = openRouterKey,
+            model = config.provider,
+            systemPrompt = SystemPrompts.deepResearchPlanner(topic, config.maxSearches),
+            userPrompt = topic,
+        )
+        val steps = parsePlan(planRaw, config.maxSearches)
+        if (steps.isEmpty()) {
+            emit(ResearchEvent.Failed("The model did not produce a research plan. Try rephrasing your question."))
+            return
+        }
+        emit(ResearchEvent.Plan(steps))
+
+        val perSearch = (config.maxSources / steps.size).coerceIn(3, 10)
+        val gathered = LinkedHashMap<String, SearchSource>()
+        steps.forEachIndexed { i, step ->
+            emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Searching ${i + 1} of ${steps.size}", i, steps.size))
+            val found = try {
+                webSearchService.search(searchProvider, searchKey, step, perSearch)
+            } catch (e: Exception) {
+                emptyList()
+            }
+            val added = mutableListOf<SearchSource>()
+            found.forEach { source ->
+                if (source.url !in gathered && gathered.size < config.maxSources) {
+                    gathered[source.url] = source
+                    added.add(source)
+                }
+            }
+            if (added.isNotEmpty()) emit(ResearchEvent.Sources(added))
+        }
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_RESEARCHING, "Reviewed ${gathered.size} sources", steps.size, steps.size))
+
+        if (gathered.isEmpty()) {
+            emit(ResearchEvent.Failed("No sources were found. Check your search provider key, or try a different question."))
+            return
+        }
+
+        emit(ResearchEvent.Phase(ResearchRun.STATUS_SYNTHESIZING, "Writing the report…"))
+        emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, gathered.values.toList())))
+    }
+
+    private suspend fun synthesize(
+        model: String,
+        apiKey: String,
+        topic: String,
+        sources: List<SearchSource>,
+    ): String = openRouterService.complete(
+        apiKey = apiKey,
+        model = model,
+        systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
+        userPrompt = "Numbered search results:\n\n" + formatSearchResultsForModel(sources),
+    )
+
+    private fun parsePlan(raw: String, max: Int): List<String> =
+        raw.lineSequence()
+            .map { it.trim().removePrefix("-").removePrefix("*").trim() }
+            .map { it.replace(Regex("^\\d+[.)]\\s*"), "").trim() }
+            .filter { it.length > 4 }
+            .distinct()
+            .take(max)
+            .toList()
+
+    // ── HTTP plumbing ────────────────────────────────────────────────────────────────
+
+    private fun post(url: String, headers: Map<String, String>, body: Map<String, Any>, label: String): Map<*, *> {
+        val reqBody = anyAdapter.toJson(body).toRequestBody("application/json".toMediaType())
+        val builder = Request.Builder().url(url).addHeader("Content-Type", "application/json").post(reqBody)
+        headers.forEach { (k, v) -> builder.addHeader(k, v) }
+        return execute(builder.build(), label)
+    }
+
+    private fun get(url: String, headers: Map<String, String>, label: String): Map<*, *> {
+        val builder = Request.Builder().url(url).get()
+        headers.forEach { (k, v) -> builder.addHeader(k, v) }
+        return execute(builder.build(), label)
+    }
+
+    private fun execute(request: Request, label: String): Map<*, *> {
+        client.newCall(request).execute().use { response ->
+            val str = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                val message = when (response.code) {
+                    401, 403 -> "Invalid $label API key — check Settings."
+                    429 -> "$label rate limit reached — try again shortly."
+                    else -> "$label request failed (HTTP ${response.code})."
+                }
+                throw Exception(message)
+            }
+            return anyAdapter.fromJson(str) as? Map<*, *>
+                ?: throw Exception("$label returned an unreadable response.")
+        }
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS = 5000L
+    }
+}

--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -500,22 +500,12 @@ class DeepResearchEngine(
         apiKey: String,
         topic: String,
         sources: List<SearchSource>,
-    ): String {
-        // Cap what we feed the model: many chat models (especially free ones) have small
-        // context windows, so an un-trimmed 20×4000-char source dump 400s the request. We
-        // trim each snippet and bound the total so synthesis stays within budget.
-        val trimmed = sources.take(MAX_SYNTHESIS_SOURCES).map { src ->
-            src.copy(snippet = src.snippet?.take(MAX_SNIPPET_CHARS))
-        }
-        var block = formatSearchResultsForModel(trimmed)
-        if (block.length > MAX_SYNTHESIS_CHARS) block = block.take(MAX_SYNTHESIS_CHARS)
-        return openRouterService.complete(
-            apiKey = apiKey,
-            model = model,
-            systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
-            userPrompt = "Numbered search results:\n\n$block",
-        )
-    }
+    ): String = openRouterService.complete(
+        apiKey = apiKey,
+        model = model,
+        systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
+        userPrompt = "Numbered search results:\n\n" + formatSearchResultsForModel(sources),
+    )
 
     private fun parsePlan(raw: String, max: Int): List<String> =
         raw.lineSequence()
@@ -560,9 +550,5 @@ class DeepResearchEngine(
     companion object {
         private const val POLL_INTERVAL_MS = 5000L
         private const val EXA_AGENT_BETA = "agent-2026-05-07"
-        // Synthesis context budget (chars) so small/free model context windows aren't exceeded.
-        private const val MAX_SYNTHESIS_SOURCES = 16
-        private const val MAX_SNIPPET_CHARS = 800
-        private const val MAX_SYNTHESIS_CHARS = 14000
     }
 }

--- a/app/src/main/java/com/echoflow/data/DeepResearchForegroundService.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchForegroundService.kt
@@ -105,6 +105,7 @@ class DeepResearchForegroundService : Service() {
         val openRouterKey = settings.getApiKeyDirect()
         val searchKey = when (config.engineKind) {
             "provider" -> settings.getSearchApiKeyDirect(config.provider)
+            "data-agent" -> settings.getSearchApiKeyDirect("firecrawl")
             else -> config.searchProvider?.let { settings.getSearchApiKeyDirect(it) }.orEmpty()
         }
 
@@ -136,8 +137,15 @@ class DeepResearchForegroundService : Service() {
                     event.sources.forEach { if (it.url !in sources) sources[it.url] = it }
                     current = current.copy(sourcesJson = ResearchJson.sourcesToJson(sources.values.toList()), updatedAt = now())
                 }
+                is ResearchEvent.Cost -> {
+                    current = current.copy(costInfo = event.label, updatedAt = now())
+                }
                 is ResearchEvent.Report -> {
                     finishCompleted(current, event.text, sources.values.toList())
+                    return@collect
+                }
+                is ResearchEvent.Structured -> {
+                    finishStructured(current, event.json, sources.values.toList())
                     return@collect
                 }
                 is ResearchEvent.Failed -> {
@@ -151,28 +159,48 @@ class DeepResearchForegroundService : Service() {
     }
 
     private fun buildConfig(run: ResearchRun): DeepResearchConfig? {
-        return if (run.engineKind == "provider") {
-            val eng = DeepResearchCatalog.providerEngineById(run.engineId) ?: return null
-            DeepResearchConfig(
-                engineId = run.engineId,
-                engineKind = "provider",
-                engineLabel = run.engineLabel,
-                provider = eng.provider,
-                providerModel = eng.providerModel,
-                searchProvider = null,
-                maxSearches = run.maxSearches,
-                maxSources = run.maxSources,
-            )
-        } else {
-            DeepResearchConfig(
+        return when (run.engineKind) {
+            "provider" -> {
+                val eng = DeepResearchCatalog.providerEngineById(run.engineId) ?: return null
+                DeepResearchConfig(
+                    engineId = run.engineId,
+                    engineKind = "provider",
+                    engineLabel = run.engineLabel,
+                    provider = eng.provider,
+                    providerModel = eng.providerModel,
+                    searchProvider = null,
+                    level = run.level,
+                    maxSearches = run.maxSearches,
+                    maxSources = run.maxSources,
+                    maxCredits = run.maxCredits,
+                )
+            }
+            "data-agent" -> {
+                val eng = DataAgentCatalog.byId(run.engineId) ?: return null
+                DeepResearchConfig(
+                    engineId = run.engineId,
+                    engineKind = "data-agent",
+                    engineLabel = run.engineLabel,
+                    provider = eng.provider,
+                    providerModel = eng.providerModel,
+                    searchProvider = null,
+                    level = run.level,
+                    maxSearches = run.maxSearches,
+                    maxSources = run.maxSources,
+                    maxCredits = run.maxCredits,
+                )
+            }
+            else -> DeepResearchConfig(
                 engineId = run.engineId,
                 engineKind = "agent",
                 engineLabel = run.engineLabel,
                 provider = run.engineId, // chat model id
                 providerModel = "",
                 searchProvider = run.searchProvider,
+                level = run.level,
                 maxSearches = run.maxSearches,
                 maxSources = run.maxSources,
+                maxCredits = run.maxCredits,
             )
         }
     }
@@ -204,6 +232,34 @@ class DeepResearchForegroundService : Service() {
                 status = ResearchRun.STATUS_COMPLETED,
                 phase = "Completed",
                 report = report,
+                sourcesJson = ResearchJson.sourcesToJson(sources),
+                assistantMessageId = messageId,
+                updatedAt = now(),
+            )
+        )
+    }
+
+    private suspend fun finishStructured(run: ResearchRun, json: String, sources: List<SearchSource>) {
+        val citations = sources.distinctBy { it.url }.map { Citation(it.title, it.url) }
+        val segments = listOf(PersistedSegment(type = "data", text = json))
+        val messageId = UUID.randomUUID().toString()
+        db.messageDao().insertMessage(
+            ChatMessage(
+                id = messageId,
+                chatId = run.chatId,
+                role = "assistant",
+                content = json,
+                createdAt = now(),
+                citationsJson = ToolEventJson.citationsToJson(citations),
+                segmentsJson = ToolEventJson.segmentsToJson(segments),
+            )
+        )
+        db.chatDao().getThreadById(run.chatId)?.let { db.chatDao().updateThread(it.copy(updatedAt = now())) }
+        persist(
+            run.copy(
+                status = ResearchRun.STATUS_COMPLETED,
+                phase = "Completed",
+                report = json,
                 sourcesJson = ResearchJson.sourcesToJson(sources),
                 assistantMessageId = messageId,
                 updatedAt = now(),

--- a/app/src/main/java/com/echoflow/data/DeepResearchForegroundService.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchForegroundService.kt
@@ -1,0 +1,352 @@
+package com.echoflow.data
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.echoflow.MainActivity
+import com.echoflow.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Foreground service that runs Deep Research to completion independently of the UI.
+ *
+ * It is the orchestration owner: it drives [DeepResearchEngine], writes every progress
+ * update to the [ResearchRun] row (the UI observes that, never this service directly),
+ * shows an ongoing notification with a Cancel action, and on completion writes the final
+ * assistant [ChatMessage]. Because all state is in Room, a run survives the app being
+ * minimized or killed and is resumed via [ACTION_RESUME] on next launch.
+ */
+class DeepResearchForegroundService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + kotlinx.coroutines.Dispatchers.IO)
+    private val jobs = ConcurrentHashMap<String, Job>()
+
+    private val db by lazy { AppDatabase.getDatabase(applicationContext) }
+    private val settings by lazy { SettingsRepository(applicationContext) }
+    private val engine by lazy {
+        DeepResearchEngine(OpenRouterService(applicationContext), WebSearchService())
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID, "Deep Research", NotificationManager.IMPORTANCE_LOW,
+            ).apply { description = "Shows progress of long-running research" }
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Always post a notification synchronously so the FGS start window is satisfied.
+        startForegroundNow("Deep Research", "Starting…")
+
+        when (intent?.action) {
+            ACTION_CANCEL -> {
+                val runId = intent.getStringExtra(EXTRA_RUN_ID)
+                if (runId != null) cancelRun(runId)
+            }
+            ACTION_RESUME -> scope.launch {
+                db.researchRunDao().getInterrupted().forEach { startRun(it.id) }
+                stopIfIdle()
+            }
+            else -> {
+                val runId = intent?.getStringExtra(EXTRA_RUN_ID)
+                if (runId != null) scope.launch { startRun(runId) }
+                else scope.launch { stopIfIdle() }
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private suspend fun startRun(runId: String) {
+        if (jobs.containsKey(runId)) return
+        val run = db.researchRunDao().getById(runId) ?: return
+        if (run.isTerminal) return
+
+        val job = scope.launch {
+            try {
+                execute(run)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // cancellation is handled by cancelRun(); never a "failure"
+            } catch (e: Exception) {
+                finishFailed(runId, e.message ?: "Deep research failed.")
+            } finally {
+                jobs.remove(runId)
+                stopIfIdle()
+            }
+        }
+        jobs[runId] = job
+    }
+
+    private suspend fun execute(initial: ResearchRun) {
+        val runId = initial.id
+        val config = buildConfig(initial) ?: run {
+            finishFailed(runId, "This research engine is no longer available.")
+            return
+        }
+
+        val openRouterKey = settings.getApiKeyDirect()
+        val searchKey = when (config.engineKind) {
+            "provider" -> settings.getSearchApiKeyDirect(config.provider)
+            else -> config.searchProvider?.let { settings.getSearchApiKeyDirect(it) }.orEmpty()
+        }
+
+        // Local mutable accumulators mirrored into Room after every event.
+        var current = initial.copy(status = ResearchRun.STATUS_RESEARCHING, updatedAt = now())
+        val sources = LinkedHashMap<String, SearchSource>()
+        ResearchJson.sourcesFromJson(initial.sourcesJson).forEach { sources[it.url] = it }
+        persist(current)
+        updateNotification(current)
+
+        engine.run(config, current.topic, openRouterKey, searchKey, initial).collect { event ->
+            when (event) {
+                is ResearchEvent.ProviderJob -> {
+                    current = current.copy(providerJobId = event.jobId, updatedAt = now())
+                }
+                is ResearchEvent.Plan -> {
+                    current = current.copy(planJson = ResearchJson.stepsToJson(event.steps), updatedAt = now())
+                }
+                is ResearchEvent.Phase -> {
+                    current = current.copy(
+                        status = event.status,
+                        phase = event.label,
+                        progressDone = event.done,
+                        progressTotal = event.total,
+                        updatedAt = now(),
+                    )
+                }
+                is ResearchEvent.Sources -> {
+                    event.sources.forEach { if (it.url !in sources) sources[it.url] = it }
+                    current = current.copy(sourcesJson = ResearchJson.sourcesToJson(sources.values.toList()), updatedAt = now())
+                }
+                is ResearchEvent.Report -> {
+                    finishCompleted(current, event.text, sources.values.toList())
+                    return@collect
+                }
+                is ResearchEvent.Failed -> {
+                    finishFailed(runId, event.message)
+                    return@collect
+                }
+            }
+            persist(current)
+            updateNotification(current)
+        }
+    }
+
+    private fun buildConfig(run: ResearchRun): DeepResearchConfig? {
+        return if (run.engineKind == "provider") {
+            val eng = DeepResearchCatalog.providerEngineById(run.engineId) ?: return null
+            DeepResearchConfig(
+                engineId = run.engineId,
+                engineKind = "provider",
+                engineLabel = run.engineLabel,
+                provider = eng.provider,
+                providerModel = eng.providerModel,
+                searchProvider = null,
+                maxSearches = run.maxSearches,
+                maxSources = run.maxSources,
+            )
+        } else {
+            DeepResearchConfig(
+                engineId = run.engineId,
+                engineKind = "agent",
+                engineLabel = run.engineLabel,
+                provider = run.engineId, // chat model id
+                providerModel = "",
+                searchProvider = run.searchProvider,
+                maxSearches = run.maxSearches,
+                maxSources = run.maxSources,
+            )
+        }
+    }
+
+    private suspend fun finishCompleted(run: ResearchRun, report: String, sources: List<SearchSource>) {
+        val citations = sources.distinctBy { it.url }.map { Citation(it.title, it.url) }
+        val steps = ResearchJson.stepsFromJson(run.planJson)
+        val segments = buildList {
+            if (steps.isNotEmpty()) add(PersistedSegment(type = "plan", text = steps.joinToString("\n")))
+            add(PersistedSegment(type = "report", text = report))
+        }
+        val messageId = UUID.randomUUID().toString()
+        db.messageDao().insertMessage(
+            ChatMessage(
+                id = messageId,
+                chatId = run.chatId,
+                role = "assistant",
+                content = report,
+                createdAt = now(),
+                citationsJson = ToolEventJson.citationsToJson(citations),
+                segmentsJson = ToolEventJson.segmentsToJson(segments),
+            )
+        )
+        db.chatDao().getThreadById(run.chatId)?.let {
+            db.chatDao().updateThread(it.copy(updatedAt = now()))
+        }
+        persist(
+            run.copy(
+                status = ResearchRun.STATUS_COMPLETED,
+                phase = "Completed",
+                report = report,
+                sourcesJson = ResearchJson.sourcesToJson(sources),
+                assistantMessageId = messageId,
+                updatedAt = now(),
+            )
+        )
+    }
+
+    private suspend fun finishFailed(runId: String, message: String) {
+        val run = db.researchRunDao().getById(runId) ?: return
+        if (run.isTerminal) return
+        writeNote(run.chatId, "⚠️ Deep Research couldn't finish: $message")
+        persist(run.copy(status = ResearchRun.STATUS_FAILED, phase = "Failed", error = message, updatedAt = now()))
+    }
+
+    private fun cancelRun(runId: String) {
+        jobs.remove(runId)?.cancel()
+        scope.launch {
+            val run = db.researchRunDao().getById(runId)
+            if (run != null && !run.isTerminal) {
+                writeNote(run.chatId, "🛑 Deep Research was cancelled.")
+                persist(run.copy(status = ResearchRun.STATUS_CANCELLED, phase = "Cancelled", updatedAt = now()))
+            }
+            stopIfIdle()
+        }
+    }
+
+    /** A plain assistant message so the chat always reflects a research outcome. */
+    private suspend fun writeNote(chatId: String, text: String) {
+        db.messageDao().insertMessage(
+            ChatMessage(
+                id = UUID.randomUUID().toString(),
+                chatId = chatId,
+                role = "assistant",
+                content = text,
+                createdAt = now(),
+            )
+        )
+        db.chatDao().getThreadById(chatId)?.let { db.chatDao().updateThread(it.copy(updatedAt = now())) }
+    }
+
+    private suspend fun persist(run: ResearchRun) {
+        db.researchRunDao().upsert(run)
+    }
+
+    private fun stopIfIdle() {
+        if (jobs.isEmpty()) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+    }
+
+    // ── Notification ─────────────────────────────────────────────────────────────────
+
+    private fun startForegroundNow(title: String, text: String) {
+        val notification = baseNotification(title, text, null).build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID, notification,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun updateNotification(run: ResearchRun) {
+        val text = buildString {
+            append(run.phase ?: "Researching…")
+            if (run.progressTotal > 0) append(" (${run.progressDone}/${run.progressTotal})")
+        }
+        val builder = baseNotification("🔬 ${run.topic.take(40)}", text, run.id)
+        if (run.progressTotal > 0) builder.setProgress(run.progressTotal, run.progressDone, false)
+        else builder.setProgress(0, 0, true)
+        getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, builder.build())
+    }
+
+    private fun baseNotification(title: String, text: String, cancelRunId: String?): NotificationCompat.Builder {
+        val openIntent = PendingIntent.getActivity(
+            this, 0, Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setOngoing(true)
+            .setContentIntent(openIntent)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+        if (cancelRunId != null) {
+            val cancelIntent = PendingIntent.getService(
+                this, cancelRunId.hashCode(),
+                Intent(this, DeepResearchForegroundService::class.java)
+                    .setAction(ACTION_CANCEL).putExtra(EXTRA_RUN_ID, cancelRunId),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            builder.addAction(0, "Cancel", cancelIntent)
+        }
+        return builder
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun now() = System.currentTimeMillis()
+
+    companion object {
+        private const val CHANNEL_ID = "deep_research"
+        private const val NOTIFICATION_ID = 73
+        private const val ACTION_CANCEL = "com.echoflow.research.CANCEL"
+        private const val ACTION_RESUME = "com.echoflow.research.RESUME"
+        private const val EXTRA_RUN_ID = "run_id"
+
+        /** Start (or continue) a specific run. Must be called from the foreground (a tap). */
+        fun start(context: Context, runId: String) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, DeepResearchForegroundService::class.java).putExtra(EXTRA_RUN_ID, runId),
+                )
+            }
+        }
+
+        /** Resume any interrupted runs (call on app launch). */
+        fun resume(context: Context) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, DeepResearchForegroundService::class.java).setAction(ACTION_RESUME),
+                )
+            }
+        }
+
+        fun cancel(context: Context, runId: String) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, DeepResearchForegroundService::class.java)
+                        .setAction(ACTION_CANCEL).putExtra(EXTRA_RUN_ID, runId),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -55,3 +55,64 @@ data class LocalModel(
     val source: String, // "curated" | "imported"
     val addedAt: Long
 )
+
+/**
+ * A cloud chat model the user has whitelisted to orchestrate agentic Deep Research.
+ * Kept separate from [CustomModel] (normal chat models) because Deep Research has its own
+ * "add model" flow and a much smaller, deliberately-curated capable-model list.
+ */
+@Entity(tableName = "deep_research_models")
+data class DeepResearchModel(
+    @PrimaryKey val id: String, // OpenRouter id, e.g. "google/gemini-2.5-pro"
+    val name: String,
+    val addedAt: Long
+)
+
+/**
+ * The durable record of one Deep Research run. This is the single source of truth: the
+ * foreground service writes progress here and the UI observes it, so a run survives the
+ * Activity/ViewModel being destroyed and can be resumed after the app is force-killed
+ * (provider-native runs by re-polling [providerJobId]; agentic runs from accumulated
+ * sources).
+ */
+@Entity(
+    tableName = "research_runs",
+    indices = [Index("chatId"), Index("status")]
+)
+data class ResearchRun(
+    @PrimaryKey val id: String,
+    val chatId: String,
+    val topic: String, // the user's research question
+    val engineId: String, // "exa-deep-reasoning" | "parallel-ultra" | "firecrawl-research" | a chat model id
+    val engineKind: String, // "provider" | "agent"
+    val engineLabel: String, // human label shown in the progress card
+    val searchProvider: String? = null, // agent mode: which search provider backs the tool
+    val maxSearches: Int = 5,
+    val maxSources: Int = 20,
+    val providerJobId: String? = null, // exa researchId / parallel run_id / firecrawl job id
+    val status: String = STATUS_QUEUED, // see STATUS_* constants
+    val phase: String? = null, // human progress line, e.g. "Searching 3 of 8"
+    val progressDone: Int = 0,
+    val progressTotal: Int = 0,
+    val planJson: String? = null, // JSON List<String>: planned sub-questions
+    val sourcesJson: String? = null, // JSON List<SearchSource>: accumulated sources
+    val report: String? = null, // final report markdown (or partial on cancel)
+    val error: String? = null,
+    val assistantMessageId: String? = null, // the chat_messages row holding the final report
+    val createdAt: Long,
+    val updatedAt: Long
+) {
+    val isTerminal: Boolean get() = status in TERMINAL_STATUSES
+
+    companion object {
+        const val STATUS_QUEUED = "queued"
+        const val STATUS_PLANNING = "planning"
+        const val STATUS_RESEARCHING = "researching"
+        const val STATUS_SYNTHESIZING = "synthesizing"
+        const val STATUS_COMPLETED = "completed"
+        const val STATUS_FAILED = "failed"
+        const val STATUS_CANCELLED = "cancelled"
+
+        val TERMINAL_STATUSES = setOf(STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED)
+    }
+}

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -83,12 +83,15 @@ data class ResearchRun(
     @PrimaryKey val id: String,
     val chatId: String,
     val topic: String, // the user's research question
-    val engineId: String, // "exa-deep-reasoning" | "parallel-ultra" | "firecrawl-research" | a chat model id
-    val engineKind: String, // "provider" | "agent"
+    val engineId: String, // "exa-deep-reasoning" | "exa-agent" | "parallel-ultra" | "firecrawl-agent-pro" | a chat model id
+    val engineKind: String, // "provider" | "agent" | "data-agent"
     val engineLabel: String, // human label shown in the progress card
     val searchProvider: String? = null, // agent mode: which search provider backs the tool
+    val level: String? = null, // Exa Agent effort, or the Firecrawl Data Agent model token
+    val costInfo: String? = null, // live cost/credits meter text (e.g. "$0.12" or "84 credits")
     val maxSearches: Int = 5,
     val maxSources: Int = 20,
+    val maxCredits: Int = 2500,
     val providerJobId: String? = null, // exa researchId / parallel run_id / firecrawl job id
     val status: String = STATUS_QUEUED, // see STATUS_* constants
     val phase: String? = null, // human progress line, e.g. "Searching 3 of 8"

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -194,7 +194,12 @@ class OpenRouterService(private val context: Context) {
             val choices = responseMap?.get("choices") as? List<*>
             val choice = choices?.firstOrNull() as? Map<*, *>
             val message = choice?.get("message") as? Map<*, *>
-            (message?.get("content") as? String) ?: throw Exception("No response content received.")
+            // Some reasoning models leave `content` empty and put the answer in a reasoning
+            // field — fall back to it so synthesis/planning never fails on those models.
+            val content = (message?.get("content") as? String)?.takeIf { it.isNotBlank() }
+                ?: (message?.get("reasoning_content") as? String)?.takeIf { it.isNotBlank() }
+                ?: (message?.get("reasoning") as? String)?.takeIf { it.isNotBlank() }
+            content ?: throw Exception("No response content received.")
         }
     }
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -154,6 +154,50 @@ class OpenRouterService(private val context: Context) {
         }
     }
 
+    /**
+     * Single non-streaming completion from a system + user prompt. Used by Deep Research's
+     * planner and synthesis stages, which need a whole answer at once rather than a stream.
+     */
+    suspend fun complete(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userPrompt: String
+    ): String = withContext(Dispatchers.IO) {
+        if (apiKey.isBlank()) {
+            throw Exception("API key is missing! Please configure it in your Settings.")
+        }
+        val requestMap = mutableMapOf<String, Any>(
+            "model" to model,
+            "messages" to listOf(
+                mapOf("role" to "system", "content" to systemPrompt),
+                mapOf("role" to "user", "content" to userPrompt)
+            ),
+            "stream" to false
+        )
+        val jsonPayload = dynamicAdapter.toJson(requestMap)
+        val request = buildHttpRequest(apiKey, jsonPayload)
+
+        client.newCall(request).execute().use { response ->
+            val responseString = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                val parsedErrorMsg = parseErrorMessage(responseString)
+                val statusMessage = when (response.code) {
+                    401 -> "Unauthorized — verify your OpenRouter API key in Settings."
+                    404 -> "Model \"$model\" is unavailable."
+                    403 -> "Action forbidden — your OpenRouter credit might be depleted."
+                    else -> parsedErrorMsg ?: "HTTP ${response.code}"
+                }
+                throw Exception("API Failure: $statusMessage")
+            }
+            val responseMap = dynamicAdapter.fromJson(responseString) as? Map<*, *>
+            val choices = responseMap?.get("choices") as? List<*>
+            val choice = choices?.firstOrNull() as? Map<*, *>
+            val message = choice?.get("message") as? Map<*, *>
+            (message?.get("content") as? String) ?: throw Exception("No response content received.")
+        }
+    }
+
     // ---------------------------------------------------------------------------------
     // Streaming internals
     // ---------------------------------------------------------------------------------

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -194,12 +194,7 @@ class OpenRouterService(private val context: Context) {
             val choices = responseMap?.get("choices") as? List<*>
             val choice = choices?.firstOrNull() as? Map<*, *>
             val message = choice?.get("message") as? Map<*, *>
-            // Some reasoning models leave `content` empty and put the answer in a reasoning
-            // field — fall back to it so synthesis/planning never fails on those models.
-            val content = (message?.get("content") as? String)?.takeIf { it.isNotBlank() }
-                ?: (message?.get("reasoning_content") as? String)?.takeIf { it.isNotBlank() }
-                ?: (message?.get("reasoning") as? String)?.takeIf { it.isNotBlank() }
-            content ?: throw Exception("No response content received.")
+            (message?.get("content") as? String) ?: throw Exception("No response content received.")
         }
     }
 

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -59,6 +59,19 @@ class SettingsRepository(context: Context) {
     private val _deepResearchMaxSources = MutableStateFlow(getDeepResearchMaxSourcesDirect())
     val deepResearchMaxSources: StateFlow<Int> = _deepResearchMaxSources.asStateFlow()
 
+    private val _deepResearchExaEffort = MutableStateFlow(getDeepResearchExaEffortDirect())
+    val deepResearchExaEffort: StateFlow<String> = _deepResearchExaEffort.asStateFlow() // auto|low|medium|high|xhigh
+
+    // Data Agent (Firecrawl-only extraction mode; off by default)
+    private val _dataAgentEnabled = MutableStateFlow(getDataAgentEnabledDirect())
+    val dataAgentEnabled: StateFlow<Boolean> = _dataAgentEnabled.asStateFlow()
+
+    private val _dataAgentEngine = MutableStateFlow(getDataAgentEngineDirect())
+    val dataAgentEngine: StateFlow<String> = _dataAgentEngine.asStateFlow()
+
+    private val _dataAgentMaxCredits = MutableStateFlow(getDataAgentMaxCreditsDirect())
+    val dataAgentMaxCredits: StateFlow<Int> = _dataAgentMaxCredits.asStateFlow()
+
     private val _hfAccessToken = MutableStateFlow(getHfAccessTokenDirect())
     val hfAccessToken: StateFlow<String> = _hfAccessToken.asStateFlow()
 
@@ -214,6 +227,40 @@ class SettingsRepository(context: Context) {
     fun saveDeepResearchMaxSources(value: Int) {
         prefs.edit().putInt("deep_research_max_sources", value).apply()
         _deepResearchMaxSources.value = value
+    }
+
+    fun getDeepResearchExaEffortDirect(): String =
+        prefs.getString("deep_research_exa_effort", "auto").orEmpty()
+
+    fun saveDeepResearchExaEffort(value: String) {
+        prefs.edit().putString("deep_research_exa_effort", value).apply()
+        _deepResearchExaEffort.value = value
+    }
+
+    // ── Data Agent ───────────────────────────────────────────────────────────────────
+
+    fun getDataAgentEnabledDirect(): Boolean =
+        prefs.getBoolean("data_agent_enabled", false)
+
+    fun saveDataAgentEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("data_agent_enabled", enabled).apply()
+        _dataAgentEnabled.value = enabled
+    }
+
+    fun getDataAgentEngineDirect(): String =
+        prefs.getString("data_agent_engine", "").orEmpty()
+
+    fun saveDataAgentEngine(id: String) {
+        prefs.edit().putString("data_agent_engine", id).apply()
+        _dataAgentEngine.value = id
+    }
+
+    fun getDataAgentMaxCreditsDirect(): Int =
+        prefs.getInt("data_agent_max_credits", 2500)
+
+    fun saveDataAgentMaxCredits(value: Int) {
+        prefs.edit().putInt("data_agent_max_credits", value).apply()
+        _dataAgentMaxCredits.value = value
     }
 
     companion object {

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -46,6 +46,19 @@ class SettingsRepository(context: Context) {
     private val _localModelsEnabled = MutableStateFlow(getLocalModelsEnabledDirect())
     val localModelsEnabled: StateFlow<Boolean> = _localModelsEnabled.asStateFlow()
 
+    // Deep Research
+    private val _deepResearchModel = MutableStateFlow(getDeepResearchModelDirect())
+    val deepResearchModel: StateFlow<String> = _deepResearchModel.asStateFlow()
+
+    private val _deepResearchSearchProvider = MutableStateFlow(getDeepResearchSearchProviderDirect())
+    val deepResearchSearchProvider: StateFlow<String> = _deepResearchSearchProvider.asStateFlow() // "auto"|"exa"|"parallel"|"firecrawl"
+
+    private val _deepResearchMaxSearches = MutableStateFlow(getDeepResearchMaxSearchesDirect())
+    val deepResearchMaxSearches: StateFlow<Int> = _deepResearchMaxSearches.asStateFlow()
+
+    private val _deepResearchMaxSources = MutableStateFlow(getDeepResearchMaxSourcesDirect())
+    val deepResearchMaxSources: StateFlow<Int> = _deepResearchMaxSources.asStateFlow()
+
     private val _hfAccessToken = MutableStateFlow(getHfAccessTokenDirect())
     val hfAccessToken: StateFlow<String> = _hfAccessToken.asStateFlow()
 
@@ -95,6 +108,26 @@ class SettingsRepository(context: Context) {
     fun saveWebSearchProvider(provider: String) {
         prefs.edit().putString(KEY_SEARCH_PROVIDER, provider).apply()
         _webSearchProvider.value = provider
+        // Remember the last real provider so the in-chat "+ → Web Search" toggle can turn
+        // search on without the user reopening Settings.
+        if (provider != "off") {
+            prefs.edit().putString(KEY_LAST_SEARCH_PROVIDER, provider).apply()
+        }
+    }
+
+    /**
+     * The provider the in-chat Web Search toggle should use: the active provider when one
+     * is on, otherwise the last one the user picked, otherwise any client provider that
+     * still has a key saved. Returns null when nothing is configured.
+     */
+    fun resolveChipSearchProvider(): String? {
+        val active = getWebSearchProviderDirect()
+        if (active != "off") return active
+        val last = prefs.getString(KEY_LAST_SEARCH_PROVIDER, null)
+        if (!last.isNullOrBlank()) {
+            if (last == "openrouter" || getSearchApiKeyDirect(last).isNotBlank()) return last
+        }
+        return listOf("exa", "parallel", "firecrawl").firstOrNull { getSearchApiKeyDirect(it).isNotBlank() }
     }
 
     fun getWebSearchScopeDirect(): String {
@@ -149,9 +182,44 @@ class SettingsRepository(context: Context) {
         _hfAccessToken.value = token
     }
 
+    // ── Deep Research ────────────────────────────────────────────────────────────────
+
+    fun getDeepResearchModelDirect(): String =
+        prefs.getString("deep_research_model", "").orEmpty()
+
+    fun saveDeepResearchModel(id: String) {
+        prefs.edit().putString("deep_research_model", id).apply()
+        _deepResearchModel.value = id
+    }
+
+    fun getDeepResearchSearchProviderDirect(): String =
+        prefs.getString("deep_research_search_provider", "auto").orEmpty()
+
+    fun saveDeepResearchSearchProvider(provider: String) {
+        prefs.edit().putString("deep_research_search_provider", provider).apply()
+        _deepResearchSearchProvider.value = provider
+    }
+
+    fun getDeepResearchMaxSearchesDirect(): Int =
+        prefs.getInt("deep_research_max_searches", 5)
+
+    fun saveDeepResearchMaxSearches(value: Int) {
+        prefs.edit().putInt("deep_research_max_searches", value).apply()
+        _deepResearchMaxSearches.value = value
+    }
+
+    fun getDeepResearchMaxSourcesDirect(): Int =
+        prefs.getInt("deep_research_max_sources", 20)
+
+    fun saveDeepResearchMaxSources(value: Int) {
+        prefs.edit().putInt("deep_research_max_sources", value).apply()
+        _deepResearchMaxSources.value = value
+    }
+
     companion object {
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
+        private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"
         const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
     }
 }

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -156,6 +156,48 @@ object SystemPrompts {
         """.trimIndent()
     }
 
+    // ── Deep Research (agentic, cloud only) ──────────────────────────────────────────
+
+    /**
+     * Planner prompt: turn the user's topic into a short list of focused sub-questions,
+     * one per line, no numbering or prose. [maxSearches] caps how many we will run.
+     */
+    fun deepResearchPlanner(topic: String, maxSearches: Int, currentDate: String = currentDate()): String =
+        """
+        You are the planning stage of a deep-research agent. Today is $currentDate.
+
+        Break the user's request into at most $maxSearches focused, self-contained web-search
+        sub-questions that together fully answer it. Cover distinct angles (avoid near-duplicates),
+        order them from most to least important, and phrase each as a complete search query.
+
+        Output ONLY the sub-questions, one per line, with no numbering, bullets, commentary,
+        or blank lines.
+
+        User request:
+        $topic
+        """.trimIndent()
+
+    /**
+     * Synthesis prompt: write the final report from the gathered, numbered sources.
+     * The model must cite inline as [n](url) and must not invent sources.
+     */
+    fun deepResearchSynthesis(topic: String, currentDate: String = currentDate()): String =
+        """
+        You are the synthesis stage of a deep-research agent. Today is $currentDate.
+
+        Write a thorough, well-structured research report answering the user's request using ONLY
+        the numbered search results provided. Requirements:
+        - Open with a short direct answer / executive summary (2–4 sentences).
+        - Then use clear markdown sections with `##` headings.
+        - When comparing options, use a markdown table.
+        - Cite every factual claim inline as [n](url) using the result numbers; never invent URLs.
+        - If the evidence is thin or sources conflict, say so explicitly rather than guessing.
+        - Do NOT append a "Sources" or "References" list at the end — the app shows sources separately.
+
+        User request:
+        $topic
+        """.trimIndent()
+
     private fun formatting(isLocalModel: Boolean): String = buildString {
         append(
             "## Style\n" +

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -178,25 +178,52 @@ object SystemPrompts {
         """.trimIndent()
 
     /**
-     * Synthesis prompt: write the final report from the gathered, numbered sources.
-     * The model must cite inline as [n](url) and must not invent sources.
+     * Synthesis prompt for the OpenRouter (chat-model) agentic path. Carries a markdown
+     * "design system" tuned to EchoFlow's renderer so reports come out polished.
      */
     fun deepResearchSynthesis(topic: String, currentDate: String = currentDate()): String =
         """
         You are the synthesis stage of a deep-research agent. Today is $currentDate.
 
-        Write a thorough, well-structured research report answering the user's request using ONLY
-        the numbered search results provided. Requirements:
-        - Open with a short direct answer / executive summary (2–4 sentences).
-        - Then use clear markdown sections with `##` headings.
-        - When comparing options, use a markdown table.
+        Write a thorough, polished research report answering the user's request using ONLY the
+        numbered search results provided.
+
+        ## Output design (the app renders GitHub-flavored markdown — use it well)
+        - Lead with a **TL;DR**: 2–4 sentence direct answer, before any heading.
+        - Organize the body with `##` section headings (and `###` sub-sections when helpful).
+        - Keep paragraphs short (2–4 sentences). Prefer bullet lists for enumerations.
+        - **Bold** the key terms, names, numbers and verdicts so the answer is scannable.
+        - When comparing options, ALWAYS use a markdown table with a header row and one row per option.
+        - Use `>` blockquotes for important caveats or uncertainty.
+        - Use fenced code blocks only for code, commands or structured data.
+
+        ## Rigor
         - Cite every factual claim inline as [n](url) using the result numbers; never invent URLs.
-        - If the evidence is thin or sources conflict, say so explicitly rather than guessing.
-        - Do NOT append a "Sources" or "References" list at the end — the app shows sources separately.
+        - If evidence is thin or sources conflict, say so explicitly rather than guessing.
+        - Do NOT append a "Sources"/"References" list — the app shows sources separately.
 
         User request:
         $topic
         """.trimIndent()
+
+    /**
+     * Formatting instructions handed to Exa's own engines (passed as `systemPrompt` to
+     * /search and appended to the Exa Agent query), since Exa writes the report itself.
+     */
+    fun exaResearchSystemPrompt(): String =
+        "Write a clear, polished markdown report. Lead with a 2–3 sentence summary, then use " +
+            "`##` headings, short paragraphs and bullet lists, and a markdown table whenever you " +
+            "compare options. Bold key terms and figures. Cite sources inline as markdown links. " +
+            "Do not append a separate Sources or References list."
+
+    /**
+     * Suffix appended to a Firecrawl Data Agent prompt so it returns clean, render-friendly
+     * structured data instead of one long text blob.
+     */
+    fun dataAgentPromptSuffix(): String =
+        "\n\nReturn the result as a JSON array of objects with consistent fields across every " +
+            "item. Prefer many short, specific fields over a single long text field, and use " +
+            "concise human-readable field names."
 
     private fun formatting(isLocalModel: Boolean): String = buildString {
         append(

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -178,6 +178,9 @@ class ChatViewModel(
     private val _webSearchChipOn = MutableStateFlow(false)
     val webSearchChipOn: StateFlow<Boolean> = _webSearchChipOn.asStateFlow()
 
+    private val _dataAgentActive = MutableStateFlow(false)
+    val dataAgentActive: StateFlow<Boolean> = _dataAgentActive.asStateFlow()
+
     /** The Deep Research engine/model the user has added (built-in provider engines + agentic). */
     val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -190,17 +193,23 @@ class ChatViewModel(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    /** Web Search and Deep Research are mutually exclusive — research already searches. */
+    // Web Search, Deep Research and Data Agent are mutually exclusive capabilities.
     fun toggleDeepResearch() {
         val next = !_deepResearchActive.value
         _deepResearchActive.value = next
-        if (next) _webSearchChipOn.value = false
+        if (next) { _webSearchChipOn.value = false; _dataAgentActive.value = false }
     }
 
     fun toggleWebSearchChip() {
         val next = !_webSearchChipOn.value
         _webSearchChipOn.value = next
-        if (next) _deepResearchActive.value = false
+        if (next) { _deepResearchActive.value = false; _dataAgentActive.value = false }
+    }
+
+    fun toggleDataAgent() {
+        val next = !_dataAgentActive.value
+        _dataAgentActive.value = next
+        if (next) { _deepResearchActive.value = false; _webSearchChipOn.value = false }
     }
 
     fun selectThread(chatId: String?) {
@@ -328,10 +337,14 @@ class ChatViewModel(
 
         if (prompt.isEmpty() && attachmentUri == null) return
 
-        // Deep Research is a different pipeline (foreground service + provider/agent
-        // orchestration), so it short-circuits the normal streaming send entirely.
+        // Deep Research and Data Agent are different pipelines (foreground service +
+        // provider/agent orchestration), so they short-circuit the normal streaming send.
         if (_deepResearchActive.value && prompt.isNotEmpty()) {
             startDeepResearch(prompt)
+            return
+        }
+        if (_dataAgentActive.value && prompt.isNotEmpty()) {
+            startDataAgent(prompt)
             return
         }
 
@@ -593,6 +606,7 @@ class ChatViewModel(
                     engineKind = if (isProvider) "provider" else "agent",
                     engineLabel = engineLabel,
                     searchProvider = searchProvider,
+                    level = if (engineId == "exa-agent") settingsRepository.getDeepResearchExaEffortDirect() else null,
                     maxSearches = maxSearches,
                     maxSources = maxSources,
                     status = ResearchRun.STATUS_QUEUED,
@@ -602,6 +616,66 @@ class ChatViewModel(
             )
             DeepResearchForegroundService.start(getApplication(), runId)
             _deepResearchActive.value = false // deliberate, per-question opt-in
+        }
+    }
+
+    /** Start a Firecrawl Data Agent run (structured extraction). */
+    private fun startDataAgent(topic: String) {
+        viewModelScope.launch {
+            clearError()
+            if (currentResearchRun.value != null) {
+                _errorMessage.value = "A run is already in progress in this chat."
+                return@launch
+            }
+            if (!settingsRepository.getDataAgentEnabledDirect()) {
+                _errorMessage.value = "Turn on Data Agent in Settings → Data Agent first."
+                return@launch
+            }
+            if (settingsRepository.getSearchApiKeyDirect("firecrawl").isBlank()) {
+                _errorMessage.value = "Add your Firecrawl API key in Settings → Web search."
+                return@launch
+            }
+            val engine = DataAgentCatalog.byId(settingsRepository.getDataAgentEngineDirect())
+                ?: DataAgentCatalog.engines.first()
+
+            val now = System.currentTimeMillis()
+            var chatId = _currentChatThreadId.value
+            if (chatId == null) {
+                chatId = UUID.randomUUID().toString()
+                chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
+                _currentChatThreadId.value = chatId
+                val words = topic.split("\\s+".toRegex())
+                val fallbackTitle = words.take(5).joinToString(" ") + if (words.size > 5) "…" else ""
+                chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(title = fallbackTitle)) }
+            }
+            messageDao.insertMessage(
+                ChatMessage(
+                    id = UUID.randomUUID().toString(),
+                    chatId = chatId,
+                    role = "user",
+                    content = topic,
+                    createdAt = now,
+                )
+            )
+            chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = now)) }
+
+            val runId = UUID.randomUUID().toString()
+            researchRunDao.upsert(
+                ResearchRun(
+                    id = runId,
+                    chatId = chatId,
+                    topic = topic,
+                    engineId = engine.id,
+                    engineKind = "data-agent",
+                    engineLabel = engine.name,
+                    maxCredits = settingsRepository.getDataAgentMaxCreditsDirect(),
+                    status = ResearchRun.STATUS_QUEUED,
+                    createdAt = now,
+                    updatedAt = now,
+                )
+            )
+            DeepResearchForegroundService.start(getApplication(), runId)
+            _dataAgentActive.value = false
         }
     }
 

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -38,7 +38,9 @@ class ChatViewModel(
     private val chatDao: ChatDao,
     private val messageDao: MessageDao,
     private val settingsRepository: SettingsRepository,
-    private val localModelDao: LocalModelDao
+    private val localModelDao: LocalModelDao,
+    private val researchRunDao: ResearchRunDao,
+    private val deepResearchModelDao: DeepResearchModelDao
 ) : AndroidViewModel(application) {
 
     private val openRouterService = OpenRouterService(application)
@@ -169,6 +171,38 @@ class ChatViewModel(
     private val _pendingAttachmentName = MutableStateFlow<String?>(null)
     val pendingAttachmentName: StateFlow<String?> = _pendingAttachmentName.asStateFlow()
 
+    // Per-message capability toggles surfaced by the "+" menu as chips above the input.
+    private val _deepResearchActive = MutableStateFlow(false)
+    val deepResearchActive: StateFlow<Boolean> = _deepResearchActive.asStateFlow()
+
+    private val _webSearchChipOn = MutableStateFlow(false)
+    val webSearchChipOn: StateFlow<Boolean> = _webSearchChipOn.asStateFlow()
+
+    /** The Deep Research engine/model the user has added (built-in provider engines + agentic). */
+    val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** The live (non-terminal) research run for the open conversation, if any. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentResearchRun: StateFlow<ResearchRun?> = _currentChatThreadId
+        .flatMapLatest { chatId ->
+            if (chatId == null) flowOf(null) else researchRunDao.observeActiveForChat(chatId)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    /** Web Search and Deep Research are mutually exclusive — research already searches. */
+    fun toggleDeepResearch() {
+        val next = !_deepResearchActive.value
+        _deepResearchActive.value = next
+        if (next) _webSearchChipOn.value = false
+    }
+
+    fun toggleWebSearchChip() {
+        val next = !_webSearchChipOn.value
+        _webSearchChipOn.value = next
+        if (next) _deepResearchActive.value = false
+    }
+
     fun selectThread(chatId: String?) {
         _currentChatThreadId.value = chatId
         clearPendingAttachment()
@@ -293,6 +327,14 @@ class ChatViewModel(
         val attachmentName = _pendingAttachmentName.value
 
         if (prompt.isEmpty() && attachmentUri == null) return
+
+        // Deep Research is a different pipeline (foreground service + provider/agent
+        // orchestration), so it short-circuits the normal streaming send entirely.
+        if (_deepResearchActive.value && prompt.isNotEmpty()) {
+            startDeepResearch(prompt)
+            return
+        }
+
         _currentChatThreadId.value?.let { chatId ->
             if (streamJobs[chatId]?.isActive == true) return
         }
@@ -303,8 +345,11 @@ class ChatViewModel(
 
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
-            val provider = settingsRepository.getWebSearchProviderDirect()
-            val searchScope = settingsRepository.getWebSearchScopeDirect()
+            // The "+ → Web Search" chip force-enables search using the last-used provider,
+            // so the user never has to open Settings just to search one message.
+            val chipProvider = if (_webSearchChipOn.value) settingsRepository.resolveChipSearchProvider() else null
+            val provider = chipProvider ?: settingsRepository.getWebSearchProviderDirect()
+            val searchScope = if (chipProvider != null) "both" else settingsRepository.getWebSearchScopeDirect()
             val isLocal = selectedModel.startsWith("local/")
 
             if (isLocal && _activeStreams.value.values.any { it.isLocal }) {
@@ -461,6 +506,108 @@ class ChatViewModel(
                 setStreamState(chatId, null)
             }
         }
+    }
+
+    // -------------------------------------------------------------------------------
+    // Deep Research
+    // -------------------------------------------------------------------------------
+
+    /**
+     * Validates the configured Deep Research engine, records the user's question, creates a
+     * durable [ResearchRun], and hands off to the foreground service which owns execution.
+     */
+    private fun startDeepResearch(topic: String) {
+        viewModelScope.launch {
+            clearError()
+            if (currentResearchRun.value != null) {
+                _errorMessage.value = "A research run is already in progress in this chat."
+                return@launch
+            }
+
+            val engineId = settingsRepository.getDeepResearchModelDirect()
+            if (engineId.isBlank()) {
+                _errorMessage.value = "Pick a Deep Research engine from the model selector first."
+                return@launch
+            }
+            val isProvider = DeepResearchCatalog.isProviderEngine(engineId)
+            val maxSearches = settingsRepository.getDeepResearchMaxSearchesDirect()
+            val maxSources = settingsRepository.getDeepResearchMaxSourcesDirect()
+
+            var searchProvider: String? = null
+            val engineLabel: String
+
+            if (isProvider) {
+                val engine = DeepResearchCatalog.providerEngineById(engineId)!!
+                engineLabel = engine.name
+                if (settingsRepository.getSearchApiKeyDirect(engine.provider).isBlank()) {
+                    _errorMessage.value = "Add your ${engine.provider.replaceFirstChar { it.uppercase() }} API key in Settings → Web search."
+                    return@launch
+                }
+            } else {
+                if (settingsRepository.getApiKeyDirect().isBlank()) {
+                    _errorMessage.value = "OpenRouter API key is missing. Add it in Settings → Cloud models."
+                    return@launch
+                }
+                val chosen = settingsRepository.getDeepResearchSearchProviderDirect()
+                searchProvider = if (chosen == "auto") {
+                    listOf("exa", "parallel", "firecrawl").firstOrNull { settingsRepository.getSearchApiKeyDirect(it).isNotBlank() }
+                } else {
+                    chosen.takeIf { settingsRepository.getSearchApiKeyDirect(it).isNotBlank() }
+                }
+                if (searchProvider == null) {
+                    _errorMessage.value = "Deep Research needs a search provider. Add an Exa, Parallel or Firecrawl key in Settings → Web search."
+                    return@launch
+                }
+                engineLabel = deepResearchModelDao.getAllSync().firstOrNull { it.id == engineId }?.name ?: engineId
+            }
+
+            val now = System.currentTimeMillis()
+            var chatId = _currentChatThreadId.value
+            if (chatId == null) {
+                chatId = UUID.randomUUID().toString()
+                chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
+                _currentChatThreadId.value = chatId
+                val words = topic.split("\\s+".toRegex())
+                val fallbackTitle = words.take(5).joinToString(" ") + if (words.size > 5) "…" else ""
+                chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(title = fallbackTitle)) }
+            }
+
+            messageDao.insertMessage(
+                ChatMessage(
+                    id = UUID.randomUUID().toString(),
+                    chatId = chatId,
+                    role = "user",
+                    content = topic,
+                    createdAt = now,
+                )
+            )
+            chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = now)) }
+
+            val runId = UUID.randomUUID().toString()
+            researchRunDao.upsert(
+                ResearchRun(
+                    id = runId,
+                    chatId = chatId,
+                    topic = topic,
+                    engineId = engineId,
+                    engineKind = if (isProvider) "provider" else "agent",
+                    engineLabel = engineLabel,
+                    searchProvider = searchProvider,
+                    maxSearches = maxSearches,
+                    maxSources = maxSources,
+                    status = ResearchRun.STATUS_QUEUED,
+                    createdAt = now,
+                    updatedAt = now,
+                )
+            )
+            DeepResearchForegroundService.start(getApplication(), runId)
+            _deepResearchActive.value = false // deliberate, per-question opt-in
+        }
+    }
+
+    /** Cancel the in-flight research for the open conversation (keeps any partial result). */
+    fun cancelResearch() {
+        currentResearchRun.value?.let { DeepResearchForegroundService.cancel(getApplication(), it.id) }
     }
 
     private suspend fun persistAssistantMessage(
@@ -724,11 +871,16 @@ class ChatViewModel(
             chatDao: ChatDao,
             messageDao: MessageDao,
             settingsRepository: SettingsRepository,
-            localModelDao: LocalModelDao
+            localModelDao: LocalModelDao,
+            researchRunDao: ResearchRunDao,
+            deepResearchModelDao: DeepResearchModelDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return ChatViewModel(application, chatDao, messageDao, settingsRepository, localModelDao) as T
+                return ChatViewModel(
+                    application, chatDao, messageDao, settingsRepository, localModelDao,
+                    researchRunDao, deepResearchModelDao
+                ) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.CustomModel
 import com.echoflow.data.CustomModelDao
+import com.echoflow.data.DeepResearchModel
+import com.echoflow.data.DeepResearchModelDao
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.LocalModel
@@ -27,7 +29,8 @@ class SettingsViewModel(
     private val repository: SettingsRepository,
     private val customModelDao: CustomModelDao,
     private val localModelDao: LocalModelDao,
-    private val downloadManager: ModelDownloadManager
+    private val downloadManager: ModelDownloadManager,
+    private val deepResearchModelDao: DeepResearchModelDao
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
 
@@ -47,6 +50,14 @@ class SettingsViewModel(
     val localModelsEnabled: StateFlow<Boolean> = repository.localModelsEnabled
     val hfAccessToken: StateFlow<String> = repository.hfAccessToken
     val downloadStates: StateFlow<Map<String, DownloadState>> = downloadManager.states
+
+    // Deep Research
+    val deepResearchModelId: StateFlow<String> = repository.deepResearchModel
+    val deepResearchSearchProvider: StateFlow<String> = repository.deepResearchSearchProvider
+    val deepResearchMaxSearches: StateFlow<Int> = repository.deepResearchMaxSearches
+    val deepResearchMaxSources: StateFlow<Int> = repository.deepResearchMaxSources
+    val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
@@ -143,6 +154,32 @@ class SettingsViewModel(
 
     fun saveHfAccessToken(token: String) {
         repository.saveHfAccessToken(token.trim())
+    }
+
+    // ── Deep Research ────────────────────────────────────────────────────────────────
+
+    fun saveDeepResearchModel(id: String) = repository.saveDeepResearchModel(id)
+    fun saveDeepResearchSearchProvider(provider: String) = repository.saveDeepResearchSearchProvider(provider)
+    fun saveDeepResearchMaxSearches(value: Int) = repository.saveDeepResearchMaxSearches(value)
+    fun saveDeepResearchMaxSources(value: Int) = repository.saveDeepResearchMaxSources(value)
+
+    fun addDeepResearchModel(id: String, name: String) {
+        viewModelScope.launch {
+            val cleanId = id.trim()
+            val cleanName = name.trim().ifEmpty { cleanId.substringAfterLast("/") }
+            if (cleanId.isNotEmpty()) {
+                deepResearchModelDao.insert(DeepResearchModel(cleanId, cleanName, System.currentTimeMillis()))
+            }
+        }
+    }
+
+    fun deleteDeepResearchModel(id: String) {
+        viewModelScope.launch {
+            deepResearchModelDao.delete(id)
+            if (repository.getDeepResearchModelDirect() == id) {
+                repository.saveDeepResearchModel("")
+            }
+        }
     }
 
     fun downloadModel(entry: CatalogEntry) {
@@ -249,11 +286,12 @@ class SettingsViewModel(
             repository: SettingsRepository,
             customModelDao: CustomModelDao,
             localModelDao: LocalModelDao,
-            downloadManager: ModelDownloadManager
+            downloadManager: ModelDownloadManager,
+            deepResearchModelDao: DeepResearchModelDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -56,8 +56,14 @@ class SettingsViewModel(
     val deepResearchSearchProvider: StateFlow<String> = repository.deepResearchSearchProvider
     val deepResearchMaxSearches: StateFlow<Int> = repository.deepResearchMaxSearches
     val deepResearchMaxSources: StateFlow<Int> = repository.deepResearchMaxSources
+    val deepResearchExaEffort: StateFlow<String> = repository.deepResearchExaEffort
     val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Data Agent
+    val dataAgentEnabled: StateFlow<Boolean> = repository.dataAgentEnabled
+    val dataAgentEngine: StateFlow<String> = repository.dataAgentEngine
+    val dataAgentMaxCredits: StateFlow<Int> = repository.dataAgentMaxCredits
 
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
@@ -162,6 +168,11 @@ class SettingsViewModel(
     fun saveDeepResearchSearchProvider(provider: String) = repository.saveDeepResearchSearchProvider(provider)
     fun saveDeepResearchMaxSearches(value: Int) = repository.saveDeepResearchMaxSearches(value)
     fun saveDeepResearchMaxSources(value: Int) = repository.saveDeepResearchMaxSources(value)
+    fun saveDeepResearchExaEffort(value: String) = repository.saveDeepResearchExaEffort(value)
+
+    fun saveDataAgentEnabled(enabled: Boolean) = repository.saveDataAgentEnabled(enabled)
+    fun saveDataAgentEngine(id: String) = repository.saveDataAgentEngine(id)
+    fun saveDataAgentMaxCredits(value: Int) = repository.saveDataAgentMaxCredits(value)
 
     fun addDeepResearchModel(id: String, name: String) {
         viewModelScope.launch {

--- a/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
@@ -1,0 +1,277 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.echoflow.data.Citation
+import com.echoflow.data.ResearchJson
+import com.echoflow.data.ResearchRun
+import com.echoflow.data.SearchSource
+import com.echoflow.ui.theme.Spacing
+
+private fun faviconFor(url: String): String =
+    "https://www.google.com/s2/favicons?domain=${runCatching { android.net.Uri.parse(url).host }.getOrNull() ?: ""}&sz=64"
+
+/**
+ * Live Deep Research progress, mirroring the foreground notification: engine + topic, the
+ * current phase with a determinate/indeterminate bar, the plan as a checklist, the sources
+ * found so far, and a Cancel action. Driven entirely from the persisted [ResearchRun] so it
+ * looks identical whether watched live or reopened after the app was killed.
+ */
+@Composable
+fun ResearchProgressCard(
+    run: ResearchRun,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val steps = remember(run.planJson) { ResearchJson.stepsFromJson(run.planJson) }
+    val sources = remember(run.sourcesJson) { ResearchJson.sourcesFromJson(run.sourcesJson) }
+
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(36.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.Science, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimary) }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Deep Research",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        run.engineLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                TextButton(onClick = onCancel) {
+                    Icon(Icons.Default.Close, null, Modifier.size(16.dp))
+                    Spacer(Modifier.width(Spacing.xs))
+                    Text("Cancel")
+                }
+            }
+
+            Spacer(Modifier.height(Spacing.m))
+            Text(
+                run.topic,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(Modifier.height(Spacing.m))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                LoadingIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    run.phase ?: "Working…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Spacer(Modifier.height(Spacing.s))
+            if (run.progressTotal > 0) {
+                LinearProgressIndicator(
+                    progress = { run.progressDone.toFloat() / run.progressTotal },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            if (steps.isNotEmpty()) {
+                Spacer(Modifier.height(Spacing.m))
+                steps.forEachIndexed { index, step ->
+                    val done = index < run.progressDone
+                    val active = index == run.progressDone && !run.isTerminal
+                    Row(
+                        Modifier.padding(vertical = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        when {
+                            done -> Icon(Icons.Default.CheckCircle, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                            active -> LoadingIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                            else -> Icon(Icons.Default.RadioButtonUnchecked, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                        Spacer(Modifier.width(Spacing.s))
+                        Text(
+                            step,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (done || active) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2, overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+
+            if (sources.isNotEmpty()) {
+                Spacer(Modifier.height(Spacing.m))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(horizontalArrangement = Arrangement.spacedBy((-6).dp)) {
+                        sources.take(6).forEach { source ->
+                            Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surface, modifier = Modifier.size(22.dp)) {
+                                AsyncImage(faviconFor(source.url), null, Modifier.padding(2.dp).clip(CircleShape))
+                            }
+                        }
+                    }
+                    Spacer(Modifier.width(Spacing.s))
+                    Text(
+                        "${sources.size} source${if (sources.size == 1) "" else "s"}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A finished research report: distinct from a normal chat bubble — a titled container with
+ * the full markdown body and a sources section, plus copy. The [planSteps] (if any) collapse
+ * into a "How this was researched" disclosure so the report leads with the answer.
+ */
+@Composable
+fun ReportCard(
+    report: String,
+    citations: List<Citation>,
+    planSteps: List<String>,
+    onCopy: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Science, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    "Research report",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+                FilledTonalIconButton(
+                    onClick = onCopy,
+                    modifier = Modifier.size(32.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                ) { Icon(Icons.Default.ContentCopy, "Copy report", Modifier.size(16.dp)) }
+            }
+
+            if (planSteps.isNotEmpty()) {
+                Spacer(Modifier.height(Spacing.s))
+                ResearchPlanDisclosure(planSteps)
+            }
+
+            Spacer(Modifier.height(Spacing.s))
+            RichMarkdown(report, Modifier.fillMaxWidth())
+
+            if (citations.isNotEmpty()) {
+                Spacer(Modifier.height(Spacing.base))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(Spacing.base))
+                SourcesRow(citations)
+            }
+        }
+    }
+}
+
+/** Collapsed "How this was researched" recap of the plan steps. */
+@Composable
+fun ResearchPlanDisclosure(steps: List<String>, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "plan-chevron")
+    Surface(
+        onClick = { expanded = !expanded },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "How this was researched · ${steps.size} steps",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand", Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            AnimatedVisibility(visible = expanded, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                Column(Modifier.padding(top = Spacing.s)) {
+                    steps.forEachIndexed { i, step ->
+                        Row(Modifier.padding(vertical = 2.dp)) {
+                            Text("${i + 1}. ", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                            Text(step, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** A removable capability chip shown above the input (Search / Deep Research / file). */
+@Composable
+fun CapabilityChip(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onRemove: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.m, end = if (onRemove != null) Spacing.xs else Spacing.m, top = 6.dp, bottom = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer)
+            Spacer(Modifier.width(Spacing.xs))
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSecondaryContainer)
+            if (onRemove != null) {
+                IconButton(onClick = onRemove, modifier = Modifier.size(22.dp)) {
+                    Icon(Icons.Default.Close, "Remove", Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
@@ -29,10 +29,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.echoflow.data.Citation
+import com.echoflow.data.ExaEffort
 import com.echoflow.data.ResearchJson
 import com.echoflow.data.ResearchRun
 import com.echoflow.data.SearchSource
 import com.echoflow.ui.theme.Spacing
+import org.json.JSONArray
+import org.json.JSONObject
 
 private fun faviconFor(url: String): String =
     "https://www.google.com/s2/favicons?domain=${runCatching { android.net.Uri.parse(url).host }.getOrNull() ?: ""}&sz=64"
@@ -66,7 +69,7 @@ fun ResearchProgressCard(
                 Spacer(Modifier.width(Spacing.m))
                 Column(Modifier.weight(1f)) {
                     Text(
-                        "Deep Research",
+                        if (run.engineKind == "data-agent") "Data Agent" else "Deep Research",
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -109,6 +112,14 @@ fun ResearchProgressCard(
                 )
             } else {
                 LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            run.costInfo?.takeIf { it.isNotBlank() }?.let { cost ->
+                Spacer(Modifier.height(Spacing.s))
+                Text(
+                    "Spent so far: $cost",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             if (steps.isNotEmpty()) {
@@ -245,6 +256,146 @@ fun ResearchPlanDisclosure(steps: List<String>, modifier: Modifier = Modifier) {
             }
         }
     }
+}
+
+/**
+ * Compact effort selector shown next to the Deep Research chip when the Exa Agent engine is
+ * picked — keeps the effort/cost dial out of the model list. Tapping cycles a dropdown.
+ */
+@Composable
+fun EffortPill(effort: String, onSelect: (String) -> Unit, modifier: Modifier = Modifier) {
+    var open by remember { mutableStateOf(false) }
+    Box(modifier) {
+        Surface(
+            onClick = { open = true },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.tertiaryContainer,
+        ) {
+            Row(
+                Modifier.padding(start = Spacing.m, end = Spacing.s, top = 6.dp, bottom = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Effort: ${ExaEffort.label(effort)}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+                Icon(Icons.Default.KeyboardArrowDown, "Change effort", Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer)
+            }
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            ExaEffort.levels.forEach { level ->
+                DropdownMenuItem(
+                    text = { Text(ExaEffort.label(level)) },
+                    trailingIcon = { if (level == effort) Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.primary) },
+                    onClick = { open = false; onSelect(level) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Adaptive renderer for a Data Agent result (a JSON string). Picks the cleanest shape:
+ * an array of objects → stacked item cards; a single object → field rows; anything else →
+ * markdown/plain text. The user never chooses "structured vs text".
+ */
+@Composable
+fun DataResultCard(
+    json: String,
+    citations: List<Citation>,
+    onCopy: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val array = remember(json) { runCatching { JSONArray(json) }.getOrNull() }
+    val obj = remember(json) { if (array == null) runCatching { JSONObject(json) }.getOrNull() else null }
+
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Science, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    "Data result",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+                FilledTonalIconButton(
+                    onClick = onCopy,
+                    modifier = Modifier.size(32.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp)) }
+            }
+            Spacer(Modifier.height(Spacing.m))
+
+            when {
+                array != null -> Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    for (i in 0 until array.length()) {
+                        when (val item = array.opt(i)) {
+                            is JSONObject -> JsonObjectCard(item)
+                            else -> Text("• ${item}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
+                        }
+                    }
+                }
+                obj != null -> JsonObjectCard(obj, flat = true)
+                else -> RichMarkdown(json, Modifier.fillMaxWidth())
+            }
+
+            if (citations.isNotEmpty()) {
+                Spacer(Modifier.height(Spacing.base))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(Spacing.base))
+                SourcesRow(citations)
+            }
+        }
+    }
+}
+
+/** One object rendered as label → value rows; nested arrays/objects are shown compactly. */
+@Composable
+private fun JsonObjectCard(obj: JSONObject, flat: Boolean = false) {
+    val content: @Composable ColumnScope.() -> Unit = {
+        val keys = obj.keys()
+        keys.forEach { key ->
+            val value = obj.opt(key)
+            Row(Modifier.padding(vertical = 3.dp)) {
+                Text(
+                    prettyKey(key),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.widthIn(min = 96.dp).weight(0.4f),
+                )
+                Text(
+                    stringifyJson(value),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(0.6f),
+                )
+            }
+        }
+    }
+    if (flat) {
+        Column(content = content)
+    } else {
+        Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerHigh, modifier = Modifier.fillMaxWidth()) {
+            Column(Modifier.padding(Spacing.m), content = content)
+        }
+    }
+}
+
+private fun prettyKey(key: String): String =
+    key.replace('_', ' ').replace(Regex("([a-z])([A-Z])"), "$1 $2").replaceFirstChar { it.uppercase() }
+
+private fun stringifyJson(value: Any?): String = when (value) {
+    null, JSONObject.NULL -> "—"
+    is JSONArray -> (0 until value.length()).joinToString(", ") { stringifyJson(value.opt(it)) }
+    is JSONObject -> value.keys().asSequence().joinToString(", ") { "${prettyKey(it)}: ${stringifyJson(value.opt(it))}" }
+    else -> value.toString()
 }
 
 /** A removable capability chip shown above the input (Search / Deep Research / file). */

--- a/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ResearchComponents.kt
@@ -183,42 +183,38 @@ fun ReportCard(
     onCopy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        Column(Modifier.padding(Spacing.base)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Science, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.width(Spacing.s))
-                Text(
-                    "Research report",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.weight(1f),
-                )
-                FilledTonalIconButton(
-                    onClick = onCopy,
-                    modifier = Modifier.size(32.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                ) { Icon(Icons.Default.ContentCopy, "Copy report", Modifier.size(16.dp)) }
-            }
+    // Plain background — the report reads like a first-class answer, not a boxed card. Only a
+    // small label + a divider before sources give it light structure.
+    Column(modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Science, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                "Research report",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+            FilledTonalIconButton(
+                onClick = onCopy,
+                modifier = Modifier.size(30.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.ContentCopy, "Copy report", Modifier.size(15.dp)) }
+        }
 
-            if (planSteps.isNotEmpty()) {
-                Spacer(Modifier.height(Spacing.s))
-                ResearchPlanDisclosure(planSteps)
-            }
-
+        if (planSteps.isNotEmpty()) {
             Spacer(Modifier.height(Spacing.s))
-            RichMarkdown(report, Modifier.fillMaxWidth())
+            ResearchPlanDisclosure(planSteps)
+        }
 
-            if (citations.isNotEmpty()) {
-                Spacer(Modifier.height(Spacing.base))
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                Spacer(Modifier.height(Spacing.base))
-                SourcesRow(citations)
-            }
+        Spacer(Modifier.height(Spacing.s))
+        RichMarkdown(report, Modifier.fillMaxWidth())
+
+        if (citations.isNotEmpty()) {
+            Spacer(Modifier.height(Spacing.base))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(Spacing.base))
+            SourcesRow(citations)
         }
     }
 }
@@ -296,9 +292,10 @@ fun EffortPill(effort: String, onSelect: (String) -> Unit, modifier: Modifier = 
 }
 
 /**
- * Adaptive renderer for a Data Agent result (a JSON string). Picks the cleanest shape:
- * an array of objects → stacked item cards; a single object → field rows; anything else →
- * markdown/plain text. The user never chooses "structured vs text".
+ * Adaptive renderer for a Data Agent result (a JSON string). Renders recursively so nested
+ * data reads cleanly: an array of objects becomes stacked item cards; a nested object becomes
+ * a titled section with indented label→value rows; primitives align in two columns; anything
+ * unparseable falls back to markdown. Plain background — no boxed grey card.
  */
 @Composable
 fun DataResultCard(
@@ -310,93 +307,114 @@ fun DataResultCard(
     val array = remember(json) { runCatching { JSONArray(json) }.getOrNull() }
     val obj = remember(json) { if (array == null) runCatching { JSONObject(json) }.getOrNull() else null }
 
-    Surface(
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        Column(Modifier.padding(Spacing.base)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Science, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.width(Spacing.s))
-                Text(
-                    "Data result",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.weight(1f),
-                )
-                FilledTonalIconButton(
-                    onClick = onCopy,
-                    modifier = Modifier.size(32.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp)) }
-            }
-            Spacer(Modifier.height(Spacing.m))
+    Column(modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Science, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                "Data result",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+            FilledTonalIconButton(
+                onClick = onCopy,
+                modifier = Modifier.size(30.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(15.dp)) }
+        }
+        Spacer(Modifier.height(Spacing.m))
 
-            when {
-                array != null -> Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
-                    for (i in 0 until array.length()) {
-                        when (val item = array.opt(i)) {
-                            is JSONObject -> JsonObjectCard(item)
-                            else -> Text("• ${item}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
-                        }
-                    }
-                }
-                obj != null -> JsonObjectCard(obj, flat = true)
-                else -> RichMarkdown(json, Modifier.fillMaxWidth())
-            }
+        when {
+            array != null -> JsonArrayView(array, Modifier.fillMaxWidth())
+            obj != null -> JsonObjectView(obj, Modifier.fillMaxWidth())
+            else -> RichMarkdown(json, Modifier.fillMaxWidth())
+        }
 
-            if (citations.isNotEmpty()) {
-                Spacer(Modifier.height(Spacing.base))
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                Spacer(Modifier.height(Spacing.base))
-                SourcesRow(citations)
-            }
+        if (citations.isNotEmpty()) {
+            Spacer(Modifier.height(Spacing.base))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(Spacing.base))
+            SourcesRow(citations)
         }
     }
 }
 
-/** One object rendered as label → value rows; nested arrays/objects are shown compactly. */
+/** Renders any JSON value, recursing into objects/arrays. */
 @Composable
-private fun JsonObjectCard(obj: JSONObject, flat: Boolean = false) {
-    val content: @Composable ColumnScope.() -> Unit = {
-        val keys = obj.keys()
-        keys.forEach { key ->
+private fun JsonValue(value: Any?, modifier: Modifier = Modifier) {
+    when (value) {
+        null, JSONObject.NULL -> Text("—", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = modifier)
+        is JSONObject -> JsonObjectView(value, modifier)
+        is JSONArray -> JsonArrayView(value, modifier)
+        else -> Text(value.toString(), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface, modifier = modifier)
+    }
+}
+
+/** Object → for each key: nested groups become titled sections, leaves become label→value rows. */
+@Composable
+private fun JsonObjectView(obj: JSONObject, modifier: Modifier = Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+        obj.keys().forEach { key ->
             val value = obj.opt(key)
-            Row(Modifier.padding(vertical = 3.dp)) {
-                Text(
-                    prettyKey(key),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.widthIn(min = 96.dp).weight(0.4f),
-                )
-                Text(
-                    stringifyJson(value),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(0.6f),
-                )
+            val nested = value is JSONObject || (value is JSONArray && arrayHasObjects(value))
+            if (nested) {
+                Column {
+                    Text(
+                        prettyKey(key),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Box(Modifier.padding(start = Spacing.m, top = Spacing.xs)) { JsonValue(value) }
+                }
+            } else {
+                Row(verticalAlignment = Alignment.Top) {
+                    Text(
+                        prettyKey(key),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(0.4f).padding(end = Spacing.s),
+                    )
+                    JsonValue(value, Modifier.weight(0.6f))
+                }
             }
         }
     }
-    if (flat) {
-        Column(content = content)
+}
+
+/** Array → object elements become stacked item cards; primitives become a bullet list. */
+@Composable
+private fun JsonArrayView(arr: JSONArray, modifier: Modifier = Modifier) {
+    if (arrayHasObjects(arr)) {
+        Column(modifier, verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+            for (i in 0 until arr.length()) {
+                val item = arr.opt(i)
+                Surface(
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Box(Modifier.padding(Spacing.m)) { JsonValue(item) }
+                }
+            }
+        }
     } else {
-        Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerHigh, modifier = Modifier.fillMaxWidth()) {
-            Column(Modifier.padding(Spacing.m), content = content)
+        Column(modifier) {
+            for (i in 0 until arr.length()) {
+                Row(Modifier.padding(vertical = 2.dp)) {
+                    Text("•  ", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+                    Text(arr.opt(i)?.toString() ?: "—", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
         }
     }
 }
+
+private fun arrayHasObjects(arr: JSONArray): Boolean =
+    (0 until arr.length()).any { arr.opt(it) is JSONObject }
 
 private fun prettyKey(key: String): String =
     key.replace('_', ' ').replace(Regex("([a-z])([A-Z])"), "$1 $2").replaceFirstChar { it.uppercase() }
-
-private fun stringifyJson(value: Any?): String = when (value) {
-    null, JSONObject.NULL -> "—"
-    is JSONArray -> (0 until value.length()).joinToString(", ") { stringifyJson(value.opt(it)) }
-    is JSONObject -> value.keys().asSequence().joinToString(", ") { "${prettyKey(it)}: ${stringifyJson(value.opt(it))}" }
-    else -> value.toString()
-}
 
 /** A removable capability chip shown above the input (Search / Deep Research / file). */
 @Composable

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.echoflow.data.ChatMessage
+import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
@@ -69,6 +70,8 @@ import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.BrandMark
 import com.echoflow.ui.components.CapabilityChip
+import com.echoflow.ui.components.DataResultCard
+import com.echoflow.ui.components.EffortPill
 import com.echoflow.ui.components.MarkdownText
 import com.echoflow.ui.components.ReportCard
 import com.echoflow.ui.components.ResearchProgressCard
@@ -113,12 +116,16 @@ fun ChatScreen(
 
     val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
     val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
+    val dataAgentActive by chatViewModel.dataAgentActive.collectAsState()
     val researchRun by chatViewModel.currentResearchRun.collectAsState()
     val drModelId by settingsViewModel.deepResearchModelId.collectAsState()
     val drModels by settingsViewModel.deepResearchModels.collectAsState()
     val exaKey by settingsViewModel.exaApiKey.collectAsState()
     val parallelKey by settingsViewModel.parallelApiKey.collectAsState()
     val firecrawlKey by settingsViewModel.firecrawlApiKey.collectAsState()
+    val exaEffort by settingsViewModel.deepResearchExaEffort.collectAsState()
+    val dataAgentEnabled by settingsViewModel.dataAgentEnabled.collectAsState()
+    val dataAgentEngineId by settingsViewModel.dataAgentEngine.collectAsState()
 
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
@@ -128,6 +135,10 @@ fun ChatScreen(
             ?: drModels.firstOrNull { it.id == drModelId }?.name
             ?: if (drModelId.isBlank()) "Choose engine" else drModelId
     }
+    val dataAgentLabel = remember(dataAgentEngineId) {
+        DataAgentCatalog.byId(dataAgentEngineId)?.name ?: "Choose agent"
+    }
+    val dataAgentAvailable = dataAgentEnabled && firecrawlKey.isNotBlank()
 
     val activeModelList = remember(customModelsList) {
         val list = mutableListOf(DEFAULT_MODEL)
@@ -188,8 +199,12 @@ fun ChatScreen(
             // Floating, transparent top bar (chat scrolls behind it).
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
-                modelName = if (deepResearchActive) drEngineLabel else modelShortName,
-                researchMode = deepResearchActive,
+                modelName = when {
+                    dataAgentActive -> dataAgentLabel
+                    deepResearchActive -> drEngineLabel
+                    else -> modelShortName
+                },
+                researchMode = deepResearchActive || dataAgentActive,
                 onMenu = onMenuClicked,
                 onModel = { showModelMenu = true },
                 onNewChat = { chatViewModel.startNewChat() },
@@ -209,12 +224,19 @@ fun ChatScreen(
                 isStreaming = isStreaming,
                 deepResearchActive = deepResearchActive,
                 webSearchChipOn = webSearchChipOn,
+                dataAgentActive = dataAgentActive,
+                dataAgentAvailable = dataAgentAvailable,
                 onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
                 onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
+                onToggleDataAgent = { chatViewModel.toggleDataAgent() },
                 researchInProgress = researchRun != null,
                 researchEngineLabel = drEngineLabel,
+                dataAgentLabel = dataAgentLabel,
+                showEffortPill = deepResearchActive && drModelId == "exa-agent",
+                exaEffort = exaEffort,
+                onSelectEffort = { settingsViewModel.saveDeepResearchExaEffort(it) },
                 blockedReason = when {
-                    researchRun != null -> "Research in progress — see the card above"
+                    researchRun != null -> "A run is in progress — see the card above"
                     localSendBlocked -> "On-device model is busy in another chat"
                     else -> null
                 },
@@ -234,7 +256,22 @@ fun ChatScreen(
     }
 
     if (showModelMenu) {
-        if (deepResearchActive) {
+        if (dataAgentActive) {
+            val dataEngines = remember(firecrawlKey) {
+                if (firecrawlKey.isNotBlank()) DataAgentCatalog.engines else emptyList()
+            }
+            DeepResearchModelSheet(
+                title = "Data Agent engine",
+                subtitle = "Firecrawl agents that extract data from the web",
+                providerEngines = dataEngines,
+                agentModels = emptyList(),
+                showAgentSection = false,
+                selectedId = dataAgentEngineId,
+                onSelect = { settingsViewModel.saveDataAgentEngine(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (deepResearchActive) {
             val availableProviderEngines = remember(exaKey, parallelKey, firecrawlKey) {
                 DeepResearchCatalog.providerEngines.filter { eng ->
                     when (eng.provider) {
@@ -555,6 +592,14 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                                 )
                                 if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                             }
+                            "data" -> {
+                                DataResultCard(
+                                    json = segment.text.orEmpty(),
+                                    citations = reportCitations,
+                                    onCopy = onCopy,
+                                )
+                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                            }
                             else -> {
                                 RichMarkdown(segment.text.orEmpty(), Modifier.fillMaxWidth())
                                 if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
@@ -784,10 +829,17 @@ private fun InputToolbar(
     isStreaming: Boolean,
     deepResearchActive: Boolean,
     webSearchChipOn: Boolean,
+    dataAgentActive: Boolean,
+    dataAgentAvailable: Boolean,
     onToggleDeepResearch: () -> Unit,
     onToggleWebSearch: () -> Unit,
+    onToggleDataAgent: () -> Unit,
     researchInProgress: Boolean,
     researchEngineLabel: String?,
+    dataAgentLabel: String,
+    showEffortPill: Boolean,
+    exaEffort: String,
+    onSelectEffort: (String) -> Unit,
     blockedReason: String? = null,
     onSend: () -> Unit,
     modifier: Modifier = Modifier,
@@ -816,7 +868,7 @@ private fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -831,6 +883,15 @@ private fun InputToolbar(
                         researchEngineLabel?.takeIf { it.isNotBlank() && it != "Choose engine" }?.let { "Research · $it" } ?: "Deep Research",
                         onRemove = onToggleDeepResearch,
                     )
+                    // Exa Agent's depth/cost dial lives here, not in the engine list.
+                    if (showEffortPill) EffortPill(effort = exaEffort, onSelect = onSelectEffort)
+                }
+                if (dataAgentActive) {
+                    CapabilityChip(
+                        Icons.Default.Science,
+                        dataAgentLabel.takeIf { it.isNotBlank() && it != "Choose agent" }?.let { "Data Agent · $it" } ?: "Data Agent",
+                        onRemove = onToggleDataAgent,
+                    )
                 }
             }
         }
@@ -843,9 +904,10 @@ private fun InputToolbar(
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
             )
         }
-        AnimatedVisibility(visible = deepResearchActive && blockedReason == null) {
+        AnimatedVisibility(visible = (deepResearchActive || dataAgentActive) && blockedReason == null) {
             Text(
-                "Runs in the background · multiple searches · a few minutes",
+                if (dataAgentActive) "Collects data into a table · runs in the background"
+                else "Runs in the background · multiple searches · a few minutes",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
@@ -878,16 +940,27 @@ private fun InputToolbar(
                         onDismiss = { plusMenuOpen = false },
                         webSearchOn = webSearchChipOn,
                         deepResearchOn = deepResearchActive,
+                        dataAgentOn = dataAgentActive,
+                        dataAgentAvailable = dataAgentAvailable,
                         onImage = { plusMenuOpen = false; onAttach() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
                         onToggleDeepResearch = { plusMenuOpen = false; onToggleDeepResearch() },
+                        onToggleDataAgent = { plusMenuOpen = false; onToggleDataAgent() },
                     )
                 }
 
                 TextField(
                     value = text,
                     onValueChange = onText,
-                    placeholder = { Text(if (deepResearchActive) "Research a topic…" else "Ask anything…") },
+                    placeholder = {
+                        Text(
+                            when {
+                                dataAgentActive -> "Describe the data to extract…"
+                                deepResearchActive -> "Research a topic…"
+                                else -> "Ask anything…"
+                            }
+                        )
+                    },
                     maxLines = 6,
                     colors = TextFieldDefaults.colors(
                         focusedContainerColor = Color.Transparent,
@@ -901,9 +974,10 @@ private fun InputToolbar(
                     modifier = Modifier.weight(1f).testTag("chat_input_field"),
                 )
 
-                val hasContent = text.trim().isNotEmpty() || (pendingUri != null && !deepResearchActive)
+                val researchMode = deepResearchActive || dataAgentActive
+                val hasContent = text.trim().isNotEmpty() || (pendingUri != null && !researchMode)
                 val canSend = hasContent && !isStreaming && !researchInProgress && blockedReason == null
-                SendButton(enabled = canSend, isStreaming = isStreaming, research = deepResearchActive) {
+                SendButton(enabled = canSend, isStreaming = isStreaming, research = researchMode) {
                     if (canSend) onSend()
                 }
             }
@@ -918,9 +992,12 @@ private fun PlusMenu(
     onDismiss: () -> Unit,
     webSearchOn: Boolean,
     deepResearchOn: Boolean,
+    dataAgentOn: Boolean,
+    dataAgentAvailable: Boolean,
     onImage: () -> Unit,
     onToggleWebSearch: () -> Unit,
     onToggleDeepResearch: () -> Unit,
+    onToggleDataAgent: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         DropdownMenuItem(
@@ -940,6 +1017,15 @@ private fun PlusMenu(
             trailingIcon = { if (deepResearchOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleDeepResearch,
         )
+        // Data Agent only appears once it's enabled in Settings and a Firecrawl key exists.
+        if (dataAgentAvailable) {
+            DropdownMenuItem(
+                text = { Text("Data Agent") },
+                leadingIcon = { Icon(Icons.Default.Dataset, null) },
+                trailingIcon = { if (dataAgentOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+                onClick = onToggleDataAgent,
+            )
+        }
     }
 }
 
@@ -1106,6 +1192,9 @@ private fun DeepResearchModelSheet(
     onSelect: (String) -> Unit,
     onManage: () -> Unit,
     onDismiss: () -> Unit,
+    title: String = "Deep Research engine",
+    subtitle: String = "Providers run research themselves; chat models orchestrate it",
+    showAgentSection: Boolean = true,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
@@ -1116,9 +1205,9 @@ private fun DeepResearchModelSheet(
         Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.l)) {
             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.base)) {
                 Column(Modifier.weight(1f)) {
-                    Text("Deep Research engine", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text(title, style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
                     Text(
-                        "Providers run research themselves; chat models orchestrate it",
+                        subtitle,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -1130,12 +1219,12 @@ private fun DeepResearchModelSheet(
                 }
             }
 
-            if (providerEngines.isEmpty() && agentModels.isEmpty()) {
+            if (providerEngines.isEmpty() && (!showAgentSection || agentModels.isEmpty())) {
                 Column(Modifier.fillMaxWidth().padding(vertical = Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
                     Icon(Icons.Default.Science, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     Spacer(Modifier.height(Spacing.s))
                     Text(
-                        "Nothing set up yet.\nAdd a search-provider key or a research model in Settings → Deep Research.",
+                        "Nothing set up yet.\nAdd a provider key (or model) in Settings.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
@@ -1149,12 +1238,12 @@ private fun DeepResearchModelSheet(
                 contentPadding = PaddingValues(bottom = Spacing.xl),
             ) {
                 if (providerEngines.isNotEmpty()) {
-                    item(key = "provider-section") { Box(Modifier.padding(top = Spacing.s)) { SectionLabel("Provider research") } }
+                    item(key = "provider-section") { Box(Modifier.padding(top = Spacing.s)) { SectionLabel(if (showAgentSection) "Provider research" else "Agents") } }
                     items(providerEngines, key = { it.id }) { engine ->
                         DrEngineRow(engine.name, engine.description, engine.id == selectedId) { onSelect(engine.id) }
                     }
                 }
-                if (agentModels.isNotEmpty()) {
+                if (showAgentSection && agentModels.isNotEmpty()) {
                     item(key = "agent-section") { Box(Modifier.padding(top = Spacing.m)) { SectionLabel("Your research models") } }
                     items(agentModels, key = { it.id }) { model ->
                         DrEngineRow(model.name, "Orchestrates searches into a report", model.id == selectedId) { onSelect(model.id) }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -59,12 +59,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.echoflow.data.ChatMessage
+import com.echoflow.data.DeepResearchCatalog
+import com.echoflow.data.DeepResearchModel
+import com.echoflow.data.DrEngine
+import com.echoflow.data.ResearchRun
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.BrandMark
+import com.echoflow.ui.components.CapabilityChip
 import com.echoflow.ui.components.MarkdownText
+import com.echoflow.ui.components.ReportCard
+import com.echoflow.ui.components.ResearchProgressCard
 import com.echoflow.ui.components.RichMarkdown
 import com.echoflow.ui.components.SearchActivityCard
 import com.echoflow.ui.components.SectionLabel
@@ -104,8 +111,23 @@ fun ChatScreen(
     val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
     val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
 
+    val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
+    val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
+    val researchRun by chatViewModel.currentResearchRun.collectAsState()
+    val drModelId by settingsViewModel.deepResearchModelId.collectAsState()
+    val drModels by settingsViewModel.deepResearchModels.collectAsState()
+    val exaKey by settingsViewModel.exaApiKey.collectAsState()
+    val parallelKey by settingsViewModel.parallelApiKey.collectAsState()
+    val firecrawlKey by settingsViewModel.firecrawlApiKey.collectAsState()
+
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
+
+    val drEngineLabel = remember(drModelId, drModels) {
+        DeepResearchCatalog.providerEngineById(drModelId)?.name
+            ?: drModels.firstOrNull { it.id == drModelId }?.name
+            ?: if (drModelId.isBlank()) "Choose engine" else drModelId
+    }
 
     val activeModelList = remember(customModelsList) {
         val list = mutableListOf(DEFAULT_MODEL)
@@ -154,6 +176,8 @@ fun ChatScreen(
                         statusNote = statusNote,
                         progressLoading = progressLoading,
                         modelLoading = localModelLoading,
+                        researchRun = researchRun,
+                        onCancelResearch = { chatViewModel.cancelResearch() },
                         topInset = topBarInset,
                         bottomInset = messageBottomInset,
                         onCopy = { clipboard.setText(AnnotatedString(it)) },
@@ -164,7 +188,8 @@ fun ChatScreen(
             // Floating, transparent top bar (chat scrolls behind it).
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
-                modelName = modelShortName,
+                modelName = if (deepResearchActive) drEngineLabel else modelShortName,
+                researchMode = deepResearchActive,
                 onMenu = onMenuClicked,
                 onModel = { showModelMenu = true },
                 onNewChat = { chatViewModel.startNewChat() },
@@ -182,7 +207,17 @@ fun ChatScreen(
                 onClearAttachment = { chatViewModel.clearPendingAttachment() },
                 onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
                 isStreaming = isStreaming,
-                blockedReason = if (localSendBlocked) "On-device model is busy in another chat" else null,
+                deepResearchActive = deepResearchActive,
+                webSearchChipOn = webSearchChipOn,
+                onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
+                onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
+                researchInProgress = researchRun != null,
+                researchEngineLabel = drEngineLabel,
+                blockedReason = when {
+                    researchRun != null -> "Research in progress — see the card above"
+                    localSendBlocked -> "On-device model is busy in another chat"
+                    else -> null
+                },
                 onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
             )
 
@@ -199,14 +234,35 @@ fun ChatScreen(
     }
 
     if (showModelMenu) {
-        ModelPickerSheet(
-            models = activeModelList,
-            localModels = localModelEntries,
-            selectedId = selectedModelID,
-            onSelect = { settingsViewModel.saveSelectedModel(it); showModelMenu = false },
-            onManage = { showModelMenu = false; onSettingsClicked() },
-            onDismiss = { showModelMenu = false },
-        )
+        if (deepResearchActive) {
+            val availableProviderEngines = remember(exaKey, parallelKey, firecrawlKey) {
+                DeepResearchCatalog.providerEngines.filter { eng ->
+                    when (eng.provider) {
+                        "exa" -> exaKey.isNotBlank()
+                        "parallel" -> parallelKey.isNotBlank()
+                        "firecrawl" -> firecrawlKey.isNotBlank()
+                        else -> false
+                    }
+                }
+            }
+            DeepResearchModelSheet(
+                providerEngines = availableProviderEngines,
+                agentModels = drModels,
+                selectedId = drModelId,
+                onSelect = { settingsViewModel.saveDeepResearchModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else {
+            ModelPickerSheet(
+                models = activeModelList,
+                localModels = localModelEntries,
+                selectedId = selectedModelID,
+                onSelect = { settingsViewModel.saveSelectedModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        }
     }
 }
 
@@ -223,6 +279,8 @@ private fun MessagesPane(
     statusNote: String?,
     progressLoading: Boolean,
     modelLoading: Boolean,
+    researchRun: ResearchRun?,
+    onCancelResearch: () -> Unit,
     topInset: Dp = Spacing.l,
     bottomInset: Dp = Spacing.l,
     onCopy: (String) -> Unit,
@@ -264,6 +322,9 @@ private fun MessagesPane(
     ) {
         items(messages, key = { it.id }) { msg ->
             MessageBubble(msg) { onCopy(msg.content) }
+        }
+        researchRun?.let { run ->
+            item(key = "research") { ResearchProgressCard(run = run, onCancel = onCancelResearch) }
         }
         if (modelLoading && segments.isEmpty()) {
             item { ModelLoadingRow() }
@@ -359,7 +420,7 @@ private fun StreamingAssistantBubble(
 }
 
 @Composable
-private fun ChatTopBar(modelName: String, onMenu: () -> Unit, onModel: () -> Unit, onNewChat: () -> Unit, modifier: Modifier = Modifier) {
+private fun ChatTopBar(modelName: String, researchMode: Boolean, onMenu: () -> Unit, onModel: () -> Unit, onNewChat: () -> Unit, modifier: Modifier = Modifier) {
     CenterAlignedTopAppBar(
         modifier = modifier,
         navigationIcon = {
@@ -372,9 +433,14 @@ private fun ChatTopBar(modelName: String, onMenu: () -> Unit, onModel: () -> Uni
         },
         title = {
             // Model selector as a Material 3 Expressive split button — both halves open the picker.
+            // In Deep Research mode it selects the research engine instead of the chat model.
             SplitButtonLayout(
                 leadingButton = {
                     SplitButtonDefaults.LeadingButton(onClick = onModel) {
+                        if (researchMode) {
+                            Icon(Icons.Default.Science, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                            Spacer(Modifier.width(Spacing.xs))
+                        }
                         Text(
                             modelName,
                             style = MaterialTheme.typography.titleSmall,
@@ -463,6 +529,11 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                     if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
                 }
                 persistedSegments.isNotEmpty() -> {
+                    val planSteps = remember(message.id) {
+                        persistedSegments.firstOrNull { it.type == "plan" }?.text
+                            ?.split("\n")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+                    }
+                    val reportCitations = remember(message.id) { ToolEventJson.citationsFromJson(message.citationsJson) }
                     persistedSegments.forEachIndexed { index, segment ->
                         when (segment.type) {
                             "reasoning" -> {
@@ -472,6 +543,17 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                             "search" -> {
                                 SearchActivityCard(query = segment.query.orEmpty(), sources = segment.sources.orEmpty(), active = false)
                                 Spacer(Modifier.height(Spacing.s))
+                            }
+                            // The plan is rendered as a disclosure inside the report card.
+                            "plan" -> Unit
+                            "report" -> {
+                                ReportCard(
+                                    report = segment.text.orEmpty(),
+                                    citations = reportCitations,
+                                    planSteps = planSteps,
+                                    onCopy = onCopy,
+                                )
+                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                             }
                             else -> {
                                 RichMarkdown(segment.text.orEmpty(), Modifier.fillMaxWidth())
@@ -700,6 +782,12 @@ private fun InputToolbar(
     onClearAttachment: () -> Unit,
     onAttach: () -> Unit,
     isStreaming: Boolean,
+    deepResearchActive: Boolean,
+    webSearchChipOn: Boolean,
+    onToggleDeepResearch: () -> Unit,
+    onToggleWebSearch: () -> Unit,
+    researchInProgress: Boolean,
+    researchEngineLabel: String?,
     blockedReason: String? = null,
     onSend: () -> Unit,
     modifier: Modifier = Modifier,
@@ -726,9 +814,38 @@ private fun InputToolbar(
                 }
             }
         }
+
+        // Active capability chips — always show what's on so behaviour is never hidden.
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                modifier = Modifier.padding(start = Spacing.s, bottom = Spacing.s),
+            ) {
+                if (webSearchChipOn) {
+                    CapabilityChip(Icons.Default.TravelExplore, "Web search", onRemove = onToggleWebSearch)
+                }
+                if (deepResearchActive) {
+                    CapabilityChip(
+                        Icons.Default.Science,
+                        researchEngineLabel?.takeIf { it.isNotBlank() && it != "Choose engine" }?.let { "Research · $it" } ?: "Deep Research",
+                        onRemove = onToggleDeepResearch,
+                    )
+                }
+            }
+        }
+
         AnimatedVisibility(visible = blockedReason != null) {
             Text(
                 blockedReason.orEmpty(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
+            )
+        }
+        AnimatedVisibility(visible = deepResearchActive && blockedReason == null) {
+            Text(
+                "Runs in the background · multiple searches · a few minutes",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
@@ -743,22 +860,34 @@ private fun InputToolbar(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Row(Modifier.padding(Spacing.s), verticalAlignment = Alignment.CenterVertically) {
-                ShapedIconButton(
-                    onClick = onAttach,
-                    enabled = true,
-                    size = 44.dp,
-                    restShape = MaterialShapes.Cookie6Sided,
-                    pressedShape = MaterialShapes.Flower,
-                    container = MaterialTheme.colorScheme.tertiaryContainer,
-                    pulseOnClick = true,
-                ) {
-                    Icon(Icons.Outlined.AddPhotoAlternate, "Attach image", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer)
+                var plusMenuOpen by remember { mutableStateOf(false) }
+                Box {
+                    ShapedIconButton(
+                        onClick = { plusMenuOpen = true },
+                        enabled = true,
+                        size = 44.dp,
+                        restShape = MaterialShapes.Cookie6Sided,
+                        pressedShape = MaterialShapes.Flower,
+                        container = MaterialTheme.colorScheme.tertiaryContainer,
+                        pulseOnClick = true,
+                    ) {
+                        Icon(Icons.Default.Add, "Add context or capability", Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer)
+                    }
+                    PlusMenu(
+                        expanded = plusMenuOpen,
+                        onDismiss = { plusMenuOpen = false },
+                        webSearchOn = webSearchChipOn,
+                        deepResearchOn = deepResearchActive,
+                        onImage = { plusMenuOpen = false; onAttach() },
+                        onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
+                        onToggleDeepResearch = { plusMenuOpen = false; onToggleDeepResearch() },
+                    )
                 }
 
                 TextField(
                     value = text,
                     onValueChange = onText,
-                    placeholder = { Text("Ask anything…") },
+                    placeholder = { Text(if (deepResearchActive) "Research a topic…" else "Ask anything…") },
                     maxLines = 6,
                     colors = TextFieldDefaults.colors(
                         focusedContainerColor = Color.Transparent,
@@ -772,9 +901,9 @@ private fun InputToolbar(
                     modifier = Modifier.weight(1f).testTag("chat_input_field"),
                 )
 
-                val hasContent = text.trim().isNotEmpty() || pendingUri != null
-                val canSend = hasContent && !isStreaming && blockedReason == null
-                SendButton(enabled = canSend, isStreaming = isStreaming) {
+                val hasContent = text.trim().isNotEmpty() || (pendingUri != null && !deepResearchActive)
+                val canSend = hasContent && !isStreaming && !researchInProgress && blockedReason == null
+                SendButton(enabled = canSend, isStreaming = isStreaming, research = deepResearchActive) {
                     if (canSend) onSend()
                 }
             }
@@ -782,8 +911,40 @@ private fun InputToolbar(
     }
 }
 
+/** The unified "+" menu: add context (image) or turn on a capability (search / research). */
 @Composable
-private fun SendButton(enabled: Boolean, isStreaming: Boolean, onClick: () -> Unit) {
+private fun PlusMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    webSearchOn: Boolean,
+    deepResearchOn: Boolean,
+    onImage: () -> Unit,
+    onToggleWebSearch: () -> Unit,
+    onToggleDeepResearch: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        DropdownMenuItem(
+            text = { Text("Image") },
+            leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
+            onClick = onImage,
+        )
+        DropdownMenuItem(
+            text = { Text("Web search") },
+            leadingIcon = { Icon(Icons.Default.TravelExplore, null) },
+            trailingIcon = { if (webSearchOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleWebSearch,
+        )
+        DropdownMenuItem(
+            text = { Text("Deep Research") },
+            leadingIcon = { Icon(Icons.Default.Science, null) },
+            trailingIcon = { if (deepResearchOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleDeepResearch,
+        )
+    }
+}
+
+@Composable
+private fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolean = false, onClick: () -> Unit) {
     if (isStreaming) {
         Box(
             Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHighest),
@@ -791,7 +952,7 @@ private fun SendButton(enabled: Boolean, isStreaming: Boolean, onClick: () -> Un
         ) { LoadingIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp)) }
     } else {
         // The hero action gets the boldest shape — a "Sunny" that morphs to a rounder cookie on
-        // press with an expressive (bouncy) spring.
+        // press with an expressive (bouncy) spring. In research mode it starts the investigation.
         ShapedIconButton(
             onClick = onClick,
             enabled = enabled,
@@ -801,7 +962,9 @@ private fun SendButton(enabled: Boolean, isStreaming: Boolean, onClick: () -> Un
             container = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHighest,
         ) {
             Icon(
-                Icons.AutoMirrored.Filled.Send, "Send", Modifier.size(20.dp),
+                if (research) Icons.Default.Science else Icons.AutoMirrored.Filled.Send,
+                if (research) "Start research" else "Send",
+                Modifier.size(20.dp),
                 tint = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
@@ -926,6 +1089,118 @@ private fun ModelPickerSheet(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Engine picker shown in Deep Research mode. Lists built-in provider-native engines (only
+ * those whose API key is configured) plus the user's added agentic chat models. Selecting
+ * one stores it as the active Deep Research engine.
+ */
+@Composable
+private fun DeepResearchModelSheet(
+    providerEngines: List<DrEngine>,
+    agentModels: List<DeepResearchModel>,
+    selectedId: String,
+    onSelect: (String) -> Unit,
+    onManage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.l)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.base)) {
+                Column(Modifier.weight(1f)) {
+                    Text("Deep Research engine", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Providers run research themselves; chat models orchestrate it",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                TextButton(onClick = onManage) {
+                    Icon(Icons.Default.Tune, null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(Spacing.s))
+                    Text("Manage")
+                }
+            }
+
+            if (providerEngines.isEmpty() && agentModels.isEmpty()) {
+                Column(Modifier.fillMaxWidth().padding(vertical = Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(Icons.Default.Science, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(
+                        "Nothing set up yet.\nAdd a search-provider key or a research model in Settings → Deep Research.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+
+            LazyColumn(
+                Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                contentPadding = PaddingValues(bottom = Spacing.xl),
+            ) {
+                if (providerEngines.isNotEmpty()) {
+                    item(key = "provider-section") { Box(Modifier.padding(top = Spacing.s)) { SectionLabel("Provider research") } }
+                    items(providerEngines, key = { it.id }) { engine ->
+                        DrEngineRow(engine.name, engine.description, engine.id == selectedId) { onSelect(engine.id) }
+                    }
+                }
+                if (agentModels.isNotEmpty()) {
+                    item(key = "agent-section") { Box(Modifier.padding(top = Spacing.m)) { SectionLabel("Your research models") } }
+                    items(agentModels, key = { it.id }) { model ->
+                        DrEngineRow(model.name, "Orchestrates searches into a report", model.id == selectedId) { onSelect(model.id) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrEngineRow(name: String, description: String, selected: Boolean, onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                Modifier.size(40.dp).clip(CircleShape).background(
+                    if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHighest
+                ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Science, null, Modifier.size(20.dp),
+                    tint = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(Spacing.base))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    name,
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (selected) Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.material.icons.filled.Visibility
@@ -76,6 +77,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
 import com.echoflow.data.CatalogEntry
+import com.echoflow.data.DeepResearchCatalog
+import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DownloadState
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelCatalog
@@ -118,6 +121,7 @@ private const val PageAppearance = "appearance"
 private const val PageCloudModels = "cloud_models"
 private const val PageWebSearch = "web_search"
 private const val PageLocalModels = "local_models"
+private const val PageDeepResearch = "deep_research"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -167,6 +171,7 @@ fun SettingsScreen(
             PageCloudModels -> CloudModelsPage(viewModel, onBack = { page = PageHome })
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
+            PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -188,6 +193,8 @@ private fun SettingsHomePage(
     val localModelsEnabled by viewModel.localModelsEnabled.collectAsState()
     val localModels by viewModel.localModels.collectAsState()
     val customModels by viewModel.customModels.collectAsState()
+    val deepResearchModelId by viewModel.deepResearchModelId.collectAsState()
+    val deepResearchModels by viewModel.deepResearchModels.collectAsState()
 
     val themeLabel = when (darkMode) {
         "light" -> "Light"
@@ -218,6 +225,12 @@ private fun SettingsHomePage(
         localModels.isEmpty() -> "On · No models installed yet"
         else -> "On · ${localModels.size} installed"
     }
+    val deepResearchSubtitle = when {
+        deepResearchModelId.isBlank() -> "No engine selected"
+        else -> DeepResearchCatalog.providerEngineById(deepResearchModelId)?.name
+            ?: deepResearchModels.firstOrNull { it.id == deepResearchModelId }?.name
+            ?: deepResearchModelId
+    }
 
     SettingsPageScaffold(title = "Settings", subtitle = "Make EchoFlow yours", onBack = onBackClicked) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
@@ -228,7 +241,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 4,
+                index = 0, count = 5,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -238,7 +251,7 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 4,
+                index = 1, count = 5,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -248,8 +261,18 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 4,
+                index = 2, count = 5,
                 onClick = { onOpen(PageWebSearch) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Science,
+                polygon = MaterialShapes.Cookie4Sided,
+                title = "Deep Research",
+                subtitle = deepResearchSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 3, count = 5,
+                onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
                 icon = Icons.Default.PhoneAndroid,
@@ -258,7 +281,7 @@ private fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 3, count = 4,
+                index = 4, count = 5,
                 onClick = { onOpen(PageLocalModels) },
             )
         }
@@ -934,6 +957,207 @@ private fun ProviderRow(
             if (selected) {
                 Spacer(Modifier.width(Spacing.s))
                 Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+// ── Deep Research ─────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun DeepResearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val searchProvider by viewModel.deepResearchSearchProvider.collectAsState()
+    val maxSearches by viewModel.deepResearchMaxSearches.collectAsState()
+    val maxSources by viewModel.deepResearchMaxSources.collectAsState()
+    val drModels by viewModel.deepResearchModels.collectAsState()
+    val exaKey by viewModel.exaApiKey.collectAsState()
+    val parallelKey by viewModel.parallelApiKey.collectAsState()
+    val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orResults by viewModel.orModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+
+    val detected = buildList {
+        if (exaKey.isNotBlank()) add("Exa")
+        if (parallelKey.isNotBlank()) add("Parallel")
+        if (firecrawlKey.isNotBlank()) add("Firecrawl")
+    }
+
+    SettingsPageScaffold(title = "Deep Research", subtitle = "Multi-step investigation mode", onBack = onBack) {
+        FormCard {
+            Text("What it is", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "An opt-in mode for questions that need real investigation. Turn it on from the " +
+                    "“+” menu in chat, then pick an engine: a provider (Exa, Parallel, Firecrawl) " +
+                    "that researches on its own, or one of your chat models that plans searches and " +
+                    "writes a cited report. It runs in the background and can take a few minutes.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection(
+            "Search provider",
+            "Used when a chat model orchestrates the research. Auto-detected from your Web search keys.",
+        )
+        ConnectedToggleRow(
+            options = listOf("auto" to "Auto", "exa" to "Exa", "parallel" to "Parallel", "firecrawl" to "Firecrawl"),
+            selected = searchProvider,
+            onSelect = viewModel::saveDeepResearchSearchProvider,
+        )
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            if (detected.isEmpty()) "No search keys saved yet — add one in Settings → Web search."
+            else "Detected: ${detected.joinToString(", ")}",
+            style = MaterialTheme.typography.bodySmall,
+            color = if (detected.isEmpty()) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Maximum searches", "More searches = deeper, slower, and pricier")
+        ConnectedToggleRow(
+            options = listOf("3" to "3", "5" to "5", "10" to "10"),
+            selected = maxSearches.toString(),
+            onSelect = { viewModel.saveDeepResearchMaxSearches(it.toInt()) },
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Maximum sources", "How many sources to gather before writing")
+        ConnectedToggleRow(
+            options = listOf("10" to "10", "20" to "20", "50" to "50"),
+            selected = maxSources.toString(),
+            onSelect = { viewModel.saveDeepResearchMaxSources(it.toInt()) },
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Research models", "Chat models allowed to orchestrate Deep Research — choose strong, tool-capable ones")
+        Button(
+            onClick = { showDirectory = true; viewModel.loadOpenRouterDirectory() },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Add a research model")
+        }
+        Spacer(Modifier.height(Spacing.m))
+        if (drModels.isEmpty()) {
+            Surface(
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(Modifier.fillMaxWidth().padding(Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(Icons.Default.Science, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(
+                        "No research models yet.\nProvider engines still work without one.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                drModels.forEachIndexed { index, model ->
+                    DeepResearchModelRow(
+                        model = model,
+                        index = index,
+                        count = drModels.size,
+                        onDelete = { viewModel.deleteDeepResearchModel(model.id) },
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("On-device")
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(40.dp).clip(RoundedPolygonShape(BrandShapes.avatarStart)).background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.PhoneAndroid, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant) }
+                Spacer(Modifier.width(Spacing.base))
+                Column(Modifier.weight(1f)) {
+                    Text("Local Deep Research", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Run research fully on-device — coming soon",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+                    Text(
+                        "Soon",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = Spacing.m, vertical = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+
+    if (showDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = drModels.map { it.id }.toSet(),
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> viewModel.addDeepResearchModel(info.id, info.name.substringAfter(": ")) },
+            onRemove = viewModel::deleteDeepResearchModel,
+            onDismiss = { showDirectory = false },
+        )
+    }
+}
+
+@Composable
+private fun DeepResearchModelRow(
+    model: DeepResearchModel,
+    index: Int,
+    count: Int,
+    onDelete: () -> Unit,
+) {
+    Surface(
+        shape = groupedItemShape(index, count),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Cookie4Sided)).background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center,
+            ) { Icon(Icons.Default.Science, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
+            Spacer(Modifier.width(Spacing.base))
+            Column(Modifier.weight(1f)) {
+                Text(model.name, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                Text(
+                    model.id,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -78,13 +78,13 @@ import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DeepResearchCatalog
-import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DownloadState
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelCatalog
 import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.components.GroupedItemGap
+import com.echoflow.ui.components.SectionLabel
 import com.echoflow.ui.components.groupedItemShape
 import com.echoflow.ui.theme.BrandShapes
 import com.echoflow.ui.theme.MorphPolygonShape
@@ -966,6 +966,7 @@ private fun ProviderRow(
 
 @Composable
 private fun DeepResearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val selectedEngineId by viewModel.deepResearchModelId.collectAsState()
     val searchProvider by viewModel.deepResearchSearchProvider.collectAsState()
     val maxSearches by viewModel.deepResearchMaxSearches.collectAsState()
     val maxSources by viewModel.deepResearchMaxSources.collectAsState()
@@ -980,74 +981,36 @@ private fun DeepResearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
     var showDirectory by remember { mutableStateOf(false) }
 
-    val detected = buildList {
-        if (exaKey.isNotBlank()) add("Exa")
-        if (parallelKey.isNotBlank()) add("Parallel")
-        if (firecrawlKey.isNotBlank()) add("Firecrawl")
+    fun keyFor(provider: String): String = when (provider) {
+        "exa" -> exaKey
+        "parallel" -> parallelKey
+        "firecrawl" -> firecrawlKey
+        else -> ""
     }
+    // Provider-native engines appear purely based on which provider keys exist — never tied
+    // to the chat-model search-provider choice below.
+    val providerEngines = DeepResearchCatalog.providerEngines.filter { keyFor(it.provider).isNotBlank() }
 
     SettingsPageScaffold(title = "Deep Research", subtitle = "Multi-step investigation mode", onBack = onBack) {
         FormCard {
-            Text("What it is", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            Text("Two ways to research", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
             Spacer(Modifier.height(Spacing.s))
             Text(
-                "An opt-in mode for questions that need real investigation. Turn it on from the " +
-                    "“+” menu in chat, then pick an engine: a provider (Exa, Parallel, Firecrawl) " +
-                    "that researches on its own, or one of your chat models that plans searches and " +
-                    "writes a cited report. It runs in the background and can take a few minutes.",
+                "1. A provider (Exa, Parallel, Firecrawl) researches on its own — add that " +
+                    "provider's key in Web search and its engines show up below.\n" +
+                    "2. A chat model orchestrates — it plans searches, runs them through a search " +
+                    "provider, and writes a cited report.\n\n" +
+                    "Pick a default engine below. You can also switch it from the “+” menu in chat. " +
+                    "Runs happen in the background and can take a few minutes.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
 
         Spacer(Modifier.height(Spacing.xl))
-        PageSection(
-            "Search provider",
-            "Used when a chat model orchestrates the research. Auto-detected from your Web search keys.",
-        )
-        ConnectedToggleRow(
-            options = listOf("auto" to "Auto", "exa" to "Exa", "parallel" to "Parallel", "firecrawl" to "Firecrawl"),
-            selected = searchProvider,
-            onSelect = viewModel::saveDeepResearchSearchProvider,
-        )
-        Spacer(Modifier.height(Spacing.s))
-        Text(
-            if (detected.isEmpty()) "No search keys saved yet — add one in Settings → Web search."
-            else "Detected: ${detected.joinToString(", ")}",
-            style = MaterialTheme.typography.bodySmall,
-            color = if (detected.isEmpty()) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = Spacing.xs),
-        )
+        PageSection("Default engine", "What runs when you start Deep Research")
 
-        Spacer(Modifier.height(Spacing.xl))
-        PageSection("Maximum searches", "More searches = deeper, slower, and pricier")
-        ConnectedToggleRow(
-            options = listOf("3" to "3", "5" to "5", "10" to "10"),
-            selected = maxSearches.toString(),
-            onSelect = { viewModel.saveDeepResearchMaxSearches(it.toInt()) },
-        )
-
-        Spacer(Modifier.height(Spacing.xl))
-        PageSection("Maximum sources", "How many sources to gather before writing")
-        ConnectedToggleRow(
-            options = listOf("10" to "10", "20" to "20", "50" to "50"),
-            selected = maxSources.toString(),
-            onSelect = { viewModel.saveDeepResearchMaxSources(it.toInt()) },
-        )
-
-        Spacer(Modifier.height(Spacing.xl))
-        PageSection("Research models", "Chat models allowed to orchestrate Deep Research — choose strong, tool-capable ones")
-        Button(
-            onClick = { showDirectory = true; viewModel.loadOpenRouterDirectory() },
-            shape = CircleShape,
-            modifier = Modifier.fillMaxWidth().height(52.dp),
-        ) {
-            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
-            Spacer(Modifier.width(Spacing.s))
-            Text("Add a research model")
-        }
-        Spacer(Modifier.height(Spacing.m))
-        if (drModels.isEmpty()) {
+        if (providerEngines.isEmpty() && drModels.isEmpty()) {
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
                 color = MaterialTheme.colorScheme.surfaceContainer,
@@ -1057,25 +1020,96 @@ private fun DeepResearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                     Icon(Icons.Default.Science, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     Spacer(Modifier.height(Spacing.s))
                     Text(
-                        "No research models yet.\nProvider engines still work without one.",
+                        "Nothing available yet.\nAdd an Exa, Parallel or Firecrawl key in Web search,\nor add a research model below.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
                     )
                 }
             }
-        } else {
+        }
+
+        if (providerEngines.isNotEmpty()) {
+            SectionLabel("Run directly by a provider")
             Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
-                drModels.forEachIndexed { index, model ->
-                    DeepResearchModelRow(
-                        model = model,
-                        index = index,
-                        count = drModels.size,
+                providerEngines.forEach { engine ->
+                    DrEngineSelectRow(
+                        name = engine.name,
+                        subtitle = engine.description,
+                        selected = engine.id == selectedEngineId,
+                        onClick = { viewModel.saveDeepResearchModel(engine.id) },
+                    )
+                }
+            }
+            Spacer(Modifier.height(Spacing.m))
+        }
+
+        SectionLabel("Run by a chat model")
+        if (drModels.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                drModels.forEach { model ->
+                    DrEngineSelectRow(
+                        name = model.name,
+                        subtitle = model.id,
+                        selected = model.id == selectedEngineId,
+                        onClick = { viewModel.saveDeepResearchModel(model.id) },
                         onDelete = { viewModel.deleteDeepResearchModel(model.id) },
                     )
                 }
             }
+            Spacer(Modifier.height(Spacing.s))
         }
+        FilledTonalButton(
+            onClick = { showDirectory = true; viewModel.loadOpenRouterDirectory() },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Add a research model")
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Chat-model options", "Only used when a chat model runs the research")
+
+        SectionLabel("Search provider")
+        ConnectedToggleRow(
+            options = listOf("auto" to "Auto", "exa" to "Exa", "parallel" to "Parallel", "firecrawl" to "Firecrawl"),
+            selected = searchProvider,
+            onSelect = viewModel::saveDeepResearchSearchProvider,
+        )
+        Spacer(Modifier.height(Spacing.s))
+        // Per-selection feedback: show whether the *chosen* provider actually has a key.
+        val autoResolved = listOf("exa", "parallel", "firecrawl").firstOrNull { keyFor(it).isNotBlank() }
+        val searchMissing = if (searchProvider == "auto") autoResolved == null else keyFor(searchProvider).isBlank()
+        val searchStatus = when {
+            searchProvider == "auto" && autoResolved == null -> "No search keys yet — add one in Settings → Web search"
+            searchProvider == "auto" -> "Using ${autoResolved!!.replaceFirstChar { it.uppercase() }} — first key found"
+            searchMissing -> "No ${searchProvider.replaceFirstChar { it.uppercase() }} key — add it in Settings → Web search"
+            else -> "${searchProvider.replaceFirstChar { it.uppercase() }} key found"
+        }
+        Text(
+            searchStatus,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (searchMissing) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
+
+        Spacer(Modifier.height(Spacing.base))
+        SectionLabel("Maximum searches")
+        ConnectedToggleRow(
+            options = listOf("3" to "3", "5" to "5", "10" to "10"),
+            selected = maxSearches.toString(),
+            onSelect = { viewModel.saveDeepResearchMaxSearches(it.toInt()) },
+        )
+
+        Spacer(Modifier.height(Spacing.base))
+        SectionLabel("Maximum sources")
+        ConnectedToggleRow(
+            options = listOf("10" to "10", "20" to "20", "50" to "50"),
+            selected = maxSources.toString(),
+            onSelect = { viewModel.saveDeepResearchMaxSources(it.toInt()) },
+        )
 
         Spacer(Modifier.height(Spacing.xl))
         PageSection("On-device")
@@ -1126,16 +1160,22 @@ private fun DeepResearchPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     }
 }
 
+/**
+ * A selectable Deep Research engine row (provider engine or chat model). Tapping it makes
+ * that engine the default; the optional trash affordance removes an added chat model.
+ */
 @Composable
-private fun DeepResearchModelRow(
-    model: DeepResearchModel,
-    index: Int,
-    count: Int,
-    onDelete: () -> Unit,
+private fun DrEngineSelectRow(
+    name: String,
+    subtitle: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onDelete: (() -> Unit)? = null,
 ) {
     Surface(
-        shape = groupedItemShape(index, count),
-        color = MaterialTheme.colorScheme.surfaceContainer,
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
@@ -1143,21 +1183,38 @@ private fun DeepResearchModelRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
-                Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Cookie4Sided)).background(MaterialTheme.colorScheme.secondaryContainer),
+                Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Cookie4Sided)).background(
+                    if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer
+                ),
                 contentAlignment = Alignment.Center,
-            ) { Icon(Icons.Default.Science, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
+            ) {
+                Icon(
+                    Icons.Default.Science, null, Modifier.size(20.dp),
+                    tint = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
             Spacer(Modifier.width(Spacing.base))
             Column(Modifier.weight(1f)) {
-                Text(model.name, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
                 Text(
-                    model.id,
+                    name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    subtitle,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1, overflow = TextOverflow.Ellipsis,
                 )
             }
-            IconButton(onClick = onDelete) {
-                Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
+            if (selected) {
+                Icon(Icons.Default.CheckCircle, "Selected", Modifier.padding(horizontal = Spacing.xs), tint = MaterialTheme.colorScheme.onPrimaryContainer)
+            }
+            if (onDelete != null) {
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
+                }
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Dataset
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandMore
@@ -77,6 +78,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
 import com.echoflow.data.CatalogEntry
+import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DownloadState
 import com.echoflow.data.LocalModel
@@ -122,6 +124,7 @@ private const val PageCloudModels = "cloud_models"
 private const val PageWebSearch = "web_search"
 private const val PageLocalModels = "local_models"
 private const val PageDeepResearch = "deep_research"
+private const val PageDataAgent = "data_agent"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -172,6 +175,7 @@ fun SettingsScreen(
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
+            PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageHome })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -195,6 +199,8 @@ private fun SettingsHomePage(
     val customModels by viewModel.customModels.collectAsState()
     val deepResearchModelId by viewModel.deepResearchModelId.collectAsState()
     val deepResearchModels by viewModel.deepResearchModels.collectAsState()
+    val dataAgentEnabled by viewModel.dataAgentEnabled.collectAsState()
+    val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
 
     val themeLabel = when (darkMode) {
         "light" -> "Light"
@@ -231,6 +237,10 @@ private fun SettingsHomePage(
             ?: deepResearchModels.firstOrNull { it.id == deepResearchModelId }?.name
             ?: deepResearchModelId
     }
+    val dataAgentSubtitle = when {
+        !dataAgentEnabled -> "Off"
+        else -> DataAgentCatalog.byId(dataAgentEngine)?.name ?: "On"
+    }
 
     SettingsPageScaffold(title = "Settings", subtitle = "Make EchoFlow yours", onBack = onBackClicked) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
@@ -241,7 +251,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 5,
+                index = 0, count = 6,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -251,7 +261,7 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 5,
+                index = 1, count = 6,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -261,7 +271,7 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 5,
+                index = 2, count = 6,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -271,8 +281,18 @@ private fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 3, count = 5,
+                index = 3, count = 6,
                 onClick = { onOpen(PageDeepResearch) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Dataset,
+                polygon = BrandShapes.avatarEnd, // Clover4Leaf
+                title = "Data Agent",
+                subtitle = dataAgentSubtitle,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                index = 4, count = 6,
+                onClick = { onOpen(PageDataAgent) },
             )
             SettingsNavRow(
                 icon = Icons.Default.PhoneAndroid,
@@ -281,7 +301,7 @@ private fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 4, count = 5,
+                index = 5, count = 6,
                 onClick = { onOpen(PageLocalModels) },
             )
         }
@@ -1215,6 +1235,95 @@ private fun DrEngineSelectRow(
                 IconButton(onClick = onDelete) {
                     Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
                 }
+            }
+        }
+    }
+}
+
+// ── Data Agent ────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun DataAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val enabled by viewModel.dataAgentEnabled.collectAsState()
+    val selectedEngine by viewModel.dataAgentEngine.collectAsState()
+    val maxCredits by viewModel.dataAgentMaxCredits.collectAsState()
+    val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
+
+    SettingsPageScaffold(title = "Data Agent", subtitle = "Extract data from the web", onBack = onBack) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text("Data Agent", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Collect data from the web into a clean table",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(checked = enabled, onCheckedChange = viewModel::saveDataAgentEnabled)
+            }
+        }
+
+        AnimatedVisibility(visible = enabled, enter = sectionEnter(), exit = sectionExit()) {
+            Column {
+                Spacer(Modifier.height(Spacing.xl))
+                FormCard {
+                    Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(
+                        "Tell it the data you want — pricing, specs, lists, contacts — and the Firecrawl " +
+                            "agent searches the web and returns it as a table. Use Deep Research instead when " +
+                            "you want an explanation or report. It runs in the background and uses Firecrawl " +
+                            "credits, so a spending limit is enforced.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Agent model", "Faster is cheaper; Accurate handles complex, multi-site tasks")
+                if (firecrawlKey.isBlank()) {
+                    Surface(
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(Modifier.fillMaxWidth().padding(Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(Icons.Default.Key, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Spacer(Modifier.height(Spacing.s))
+                            Text(
+                                "Add your Firecrawl API key in Settings → Web search to use the Data Agent.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                        DataAgentCatalog.engines.forEach { engine ->
+                            DrEngineSelectRow(
+                                name = engine.name,
+                                subtitle = engine.description,
+                                selected = engine.id == selectedEngine,
+                                onClick = { viewModel.saveDataAgentEngine(engine.id) },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Spending limit", "Caps how many Firecrawl credits a single run may use")
+                ConnectedToggleRow(
+                    options = listOf("1000" to "Low", "2500" to "Standard", "10000" to "High"),
+                    selected = maxCredits.toString(),
+                    onSelect = { viewModel.saveDataAgentMaxCredits(it.toInt()) },
+                )
             }
         }
     }


### PR DESCRIPTION
## What

Adds an opt-in, power-user **Deep Research** mode alongside normal chat. It stays chat-first/BYOK-first — Deep Research is a deliberate per-question toggle in a new unified **`+`** menu, never the default.

Two execution kinds, both orchestrated by a **foreground service** that persists progress to Room (the single source of truth), so a run survives the app being minimized or killed and resumes on next launch:

- **Provider-native** (provider does the research):
  - **Exa** — synchronous `POST /search` with `type: deep-reasoning|deep|deep-lite` + `outputSchema:{type:text}` (one call, ~12–40s, no polling). Report from `output.content`, sources from `results[]`.
  - **Parallel** — `POST /v1/tasks/runs` → poll status → `GET …/result`. Report from `output.content`, sources from `output.basis[].citations[]`.
  - **Firecrawl** — legacy `POST /v1/deep-research` + poll (still live). The modern search→scrape→analyze pattern is covered by agentic mode below.
- **Agentic** (a cloud chat model orchestrates): the model plans sub-questions, each search runs locally via the existing `WebSearchService`, then the model synthesizes a cited report. These models are added separately from normal chat models.

## Why

Some questions (comparisons, market/option research) genuinely need multi-step investigation that a single chat turn can't do well. This makes that a first-class, transparent mode without changing the default chat experience.

## Changes

- **Data**: `ResearchRun` + `DeepResearchModel` entities, DAOs, `AppDatabase` **migration v4 → v5**.
- **Engine/Service**: `DeepResearchEngine` (provider + agentic), `DeepResearchForegroundService` (ongoing notification with progress + **Cancel**, resume of interrupted runs), `OpenRouterService.complete()`, deep-research prompts in `SystemPrompts`.
- **UI**: unified `+` menu (Image / Web search / Deep Research) replacing the attach button; active-capability **chips**; research-aware **engine picker**; live `ResearchProgressCard` (plan checklist, accumulating sources); dedicated `ReportCard` (sections, collapsible "how this was researched", sources, copy).
- **Settings**: new **Deep Research** page — search provider (auto/Exa/Parallel/Firecrawl, auto-detected from Web search keys), max searches/sources, add research models (via the OpenRouter directory), and a local "coming soon" row.
- **Web search `+` toggle**: force-enables search for one message using the last-used provider (no Settings trip); mutually exclusive with Deep Research.

## Reviewer notes

- **Cloud-only** for now; local Deep Research is intentionally a disabled "coming soon" entry.
- DB schema version bumps to **5** (additive migration; existing data preserved).
- The app can't be built from the CLI in this environment — **needs an Android Studio build** to verify, and the provider calls should be exercised against live keys. Provider JSON parsing is defensive, but live field names are the most likely thing to need a minor tweak. The Exa `/search` path is the only provider integration whose shape changed during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Deep Research mode with provider-native and agentic cloud research engines
> - Introduces a `DeepResearchForegroundService` that orchestrates long-running research runs off-UI, persists progress to Room, posts live progress notifications with cancel actions, resumes interrupted runs on app launch, and writes final assistant messages on completion/failure.
> - Adds a `DeepResearchEngine` that supports three execution paths: provider-native (Exa, Parallel, Firecrawl), agentic (OpenRouter planning + web search + synthesis), and Firecrawl Data Agent, all emitting a `ResearchEvent` flow with progress, cost, sources, and final report or structured JSON.
> - Adds `research_runs` and `deep_research_models` Room tables (schema v4→v6) with DAOs for persisting run state and user-added chat models.
> - Extends the chat screen with Deep Research and Data Agent capability chips, a `+` menu to toggle modes, a dedicated engine/model picker sheet, and a live `ResearchProgressCard` showing plan steps, sources, and a cancel action.
> - Adds `ReportCard` and `DataResultCard` message renderers so completed research results appear as structured assistant messages with citations and collapsible plan steps.
> - Extends Settings with `DeepResearchPage` (engine selection, search provider, limits) and `DataAgentPage` (enable toggle, engine, spending cap) backed by new `SettingsViewModel` and `SettingsRepository` accessors.
> - Risk: `DeepResearchForegroundService` uses `FOREGROUND_SERVICE_TYPE_DATA_SYNC` and requires `POST_NOTIFICATIONS` on Android 13+; missing permissions or API keys are surfaced as failed run states rather than preventing service start.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7127d02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added **Deep Research** and **Data Agent** capabilities with configurable engines/providers, including Exa Agent effort selection.
* Introduced **durable research runs** running in the background, with in-chat **progress UI**, **cancellation**, and **automatic resume** for interrupted runs.
* Integrated **research outputs** into chat as a report with **citations**, **plan recap**, and **copy** options (including structured data rendering for data-agent results).
* Expanded **settings and model management** for Deep Research (engine/model selection, max searches/sources, and Data Agent enablement/credits).
* Added **notification permission** handling on Android 13+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->