### PR TITLE
Add full LaTeX rendering and clean up local model labels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
   implementation(libs.markdown.renderer.m3)
   implementation(libs.markdown.renderer.code)
   implementation(libs.highlights)
+  implementation(libs.latex.renderer)
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.datastore.preferences)
   implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -229,7 +229,8 @@ object SystemPrompts {
         append(
             "## Style\n" +
                 "Use markdown when it helps. Match the user's language and tone. Be direct — lead with the answer, " +
-                "then add detail."
+                "then add detail. When writing math, use LaTeX: `${'$'}...${'$'}` for short inline expressions and " +
+                "`${'$'}${'$'}...${'$'}${'$'}` for important equations or multi-step derivations. Do not leave unmatched `${'$'}` delimiters."
         )
         if (isLocalModel) {
             append(" Do not prefix replies with \"User:\" or \"Assistant:\".")

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownText.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
@@ -20,8 +22,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -36,11 +41,17 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.TextUnit
 import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.BoldHighlight
 import dev.snipme.highlights.model.ColorHighlight
 import dev.snipme.highlights.model.SyntaxLanguage
 import dev.snipme.highlights.model.SyntaxThemes
+import com.hrm.latex.renderer.Latex
+import com.hrm.latex.renderer.LatexAutoWrap
+import com.hrm.latex.renderer.measure.rememberLatexMeasurer
+import com.hrm.latex.renderer.model.LatexConfig
+import com.hrm.latex.renderer.model.LatexTheme
 
 /**
  * One markdown renderer for the whole app — used identically while a message streams and once it is
@@ -49,7 +60,8 @@ import dev.snipme.highlights.model.SyntaxThemes
  * child composable taking only stable params, so during streaming only the final, still-growing
  * block re-renders each frame. Supports headers, ordered/bulleted (nested) lists, blockquotes,
  * horizontal rules, GFM tables (wrapping cells — never truncated), fenced code blocks with real
- * syntax highlighting, and inline bold/italic/strikethrough/code/links.
+ * syntax highlighting, LaTeX math (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`), and inline
+ * bold/italic/strikethrough/code/links.
  */
 @Composable
 fun RichMarkdown(text: String, modifier: Modifier = Modifier) {
@@ -71,6 +83,7 @@ fun MarkdownText(
             when (block) {
                 is MarkdownBlock.Header -> MdHeader(block.text, block.level, textColor, linkColor)
                 is MarkdownBlock.CodeBlock -> CodeBlockItem(code = block.code, language = block.language)
+                is MarkdownBlock.MathBlock -> MdMathBlock(block, textColor, linkColor, style)
                 is MarkdownBlock.BulletItem -> MdBullet(block.text, block.indent, block.ordinal, textColor, linkColor, style)
                 is MarkdownBlock.Quote -> MdQuote(block.text, textColor, linkColor, style)
                 is MarkdownBlock.Divider -> HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -83,27 +96,54 @@ fun MarkdownText(
 
 @Composable
 private fun MdHeader(text: String, level: Int, color: Color, linkColor: Color) {
-    val annotated = remember(text, color, linkColor) { parseInlineStyles(text, linkColor) }
     val base = when (level) {
         1 -> MaterialTheme.typography.headlineMedium
         2 -> MaterialTheme.typography.titleLarge
         3 -> MaterialTheme.typography.titleMedium
         else -> MaterialTheme.typography.titleSmall
     }
-    Text(annotated, style = base.copy(fontWeight = FontWeight.Bold, color = color), modifier = Modifier.padding(top = 4.dp, bottom = 2.dp))
+    InlineMarkdownText(
+        text = text,
+        color = color,
+        linkColor = linkColor,
+        style = base.copy(fontWeight = FontWeight.Bold, color = color),
+        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
+    )
 }
 
 @Composable
 private fun MdParagraph(text: String, color: Color, linkColor: Color, style: TextStyle) {
-    val annotated = remember(text, color, linkColor) { parseInlineStyles(text, linkColor) }
     SelectionContainer {
-        Text(annotated, style = style.copy(color = color), modifier = Modifier.fillMaxWidth())
+        InlineMarkdownText(
+            text = text,
+            color = color,
+            linkColor = linkColor,
+            style = style.copy(color = color),
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
 @Composable
+private fun MdMathBlock(block: MarkdownBlock.MathBlock, color: Color, linkColor: Color, style: TextStyle) {
+    if (!block.complete || block.latex.isBlank()) {
+        MdParagraph(block.raw, color, linkColor, style)
+        return
+    }
+
+    val config = latexConfigFor(style, scale = 1.05f)
+    LatexAutoWrap(
+        latex = block.latex,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        config = config,
+        isDarkTheme = isSystemInDarkTheme()
+    )
+}
+
+@Composable
 private fun MdBullet(text: String, indent: Int, ordinal: Int?, color: Color, linkColor: Color, style: TextStyle) {
-    val annotated = remember(text, color, linkColor) { parseInlineStyles(text, linkColor) }
     val marker = if (ordinal != null) "$ordinal." else "•"
     Row(
         modifier = Modifier.fillMaxWidth().padding(start = (8 + indent * 16).dp),
@@ -115,14 +155,19 @@ private fun MdBullet(text: String, indent: Int, ordinal: Int?, color: Color, lin
             modifier = Modifier.widthIn(min = 18.dp)
         )
         SelectionContainer {
-            Text(annotated, style = style.copy(color = color), modifier = Modifier.weight(1f))
+            InlineMarkdownText(
+                text = text,
+                color = color,
+                linkColor = linkColor,
+                style = style.copy(color = color),
+                modifier = Modifier.weight(1f)
+            )
         }
     }
 }
 
 @Composable
 private fun MdQuote(text: String, color: Color, linkColor: Color, style: TextStyle) {
-    val annotated = remember(text, color, linkColor) { parseInlineStyles(text, linkColor) }
     Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp), verticalAlignment = Alignment.Top) {
         Box(
             Modifier
@@ -133,8 +178,10 @@ private fun MdQuote(text: String, color: Color, linkColor: Color, style: TextSty
                 .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.6f), RoundedCornerShape(2.dp))
         )
         SelectionContainer {
-            Text(
-                annotated,
+            InlineMarkdownText(
+                text = text,
+                color = color.copy(alpha = 0.85f),
+                linkColor = linkColor,
                 style = style.copy(color = color.copy(alpha = 0.85f), fontStyle = FontStyle.Italic),
                 modifier = Modifier.weight(1f)
             )
@@ -189,9 +236,10 @@ private fun TableRow(
         for (c in 0 until columnCount) {
             val cellText = cells.getOrNull(c).orEmpty()
             val align = aligns.getOrNull(c) ?: TextAlign.Start
-            val annotated = remember(cellText, linkColor) { parseInlineStyles(cellText, linkColor) }
-            Text(
-                annotated,
+            InlineMarkdownText(
+                text = cellText,
+                color = color,
+                linkColor = linkColor,
                 style = style.copy(color = color, textAlign = align),
                 modifier = Modifier
                     .weight(1f)
@@ -204,6 +252,7 @@ private fun TableRow(
 sealed class MarkdownBlock {
     data class Header(val text: String, val level: Int) : MarkdownBlock()
     data class CodeBlock(val code: String, val language: String?) : MarkdownBlock()
+    data class MathBlock(val latex: String, val raw: String, val complete: Boolean) : MarkdownBlock()
     /** A list item. [ordinal] is null for bullets, the number for ordered items. */
     data class BulletItem(val text: String, val indent: Int, val ordinal: Int?) : MarkdownBlock()
     data class Quote(val text: String) : MarkdownBlock()
@@ -260,6 +309,13 @@ fun parseMarkdownBlocks(text: String): List<MarkdownBlock> {
         if (insideCodeBlock) {
             codeAccumulator.append(line).append('\n')
             i++
+            continue
+        }
+
+        parseDisplayMathBlock(lines, i)?.let { parsed ->
+            flushParagraph()
+            blocks.add(parsed.block)
+            i = parsed.nextIndex
             continue
         }
 
@@ -349,6 +405,281 @@ private fun parseTableAligns(separator: String): List<TextAlign> =
             else -> TextAlign.Start
         }
     }
+
+private data class ParsedDisplayMath(val block: MarkdownBlock.MathBlock, val nextIndex: Int)
+
+private fun parseDisplayMathBlock(lines: List<String>, index: Int): ParsedDisplayMath? {
+    val line = lines[index]
+    val trimmed = line.trim()
+    val delimiter = when {
+        trimmed.startsWith("$$") -> "$$"
+        trimmed.startsWith("\\[") -> "\\]"
+        else -> return null
+    }
+    val open = if (delimiter == "$$") "$$" else "\\["
+    val close = delimiter
+    val firstContent = trimmed.removePrefix(open)
+
+    if (firstContent.contains(close)) {
+        val latex = firstContent.substringBefore(close).trim()
+        val tail = firstContent.substringAfter(close)
+        if (tail.isBlank()) {
+            return ParsedDisplayMath(
+                MarkdownBlock.MathBlock(latex = latex, raw = line, complete = latex.isNotBlank()),
+                index + 1
+            )
+        }
+        return null
+    }
+
+    val raw = StringBuilder(line)
+    val latex = StringBuilder(firstContent.trimStart())
+    var i = index + 1
+    while (i < lines.size) {
+        val current = lines[i]
+        raw.append('\n').append(current)
+        val closeAt = current.indexOf(close)
+        if (closeAt != -1) {
+            if (latex.isNotEmpty()) latex.append('\n')
+            latex.append(current.substring(0, closeAt).trimEnd())
+            return ParsedDisplayMath(
+                MarkdownBlock.MathBlock(
+                    latex = latex.toString().trim(),
+                    raw = raw.toString(),
+                    complete = true
+                ),
+                i + 1
+            )
+        }
+        if (latex.isNotEmpty()) latex.append('\n')
+        latex.append(current)
+        i++
+    }
+
+    return ParsedDisplayMath(
+        MarkdownBlock.MathBlock(
+            latex = latex.toString().trim(),
+            raw = raw.toString(),
+            complete = false
+        ),
+        lines.size
+    )
+}
+
+private sealed class InlineSegment {
+    data class Text(val text: String) : InlineSegment()
+    data class Math(val latex: String, val raw: String) : InlineSegment()
+}
+
+private fun parseInlineMathSegments(text: String): List<InlineSegment> {
+    val segments = mutableListOf<InlineSegment>()
+    val plain = StringBuilder()
+    var i = 0
+
+    fun flushPlain() {
+        if (plain.isNotEmpty()) {
+            segments.add(InlineSegment.Text(plain.toString()))
+            plain.setLength(0)
+        }
+    }
+
+    while (i < text.length) {
+        when {
+            text.startsWith("\\(", i) -> {
+                val end = text.indexOf("\\)", i + 2)
+                if (end == -1) {
+                    plain.append(text.substring(i))
+                    break
+                }
+                val raw = text.substring(i, end + 2)
+                val latex = text.substring(i + 2, end).trim()
+                if (latex.isNotEmpty()) {
+                    flushPlain()
+                    segments.add(InlineSegment.Math(latex, raw))
+                } else {
+                    plain.append(raw)
+                }
+                i = end + 2
+            }
+
+            text.startsWith("\\[", i) -> {
+                val end = text.indexOf("\\]", i + 2)
+                if (end == -1) {
+                    plain.append(text.substring(i))
+                    break
+                }
+                val raw = text.substring(i, end + 2)
+                val latex = text.substring(i + 2, end).trim()
+                if (latex.isNotEmpty()) {
+                    flushPlain()
+                    segments.add(InlineSegment.Math(latex, raw))
+                } else {
+                    plain.append(raw)
+                }
+                i = end + 2
+            }
+
+            text.startsWith("$$", i) && !isEscaped(text, i) -> {
+                val end = text.indexOf("$$", i + 2)
+                if (end == -1) {
+                    plain.append(text.substring(i))
+                    break
+                }
+                val raw = text.substring(i, end + 2)
+                val latex = text.substring(i + 2, end).trim()
+                if (latex.isNotEmpty()) {
+                    flushPlain()
+                    segments.add(InlineSegment.Math(latex, raw))
+                } else {
+                    plain.append(raw)
+                }
+                i = end + 2
+            }
+
+            text[i] == '$' && !isEscaped(text, i) -> {
+                val end = findInlineDollarClose(text, i + 1)
+                if (end == -1) {
+                    plain.append(text[i])
+                    i++
+                    continue
+                }
+                val raw = text.substring(i, end + 1)
+                val latex = text.substring(i + 1, end).trim()
+                if (looksLikeMath(latex, text.getOrNull(i - 1), text.getOrNull(end + 1))) {
+                    flushPlain()
+                    segments.add(InlineSegment.Math(latex, raw))
+                } else {
+                    plain.append(raw)
+                }
+                i = end + 1
+            }
+
+            else -> {
+                plain.append(text[i])
+                i++
+            }
+        }
+    }
+
+    flushPlain()
+    return segments
+}
+
+private fun findInlineDollarClose(text: String, from: Int): Int {
+    var i = from
+    while (i < text.length) {
+        if (text[i] == '$' && !isEscaped(text, i) && text.getOrNull(i + 1) != '$') return i
+        i++
+    }
+    return -1
+}
+
+private fun isEscaped(text: String, index: Int): Boolean {
+    var slashCount = 0
+    var i = index - 1
+    while (i >= 0 && text[i] == '\\') {
+        slashCount++
+        i--
+    }
+    return slashCount % 2 == 1
+}
+
+private fun looksLikeMath(content: String, before: Char?, after: Char?): Boolean {
+    if (content.isBlank()) return false
+    if (content.first().isWhitespace() || content.last().isWhitespace()) return false
+    if (content.length > 160) return false
+    if (before?.isLetterOrDigit() == true && after?.isLetterOrDigit() == true) return false
+    val lower = content.lowercase()
+    val hasMathSignal = content.any { it in "\\^_=+-*/()[]{}<>|'" } ||
+        listOf("frac", "sqrt", "lim", "sum", "int", "text", "sin", "cos", "tan", "log", "ln").any { it in lower }
+    val isTinyVariable = content.length <= 4 && content.any { it.isLetter() } && content.none { it.isDigit() }
+    return hasMathSignal || isTinyVariable
+}
+
+@Composable
+private fun InlineMarkdownText(
+    text: String,
+    color: Color,
+    linkColor: Color,
+    style: TextStyle,
+    modifier: Modifier = Modifier
+) {
+    val segments = remember(text) { parseInlineMathSegments(text) }
+    val hasMath = segments.any { it is InlineSegment.Math }
+    if (!hasMath) {
+        val annotated = remember(text, linkColor) { parseInlineStyles(text, linkColor) }
+        Text(annotated, style = style.copy(color = color), modifier = modifier)
+        return
+    }
+
+    val config = latexConfigFor(style, scale = 0.92f)
+    val measurer = rememberLatexMeasurer(config)
+    val density = LocalDensity.current
+    val darkTheme = isSystemInDarkTheme()
+    val measured = remember(segments, config, darkTheme) {
+        segments.map { segment ->
+            if (segment is InlineSegment.Math) measurer.measure(segment.latex, config, darkTheme) else null
+        }
+    }
+    val annotated = remember(segments, measured, linkColor) {
+        buildAnnotatedString {
+            segments.forEachIndexed { index, segment ->
+                when (segment) {
+                    is InlineSegment.Text -> appendInline(segment.text, linkColor)
+                    is InlineSegment.Math -> {
+                        if (measured[index] != null) {
+                            appendInlineContent("math_$index", segment.raw)
+                        } else {
+                            appendInline(segment.raw, linkColor)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    val inlineContent = remember(segments, measured, config, density, darkTheme) {
+        buildMap {
+            segments.forEachIndexed { index, segment ->
+                val dims = measured[index] ?: return@forEachIndexed
+                if (segment is InlineSegment.Math) {
+                    put(
+                        "math_$index",
+                        InlineTextContent(
+                            placeholder = Placeholder(
+                                width = with(density) { dims.widthPx.toSp() },
+                                height = with(density) { dims.heightPx.toSp() },
+                                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+                            )
+                        ) {
+                            Latex(
+                                latex = segment.latex,
+                                config = config,
+                                isDarkTheme = darkTheme
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    Text(
+        text = annotated,
+        inlineContent = inlineContent,
+        style = style.copy(color = color),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun latexConfigFor(style: TextStyle, scale: Float): LatexConfig {
+    val baseSize = if (style.fontSize == TextUnit.Unspecified) 16.sp else style.fontSize
+    return LatexConfig(
+        fontSize = baseSize * scale,
+        theme = LatexTheme.material3(),
+        accessibilityEnabled = true
+    )
+}
 
 /**
  * Parses inline markdown — **bold**, *italic*, ~~strikethrough~~, `code`, and [text](url) links —

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -1315,6 +1315,7 @@ private fun DrEngineRow(name: String, description: String, selected: Boolean, on
 
 @Composable
 private fun ModelRow(name: String, modelId: String, selected: Boolean, isLocal: Boolean = false, onClick: () -> Unit) {
+    val displayName = remember(name, isLocal) { modelPickerDisplayName(name, isLocal) }
     val provider = when {
         isLocal -> "Runs on this device — private & offline"
         modelId.contains("/") -> modelId.substringBefore("/").replaceFirstChar { it.uppercase() }
@@ -1332,10 +1333,12 @@ private fun ModelRow(name: String, modelId: String, selected: Boolean, isLocal: 
             Column(Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        name,
+                        displayName,
                         style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
                         color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1, overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
                     if (isLocal) {
                         Spacer(Modifier.width(Spacing.s))
@@ -1351,9 +1354,44 @@ private fun ModelRow(name: String, modelId: String, selected: Boolean, isLocal: 
                         }
                     }
                 }
-                Text(provider, style = MaterialTheme.typography.bodySmall, color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    provider,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
             if (selected) Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
         }
     }
+}
+
+private fun modelPickerDisplayName(name: String, isLocal: Boolean): String {
+    if (!isLocal || name.length <= 24) return name
+
+    var clean = name
+        .removeSuffix(".gguf")
+        .removeSuffix(".GGUF")
+        .removeSuffix(".task")
+        .removeSuffix(".TASK")
+        .removeSuffix(".litertlm")
+        .removeSuffix(".LITERTLM")
+        .trim()
+
+    val quantOrPrecisionSuffix = Regex(
+        pattern = """(?i)(?:[-_](?:q[2-8](?:[-_][a-z0-9]+){0,5}|iq[1-4](?:[-_][a-z0-9]+){0,5}|mixed[-_]?int[48]|int[48]|f16|fp16|bf16))+$"""
+    )
+    clean = clean.replace(quantOrPrecisionSuffix, "")
+
+    if (clean.length > 24) {
+        clean = clean.replace(Regex("""(?i)[-_](?:20\d{2}|2[0-9]{3}|[0-9]{4})(?=$|[-_])"""), "")
+    }
+    if (clean.length > 30) {
+        clean = clean
+            .replace(Regex("""(?i)[-_](?:gguf|k[-_]?m|instruct[-_]?gguf)$"""), "")
+            .trim('-', '_', ' ')
+    }
+
+    return clean.ifBlank { name }.takeIf { it.length >= 8 } ?: name
 }

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -1,0 +1,61 @@
+package com.echoflow
+
+import com.echoflow.ui.components.MarkdownBlock
+import com.echoflow.ui.components.parseMarkdownBlocks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownTextTest {
+
+    @Test
+    fun parsesDollarDisplayMathBlock() {
+        val blocks = parseMarkdownBlocks(
+            """
+            Before
+
+            $$
+            f'(x) = \lim_{h \to 0} \frac{f(x+h)-f(x)}{h}
+            $$
+
+            After
+            """.trimIndent()
+        )
+
+        assertEquals("Before", (blocks[0] as MarkdownBlock.Paragraph).text)
+        val math = blocks[1] as MarkdownBlock.MathBlock
+        assertTrue(math.complete)
+        assertEquals("f'(x) = \\lim_{h \\to 0} \\frac{f(x+h)-f(x)}{h}", math.latex)
+        assertEquals("After", (blocks[2] as MarkdownBlock.Paragraph).text)
+    }
+
+    @Test
+    fun parsesBracketDisplayMathBlock() {
+        val blocks = parseMarkdownBlocks(
+            """
+            \[
+            E = mc^2
+            \]
+            """.trimIndent()
+        )
+
+        val math = blocks.single() as MarkdownBlock.MathBlock
+        assertTrue(math.complete)
+        assertEquals("E = mc^2", math.latex)
+    }
+
+    @Test
+    fun keepsUnclosedDisplayMathVisibleWhileStreaming() {
+        val blocks = parseMarkdownBlocks(
+            """
+            $$
+            \frac{x}{y}
+            """.trimIndent()
+        )
+
+        val math = blocks.single() as MarkdownBlock.MathBlock
+        assertFalse(math.complete)
+        assertEquals("$$\n\\frac{x}{y}", math.raw)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ material3 = "1.5.0-alpha20"
 graphicsShapes = "1.0.1"
 markdownRenderer = "0.41.0"
 highlights = "1.1.0"
+latexRenderer = "1.4.7"
 googleDevtoolsKsp = "2.3.5"
 navigationCompose = "2.8.9"
 roomRuntime = "2.7.0"
@@ -81,6 +82,7 @@ markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-ren
 markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-code = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-code", version.ref = "markdownRenderer" }
 highlights = { group = "dev.snipme", name = "highlights", version.ref = "highlights" }
+latex-renderer = { group = "io.github.huarangmeng", name = "latex-renderer", version.ref = "latexRenderer" }
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coilCompose" }


### PR DESCRIPTION
## Summary
- Add the open-source LaTeX renderer and wire math support into the custom markdown component
- Support inline and block math with streaming-safe fallbacks for incomplete formulas
- Nudge model prompts to emit LaTeX more consistently
- Keep the Local badge in the model picker while shortening long GGUF/imported names for display only

## Testing
- `:app:compileDebugKotlin` passed
- `:app:testDebugUnitTest --tests com.echoflow.MarkdownTextTest` passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LaTeX rendering to markdown components and clean up local model labels
> - Adds the `latex-renderer` library and introduces `MdMathBlock` and `InlineMarkdownText` composables in [MarkdownText.kt](https://github.com/adityavardhansharma/EchoFlow/pull/24/files#diff-915dc877dda1c1e1d6c9389473d2b3ab77e3bae843ecfa3659700813478b0b68) to render display and inline LaTeX in paragraphs, headers, bullets, blockquotes, and table cells.
> - Extends the markdown block parser to recognize `$$...$$` and `\[...\]` display math delimiters, emitting `MathBlock` nodes; incomplete (streaming) blocks fall back to raw text.
> - Adds inline math segmentation via `parseInlineMathSegments`, handling `$...$`, `$$...$$`, `\(...\)`, and `\[...\]` with heuristics to avoid treating stray `$` as math.
> - Updates the system prompt in [SystemPrompts.kt](https://github.com/adityavardhansharma/EchoFlow/pull/24/files#diff-a6a21058517266f1bcc62a4e1b828d8414534a65838136ca5daf5fb5ff2dfbd2) to instruct the model to use LaTeX delimiters for math and avoid unmatched `$`.
> - Adds `modelPickerDisplayName` in [ChatScreen.kt](https://github.com/adityavardhansharma/EchoFlow/pull/24/files#diff-63925e52d2910907ae272a548ab47afae1a567a3832ad5f9d4abf74dfa10e4e8) to strip `.gguf`/quantization suffixes from local model filenames for cleaner display in the model picker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f061994.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LaTeX mathematical equations now render in chat and markdown with support for both inline and display math notation.
  * Model picker display names are now cleaner, with technical qualifiers removed for better readability.

* **Tests**
  * Added comprehensive test coverage for LaTeX math parsing in markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->