### PR TITLE
Add GGUF local model support and expand inference settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.logging.interceptor)
   implementation(libs.litertlm.android)
+  implementation(libs.llamacpp.kotlin)
   implementation(libs.mediapipe.tasks.genai)
   implementation(libs.moshi.kotlin)
   implementation(libs.okhttp)

--- a/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
+++ b/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
@@ -25,6 +25,12 @@ class HuggingFaceModelSearch {
     private val resultType = Types.newParameterizedType(List::class.java, HfModel::class.java)
     private val resultAdapter = moshi.adapter<List<HfModel>>(resultType)
 
+    /**
+     * Searches Hugging Face for mobile-runnable model bundles. Deliberately limited to the
+     * first-class on-device formats — LiteRT-LM `.litertlm` and MediaPipe `.task` from
+     * litert-community. GGUF is intentionally **not** searchable: it's a community format
+     * with variable quality, so it's import-only (and behind the "Allow GGUF" toggle).
+     */
     suspend fun search(query: String, hfToken: String?): List<CatalogEntry> = withContext(Dispatchers.IO) {
         val cleanQuery = query.trim().ifEmpty { "qwen3 gemma" }
         val url = "https://huggingface.co/api/models".toHttpUrl().newBuilder()

--- a/app/src/main/java/com/echoflow/data/InferenceParams.kt
+++ b/app/src/main/java/com/echoflow/data/InferenceParams.kt
@@ -1,0 +1,109 @@
+package com.echoflow.data
+
+/**
+ * The sampler knobs the user can tune globally. One set applies to every on-device model,
+ * a second set to every OpenRouter (cloud) model — they don't share values because their
+ * sane ranges differ (on-device top-k is capped low; cloud top-k is usually disabled).
+ *
+ * Values here are the *user's chosen* numbers. They are run through [InferenceLimits.coerce]
+ * against the active model's [ModelCapabilities] before they reach an engine, so a value
+ * that's too big for the model currently loaded is quietly brought back to a safe default
+ * (see the class doc on [InferenceLimits.coerce]).
+ *
+ * @param temperature softmax temperature. 0 = greedy/deterministic.
+ * @param topK keep only the K most-likely tokens. 0 = disabled (no top-k cut).
+ * @param topP nucleus sampling mass in (0, 1]. 1.0 = disabled.
+ * @param maxTokens response/context budget. 0 = "use the model's own default":
+ *   for on-device models that means the file's exported kv-cache size; for cloud models it
+ *   means "don't send max_tokens" (let the provider decide).
+ */
+data class InferenceParams(
+    val temperature: Float,
+    val topK: Int,
+    val topP: Float,
+    val maxTokens: Int,
+)
+
+/**
+ * What the currently-selected model can actually accept. Used to clamp [InferenceParams]
+ * so the user can keep one global preference while every model still gets legal values.
+ *
+ * @param maxContextTokens the largest token budget this model supports (0 = unknown, so
+ *   don't clamp on it — e.g. a cloud model whose context length we couldn't read).
+ * @param maxTopK the largest legal top-k for this runtime.
+ */
+data class ModelCapabilities(
+    val maxContextTokens: Int,
+    val maxTopK: Int,
+)
+
+/**
+ * Defaults we ship, the UI slider ranges, and the clamping rule. Kept in one place so the
+ * repository, the engines, and the Settings sliders agree on every number.
+ */
+object InferenceLimits {
+
+    // Defaults shipped for on-device models (mirror the values the engines used to hardcode:
+    // Gemma/Qwen LiteRT bundles are tuned for temperature 1.0, topK 64, topP 0.95).
+    val LOCAL_DEFAULTS = InferenceParams(temperature = 1.0f, topK = 64, topP = 0.95f, maxTokens = 0)
+
+    // Defaults shipped for OpenRouter cloud models (conventional chat defaults; top-k off,
+    // top-p off, no explicit max so the provider streams a full answer).
+    val CLOUD_DEFAULTS = InferenceParams(temperature = 0.7f, topK = 0, topP = 1.0f, maxTokens = 0)
+
+    // Slider bounds. Temperature/top-p are universal; top-k and max-tokens differ per side.
+    const val TEMP_MIN = 0.0f
+    const val TEMP_MAX = 2.0f
+    const val TOP_P_MIN = 0.0f
+    const val TOP_P_MAX = 1.0f
+
+    const val LOCAL_TOP_K_MAX = 128
+    const val CLOUD_TOP_K_MAX = 200
+
+    // Max-tokens sliders run from 0 ("model default") up to these ceilings, stepped.
+    const val LOCAL_MAX_TOKENS_CEIL = 8192
+    const val CLOUD_MAX_TOKENS_CEIL = 32768
+    const val MAX_TOKENS_STEP = 256
+
+    /**
+     * Brings [params] into what [caps] allows, falling back to [defaults] when a value is
+     * out of its legal range. This is where the "reset to defaults on a smaller model"
+     * behaviour lives:
+     *
+     * - **temperature / top-p**: clamped to their universal ranges; a NaN/garbage value
+     *   falls back to the default.
+     * - **top-k**: if above the runtime's [ModelCapabilities.maxTopK] (or negative) it
+     *   falls back to the default; 0 (disabled) is always allowed.
+     * - **max-tokens**: 0 means "model default", which resolves to the model's own
+     *   [ModelCapabilities.maxContextTokens]. A non-zero value larger than the model can
+     *   hold is reset to that default — so a budget set for a big-context model is honored
+     *   when you go back to it, but a smaller model you switch to gets the safe default
+     *   instead of an illegal value. A non-zero value that *fits* is kept as-is.
+     *
+     * The result is always safe to hand straight to an engine.
+     */
+    fun coerce(params: InferenceParams, caps: ModelCapabilities, defaults: InferenceParams): InferenceParams {
+        val temperature = params.temperature
+            .takeIf { it.isFinite() && it in TEMP_MIN..TEMP_MAX }
+            ?: defaults.temperature
+
+        val topP = params.topP
+            .takeIf { it.isFinite() && it > 0f && it <= TOP_P_MAX }
+            ?: defaults.topP
+
+        val topK = when {
+            params.topK == 0 -> 0
+            params.topK < 0 || params.topK > caps.maxTopK -> defaults.topK.coerceAtMost(caps.maxTopK)
+            else -> params.topK
+        }
+
+        val modelDefaultTokens = if (caps.maxContextTokens > 0) caps.maxContextTokens else params.maxTokens
+        val maxTokens = when {
+            params.maxTokens <= 0 -> modelDefaultTokens
+            caps.maxContextTokens > 0 && params.maxTokens > caps.maxContextTokens -> modelDefaultTokens
+            else -> params.maxTokens
+        }
+
+        return InferenceParams(temperature = temperature, topK = topK, topP = topP, maxTokens = maxTokens)
+    }
+}

--- a/app/src/main/java/com/echoflow/data/LocalLlmService.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmService.kt
@@ -1,6 +1,9 @@
 package com.echoflow.data
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.Contents
@@ -13,7 +16,10 @@ import com.google.ai.edge.litertlm.MessageCallback
 import com.google.ai.edge.litertlm.SamplerConfig
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
@@ -24,46 +30,78 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.nehuatl.llamacpp.LlamaAndroid
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * On-device inference behind one facade, with two runtimes:
+ * On-device inference behind one facade, with three runtimes:
  *
  * - `.litertlm` bundles (Gemma 4, Qwen3, ...) run on the standalone **LiteRT-LM engine**
  *   ([Engine]/[Conversation]) — the same stack AI Edge Gallery uses. The newer bundles
  *   crash natively under the MediaPipe wrapper, so they must not go through it.
  * - `.task` files keep using MediaPipe LLM Inference ([LlmInference]), which is their
  *   native format.
+ * - `.gguf` files run on the **llama.cpp engine** ([LlamaAndroid]) — the standard format
+ *   for community quantized models pulled from Hugging Face.
  *
  * One engine (model) is resident at a time; one conversation/session is kept per chat so
  * multi-turn context is reused instead of re-prefilling the transcript every message.
+ *
+ * Every generation runs the user's global [InferenceParams] (already coerced to the active
+ * model's limits by the caller) through the runtime's native sampler.
  */
 class LocalLlmService(private val context: Context) {
+
+    private enum class Runtime { MEDIAPIPE, LITERT, GGUF }
 
     // ── MediaPipe runtime (.task) ────────────────────────────────────────────────────
     private var mpEngine: LlmInference? = null
     private var mpLoadedPath: String? = null
+    private var mpLoadedMaxTokens = -1
+    private var mpLoadedMaxTopK = -1
     private var mpSession: LlmInferenceSession? = null
     private var mpSessionChatId: String? = null
     private var mpLastHistorySize = -1
+    private var mpParams: InferenceParams? = null
 
     // ── LiteRT-LM runtime (.litertlm) ────────────────────────────────────────────────
     private var lrtEngine: Engine? = null
     private var lrtLoadedPath: String? = null
+    private var lrtLoadedMaxTokens = -1
     private var lrtConversation: Conversation? = null
     private var lrtChatId: String? = null
     private var lrtLastHistorySize = -1
     private var lrtSystemPrompt: String? = null
+    private var lrtParams: InferenceParams? = null
 
     /** Search results waiting to be sent on the next [continueGeneration] round. */
     private var lrtPendingContext: String? = null
 
+    // ── llama.cpp runtime (.gguf) ─────────────────────────────────────────────────────
+    private var ggufEngine: LlamaAndroid? = null
+    private var ggufContextId: Int? = null
+    private var ggufLoadedPath: String? = null
+    private var ggufLoadedMaxTokens = -1
+    private var ggufChatId: String? = null
+    /** Conversation text the next completion continues from (full reprompt per turn). */
+    private var ggufBasePrompt: String = ""
+    /** Tokens streamed so far in the in-flight completion (for search continuation). */
+    private var ggufFullText = StringBuilder()
+    private var ggufPendingContext: String? = null
+    private var ggufJob: Job? = null
+    private val ggufScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     /** Which runtime the in-flight generation belongs to (for appendContext/continue). */
-    private var activeIsLitert = false
+    private var activeRuntime = Runtime.MEDIAPIPE
+    /** Params of the in-flight generation, reused by [continueGeneration]. */
+    private var activeParams: InferenceParams = InferenceLimits.LOCAL_DEFAULTS
 
     private val setupMutex = Mutex()
     private val generating = AtomicBoolean(false)
@@ -81,8 +119,15 @@ class LocalLlmService(private val context: Context) {
 
     fun modelFileExists(model: LocalModel): Boolean = modelFile(model).exists()
 
-    private fun usesLiteRtLm(model: LocalModel): Boolean =
-        model.fileName.endsWith(".litertlm", ignoreCase = true)
+    private fun runtimeFor(model: LocalModel): Runtime = when {
+        LocalModelCatalog.isGguf(model.fileName) -> Runtime.GGUF
+        LocalModelCatalog.isLiteRtLm(model.fileName) -> Runtime.LITERT
+        else -> Runtime.MEDIAPIPE
+    }
+
+    /** Resolves the effective token budget: the coerced param, or the model's own default. */
+    private fun effectiveMaxTokens(model: LocalModel, params: InferenceParams): Int =
+        params.maxTokens.takeIf { it > 0 } ?: LocalModelCatalog.maxTokensFor(model.id, model.fileName)
 
     /**
      * Native OOM during weight loading aborts the whole process and is uncatchable, so
@@ -115,6 +160,30 @@ class LocalLlmService(private val context: Context) {
     }
 
     /**
+     * Decodes an attachment URI into a downscaled JPEG [Content.ImageBytes] for multimodal
+     * .litertlm bundles. Returns null when there's no image or it can't be read.
+     */
+    private fun imageContentFromUri(uriString: String?): Content? {
+        if (uriString.isNullOrBlank()) return null
+        return try {
+            val raw = context.contentResolver.openInputStream(Uri.parse(uriString))?.use { it.readBytes() }
+                ?: return null
+            var bmp = BitmapFactory.decodeByteArray(raw, 0, raw.size) ?: return null
+            val max = 768
+            val longest = maxOf(bmp.width, bmp.height)
+            if (longest > max) {
+                val scale = max.toFloat() / longest
+                bmp = Bitmap.createScaledBitmap(bmp, (bmp.width * scale).toInt(), (bmp.height * scale).toInt(), true)
+            }
+            val out = ByteArrayOutputStream()
+            bmp.compress(Bitmap.CompressFormat.JPEG, 85, out)
+            Content.ImageBytes(out.toByteArray())
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
      * Prepares the runtime for a new user turn and starts generation.
      *
      * @param history full chat history including the just-sent user message (last element).
@@ -123,11 +192,16 @@ class LocalLlmService(private val context: Context) {
         model: LocalModel,
         chatId: String,
         history: List<ChatMessage>,
-        systemPrompt: String
+        systemPrompt: String,
+        params: InferenceParams = InferenceLimits.LOCAL_DEFAULTS
     ): Flow<StreamChunk> {
-        activeIsLitert = usesLiteRtLm(model)
-        return if (activeIsLitert) generateLitert(model, chatId, history, systemPrompt)
-        else generateMediaPipe(model, chatId, history, systemPrompt)
+        activeRuntime = runtimeFor(model)
+        activeParams = params
+        return when (activeRuntime) {
+            Runtime.GGUF -> generateGguf(model, chatId, history, systemPrompt, params)
+            Runtime.LITERT -> generateLitert(model, chatId, history, systemPrompt, params)
+            Runtime.MEDIAPIPE -> generateMediaPipe(model, chatId, history, systemPrompt, params)
+        }
     }
 
     /**
@@ -135,16 +209,19 @@ class LocalLlmService(private val context: Context) {
      * [continueGeneration] round of the prompt-protocol search loop.
      */
     fun appendContext(text: String) {
-        if (activeIsLitert) {
-            lrtPendingContext = (lrtPendingContext ?: "") + text
-        } else {
-            runCatching { mpSession?.addQueryChunk(text) }
+        when (activeRuntime) {
+            Runtime.LITERT -> lrtPendingContext = (lrtPendingContext ?: "") + text
+            Runtime.GGUF -> ggufPendingContext = (ggufPendingContext ?: "") + text
+            Runtime.MEDIAPIPE -> runCatching { mpSession?.addQueryChunk(text) }
         }
     }
 
     /** Continues generating after [appendContext], without a new user message. */
-    fun continueGeneration(): Flow<StreamChunk> =
-        if (activeIsLitert) continueLitert() else continueMediaPipe()
+    fun continueGeneration(): Flow<StreamChunk> = when (activeRuntime) {
+        Runtime.LITERT -> continueLitert()
+        Runtime.GGUF -> continueGguf()
+        Runtime.MEDIAPIPE -> continueMediaPipe()
+    }
 
     /** Frees all engines and sessions (model switch away from local, or ViewModel cleared). */
     fun releaseAll() {
@@ -152,25 +229,33 @@ class LocalLlmService(private val context: Context) {
         runCatching { mpEngine?.close() }
         mpEngine = null
         mpLoadedPath = null
+        mpLoadedMaxTokens = -1
+        mpLoadedMaxTopK = -1
 
         closeLrtConversationInternal()
         runCatching { lrtEngine?.close() }
         lrtEngine = null
         lrtLoadedPath = null
+        lrtLoadedMaxTokens = -1
+
+        releaseGgufInternal()
 
         generating.set(false)
     }
 
     // ── LiteRT-LM implementation ─────────────────────────────────────────────────────
 
-    private fun createLitertEngine(path: String, maxTokens: Int, backend: Backend): Engine {
+    private fun createLitertEngine(path: String, maxTokens: Int, backend: Backend, visionBackend: Backend?): Engine {
         val engine = Engine(
             EngineConfig(
                 modelPath = path,
                 backend = backend,
-                visionBackend = null,
+                // Vision is enabled for every .litertlm engine so image attachments work on
+                // multimodal bundles (Gemma 4). Text-only bundles simply ignore the image.
+                visionBackend = visionBackend,
                 audioBackend = null,
                 maxNumTokens = maxTokens,
+                maxNumImages = if (visionBackend != null) 1 else null,
                 cacheDir = null,
             )
         )
@@ -183,30 +268,33 @@ class LocalLlmService(private val context: Context) {
         return engine
     }
 
-    private fun ensureLitertEngine(model: LocalModel) {
+    private fun ensureLitertEngine(model: LocalModel, maxTokens: Int) {
         val file = modelFile(model)
         val path = file.absolutePath
-        if (lrtEngine != null && lrtLoadedPath == path) return
+        // The kv-cache size is baked in at engine creation, so a changed token budget needs
+        // a fresh engine, not just a fresh conversation.
+        if (lrtEngine != null && lrtLoadedPath == path && lrtLoadedMaxTokens == maxTokens) return
 
         closeLrtConversationInternal()
         runCatching { lrtEngine?.close() }
         lrtEngine = null
         lrtLoadedPath = null
+        lrtLoadedMaxTokens = -1
 
         checkRamBudget(file)
-        val maxTokens = LocalModelCatalog.maxTokensFor(model.id, model.fileName)
 
         lrtEngine = try {
-            createLitertEngine(path, maxTokens, Backend.GPU())
+            createLitertEngine(path, maxTokens, Backend.GPU(), visionBackend = Backend.GPU())
         } catch (gpuError: Throwable) {
             // Some devices lack a usable GPU delegate; retry on CPU before giving up.
             try {
-                createLitertEngine(path, maxTokens, Backend.CPU())
+                createLitertEngine(path, maxTokens, Backend.CPU(), visionBackend = Backend.CPU())
             } catch (cpuError: Throwable) {
                 throw Exception(friendlyLoadError(cpuError))
             }
         }
         lrtLoadedPath = path
+        lrtLoadedMaxTokens = maxTokens
     }
 
     private fun closeLrtConversationInternal() {
@@ -216,25 +304,29 @@ class LocalLlmService(private val context: Context) {
         lrtLastHistorySize = -1
         lrtSystemPrompt = null
         lrtPendingContext = null
+        lrtParams = null
     }
 
     private fun generateLitert(
         model: LocalModel,
         chatId: String,
         history: List<ChatMessage>,
-        systemPrompt: String
+        systemPrompt: String,
+        params: InferenceParams
     ): Flow<StreamChunk> = callbackFlow {
         setupMutex.withLock {
             if (generating.get()) throw Exception("The on-device model is still responding — wait for it to finish.")
             val text: String
             try {
-                val coldStart = lrtLoadedPath != modelFile(model).absolutePath
+                val maxTokens = effectiveMaxTokens(model, params)
+                val coldStart = lrtLoadedPath != modelFile(model).absolutePath || lrtLoadedMaxTokens != maxTokens
                 if (coldStart) _modelLoading.value = true
-                ensureLitertEngine(model)
+                ensureLitertEngine(model, maxTokens)
 
                 val incremental = lrtConversation != null &&
                     lrtChatId == chatId &&
                     lrtSystemPrompt == systemPrompt &&
+                    lrtParams == params &&
                     history.size == lrtLastHistorySize + 2
 
                 if (incremental) {
@@ -244,13 +336,18 @@ class LocalLlmService(private val context: Context) {
                     closeLrtConversationInternal()
                     lrtConversation = lrtEngine!!.createConversation(
                         ConversationConfig(
-                            samplerConfig = SamplerConfig(topK = 64, topP = 0.95, temperature = 1.0),
+                            samplerConfig = SamplerConfig(
+                                topK = params.topK.coerceAtLeast(1),
+                                topP = params.topP.toDouble(),
+                                temperature = params.temperature.toDouble(),
+                            ),
                             systemInstruction = systemPrompt.takeIf { it.isNotBlank() }
                                 ?.let { Contents.of(mutableListOf<Content>(Content.Text(it))) },
                         )
                     )
                     lrtChatId = chatId
                     lrtSystemPrompt = systemPrompt
+                    lrtParams = params
 
                     // Replay older turns as a transcript preamble; the engine applies the
                     // model's chat template to the message itself.
@@ -266,7 +363,9 @@ class LocalLlmService(private val context: Context) {
             } finally {
                 _modelLoading.value = false
             }
-            sendLitertMessage(this@callbackFlow, text)
+            // An image on the latest user turn is sent alongside the text (multimodal bundles).
+            val image = history.lastOrNull()?.takeIf { it.role == "user" }?.let { imageContentFromUri(it.localAttachmentUri) }
+            sendLitertMessage(this@callbackFlow, text, image)
         }
         awaitClose { onLitertFlowClosed() }
     }.buffer(Channel.UNLIMITED).flowOn(Dispatchers.IO)
@@ -293,12 +392,14 @@ class LocalLlmService(private val context: Context) {
         awaitClose { onLitertFlowClosed() }
     }.buffer(Channel.UNLIMITED).flowOn(Dispatchers.IO)
 
-    private fun sendLitertMessage(producer: ProducerScope<StreamChunk>, text: String) {
+    private fun sendLitertMessage(producer: ProducerScope<StreamChunk>, text: String, image: Content? = null) {
         val conversation = lrtConversation ?: throw Exception("No active on-device conversation.")
         generating.set(true)
         try {
+            val parts = mutableListOf<Content>(Content.Text(text))
+            if (image != null) parts.add(image)
             conversation.sendMessageAsync(
-                Contents.of(mutableListOf<Content>(Content.Text(text))),
+                Contents.of(parts),
                 object : MessageCallback {
                     override fun onMessage(message: Message) {
                         val thought = message.channels["thought"]
@@ -334,30 +435,33 @@ class LocalLlmService(private val context: Context) {
     }
 
     private fun onLitertFlowClosed() {
-        if (activeIsLitert && generating.getAndSet(false)) {
+        if (activeRuntime == Runtime.LITERT && generating.getAndSet(false)) {
             runCatching { lrtConversation?.cancelProcess() }
         }
     }
 
     // ── MediaPipe implementation ─────────────────────────────────────────────────────
 
-    private fun ensureMpEngine(model: LocalModel) {
+    private fun ensureMpEngine(model: LocalModel, maxTokens: Int, maxTopK: Int) {
         val file = modelFile(model)
         val path = file.absolutePath
-        if (mpEngine != null && mpLoadedPath == path) return
+        // Token budget and the top-k ceiling are fixed at engine creation, so a change in
+        // either forces a rebuild.
+        if (mpEngine != null && mpLoadedPath == path && mpLoadedMaxTokens == maxTokens && mpLoadedMaxTopK == maxTopK) return
 
         closeMpSessionInternal()
         runCatching { mpEngine?.close() }
         mpEngine = null
         mpLoadedPath = null
+        mpLoadedMaxTokens = -1
+        mpLoadedMaxTopK = -1
 
         checkRamBudget(file)
-        val maxTokens = LocalModelCatalog.maxTokensFor(model.id, model.fileName)
 
         fun options(backend: LlmInference.Backend) = LlmInference.LlmInferenceOptions.builder()
             .setModelPath(path)
             .setMaxTokens(maxTokens)
-            .setMaxTopK(64)
+            .setMaxTopK(maxTopK)
             .setPreferredBackend(backend)
             .build()
 
@@ -372,18 +476,20 @@ class LocalLlmService(private val context: Context) {
             }
         }
         mpLoadedPath = path
+        mpLoadedMaxTokens = maxTokens
+        mpLoadedMaxTopK = maxTopK
     }
 
-    private fun newMpSession(): LlmInferenceSession {
+    private fun newMpSession(params: InferenceParams, maxTopK: Int): LlmInferenceSession {
         val eng = mpEngine ?: throw Exception("Local model engine not initialized.")
-        // Sampler values mirror AI Edge Gallery's defaults for these bundles (Gemma is
-        // tuned for temperature 1.0); topK must stay <= the engine's setMaxTopK.
+        // topK must stay <= the engine's setMaxTopK; 0 (disabled) isn't valid here, so the
+        // engine ceiling stands in for "no cut".
         return LlmInferenceSession.createFromOptions(
             eng,
             LlmInferenceSession.LlmInferenceSessionOptions.builder()
-                .setTopK(64)
-                .setTopP(0.95f)
-                .setTemperature(1.0f)
+                .setTopK(if (params.topK <= 0) maxTopK else params.topK)
+                .setTopP(params.topP)
+                .setTemperature(params.temperature)
                 .build()
         )
     }
@@ -393,6 +499,7 @@ class LocalLlmService(private val context: Context) {
         mpSession = null
         mpSessionChatId = null
         mpLastHistorySize = -1
+        mpParams = null
     }
 
     private fun userTurnPrompt(content: String): String =
@@ -402,17 +509,24 @@ class LocalLlmService(private val context: Context) {
         model: LocalModel,
         chatId: String,
         history: List<ChatMessage>,
-        systemPrompt: String
+        systemPrompt: String,
+        params: InferenceParams
     ): Flow<StreamChunk> = callbackFlow {
         setupMutex.withLock {
             if (generating.get()) throw Exception("The on-device model is still responding — wait for it to finish.")
             try {
-                val coldStart = mpLoadedPath != modelFile(model).absolutePath
+                val maxTokens = effectiveMaxTokens(model, params)
+                // The session top-k must be <= the engine ceiling, so the ceiling is the
+                // larger of the default 64 and whatever the user asked for.
+                val maxTopK = maxOf(64, params.topK)
+                val coldStart = mpLoadedPath != modelFile(model).absolutePath ||
+                    mpLoadedMaxTokens != maxTokens || mpLoadedMaxTopK != maxTopK
                 if (coldStart) _modelLoading.value = true
-                ensureMpEngine(model)
+                ensureMpEngine(model, maxTokens, maxTopK)
 
                 val incremental = mpSession != null &&
                     mpSessionChatId == chatId &&
+                    mpParams == params &&
                     history.size == mpLastHistorySize + 2
 
                 // Rebuilding a session with prior turns means a slow prefill, surface it too.
@@ -424,9 +538,10 @@ class LocalLlmService(private val context: Context) {
                     activeSession.addQueryChunk(userTurnPrompt(history.last().content))
                 } else {
                     closeMpSessionInternal()
-                    activeSession = newMpSession()
+                    activeSession = newMpSession(params, maxTopK)
                     mpSession = activeSession
                     mpSessionChatId = chatId
+                    mpParams = params
 
                     if (systemPrompt.isNotBlank()) {
                         activeSession.addQueryChunk(
@@ -439,7 +554,6 @@ class LocalLlmService(private val context: Context) {
                     if (prior.isNotEmpty()) {
                         // Replay older turns as one transcript chunk, trimming the oldest turns
                         // when they would crowd out room for the answer.
-                        val maxTokens = LocalModelCatalog.maxTokensFor(model.id, model.fileName)
                         var turns = prior
                         var transcript = transcriptOf(turns)
                         while (turns.size > 1 &&
@@ -509,8 +623,193 @@ class LocalLlmService(private val context: Context) {
     }
 
     private fun onMpFlowClosed() {
-        if (!activeIsLitert && generating.getAndSet(false)) {
+        if (activeRuntime == Runtime.MEDIAPIPE && generating.getAndSet(false)) {
             runCatching { mpSession?.cancelGenerateResponseAsync() }
+        }
+    }
+
+    // ── llama.cpp (.gguf) implementation ───────────────────────────────────────────────
+
+    private fun releaseGgufInternal() {
+        ggufJob?.cancel()
+        ggufJob = null
+        val id = ggufContextId
+        val engine = ggufEngine
+        if (id != null && engine != null) {
+            runCatching { engine.releaseContext(id) }
+        }
+        ggufEngine = null
+        ggufContextId = null
+        ggufLoadedPath = null
+        ggufLoadedMaxTokens = -1
+        ggufChatId = null
+        ggufBasePrompt = ""
+        ggufPendingContext = null
+        ggufFullText = StringBuilder()
+    }
+
+    private fun ensureGgufEngine(model: LocalModel, maxTokens: Int) {
+        val file = modelFile(model)
+        val path = file.absolutePath
+        if (ggufEngine != null && ggufContextId != null && ggufLoadedPath == path && ggufLoadedMaxTokens == maxTokens) return
+
+        releaseGgufInternal()
+        checkRamBudget(file)
+
+        val engine = LlamaAndroid(context.contentResolver)
+        val uri = Uri.fromFile(file)
+        val fd = context.contentResolver.openFileDescriptor(uri, "r")?.detachFd()
+            ?: throw Exception("Could not open the on-device model file.")
+        val config = mapOf<String, Any>(
+            "model" to uri.toString(),
+            "model_fd" to fd,
+            "use_mmap" to false,
+            "use_mlock" to false,
+            "n_ctx" to maxTokens,
+            "embedding" to false,
+            "n_batch" to 512,
+            "n_threads" to 0, // 0 = let llama.cpp pick a good thread count
+            "n_gpu_layers" to 0, // the AAR runs CPU-only
+            "vocab_only" to false,
+            "lora" to "",
+            "lora_scaled" to 1.0,
+            "rope_freq_base" to 0.0,
+            "rope_freq_scale" to 0.0,
+        )
+
+        // The token callback streams to whichever generation is in flight; it reads the
+        // current producer at call time, so reusing one engine across turns is fine.
+        val result = engine.startEngine(config) { token ->
+            ggufFullText.append(token)
+            ggufProducer?.trySend(StreamChunk.Content(token))
+        } ?: throw Exception(
+            "Could not load this GGUF model. It may be corrupt, an unsupported quantization, " +
+                "or too large for this device."
+        )
+
+        ggufContextId = (result["contextId"] as Number).toInt()
+        ggufEngine = engine
+        ggufLoadedPath = path
+        ggufLoadedMaxTokens = maxTokens
+    }
+
+    /** Producer of the in-flight GGUF generation; set under the setup lock before launch. */
+    @Volatile
+    private var ggufProducer: ProducerScope<StreamChunk>? = null
+
+    /**
+     * Builds the prompt for a turn by applying the model's own chat template (via llama.cpp)
+     * to the system prompt + conversation. Falls back to a plain transcript if the embedded
+     * template can't be applied.
+     */
+    private suspend fun buildGgufPrompt(systemPrompt: String, history: List<ChatMessage>): String {
+        val engine = ggufEngine ?: return transcriptOf(history)
+        val id = ggufContextId ?: return transcriptOf(history)
+        val messages = buildList {
+            if (systemPrompt.isNotBlank()) add(mapOf("role" to "system", "content" to systemPrompt as Any))
+            history.filter { it.role == "user" || it.role == "assistant" }
+                .forEach { add(mapOf("role" to it.role, "content" to it.content as Any)) }
+        }
+        return runCatching { engine.getFormattedChat(id, messages, "").first() }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: buildString {
+                if (systemPrompt.isNotBlank()) append("System: ").append(systemPrompt).append("\n\n")
+                append(transcriptOf(history.filter { it.role == "user" || it.role == "assistant" }))
+                append("\nEchoFlow:")
+            }
+    }
+
+    private fun generateGguf(
+        model: LocalModel,
+        chatId: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams
+    ): Flow<StreamChunk> = callbackFlow {
+        setupMutex.withLock {
+            if (generating.get()) throw Exception("The on-device model is still responding — wait for it to finish.")
+            val prompt: String
+            try {
+                val maxTokens = effectiveMaxTokens(model, params)
+                val coldStart = ggufLoadedPath != modelFile(model).absolutePath || ggufLoadedMaxTokens != maxTokens
+                if (coldStart) _modelLoading.value = true
+                ensureGgufEngine(model, maxTokens)
+                if (history.size > 1) _modelLoading.value = true
+                ggufChatId = chatId
+                prompt = buildGgufPrompt(systemPrompt, history)
+                ggufBasePrompt = prompt
+            } finally {
+                _modelLoading.value = false
+            }
+            launchGgufCompletion(this@callbackFlow, prompt, params)
+        }
+        awaitClose { onGgufFlowClosed() }
+    }.buffer(Channel.UNLIMITED).flowOn(Dispatchers.IO)
+
+    private fun continueGguf(): Flow<StreamChunk> = callbackFlow {
+        val pending = ggufPendingContext
+            ?: throw Exception("No pending context for the on-device conversation.")
+        ggufPendingContext = null
+        // Continue from the conversation plus what the model produced so far, then the
+        // injected search results — a full reprompt, since llama.cpp completion is stateless
+        // across calls here.
+        val prompt = ggufBasePrompt + ggufFullText.toString() + "\n" + pending
+        ggufBasePrompt = prompt
+
+        var started = false
+        var lastError: Throwable? = null
+        for (attempt in 0 until 10) {
+            try {
+                launchGgufCompletion(this@callbackFlow, prompt, activeParams)
+                started = true
+                break
+            } catch (e: Exception) {
+                lastError = e
+                delay(250)
+            }
+        }
+        if (!started) throw Exception("On-device model is busy: ${lastError?.message}")
+        awaitClose { onGgufFlowClosed() }
+    }.buffer(Channel.UNLIMITED).flowOn(Dispatchers.IO)
+
+    private fun launchGgufCompletion(producer: ProducerScope<StreamChunk>, prompt: String, params: InferenceParams) {
+        val engine = ggufEngine ?: throw Exception("No active on-device engine.")
+        val id = ggufContextId ?: throw Exception("No active on-device context.")
+        generating.set(true)
+        ggufProducer = producer
+        ggufFullText = StringBuilder()
+        val completionParams = mapOf<String, Any>(
+            "prompt" to prompt,
+            "emit_partial_completion" to true,
+            "temperature" to params.temperature.toDouble(),
+            "top_k" to params.topK,
+            "top_p" to params.topP.toDouble(),
+            "n_predict" to -1, // stream until EOS or the context window fills
+            "n_threads" to 0,
+        )
+        // launchCompletion blocks until done while streaming via the token callback, so run
+        // it off the flow's coroutine and close the producer when it returns.
+        ggufJob = ggufScope.launch {
+            try {
+                engine.launchCompletion(id, completionParams)
+                generating.set(false)
+                producer.close()
+            } catch (e: Throwable) {
+                generating.set(false)
+                producer.close(Exception("On-device model error: ${e.message?.take(160)}"))
+            }
+        }
+    }
+
+    private fun onGgufFlowClosed() {
+        if (activeRuntime == Runtime.GGUF && generating.getAndSet(false)) {
+            val id = ggufContextId
+            val engine = ggufEngine
+            if (id != null && engine != null) {
+                ggufScope.launch { runCatching { engine.stopCompletion(id) } }
+            }
+            ggufJob?.cancel()
         }
     }
 }

--- a/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
@@ -94,6 +94,14 @@ object LocalModelCatalog {
 
     fun entryById(id: String): CatalogEntry? = entries.firstOrNull { it.id == id }
 
+    /** File-name based runtime detection — kept here so every layer agrees on the rules. */
+    fun isGguf(fileName: String): Boolean = fileName.endsWith(".gguf", ignoreCase = true)
+    fun isLiteRtLm(fileName: String): Boolean = fileName.endsWith(".litertlm", ignoreCase = true)
+    fun isTask(fileName: String): Boolean = fileName.endsWith(".task", ignoreCase = true)
+
+    /** Supported on-device model file extensions, for the import picker and validation. */
+    val supportedExtensions = listOf(".task", ".litertlm", ".gguf")
+
     private val ekvHint = Regex("ekv(\\d+)", RegexOption.IGNORE_CASE)
 
     /**
@@ -106,6 +114,12 @@ object LocalModelCatalog {
         val file = fileName ?: return 1280
         entries.firstOrNull { it.fileName.equals(file, ignoreCase = true) }?.let { return it.maxTokens }
         ekvHint.find(file)?.groupValues?.get(1)?.toIntOrNull()?.let { return it.coerceIn(512, 4096) }
-        return if (file.endsWith(".litertlm", ignoreCase = true)) 2048 else 1280
+        return when {
+            // GGUF files carry no kv-cache marker in the name; llama.cpp lets us size the
+            // context window ourselves, so use a comfortable mobile default.
+            isGguf(file) -> 4096
+            isLiteRtLm(file) -> 2048
+            else -> 1280
+        }
     }
 }

--- a/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
+++ b/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
@@ -150,8 +150,8 @@ class ModelDownloadManager(
         setState(entryId, null)
     }
 
-    /** Copies a user-picked .task/.litertlm file into app storage with progress. */
-    suspend fun importFromUri(uri: Uri): LocalModel = withContext(Dispatchers.IO) {
+    /** Display name + declared byte size for a picked document (size 0 when unknown). */
+    private fun queryNameAndSize(uri: Uri): Pair<String, Long> {
         var displayName = "model.task"
         var declaredSize = 0L
         context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
@@ -162,15 +162,53 @@ class ModelDownloadManager(
                 if (sizeIdx >= 0 && !cursor.isNull(sizeIdx)) declaredSize = cursor.getLong(sizeIdx)
             }
         }
+        return displayName to declaredSize
+    }
+
+    private fun deviceTotalRamBytes(): Long {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as android.app.ActivityManager
+        return android.app.ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) }.totalMem
+    }
+
+    /**
+     * Pre-import sizing check for a picked file. Weights peak RAM at ~1.8× the file size
+     * (the same factor [LocalLlmService] uses to refuse loads) so the warning predicts the
+     * actual failure rather than letting a multi-GB copy finish first.
+     */
+    data class ImportAssessment(
+        val displayName: String,
+        val sizeBytes: Long,
+        val isGguf: Boolean,
+        val tooBig: Boolean,
+        val estimatedPeakBytes: Long,
+        val deviceTotalRamBytes: Long,
+    )
+
+    suspend fun assessImport(uri: Uri): ImportAssessment = withContext(Dispatchers.IO) {
+        val (name, size) = queryNameAndSize(uri)
+        val peak = (size * 1.8).toLong()
+        val total = deviceTotalRamBytes()
+        // Warn a little before the hard ceiling: OS + app overhead means a model that barely
+        // fits total RAM still tends to fail to load.
+        val tooBig = LocalModelCatalog.isGguf(name) && size > 0 && total > 0 && peak > total * 0.85
+        ImportAssessment(name, size, LocalModelCatalog.isGguf(name), tooBig, peak, total)
+    }
+
+    /** Copies a user-picked .task/.litertlm/.gguf file into app storage with progress. */
+    suspend fun importFromUri(uri: Uri, allowGguf: Boolean): LocalModel = withContext(Dispatchers.IO) {
+        val (displayName, declaredSize) = queryNameAndSize(uri)
 
         val lower = displayName.lowercase()
-        if (!lower.endsWith(".task") && !lower.endsWith(".litertlm")) {
-            throw Exception("Unsupported file. Pick a .task or .litertlm model file.")
+        if (LocalModelCatalog.isGguf(lower) && !allowGguf) {
+            throw Exception("GGUF support is off. Turn on “Allow GGUF models” in Local models settings to import .gguf files.")
+        }
+        if (LocalModelCatalog.supportedExtensions.none { lower.endsWith(it) }) {
+            throw Exception("Unsupported file. Pick a .task, .litertlm or .gguf model file.")
         }
 
         val safeName = displayName.replace(Regex("[^A-Za-z0-9._-]"), "_")
         val id = "local/imported-" + safeName.lowercase()
-            .removeSuffix(".task").removeSuffix(".litertlm")
+            .removeSuffix(".task").removeSuffix(".litertlm").removeSuffix(".gguf")
         val finalFile = File(modelsDir, safeName)
         val partFile = File(modelsDir, "$safeName.part")
 
@@ -203,7 +241,7 @@ class ModelDownloadManager(
             }
             val model = LocalModel(
                 id = id,
-                name = displayName.removeSuffix(".task").removeSuffix(".litertlm"),
+                name = displayName.removeSuffix(".task").removeSuffix(".litertlm").removeSuffix(".gguf"),
                 fileName = safeName,
                 sizeBytes = finalFile.length(),
                 source = "imported",
@@ -245,17 +283,18 @@ class ModelDownloadManager(
                 // Already represented by a DB row — don't create a duplicate "recovered" entry.
                 file.name.lowercase() in trackedFileNames -> Unit
                 file.isFile &&
-                    (file.name.endsWith(".task", ignoreCase = true) ||
-                        file.name.endsWith(".litertlm", ignoreCase = true)) -> {
+                    LocalModelCatalog.supportedExtensions.any { file.name.endsWith(it, ignoreCase = true) } -> {
                     val catalogEntry = LocalModelCatalog.entries.firstOrNull { it.fileName == file.name }
                     val safeId = catalogEntry?.id ?: "local/recovered-" + file.name.lowercase()
                         .removeSuffix(".task")
                         .removeSuffix(".litertlm")
+                        .removeSuffix(".gguf")
                         .replace(Regex("[^a-z0-9]+"), "-")
                         .trim('-')
                     val displayName = catalogEntry?.name ?: file.name
                         .removeSuffix(".task")
                         .removeSuffix(".litertlm")
+                        .removeSuffix(".gguf")
                         .replace('_', ' ')
                         .replace('-', ' ')
                     localModelDao.insertLocalModel(

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -248,6 +248,7 @@ class OpenRouterService(private val context: Context) {
         model: String,
         payloadMessages: List<Map<String, Any>>,
         tools: List<Map<String, Any>>?,
+        params: InferenceParams?,
         onChunk: suspend (StreamChunk) -> Unit
     ): TurnResult {
         val requestMap = mutableMapOf<String, Any>(
@@ -261,6 +262,14 @@ class OpenRouterService(private val context: Context) {
         )
         if (tools != null) {
             requestMap["tools"] = tools
+        }
+        // The user's global cloud sampler settings. top_k / max_tokens are only sent when set
+        // (0 means "leave it to the model"); temperature / top_p always apply.
+        if (params != null) {
+            requestMap["temperature"] = params.temperature
+            requestMap["top_p"] = params.topP
+            if (params.topK > 0) requestMap["top_k"] = params.topK
+            if (params.maxTokens > 0) requestMap["max_tokens"] = params.maxTokens
         }
 
         val jsonPayload = dynamicAdapter.toJson(requestMap)
@@ -402,7 +411,8 @@ class OpenRouterService(private val context: Context) {
         model: String,
         history: List<ChatMessage>,
         systemPrompt: String? = null,
-        serverWebSearch: Boolean = false
+        serverWebSearch: Boolean = false,
+        params: InferenceParams? = null
     ): Flow<StreamChunk> = flow {
         if (apiKey.isBlank()) {
             throw Exception("API key is missing! Please configure it in your Settings.")
@@ -422,7 +432,7 @@ class OpenRouterService(private val context: Context) {
             )
         } else null
 
-        streamCompletion(apiKey, model, buildMessagesPayload(history, systemPrompt), tools) { emit(it) }
+        streamCompletion(apiKey, model, buildMessagesPayload(history, systemPrompt), tools, params) { emit(it) }
     }.flowOn(Dispatchers.IO)
 
     /**
@@ -436,6 +446,7 @@ class OpenRouterService(private val context: Context) {
         model: String,
         history: List<ChatMessage>,
         systemPrompt: String,
+        params: InferenceParams? = null,
         runSearch: suspend (String) -> List<SearchSource>
     ): Flow<StreamChunk> = flow {
         if (apiKey.isBlank()) {
@@ -474,7 +485,7 @@ class OpenRouterService(private val context: Context) {
             // Once the budget is spent (or on the last round) drop the tool so the model
             // is forced to answer with what it has.
             val tools = if (searchesUsed >= maxSearches || round == maxRounds - 1) null else toolSpec
-            val result = streamCompletion(apiKey, model, messages, tools) { emit(it) }
+            val result = streamCompletion(apiKey, model, messages, tools, params) { emit(it) }
 
             val searchCalls = result.toolCalls
             if (result.finishReason != "tool_calls" || searchCalls.isEmpty()) break

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -46,6 +46,11 @@ class SettingsRepository(context: Context) {
     private val _localModelsEnabled = MutableStateFlow(getLocalModelsEnabledDirect())
     val localModelsEnabled: StateFlow<Boolean> = _localModelsEnabled.asStateFlow()
 
+    // GGUF (llama.cpp) is opt-in: it's a community format with variable quality and a
+    // separate CPU-only runtime, so it stays off until the user enables it.
+    private val _ggufEnabled = MutableStateFlow(getGgufEnabledDirect())
+    val ggufEnabled: StateFlow<Boolean> = _ggufEnabled.asStateFlow()
+
     // Deep Research
     private val _deepResearchModel = MutableStateFlow(getDeepResearchModelDirect())
     val deepResearchModel: StateFlow<String> = _deepResearchModel.asStateFlow()
@@ -74,6 +79,13 @@ class SettingsRepository(context: Context) {
 
     private val _hfAccessToken = MutableStateFlow(getHfAccessTokenDirect())
     val hfAccessToken: StateFlow<String> = _hfAccessToken.asStateFlow()
+
+    // Inference parameters: one global set for on-device models, one for OpenRouter models.
+    private val _localInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = true))
+    val localInferenceParams: StateFlow<InferenceParams> = _localInferenceParams.asStateFlow()
+
+    private val _cloudInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = false))
+    val cloudInferenceParams: StateFlow<InferenceParams> = _cloudInferenceParams.asStateFlow()
 
     fun getApiKeyDirect(): String {
         return prefs.getString("openrouter_api_key", "").orEmpty()
@@ -186,6 +198,15 @@ class SettingsRepository(context: Context) {
         _localModelsEnabled.value = enabled
     }
 
+    fun getGgufEnabledDirect(): Boolean {
+        return prefs.getBoolean("gguf_enabled", false)
+    }
+
+    fun saveGgufEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("gguf_enabled", enabled).apply()
+        _ggufEnabled.value = enabled
+    }
+
     fun getHfAccessTokenDirect(): String {
         return prefs.getString("hf_access_token", "").orEmpty()
     }
@@ -193,6 +214,38 @@ class SettingsRepository(context: Context) {
     fun saveHfAccessToken(token: String) {
         prefs.edit().putString("hf_access_token", token).apply()
         _hfAccessToken.value = token
+    }
+
+    // ── Inference parameters ───────────────────────────────────────────────────────────
+
+    /**
+     * Reads the stored sampler params for one side, falling back to the shipped defaults for
+     * any value never set. [local] picks the on-device set; otherwise the OpenRouter set.
+     */
+    fun getInferenceParamsDirect(local: Boolean): InferenceParams {
+        val defaults = if (local) InferenceLimits.LOCAL_DEFAULTS else InferenceLimits.CLOUD_DEFAULTS
+        val p = if (local) "local" else "cloud"
+        return InferenceParams(
+            temperature = prefs.getFloat("ip_${p}_temperature", defaults.temperature),
+            topK = prefs.getInt("ip_${p}_top_k", defaults.topK),
+            topP = prefs.getFloat("ip_${p}_top_p", defaults.topP),
+            maxTokens = prefs.getInt("ip_${p}_max_tokens", defaults.maxTokens),
+        )
+    }
+
+    fun saveInferenceParams(local: Boolean, params: InferenceParams) {
+        val p = if (local) "local" else "cloud"
+        prefs.edit()
+            .putFloat("ip_${p}_temperature", params.temperature)
+            .putInt("ip_${p}_top_k", params.topK)
+            .putFloat("ip_${p}_top_p", params.topP)
+            .putInt("ip_${p}_max_tokens", params.maxTokens)
+            .apply()
+        if (local) _localInferenceParams.value = params else _cloudInferenceParams.value = params
+    }
+
+    fun resetInferenceParams(local: Boolean) {
+        saveInferenceParams(local, if (local) InferenceLimits.LOCAL_DEFAULTS else InferenceLimits.CLOUD_DEFAULTS)
     }
 
     // ── Deep Research ────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -464,19 +464,41 @@ class ChatViewModel(
             // Load updated dialog history
             val fullHistory = messageDao.getMessagesForChatSync(chatId)
 
+            // Resolve the user's global sampler settings for whichever model is about to run,
+            // clamped to that model's limits (so a budget set for a big model can't break a
+            // smaller one — it falls back to the shipped default instead).
+            val inferenceParams = if (isLocal) {
+                val lm = localModel!!
+                InferenceLimits.coerce(
+                    settingsRepository.getInferenceParamsDirect(local = true),
+                    ModelCapabilities(
+                        maxContextTokens = LocalModelCatalog.maxTokensFor(lm.id, lm.fileName),
+                        maxTopK = InferenceLimits.LOCAL_TOP_K_MAX,
+                    ),
+                    InferenceLimits.LOCAL_DEFAULTS,
+                )
+            } else {
+                InferenceLimits.coerce(
+                    settingsRepository.getInferenceParamsDirect(local = false),
+                    // Cloud context length isn't known here; OpenRouter clamps server-side.
+                    ModelCapabilities(maxContextTokens = 0, maxTopK = InferenceLimits.CLOUD_TOP_K_MAX),
+                    InferenceLimits.CLOUD_DEFAULTS,
+                )
+            }
+
             val responseFlow: Flow<StreamChunk> = when {
                 isLocal && clientSearchReady ->
-                    localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey)
+                    localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey, inferenceParams)
                 isLocal ->
-                    localLlmService.generate(localModel!!, chatId, fullHistory, systemPrompt)
+                    localLlmService.generate(localModel!!, chatId, fullHistory, systemPrompt, inferenceParams)
                 provider == "openrouter" ->
-                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = true)
+                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = true, params = inferenceParams)
                 clientSearchReady ->
-                    openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt) { query ->
+                    openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
                         webSearchService.search(provider, searchKey, query)
                     }
                 else ->
-                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false)
+                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false, params = inferenceParams)
             }
 
             // Begin Streaming Assistant response
@@ -816,7 +838,8 @@ class ChatViewModel(
         history: List<ChatMessage>,
         systemPrompt: String,
         provider: String,
-        searchKey: String
+        searchKey: String,
+        params: InferenceParams
     ): Flow<StreamChunk> = flow {
         var round = 0
         var continuation = false
@@ -826,7 +849,7 @@ class ChatViewModel(
             val upstream = if (continuation) {
                 localLlmService.continueGeneration()
             } else {
-                localLlmService.generate(model, chatId, history, systemPrompt)
+                localLlmService.generate(model, chatId, history, systemPrompt, params)
             }
 
             val buf = StringBuilder()

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DeepResearchModelDao
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
+import com.echoflow.data.InferenceParams
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelDao
 import com.echoflow.data.ModelDownloadManager
@@ -48,8 +49,13 @@ class SettingsViewModel(
 
     // Local models
     val localModelsEnabled: StateFlow<Boolean> = repository.localModelsEnabled
+    val ggufEnabled: StateFlow<Boolean> = repository.ggufEnabled
     val hfAccessToken: StateFlow<String> = repository.hfAccessToken
     val downloadStates: StateFlow<Map<String, DownloadState>> = downloadManager.states
+
+    // Inference parameters (global, one set per side)
+    val localInferenceParams: StateFlow<InferenceParams> = repository.localInferenceParams
+    val cloudInferenceParams: StateFlow<InferenceParams> = repository.cloudInferenceParams
 
     // Deep Research
     val deepResearchModelId: StateFlow<String> = repository.deepResearchModel
@@ -67,6 +73,11 @@ class SettingsViewModel(
 
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
+
+    // A picked file the user must confirm before we copy it (too big to load on this device).
+    private var pendingImportUri: Uri? = null
+    private val _importWarning = MutableStateFlow<String?>(null)
+    val importWarning: StateFlow<String?> = _importWarning.asStateFlow()
 
     // Starts empty on purpose: the search sheet must open idle, never replaying a stale
     // query or kicking off a search by itself.
@@ -158,8 +169,20 @@ class SettingsViewModel(
         repository.saveLocalModelsEnabled(enabled)
     }
 
+    fun saveGgufEnabled(enabled: Boolean) {
+        repository.saveGgufEnabled(enabled)
+    }
+
     fun saveHfAccessToken(token: String) {
         repository.saveHfAccessToken(token.trim())
+    }
+
+    fun saveInferenceParams(local: Boolean, params: InferenceParams) {
+        repository.saveInferenceParams(local, params)
+    }
+
+    fun resetInferenceParams(local: Boolean) {
+        repository.resetInferenceParams(local)
     }
 
     // ── Deep Research ────────────────────────────────────────────────────────────────
@@ -250,13 +273,48 @@ class SettingsViewModel(
     fun importModel(uri: Uri) {
         viewModelScope.launch {
             _importError.value = null
+            val allow = repository.getGgufEnabledDirect()
+            val assessment = downloadManager.assessImport(uri)
+            if (assessment.isGguf && !allow) {
+                _importError.value = "GGUF support is off. Turn on “Allow GGUF models” below to import .gguf files."
+                return@launch
+            }
+            if (assessment.tooBig) {
+                // Hold the file and ask first — don't copy multiple GB only to fail at load.
+                pendingImportUri = uri
+                _importWarning.value = "“${assessment.displayName}” needs roughly ${gb(assessment.estimatedPeakBytes)} " +
+                    "of RAM to run — more than this device's ${gb(assessment.deviceTotalRamBytes)}. " +
+                    "It will very likely fail to load. Import anyway?"
+                return@launch
+            }
+            runImport(uri, allow)
+        }
+    }
+
+    /** User chose to import despite the size warning. */
+    fun confirmImport() {
+        val uri = pendingImportUri ?: return
+        pendingImportUri = null
+        _importWarning.value = null
+        runImport(uri, repository.getGgufEnabledDirect())
+    }
+
+    fun dismissImportWarning() {
+        pendingImportUri = null
+        _importWarning.value = null
+    }
+
+    private fun runImport(uri: Uri, allowGguf: Boolean) {
+        viewModelScope.launch {
             try {
-                downloadManager.importFromUri(uri)
+                downloadManager.importFromUri(uri, allowGguf)
             } catch (e: Exception) {
                 _importError.value = e.message ?: "Import failed."
             }
         }
     }
+
+    private fun gb(bytes: Long): String = "%.1f GB".format(bytes / (1024.0 * 1024 * 1024))
 
     fun clearImportError() {
         _importError.value = null

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -140,6 +140,18 @@ fun ChatScreen(
     }
     val dataAgentAvailable = dataAgentEnabled && firecrawlKey.isNotBlank()
 
+    // Image attachments work for cloud models and for on-device .litertlm bundles (which
+    // support vision); .task models are text-only, so the Image option is hidden for them.
+    val imageAttachAllowed = remember(selectedModelID, localModelsList) {
+        if (selectedModelID.startsWith("local/")) {
+            localModelsList.firstOrNull { it.id == selectedModelID }
+                ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
+        } else true
+    }
+    LaunchedEffect(imageAttachAllowed) {
+        if (!imageAttachAllowed) chatViewModel.clearPendingAttachment()
+    }
+
     val activeModelList = remember(customModelsList) {
         val list = mutableListOf(DEFAULT_MODEL)
         customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
@@ -221,6 +233,7 @@ fun ChatScreen(
                 pendingName = pendingName,
                 onClearAttachment = { chatViewModel.clearPendingAttachment() },
                 onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
+                imageAttachEnabled = imageAttachAllowed,
                 isStreaming = isStreaming,
                 deepResearchActive = deepResearchActive,
                 webSearchChipOn = webSearchChipOn,
@@ -826,6 +839,7 @@ private fun InputToolbar(
     pendingName: String?,
     onClearAttachment: () -> Unit,
     onAttach: () -> Unit,
+    imageAttachEnabled: Boolean,
     isStreaming: Boolean,
     deepResearchActive: Boolean,
     webSearchChipOn: Boolean,
@@ -938,6 +952,7 @@ private fun InputToolbar(
                     PlusMenu(
                         expanded = plusMenuOpen,
                         onDismiss = { plusMenuOpen = false },
+                        showImage = imageAttachEnabled,
                         webSearchOn = webSearchChipOn,
                         deepResearchOn = deepResearchActive,
                         dataAgentOn = dataAgentActive,
@@ -990,6 +1005,7 @@ private fun InputToolbar(
 private fun PlusMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
+    showImage: Boolean,
     webSearchOn: Boolean,
     deepResearchOn: Boolean,
     dataAgentOn: Boolean,
@@ -1000,11 +1016,14 @@ private fun PlusMenu(
     onToggleDataAgent: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        DropdownMenuItem(
-            text = { Text("Image") },
-            leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
-            onClick = onImage,
-        )
+        // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
+        if (showImage) {
+            DropdownMenuItem(
+                text = { Text("Image") },
+                leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
+                onClick = onImage,
+            )
+        }
         DropdownMenuItem(
             text = { Text("Web search") },
             leadingIcon = { Icon(Icons.Default.TravelExplore, null) },

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -50,8 +50,10 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
@@ -70,6 +72,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -81,6 +84,8 @@ import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DownloadState
+import com.echoflow.data.InferenceLimits
+import com.echoflow.data.InferenceParams
 import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelCatalog
 import com.echoflow.data.OpenRouterModelInfo
@@ -93,6 +98,7 @@ import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
 import com.echoflow.ui.theme.rememberMorph
+import kotlin.math.roundToInt
 
 private data class Accent(val id: String, val label: String, val swatch: Color)
 
@@ -457,6 +463,7 @@ private fun MorphSwatch(
 private fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val apiKey by viewModel.apiKey.collectAsState()
     val customModels by viewModel.customModels.collectAsState()
+    val cloudParams by viewModel.cloudInferenceParams.collectAsState()
     val orQuery by viewModel.orModelQuery.collectAsState()
     val orResults by viewModel.orModelResults.collectAsState()
     val orLoading by viewModel.orDirectoryLoading.collectAsState()
@@ -564,6 +571,15 @@ private fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                 }
             }
         }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Tuning", "Sampler settings applied to every OpenRouter model")
+        InferenceParamsCard(
+            local = false,
+            params = cloudParams,
+            onChange = { viewModel.saveInferenceParams(local = false, params = it) },
+            onReset = { viewModel.resetInferenceParams(local = false) },
+        )
     }
 
     if (showModelDirectory) {
@@ -1334,10 +1350,13 @@ private fun DataAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 @Composable
 private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val localModelsEnabled by viewModel.localModelsEnabled.collectAsState()
+    val ggufEnabled by viewModel.ggufEnabled.collectAsState()
     val hfToken by viewModel.hfAccessToken.collectAsState()
+    val localParams by viewModel.localInferenceParams.collectAsState()
     val localModels by viewModel.localModels.collectAsState()
     val downloadStates by viewModel.downloadStates.collectAsState()
     val importError by viewModel.importError.collectAsState()
+    val importWarning by viewModel.importWarning.collectAsState()
     val hfModelQuery by viewModel.hfModelQuery.collectAsState()
     val hfSearchResults by viewModel.hfSearchResults.collectAsState()
     val hfSearchLoading by viewModel.hfSearchLoading.collectAsState()
@@ -1413,6 +1432,13 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                         Text("Import")
                     }
                 }
+                Spacer(Modifier.height(Spacing.s))
+                Text(
+                    "Search lists LiteRT models (.task / .litertlm). GGUF (.gguf) is import-only — enable it below first.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = Spacing.xs),
+                )
                 importError?.let { error ->
                     Spacer(Modifier.height(Spacing.s))
                     Text(
@@ -1421,6 +1447,32 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                         color = MaterialTheme.colorScheme.error,
                         modifier = Modifier.padding(start = Spacing.xs),
                     )
+                }
+
+                Spacer(Modifier.height(Spacing.m))
+                Surface(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Gem))
+                                .background(MaterialTheme.colorScheme.tertiaryContainer),
+                            contentAlignment = Alignment.Center,
+                        ) { Icon(Icons.Default.Memory, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer) }
+                        Spacer(Modifier.width(Spacing.base))
+                        Column(Modifier.weight(1f)) {
+                            Text("Allow GGUF models", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                            Text(
+                                "Experimental llama.cpp format. Off by default — runs CPU-only and quality varies. Lets you import .gguf files (search stays LiteRT/.task only).",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(Modifier.width(Spacing.s))
+                        Switch(checked = ggufEnabled, onCheckedChange = viewModel::saveGgufEnabled)
+                    }
                 }
 
                 Spacer(Modifier.height(Spacing.m))
@@ -1520,8 +1572,28 @@ private fun LocalModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                         }
                     }
                 }
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Tuning", "Sampler settings applied to every on-device model")
+                InferenceParamsCard(
+                    local = true,
+                    params = localParams,
+                    onChange = { viewModel.saveInferenceParams(local = true, params = it) },
+                    onReset = { viewModel.resetInferenceParams(local = true) },
+                )
             }
         }
+    }
+
+    importWarning?.let { message ->
+        AlertDialog(
+            onDismissRequest = viewModel::dismissImportWarning,
+            icon = { Icon(Icons.Default.Memory, null) },
+            title = { Text("This model may be too large") },
+            text = { Text(message) },
+            confirmButton = { TextButton(onClick = viewModel::confirmImport) { Text("Import anyway") } },
+            dismissButton = { TextButton(onClick = viewModel::dismissImportWarning) { Text("Cancel") } },
+        )
     }
 
     if (showHfModelSearch) {
@@ -1603,6 +1675,250 @@ private fun PageSection(title: String, supporting: String? = null) {
             )
         }
     }
+}
+
+/**
+ * Collapsible "generation parameters" card used on both the Cloud and Local model pages.
+ * One global set of sampler knobs per side; values persist as the user releases each slider.
+ * Out-of-range values are clamped per model at generation time, so the sliders here are the
+ * user's *preferences*, not necessarily what a given small model will run with.
+ */
+@Composable
+private fun InferenceParamsCard(
+    local: Boolean,
+    params: InferenceParams,
+    onChange: (InferenceParams) -> Unit,
+    onReset: () -> Unit,
+) {
+    var open by rememberSaveable(local) { mutableStateOf(false) }
+    // Live draft so dragging is smooth; persisted only when a slider is released.
+    var draft by remember(params) { mutableStateOf(params) }
+
+    val defaults = if (local) InferenceLimits.LOCAL_DEFAULTS else InferenceLimits.CLOUD_DEFAULTS
+    val isDefault = params == defaults
+    val topKMax = if (local) InferenceLimits.LOCAL_TOP_K_MAX else InferenceLimits.CLOUD_TOP_K_MAX
+    val maxTokCeil = if (local) InferenceLimits.LOCAL_MAX_TOKENS_CEIL else InferenceLimits.CLOUD_MAX_TOKENS_CEIL
+    val tokenSteps = (maxTokCeil / InferenceLimits.MAX_TOKENS_STEP) - 1
+
+    val chevron by animateFloatAsState(
+        targetValue = if (open) 180f else 0f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "paramsChevron",
+    )
+
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column {
+            Surface(onClick = { open = !open }, color = Color.Transparent, modifier = Modifier.fillMaxWidth()) {
+                Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        Modifier.size(40.dp).clip(RoundedPolygonShape(MaterialShapes.Cookie4Sided))
+                            .background(MaterialTheme.colorScheme.secondaryContainer),
+                        contentAlignment = Alignment.Center,
+                    ) { Icon(Icons.Default.Tune, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
+                    Spacer(Modifier.width(Spacing.base))
+                    Column(Modifier.weight(1f)) {
+                        Text("Generation parameters", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                        Text(
+                            if (isDefault) "Shipped defaults" else "Customized",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (isDefault) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    Icon(
+                        Icons.Default.ExpandMore, if (open) "Collapse" else "Expand",
+                        Modifier.rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            AnimatedVisibility(visible = open, enter = sectionEnter(), exit = sectionExit()) {
+                Column(Modifier.padding(start = Spacing.base, end = Spacing.base, bottom = Spacing.base)) {
+                    ParamSliderRow(
+                        label = "Temperature",
+                        value = draft.temperature,
+                        valueRange = InferenceLimits.TEMP_MIN..InferenceLimits.TEMP_MAX,
+                        steps = 39,
+                        display = { "%.2f".format(it) },
+                        editPrefill = { "%.2f".format(it) },
+                        editHint = "0.00 – 2.00",
+                        editDecimals = true,
+                        onValueChange = { draft = draft.copy(temperature = (it * 100).roundToInt() / 100f) },
+                        onCommit = { onChange(draft) },
+                    )
+                    ParamSliderRow(
+                        label = "Top P",
+                        value = draft.topP,
+                        valueRange = InferenceLimits.TOP_P_MIN..InferenceLimits.TOP_P_MAX,
+                        steps = 19,
+                        display = { "%.2f".format(it) },
+                        editPrefill = { "%.2f".format(it) },
+                        editHint = "0.00 – 1.00",
+                        editDecimals = true,
+                        onValueChange = { draft = draft.copy(topP = (it * 100).roundToInt() / 100f) },
+                        onCommit = { onChange(draft) },
+                    )
+                    ParamSliderRow(
+                        label = "Top K",
+                        value = draft.topK.toFloat(),
+                        valueRange = 0f..topKMax.toFloat(),
+                        steps = 0,
+                        display = { if (it < 1f) "Off" else it.roundToInt().toString() },
+                        editPrefill = { it.roundToInt().toString() },
+                        editHint = "0 (off) – $topKMax",
+                        editDecimals = false,
+                        onValueChange = { draft = draft.copy(topK = it.roundToInt()) },
+                        onCommit = { onChange(draft) },
+                    )
+                    ParamSliderRow(
+                        label = "Max tokens",
+                        value = draft.maxTokens.coerceIn(0, maxTokCeil).toFloat(),
+                        valueRange = 0f..maxTokCeil.toFloat(),
+                        steps = tokenSteps,
+                        display = {
+                            val v = it.roundToInt()
+                            if (v <= 0) (if (local) "Model default" else "Unlimited") else v.toString()
+                        },
+                        editPrefill = { it.roundToInt().toString() },
+                        editHint = "0 (${if (local) "model default" else "unlimited"}) – $maxTokCeil",
+                        editDecimals = false,
+                        onValueChange = { draft = draft.copy(maxTokens = it.roundToInt()) },
+                        onCommit = { onChange(draft) },
+                    )
+                    Text(
+                        if (local)
+                            "Applied to every on-device model. If a value exceeds what the running model supports, it falls back to the default for that model."
+                        else
+                            "Applied to every OpenRouter model. Top K and Max tokens are only sent when set above their off position.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = Spacing.xs),
+                    )
+                    Spacer(Modifier.height(Spacing.s))
+                    TextButton(
+                        onClick = onReset,
+                        enabled = !isDefault,
+                        modifier = Modifier.align(Alignment.End),
+                    ) {
+                        Icon(Icons.Default.RestartAlt, null, Modifier.size(18.dp))
+                        Spacer(Modifier.width(Spacing.xs))
+                        Text("Reset to defaults")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One labeled slider row with a value chip that's both a readout and a tap target: tapping
+ * it opens a small dialog for typing an exact number. Either way the value is snapped to the
+ * slider's step grid and clamped to [valueRange] before [onCommit] persists it.
+ */
+@Composable
+private fun ParamSliderRow(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    display: (Float) -> String,
+    editPrefill: (Float) -> String,
+    editHint: String,
+    editDecimals: Boolean,
+    onValueChange: (Float) -> Unit,
+    onCommit: () -> Unit,
+) {
+    var editing by remember { mutableStateOf(false) }
+
+    Column(Modifier.padding(top = Spacing.s)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+            Surface(
+                onClick = { editing = true },
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Text(
+                    display(value),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.padding(horizontal = Spacing.m, vertical = 4.dp),
+                )
+            }
+        }
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            onValueChangeFinished = onCommit,
+            valueRange = valueRange,
+            steps = steps,
+        )
+    }
+
+    if (editing) {
+        ParamValueDialog(
+            label = label,
+            initial = editPrefill(value),
+            hint = "Allowed: $editHint",
+            decimals = editDecimals,
+            onDismiss = { editing = false },
+            onConfirm = { typed ->
+                editing = false
+                typed.trim().toFloatOrNull()?.let { raw ->
+                    val clamped = raw.coerceIn(valueRange.start, valueRange.endInclusive)
+                    onValueChange(snapToStep(clamped, valueRange, steps))
+                    onCommit()
+                }
+            },
+        )
+    }
+}
+
+/** Snaps a value to the slider's discrete grid (a no-op for continuous sliders). */
+private fun snapToStep(value: Float, range: ClosedFloatingPointRange<Float>, steps: Int): Float {
+    if (steps <= 0) return value
+    val stepSize = (range.endInclusive - range.start) / (steps + 1)
+    if (stepSize <= 0f) return value
+    return range.start + ((value - range.start) / stepSize).roundToInt() * stepSize
+}
+
+/** Numeric entry dialog for a single parameter; accepts integers or decimals per [decimals]. */
+@Composable
+private fun ParamValueDialog(
+    label: String,
+    initial: String,
+    hint: String,
+    decimals: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(label) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    singleLine = true,
+                    shape = MaterialTheme.shapes.medium,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = if (decimals) KeyboardType.Decimal else KeyboardType.Number,
+                        imeAction = ImeAction.Done,
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { onConfirm(text) }),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(Spacing.s))
+                Text(hint, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(text) }) { Text("Set") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 @Composable
@@ -1831,7 +2147,7 @@ private fun HfModelSearchSheet(
             Text("Search mobile models", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onSurface)
             Spacer(Modifier.height(Spacing.xs))
             Text(
-                "LiteRT-LM bundles from Hugging Face (.task / .litertlm) that run fully on-device.",
+                "LiteRT-LM bundles from Hugging Face (.task / .litertlm) that run fully on-device. GGUF models are import-only.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,9 @@ mediapipeTasksGenai = "0.10.35"
 # Standalone LiteRT-LM engine — what AI Edge Gallery actually runs .litertlm bundles on
 # (gemma-4 crashes under the MediaPipe wrapper even at 0.10.35). Gallery pins 0.11.0.
 litertlm = "0.11.0"
+# llama.cpp-backed GGUF runtime (prebuilt arm64-v8a + x86_64 .so via the published AAR).
+# Used only for .gguf models; .task/.litertlm keep their existing runtimes.
+llamacppKotlin = "0.4.0"
 moshiKotlin = "1.15.2"
 moshiKotlinCodegen = "1.15.2"
 datastorePreferences = "1.1.7"
@@ -95,6 +98,7 @@ logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-intercep
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 mediapipe-tasks-genai = { group = "com.google.mediapipe", name = "tasks-genai", version.ref = "mediapipeTasksGenai" }
 litertlm-android = { group = "com.google.ai.edge.litertlm", name = "litertlm-android", version.ref = "litertlm" }
+llamacpp-kotlin = { group = "io.github.ljcamargo", name = "llamacpp-kotlin", version.ref = "llamacppKotlin" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }


### PR DESCRIPTION
## Summary
- add GGUF as a first-class local model format alongside the existing on-device runtimes
- extend local model loading, download/import flow, and inference parameter handling for the new runtime
- Added Image Support For .litertlm based models 
- update settings, chat routing, and model catalog logic so local models expose the right capabilities and defaults
- refresh dependency versions needed for the local inference stack changes

## Testing
- Local validation of the updated model flow and settings paths
- Build and integration checks for the affected Android modules passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GGUF local model support via llama.cpp and expand inference parameter settings
> - Adds llama.cpp (`.gguf`) as a third local inference runtime in `LocalLlmService`, alongside existing MediaPipe and LiteRT-LM backends, with streaming output and continuation support.
> - Introduces `InferenceParams` and `InferenceLimits` in [InferenceParams.kt](https://github.com/adityavardhansharma/EchoFlow/pull/21/files#diff-0fe994f4a18a6cd9e261894880fe5b2649075dc92a5ca54d7ae0609b4de30ec7) to centralize temperature, top-k, top-p, and max-token settings, clamped per-model before dispatch.
> - Adds UI in [SettingsScreen.kt](https://github.com/adityavardhansharma/EchoFlow/pull/21/files#diff-56fd121882bb279ab6fe1763d8783dced0e961ae9aa5e245b5d14b6b342cba66) for tuning inference parameters for both local and cloud models, with sliders and a numeric input dialog.
> - Pre-import RAM assessment warns users when a GGUF file is likely too large (~1.8× file size vs 85% of device RAM); GGUF import is gated behind an explicit opt-in toggle.
> - Restricts image attachments in chat to cloud models and `.litertlm` local models only; adds multimodal image input support for LiteRT-LM via `imageContentFromUri`.
> - Risk: GGUF models run via llama.cpp on-device and may cause OOM on devices with limited RAM despite the pre-import warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fa3ab9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GGUF model imports with optional enable/disable toggle behind experimental settings.
  * Introduced inference parameter tuning (temperature, top-p, top-k, max tokens) for both on-device and cloud models with preset defaults and per-model clamping.
  * Added image attachment capability for cloud models and select on-device formats.
  * Implemented import validation with warnings for oversized files requiring explicit confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->