### PR TITLE
Persist local context caps and improve picker display

### DIFF
--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
         DeepResearchModel::class, ResearchRun::class
     ],
-    version = 6, // v6: research_runs.level/costInfo/maxCredits — Exa Agent effort + Data Agent (MIGRATION_5_6)
+    version = 7, // v7: local_models.maxTokens — persisted on-device context capability (MIGRATION_6_7)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -94,6 +94,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE local_models ADD COLUMN maxTokens INTEGER")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -101,7 +107,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
+++ b/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
@@ -87,9 +87,26 @@ class HuggingFaceModelSearch {
             url = "https://huggingface.co/$repoId/resolve/main/$file",
             approxSizeBytes = size,
             requiresAuth = requiresAuth,
-            maxTokens = if (file.contains("4096")) 4096 else 2048,
+            maxTokens = inferredMaxTokens(repoId, file),
             description = "Hugging Face mobile bundle from $repoId. File: ${file.substringAfterLast("/")}"
         )
+    }
+
+    private fun inferredMaxTokens(repoId: String, fileName: String): Int {
+        val combined = "$repoId/$fileName"
+        if (fileName.endsWith(".litertlm", ignoreCase = true) && combined.contains("gemma-4", ignoreCase = true)) {
+            return 32768
+        }
+        val contextHint = Regex("""(?i)(?:ekv|ctx|context|nctx)[-_]?(\d+k?|\d+)""")
+            .find(combined)
+            ?.groupValues
+            ?.get(1)
+            ?.let { raw ->
+                if (raw.endsWith("k", ignoreCase = true)) raw.dropLast(1).toIntOrNull()?.times(1024)
+                else raw.toIntOrNull()
+            }
+        return contextHint?.coerceIn(512, 32768)
+            ?: if (fileName.contains("4096")) 4096 else 2048
     }
 
     private fun resolveSize(repoId: String, fileName: String, hfToken: String?): Long {

--- a/app/src/main/java/com/echoflow/data/InferenceParams.kt
+++ b/app/src/main/java/com/echoflow/data/InferenceParams.kt
@@ -61,7 +61,9 @@ object InferenceLimits {
     const val CLOUD_TOP_K_MAX = 200
 
     // Max-tokens sliders run from 0 ("model default") up to these ceilings, stepped.
-    const val LOCAL_MAX_TOKENS_CEIL = 8192
+    // LiteRT-LM Gemma 4 mobile bundles support up to 32K context, so expose that full
+    // range while still clamping each selected model to its own catalog/filename limit.
+    const val LOCAL_MAX_TOKENS_CEIL = 32768
     const val CLOUD_MAX_TOKENS_CEIL = 32768
     const val MAX_TOKENS_STEP = 256
 

--- a/app/src/main/java/com/echoflow/data/LocalLlmService.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmService.kt
@@ -127,7 +127,7 @@ class LocalLlmService(private val context: Context) {
 
     /** Resolves the effective token budget: the coerced param, or the model's own default. */
     private fun effectiveMaxTokens(model: LocalModel, params: InferenceParams): Int =
-        params.maxTokens.takeIf { it > 0 } ?: LocalModelCatalog.maxTokensFor(model.id, model.fileName)
+        params.maxTokens.takeIf { it > 0 } ?: model.maxTokens ?: LocalModelCatalog.maxTokensFor(model.id, model.fileName)
 
     /**
      * Native OOM during weight loading aborts the whole process and is uncatchable, so

--- a/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
@@ -67,7 +67,7 @@ object LocalModelCatalog {
             url = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
             approxSizeBytes = 2_588_147_712L,
             requiresAuth = false,
-            maxTokens = 4096,
+            maxTokens = 32768,
             description = "Latest Gemma generation with an effective 2B footprint. Strong quality on flagship phones, no login needed (~3.5 GB RAM)."
         ),
         CatalogEntry(
@@ -87,7 +87,7 @@ object LocalModelCatalog {
             url = "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm",
             approxSizeBytes = 3_659_530_240L,
             requiresAuth = false,
-            maxTokens = 4096,
+            maxTokens = 32768,
             description = "Largest Gemma 4 mobile bundle — best answers, needs a high-end phone (~5 GB RAM), no login needed."
         )
     )
@@ -102,7 +102,16 @@ object LocalModelCatalog {
     /** Supported on-device model file extensions, for the import picker and validation. */
     val supportedExtensions = listOf(".task", ".litertlm", ".gguf")
 
-    private val ekvHint = Regex("ekv(\\d+)", RegexOption.IGNORE_CASE)
+    private val contextHint = Regex("""(?:ekv|ctx|context|nctx)[-_]?(\d+k?|\d+)""", RegexOption.IGNORE_CASE)
+
+    private fun parseContextHint(fileName: String): Int? {
+        val raw = contextHint.find(fileName)?.groupValues?.get(1) ?: return null
+        return if (raw.endsWith("k", ignoreCase = true)) {
+            raw.dropLast(1).toIntOrNull()?.times(1024)
+        } else {
+            raw.toIntOrNull()
+        }
+    }
 
     /**
      * Safe context budget for a model. Catalog entries know their value; imported or
@@ -113,8 +122,11 @@ object LocalModelCatalog {
         entryById(modelId)?.let { return it.maxTokens }
         val file = fileName ?: return 1280
         entries.firstOrNull { it.fileName.equals(file, ignoreCase = true) }?.let { return it.maxTokens }
-        ekvHint.find(file)?.groupValues?.get(1)?.toIntOrNull()?.let { return it.coerceIn(512, 4096) }
+        val combined = "$modelId/$file"
+        parseContextHint(combined)?.let { return it.coerceIn(512, 32768) }
         return when {
+            // Gemma 4 LiteRT-LM mobile bundles advertise up to 32K context in LiteRT-LM.
+            isLiteRtLm(file) && combined.contains("gemma-4", ignoreCase = true) -> 32768
             // GGUF files carry no kv-cache marker in the name; llama.cpp lets us size the
             // context window ourselves, so use a comfortable mobile default.
             isGguf(file) -> 4096

--- a/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
+++ b/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
@@ -122,7 +122,8 @@ class ModelDownloadManager(
                             fileName = entry.fileName,
                             sizeBytes = finalFile.length(),
                             source = "curated",
-                            addedAt = System.currentTimeMillis()
+                            addedAt = System.currentTimeMillis(),
+                            maxTokens = entry.maxTokens
                         )
                     )
                     setState(entry.id, DownloadState.Done)
@@ -245,7 +246,8 @@ class ModelDownloadManager(
                 fileName = safeName,
                 sizeBytes = finalFile.length(),
                 source = "imported",
-                addedAt = System.currentTimeMillis()
+                addedAt = System.currentTimeMillis(),
+                maxTokens = LocalModelCatalog.maxTokensFor(id, safeName)
             )
             localModelDao.insertLocalModel(model)
             setState(id, DownloadState.Done)
@@ -304,7 +306,8 @@ class ModelDownloadManager(
                             fileName = file.name,
                             sizeBytes = file.length(),
                             source = catalogEntry?.let { "curated" } ?: "recovered",
-                            addedAt = file.lastModified().takeIf { it > 0L } ?: System.currentTimeMillis()
+                            addedAt = file.lastModified().takeIf { it > 0L } ?: System.currentTimeMillis(),
+                            maxTokens = catalogEntry?.maxTokens ?: LocalModelCatalog.maxTokensFor(safeId, file.name)
                         )
                     )
                 }

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -53,7 +53,8 @@ data class LocalModel(
     val fileName: String, // file name inside filesDir/models/
     val sizeBytes: Long,
     val source: String, // "curated" | "imported"
-    val addedAt: Long
+    val addedAt: Long,
+    val maxTokens: Int? = null // known context window, when catalog/search/import can infer it
 )
 
 /**

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -472,7 +472,7 @@ class ChatViewModel(
                 InferenceLimits.coerce(
                     settingsRepository.getInferenceParamsDirect(local = true),
                     ModelCapabilities(
-                        maxContextTokens = LocalModelCatalog.maxTokensFor(lm.id, lm.fileName),
+                        maxContextTokens = lm.maxTokens ?: LocalModelCatalog.maxTokensFor(lm.id, lm.fileName),
                         maxTopK = InferenceLimits.LOCAL_TOP_K_MAX,
                     ),
                     InferenceLimits.LOCAL_DEFAULTS,

--- a/app/src/test/java/com/echoflow/LocalModelCatalogTest.kt
+++ b/app/src/test/java/com/echoflow/LocalModelCatalogTest.kt
@@ -1,0 +1,44 @@
+package com.echoflow
+
+import com.echoflow.data.LocalModelCatalog
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalModelCatalogTest {
+
+    @Test
+    fun gemma4LiteRtModelsUseFullThirtyTwoKContext() {
+        assertEquals(
+            32768,
+            LocalModelCatalog.maxTokensFor(
+                "local/gemma-4-e2b-it",
+                "gemma-4-E2B-it.litertlm"
+            )
+        )
+        assertEquals(
+            32768,
+            LocalModelCatalog.maxTokensFor(
+                "local/recovered-gemma-4-e2b",
+                "gemma-4-E2B-it.litertlm"
+            )
+        )
+    }
+
+    @Test
+    fun contextHintsCanExposeLargerImportedModelWindows() {
+        assertEquals(
+            32768,
+            LocalModelCatalog.maxTokensFor(
+                "local/imported",
+                "Some-Model-ctx32k.litertlm"
+            )
+        )
+        assertEquals(
+            8192,
+            LocalModelCatalog.maxTokensFor(
+                "local/imported",
+                "Some-Model-ekv8192.task"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Persist known local-model context caps in Room so curated, imported, and recovered models can run at their full supported window when available
- Raise local token UI limits to 32K and improve Gemma 4 / LiteRT-LM capability inference from catalog and filename hints
- Keep GGUF and local model selection readable by using stored capability metadata instead of relying only on filename heuristics

## Testing
- `:app:compileDebugKotlin`
- `:app:testDebugUnitTest --tests com.echoflow.LocalModelCatalogTest`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist local model context caps and improve max-token inference accuracy
> - Adds a `maxTokens` field to `LocalModel` with a Room database migration (v6→v7) to persist the value across sessions.
> - Improves context window inference in `LocalModelCatalog` and `HuggingFaceModelSearch` to recognize broader filename hints (e.g. `ctx32k`, `ekv8192`) and raises the ceiling from 4096 to 32768 tokens, with special-casing for Gemma 4 LiteRT-LM bundles.
> - Populates `maxTokens` on curated downloads, imported models, and library-scan recovery in `ModelDownloadManager`.
> - `ChatViewModel` and `LocalLlmService` now prefer the persisted `maxTokens` over catalog lookups when available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6fd25c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->