### PR TITLE
Ship arm64-only release APK and update local AI handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,10 +19,11 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-    // MediaPipe LLM inference ships large native libs per ABI; limit to the ABIs we
-    // actually target (arm64 devices + x86_64 emulator) to keep the APK size sane.
+    // Local AI runtimes ship large native libs per ABI. Release APKs target modern
+    // Android phones, so package arm64 only; emulator/x86 builds should use a debug
+    // override if needed.
     ndk {
-      abiFilters += listOf("arm64-v8a", "x86_64")
+      abiFilters += listOf("arm64-v8a")
     }
   }
 


### PR DESCRIPTION
## Summary
- limit release packaging to `arm64-v8a` so the APK stops carrying x86/x86_64 native AI libraries
- keep the app targeted at modern Android phones while reducing release size significantly
- retain local AI runtime support in the app code for the supported ABI

## Testing
- Not run (not requested)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship arm64-only release APK by removing x86_64 from ABI filters
> Updates [app/build.gradle.kts](https://github.com/adityavardhansharma/EchoFlow/pull/22/files#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46) to remove `x86_64` from the ABI filter, so release builds only package `arm64-v8a` native libraries. Risk: x86_64 emulator builds will no longer work without a debug override.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a13872.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android NDK native library packaging to include arm64-v8a architecture exclusively. Support for x86_64 architecture has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->