### PR TITLE
Add Echo Adviser & Echo Fusion modes, plus web_fetch

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.echoflow
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -26,7 +27,9 @@ import androidx.compose.material.icons.filled.Settings
 import com.echoflow.data.AppDatabase
 import com.echoflow.data.DeepResearchForegroundService
 import com.echoflow.data.ModelDownloadManager
+import com.echoflow.data.ReplyNotifications
 import com.echoflow.data.SettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.components.ChatDrawerContent
@@ -39,9 +42,19 @@ class MainActivity : ComponentActivity() {
     private val notificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* best effort */ }
 
+    // A chat id to open, set when launched/resumed from a reply-ready notification tap.
+    private val openChatRequest = MutableStateFlow<String?>(null)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        intent.getStringExtra(ReplyNotifications.EXTRA_OPEN_CHAT)?.let { openChatRequest.value = it }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        openChatRequest.value = intent?.getStringExtra(ReplyNotifications.EXTRA_OPEN_CHAT)
 
         // Android 13+ needs runtime POST_NOTIFICATIONS for the Deep Research / Data Agent
         // foreground-service progress notification to appear in the status bar.
@@ -72,7 +85,9 @@ class MainActivity : ComponentActivity() {
                     database.customModelDao(),
                     database.localModelDao(),
                     modelDownloadManager,
-                    database.deepResearchModelDao()
+                    database.deepResearchModelDao(),
+                    database.advisorProfileDao(),
+                    database.fusionPanelDao()
                 )
             )
 
@@ -84,9 +99,20 @@ class MainActivity : ComponentActivity() {
                     settingsRepo,
                     database.localModelDao(),
                     database.researchRunDao(),
-                    database.deepResearchModelDao()
+                    database.deepResearchModelDao(),
+                    database.advisorProfileDao(),
+                    database.fusionPanelDao()
                 )
             )
+
+            // Notification tap → jump to that conversation once the ViewModel is ready.
+            val pendingChat by openChatRequest.collectAsState()
+            LaunchedEffect(pendingChat) {
+                pendingChat?.let { chatId ->
+                    chatVm.selectThread(chatId)
+                    openChatRequest.value = null
+                }
+            }
 
             // 3. Reacting to global themes selections
             val userThemeColor by settingsVm.themeColor.collectAsState()

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -10,9 +10,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 @Database(
     entities = [
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
-        DeepResearchModel::class, ResearchRun::class
+        DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class
     ],
-    version = 7, // v7: local_models.maxTokens — persisted on-device context capability (MIGRATION_6_7)
+    version = 8, // v8: advisor_profiles + fusion_panels — Echo Adviser / Echo Fusion (MIGRATION_7_8)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -22,6 +22,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun localModelDao(): LocalModelDao
     abstract fun deepResearchModelDao(): DeepResearchModelDao
     abstract fun researchRunDao(): ResearchRunDao
+    abstract fun advisorProfileDao(): AdvisorProfileDao
+    abstract fun fusionPanelDao(): FusionPanelDao
 
     companion object {
         @Volatile
@@ -100,6 +102,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS advisor_profiles (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "modelId TEXT NOT NULL, " +
+                        "modelName TEXT NOT NULL, " +
+                        "createdAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS fusion_panels (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "modelIds TEXT NOT NULL, " +
+                        "modelNames TEXT NOT NULL, " +
+                        "judgeModelId TEXT, " +
+                        "createdAt INTEGER NOT NULL)"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -107,7 +131,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -26,6 +26,58 @@ sealed class StreamChunk {
 
     /** Transient status line, not persisted (e.g. "Search limit reached"). */
     data class StatusNote(val text: String) : StreamChunk()
+
+    // ── Echo Adviser (openrouter:advisor) ──────────────────────────────────────────
+    /** The answering model consulted its advisor; the question is known, advice pending. */
+    data class AdvisorStarted(val advisorName: String, val advisorModel: String, val prompt: String) : StreamChunk()
+
+    /** The advisor replied. [advice] may be blank if the result body could not be parsed. */
+    data class AdvisorResolved(val advice: AdvisorAdvice) : StreamChunk()
+
+    // ── Echo Fusion (openrouter:fusion) ────────────────────────────────────────────
+    /** A fusion panel started deliberating; the roster is known, analysis pending. */
+    data class FusionStarted(val panelName: String, val models: List<String>) : StreamChunk()
+
+    /** The fusion judge returned its structured analysis (and per-model responses). */
+    data class FusionResolved(val analysis: FusionAnalysis) : StreamChunk()
+}
+
+// ── Echo Adviser / Echo Fusion result records ──────────────────────────────────────
+
+/** One advisor consultation: what the model asked and what the advisor (a stronger model) said. */
+data class AdvisorAdvice(
+    val advisorName: String, // the profile name, e.g. "Coding"
+    val advisorModel: String, // the OpenRouter model id that served as advisor
+    val prompt: String, // the question the answering model asked
+    val advice: String, // the advice text (may be blank if not captured from the stream)
+)
+
+/** One panel model's full answer in a fusion deliberation. */
+data class FusionResponse(val model: String, val content: String)
+
+/** A point where the panel models disagreed, with each model's stance. */
+data class FusionContradiction(val topic: String, val stances: List<String>)
+
+/** An observation only one model made. */
+data class FusionInsight(val model: String, val insight: String)
+
+/** The fusion judge's structured comparison of the panel plus the raw per-model answers. */
+data class FusionAnalysis(
+    val panelName: String,
+    val judgeModel: String?,
+    val models: List<String>, // the panel roster (OpenRouter ids)
+    val consensus: List<String> = emptyList(),
+    val contradictions: List<FusionContradiction> = emptyList(),
+    val partialCoverage: List<String> = emptyList(),
+    val uniqueInsights: List<FusionInsight> = emptyList(),
+    val blindSpots: List<String> = emptyList(),
+    val responses: List<FusionResponse> = emptyList(),
+    val failedModels: List<String> = emptyList(),
+) {
+    /** True when the judge produced no structured analysis (only raw panel responses, or nothing). */
+    val isEmpty: Boolean
+        get() = consensus.isEmpty() && contradictions.isEmpty() && partialCoverage.isEmpty() &&
+            uniqueInsights.isEmpty() && blindSpots.isEmpty()
 }
 
 /**
@@ -63,10 +115,12 @@ data class Citation(
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion"
     val text: String? = null,
     val query: String? = null,
-    val sources: List<SearchSource>? = null
+    val sources: List<SearchSource>? = null,
+    val advisor: AdvisorAdvice? = null, // present when type == "advisor"
+    val fusion: FusionAnalysis? = null // present when type == "fusion"
 )
 
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -74,6 +74,42 @@ interface DeepResearchModelDao {
 }
 
 @Dao
+interface AdvisorProfileDao {
+    @Query("SELECT * FROM advisor_profiles ORDER BY createdAt ASC")
+    fun getAll(): Flow<List<AdvisorProfile>>
+
+    @Query("SELECT * FROM advisor_profiles ORDER BY createdAt ASC")
+    suspend fun getAllSync(): List<AdvisorProfile>
+
+    @Query("SELECT * FROM advisor_profiles WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): AdvisorProfile?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(profile: AdvisorProfile)
+
+    @Query("DELETE FROM advisor_profiles WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
+interface FusionPanelDao {
+    @Query("SELECT * FROM fusion_panels ORDER BY createdAt ASC")
+    fun getAll(): Flow<List<FusionPanel>>
+
+    @Query("SELECT * FROM fusion_panels ORDER BY createdAt ASC")
+    suspend fun getAllSync(): List<FusionPanel>
+
+    @Query("SELECT * FROM fusion_panels WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): FusionPanel?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(panel: FusionPanel)
+
+    @Query("DELETE FROM fusion_panels WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
 interface ResearchRunDao {
     @Query("SELECT * FROM research_runs WHERE chatId = :chatId AND status NOT IN ('completed','failed','cancelled') ORDER BY createdAt DESC LIMIT 1")
     fun observeActiveForChat(chatId: String): Flow<ResearchRun?>

--- a/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
+++ b/app/src/main/java/com/echoflow/data/HuggingFaceModelSearch.kt
@@ -95,7 +95,7 @@ class HuggingFaceModelSearch {
     private fun inferredMaxTokens(repoId: String, fileName: String): Int {
         val combined = "$repoId/$fileName"
         if (fileName.endsWith(".litertlm", ignoreCase = true) && combined.contains("gemma-4", ignoreCase = true)) {
-            return 32768
+            return InferenceLimits.LOCAL_MAX_TOKENS_CEIL
         }
         val contextHint = Regex("""(?i)(?:ekv|ctx|context|nctx)[-_]?(\d+k?|\d+)""")
             .find(combined)
@@ -105,7 +105,7 @@ class HuggingFaceModelSearch {
                 if (raw.endsWith("k", ignoreCase = true)) raw.dropLast(1).toIntOrNull()?.times(1024)
                 else raw.toIntOrNull()
             }
-        return contextHint?.coerceIn(512, 32768)
+        return contextHint?.coerceIn(512, InferenceLimits.LOCAL_MAX_TOKENS_CEIL)
             ?: if (fileName.contains("4096")) 4096 else 2048
     }
 

--- a/app/src/main/java/com/echoflow/data/InferenceParams.kt
+++ b/app/src/main/java/com/echoflow/data/InferenceParams.kt
@@ -61,9 +61,10 @@ object InferenceLimits {
     const val CLOUD_TOP_K_MAX = 200
 
     // Max-tokens sliders run from 0 ("model default") up to these ceilings, stepped.
-    // LiteRT-LM Gemma 4 mobile bundles support up to 32K context, so expose that full
-    // range while still clamping each selected model to its own catalog/filename limit.
-    const val LOCAL_MAX_TOKENS_CEIL = 32768
+    // Some LiteRT-LM bundles advertise larger windows, but 32K can crash on phones due
+    // to KV/cache allocation. Keep a hard mobile safety cap of 8K; smaller models keep
+    // their own lower max.
+    const val LOCAL_MAX_TOKENS_CEIL = 8192
     const val CLOUD_MAX_TOKENS_CEIL = 32768
     const val MAX_TOKENS_STEP = 256
 
@@ -99,10 +100,15 @@ object InferenceLimits {
             else -> params.topK
         }
 
-        val modelDefaultTokens = if (caps.maxContextTokens > 0) caps.maxContextTokens else params.maxTokens
+        val contextCap = if (caps.maxContextTokens > 0) {
+            caps.maxContextTokens.coerceAtMost(LOCAL_MAX_TOKENS_CEIL)
+        } else {
+            params.maxTokens
+        }
+        val modelDefaultTokens = contextCap
         val maxTokens = when {
             params.maxTokens <= 0 -> modelDefaultTokens
-            caps.maxContextTokens > 0 && params.maxTokens > caps.maxContextTokens -> modelDefaultTokens
+            caps.maxContextTokens > 0 && params.maxTokens > contextCap -> modelDefaultTokens
             else -> params.maxTokens
         }
 

--- a/app/src/main/java/com/echoflow/data/LocalLlmService.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmService.kt
@@ -127,7 +127,8 @@ class LocalLlmService(private val context: Context) {
 
     /** Resolves the effective token budget: the coerced param, or the model's own default. */
     private fun effectiveMaxTokens(model: LocalModel, params: InferenceParams): Int =
-        params.maxTokens.takeIf { it > 0 } ?: model.maxTokens ?: LocalModelCatalog.maxTokensFor(model.id, model.fileName)
+        (params.maxTokens.takeIf { it > 0 } ?: model.maxTokens ?: LocalModelCatalog.maxTokensFor(model.id, model.fileName))
+            .coerceAtMost(InferenceLimits.LOCAL_MAX_TOKENS_CEIL)
 
     /**
      * Native OOM during weight loading aborts the whole process and is uncatchable, so

--- a/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalModelCatalog.kt
@@ -67,7 +67,7 @@ object LocalModelCatalog {
             url = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
             approxSizeBytes = 2_588_147_712L,
             requiresAuth = false,
-            maxTokens = 32768,
+            maxTokens = 8192,
             description = "Latest Gemma generation with an effective 2B footprint. Strong quality on flagship phones, no login needed (~3.5 GB RAM)."
         ),
         CatalogEntry(
@@ -87,7 +87,7 @@ object LocalModelCatalog {
             url = "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm",
             approxSizeBytes = 3_659_530_240L,
             requiresAuth = false,
-            maxTokens = 32768,
+            maxTokens = 8192,
             description = "Largest Gemma 4 mobile bundle — best answers, needs a high-end phone (~5 GB RAM), no login needed."
         )
     )
@@ -123,10 +123,11 @@ object LocalModelCatalog {
         val file = fileName ?: return 1280
         entries.firstOrNull { it.fileName.equals(file, ignoreCase = true) }?.let { return it.maxTokens }
         val combined = "$modelId/$file"
-        parseContextHint(combined)?.let { return it.coerceIn(512, 32768) }
+        parseContextHint(combined)?.let { return it.coerceIn(512, InferenceLimits.LOCAL_MAX_TOKENS_CEIL) }
         return when {
-            // Gemma 4 LiteRT-LM mobile bundles advertise up to 32K context in LiteRT-LM.
-            isLiteRtLm(file) && combined.contains("gemma-4", ignoreCase = true) -> 32768
+            // Gemma 4 LiteRT-LM mobile bundles advertise larger windows, but EchoFlow
+            // caps local inference at 8K to avoid native OOM/crashes on phones.
+            isLiteRtLm(file) && combined.contains("gemma-4", ignoreCase = true) -> InferenceLimits.LOCAL_MAX_TOKENS_CEIL
             // GGUF files carry no kv-cache marker in the name; llama.cpp lets us size the
             // context window ourselves, so use a comfortable mobile default.
             isGguf(file) -> 4096

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -70,6 +70,38 @@ data class DeepResearchModel(
 )
 
 /**
+ * One Echo Adviser profile: a named, domain-specific advisor (e.g. "Coding", "Maths") backed
+ * by a single strong OpenRouter model. In chat, any cloud model answers and consults the
+ * selected profile's [modelId] mid-generation via the `openrouter:advisor` server tool.
+ */
+@Entity(tableName = "advisor_profiles")
+data class AdvisorProfile(
+    @PrimaryKey val id: String, // UUID
+    val name: String, // "Coding", "Maths", "Research", …
+    val modelId: String, // the advisor OpenRouter model id
+    val modelName: String, // human label for the advisor model
+    val createdAt: Long,
+)
+
+/**
+ * One Echo Fusion panel: a named set of OpenRouter models that answer in parallel, plus an
+ * optional judge that compares them, via the `openrouter:fusion` server tool. Model ids and
+ * their display names are stored newline-joined (ids never contain newlines).
+ */
+@Entity(tableName = "fusion_panels")
+data class FusionPanel(
+    @PrimaryKey val id: String, // UUID
+    val name: String, // "Heavy hitters", "Fast trio", …
+    val modelIds: String, // newline-joined OpenRouter ids (2–8)
+    val modelNames: String, // newline-joined display names, parallel to modelIds
+    val judgeModelId: String? = null, // judge model; null = use the first panel model
+    val createdAt: Long,
+) {
+    val models: List<String> get() = modelIds.split("\n").filter { it.isNotBlank() }
+    val names: List<String> get() = modelNames.split("\n").filter { it.isNotBlank() }
+}
+
+/**
  * The durable record of one Deep Research run. This is the single source of truth: the
  * foreground service writes progress here and the UI observes it, so a run survives the
  * Activity/ViewModel being destroyed and can be resumed after the app is force-killed

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -217,9 +217,25 @@ class OpenRouterService(private val context: Context) {
         val args = StringBuilder()
         var announced = false
 
-        fun looksLikeWebSearch(): Boolean =
-            (type?.contains("web_search") == true) || (name?.contains("web_search") == true)
+        private fun mentions(token: String): Boolean =
+            (type?.contains(token) == true) || (name?.contains(token) == true)
+
+        fun looksLikeWebSearch(): Boolean = mentions("web_search")
+        fun looksLikeWebFetch(): Boolean = mentions("web_fetch")
+        fun looksLikeAdvisor(): Boolean = mentions("advisor")
+        fun looksLikeFusion(): Boolean = mentions("fusion")
     }
+
+    /**
+     * Labels for the active Echo Adviser/Fusion server tool so the stream can tag its chunks
+     * with the user-facing profile/panel names (the raw stream only carries model ids).
+     */
+    data class EchoContext(
+        val advisorName: String? = null,
+        val advisorModel: String? = null,
+        val fusionPanelName: String? = null,
+        val fusionModels: List<String> = emptyList(),
+    )
 
     private data class TurnResult(
         val content: String,
@@ -236,6 +252,118 @@ class OpenRouterService(private val context: Context) {
         null
     }
 
+    private fun parsePromptArgument(argsJson: String): String? = try {
+        val map = dynamicAdapter.fromJson(argsJson) as? Map<*, *>
+        (map?.get("prompt") as? String)?.takeIf { it.isNotBlank() }
+    } catch (e: Exception) {
+        null
+    }
+
+    private fun parseUrlArgument(argsJson: String): String? = try {
+        val map = dynamicAdapter.fromJson(argsJson) as? Map<*, *>
+        (map?.get("url") as? String)?.takeIf { it.isNotBlank() }
+    } catch (e: Exception) {
+        null
+    }
+
+    /** Parse a string only if it looks like a JSON object/array (some tool results are stringified). */
+    private fun parseMaybeJson(s: String): Any? {
+        val t = s.trim()
+        if (!(t.startsWith("{") || t.startsWith("["))) return null
+        return try { dynamicAdapter.fromJson(t) } catch (e: Exception) { null }
+    }
+
+    /** Walks an SSE chunk for an advisor result `{model?, advice}`. Returns (advisorModel, advice). */
+    private fun scanForAdvisorResult(node: Any?, depth: Int = 0): Pair<String?, String>? {
+        if (depth > 8) return null
+        when (node) {
+            is Map<*, *> -> {
+                (node["advice"] as? String)?.takeIf { it.isNotBlank() }?.let { advice ->
+                    return (node["model"] as? String) to advice
+                }
+                (node["content"] as? String)?.let { c ->
+                    parseMaybeJson(c)?.let { scanForAdvisorResult(it, depth + 1)?.let { r -> return r } }
+                }
+                for (v in node.values) scanForAdvisorResult(v, depth + 1)?.let { return it }
+            }
+            is List<*> -> for (v in node) scanForAdvisorResult(v, depth + 1)?.let { return it }
+        }
+        return null
+    }
+
+    private fun isFusionResponseList(list: List<*>?): Boolean =
+        list != null && list.isNotEmpty() && list.all {
+            (it as? Map<*, *>)?.containsKey("content") == true && (it as? Map<*, *>)?.containsKey("model") == true
+        }
+
+    /** Walks an SSE chunk for a fusion result `{analysis?, responses?, failed_models?}`. */
+    private fun scanForFusionResult(node: Any?, depth: Int = 0): FusionAnalysis? {
+        if (depth > 8) return null
+        when (node) {
+            is Map<*, *> -> {
+                val analysisObj = node["analysis"] as? Map<*, *>
+                val responses = node["responses"] as? List<*>
+                if (analysisObj != null || isFusionResponseList(responses)) {
+                    return buildFusionAnalysis(node)
+                }
+                (node["content"] as? String)?.let { c ->
+                    parseMaybeJson(c)?.let { scanForFusionResult(it, depth + 1)?.let { r -> return r } }
+                }
+                for (v in node.values) scanForFusionResult(v, depth + 1)?.let { return it }
+            }
+            is List<*> -> for (v in node) scanForFusionResult(v, depth + 1)?.let { return it }
+        }
+        return null
+    }
+
+    private fun buildFusionAnalysis(result: Map<*, *>): FusionAnalysis {
+        val analysis = result["analysis"] as? Map<*, *>
+        fun strList(key: String): List<String> =
+            (analysis?.get(key) as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+
+        val contradictions = (analysis?.get("contradictions") as? List<*>)?.mapNotNull { raw ->
+            val m = raw as? Map<*, *> ?: return@mapNotNull null
+            val topic = m["topic"] as? String ?: return@mapNotNull null
+            val stances = (m["stances"] as? List<*>)?.map { it.toString() } ?: emptyList()
+            FusionContradiction(topic, stances)
+        } ?: emptyList()
+
+        val partial = (analysis?.get("partial_coverage") as? List<*>)?.mapNotNull { raw ->
+            when (raw) {
+                is Map<*, *> -> raw["point"] as? String
+                is String -> raw
+                else -> null
+            }
+        } ?: emptyList()
+
+        val insights = (analysis?.get("unique_insights") as? List<*>)?.mapNotNull { raw ->
+            val m = raw as? Map<*, *> ?: return@mapNotNull null
+            val insight = m["insight"] as? String ?: return@mapNotNull null
+            FusionInsight((m["model"] as? String).orEmpty(), insight)
+        } ?: emptyList()
+
+        val responses = (result["responses"] as? List<*>)?.mapNotNull { raw ->
+            val m = raw as? Map<*, *> ?: return@mapNotNull null
+            val content = m["content"] as? String ?: return@mapNotNull null
+            FusionResponse((m["model"] as? String).orEmpty(), content)
+        } ?: emptyList()
+
+        val failed = (result["failed_models"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+
+        return FusionAnalysis(
+            panelName = "",
+            judgeModel = null,
+            models = responses.map { it.model }.filter { it.isNotBlank() },
+            consensus = strList("consensus"),
+            contradictions = contradictions,
+            partialCoverage = partial,
+            uniqueInsights = insights,
+            blindSpots = strList("blind_spots"),
+            responses = responses,
+            failedModels = failed,
+        )
+    }
+
     /**
      * Executes one streaming chat completion, emitting chunks as they arrive and returning
      * the accumulated turn. Handles plain content/reasoning deltas, OpenRouter server-tool
@@ -249,6 +377,8 @@ class OpenRouterService(private val context: Context) {
         payloadMessages: List<Map<String, Any>>,
         tools: List<Map<String, Any>>?,
         params: InferenceParams?,
+        toolChoice: String? = null,
+        echo: EchoContext? = null,
         onChunk: suspend (StreamChunk) -> Unit
     ): TurnResult {
         val requestMap = mutableMapOf<String, Any>(
@@ -262,6 +392,11 @@ class OpenRouterService(private val context: Context) {
         )
         if (tools != null) {
             requestMap["tools"] = tools
+        }
+        // For Echo Adviser/Fusion the user made a deliberate, cost-heavy choice from the "+"
+        // menu — so we force the tool to actually run rather than leaving it to the model.
+        if (toolChoice != null) {
+            requestMap["tool_choice"] = toolChoice
         }
         // The user's global cloud sampler settings. top_k / max_tokens are only sent when set
         // (0 means "leave it to the model"); temperature / top_p always apply.
@@ -282,6 +417,14 @@ class OpenRouterService(private val context: Context) {
         val seenSourceUrls = mutableSetOf<String>()
         var finishReason: String? = null
         var lastAnnouncedQuery: String? = null
+
+        // Echo Adviser / Fusion: announce the consult/deliberation the moment its tool call
+        // appears, then resolve once the (beta, undocumented-shape) result is seen in the stream.
+        var advisorAnnounced = false
+        var advisorResolved = false
+        var advisorPrompt: String? = null
+        var fusionAnnounced = false
+        var fusionResolved = false
 
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
@@ -348,6 +491,28 @@ class OpenRouterService(private val context: Context) {
                                 onChunk(StreamChunk.SearchStarted(query))
                             }
                         }
+                        // web_fetch reads a specific URL: surface it on the same search timeline
+                        // as a one-URL "search" so citations and the activity card just work.
+                        if (!builder.announced && builder.looksLikeWebFetch()) {
+                            val url = parseUrlArgument(builder.args.toString())
+                            if (url != null) {
+                                builder.announced = true
+                                lastAnnouncedQuery = url
+                                onChunk(StreamChunk.SearchStarted(url))
+                            }
+                        }
+                        if (echo?.advisorName != null && !advisorAnnounced && builder.looksLikeAdvisor()) {
+                            val prompt = parsePromptArgument(builder.args.toString())
+                            if (prompt != null) {
+                                advisorAnnounced = true
+                                advisorPrompt = prompt
+                                onChunk(StreamChunk.AdvisorStarted(echo.advisorName, echo.advisorModel.orEmpty(), prompt))
+                            }
+                        }
+                        if (echo?.fusionPanelName != null && !fusionAnnounced && builder.looksLikeFusion()) {
+                            fusionAnnounced = true
+                            onChunk(StreamChunk.FusionStarted(echo.fusionPanelName, echo.fusionModels))
+                        }
                     }
 
                     // url_citation annotations may arrive on the delta or on a message object.
@@ -371,6 +536,41 @@ class OpenRouterService(private val context: Context) {
                         }
                         if (fresh.isNotEmpty()) {
                             onChunk(StreamChunk.SearchSources(lastAnnouncedQuery.orEmpty(), fresh))
+                        }
+                    }
+
+                    // Echo Adviser/Fusion results arrive as a tool result somewhere in the chunk
+                    // tree. The exact shape is beta/undocumented, so we walk the whole chunk
+                    // defensively for the signature keys and degrade to "consulted, no body" if
+                    // nothing parses — never a crash. (Verify shapes against a live key.)
+                    if (echo != null && map != null) {
+                        if (echo.advisorName != null && !advisorResolved) {
+                            scanForAdvisorResult(map)?.let { (advisorModel, advice) ->
+                                advisorResolved = true
+                                onChunk(
+                                    StreamChunk.AdvisorResolved(
+                                        AdvisorAdvice(
+                                            advisorName = echo.advisorName,
+                                            advisorModel = advisorModel ?: echo.advisorModel.orEmpty(),
+                                            prompt = advisorPrompt.orEmpty(),
+                                            advice = advice,
+                                        )
+                                    )
+                                )
+                            }
+                        }
+                        if (echo.fusionPanelName != null && !fusionResolved) {
+                            scanForFusionResult(map)?.let { analysis ->
+                                fusionResolved = true
+                                onChunk(
+                                    StreamChunk.FusionResolved(
+                                        analysis.copy(
+                                            panelName = echo.fusionPanelName,
+                                            models = echo.fusionModels.ifEmpty { analysis.models },
+                                        )
+                                    )
+                                )
+                            }
                         }
                     }
 
@@ -418,21 +618,103 @@ class OpenRouterService(private val context: Context) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
 
-        val tools = if (serverWebSearch) {
-            listOf(
-                mapOf(
-                    "type" to "openrouter:web_search",
-                    // max_total_results backs up the prompt's "at most 3 searches" rule:
-                    // 3 searches × 5 results caps what OpenRouter will return overall.
-                    "parameters" to mapOf(
-                        "max_results" to 5,
-                        "max_total_results" to 15
-                    )
-                )
-            )
-        } else null
+        val tools = if (serverWebSearch) openRouterWebTools() else null
 
         streamCompletion(apiKey, model, buildMessagesPayload(history, systemPrompt), tools, params) { emit(it) }
+    }.flowOn(Dispatchers.IO)
+
+    /**
+     * The OpenRouter server-side web toolset: `web_search` (the model searches the web zero,
+     * one or many times) plus `web_fetch` (the model pulls a specific URL's full content).
+     * Both run on OpenRouter's side and surface here as SearchStarted/SearchSources chunks.
+     */
+    private fun openRouterWebTools(): List<Map<String, Any>> = listOf(
+        mapOf(
+            "type" to "openrouter:web_search",
+            // max_total_results backs up the prompt's "at most 3 searches" rule:
+            // 3 searches × 5 results caps what OpenRouter will return overall.
+            "parameters" to mapOf(
+                "max_results" to 5,
+                "max_total_results" to 15
+            )
+        ),
+        mapOf(
+            "type" to "openrouter:web_fetch",
+            "parameters" to mapOf(
+                "engine" to "auto",
+                "max_uses" to 3
+            )
+        )
+    )
+
+    /** Config for one Echo Adviser consult: which profile (display name) and advisor model. */
+    data class AdvisorRequest(val name: String, val model: String)
+
+    /** Config for one Echo Fusion deliberation: the panel (display name + roster) and judge. */
+    data class FusionRequest(val panelName: String, val models: List<String>, val judge: String?)
+
+    /**
+     * Streaming completion with an Echo Adviser or Echo Fusion server tool attached. Both are
+     * OpenRouter-only and forced via `tool_choice: "required"` because the user opted into the
+     * (cost-heavy) mode from the "+" menu. OpenRouter web_search/web_fetch are enabled too:
+     * the advisor sub-agent gets them, and fusion panels/judge run them server-side natively.
+     *
+     * The model resolves as: advisor mode → the answering model (the user's selected cloud
+     * model); fusion mode → the judge (or the first panel model). Exactly one of
+     * [advisor]/[fusion] should be non-null.
+     */
+    fun sendWithEchoTools(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        advisor: AdvisorRequest? = null,
+        fusion: FusionRequest? = null,
+        params: InferenceParams? = null,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) {
+            throw Exception("API key is missing! Please configure it in your Settings.")
+        }
+
+        val tools = mutableListOf<Map<String, Any>>()
+        var echo = EchoContext()
+
+        if (advisor != null) {
+            // Advisor first so `tool_choice: "required"` targets it; it may itself web-search/fetch.
+            val advisorParams = mutableMapOf<String, Any>(
+                "model" to advisor.model,
+                "name" to advisor.name,
+                "forward_transcript" to true,
+                "tools" to listOf(
+                    mapOf("type" to "openrouter:web_search"),
+                    mapOf("type" to "openrouter:web_fetch"),
+                ),
+            )
+            tools.add(mapOf("type" to "openrouter:advisor", "parameters" to advisorParams))
+            tools.addAll(openRouterWebTools())
+            echo = echo.copy(advisorName = advisor.name, advisorModel = advisor.model)
+        }
+
+        if (fusion != null) {
+            // Fusion panels/judge run web_search/web_fetch natively, so we don't attach them
+            // at the outer level — fusion is the only outer tool, forced via tool_choice.
+            val fusionParams = mutableMapOf<String, Any>(
+                "analysis_models" to fusion.models,
+            )
+            fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionParams["model"] = it }
+            tools.add(mapOf("type" to "openrouter:fusion", "parameters" to fusionParams))
+            echo = echo.copy(fusionPanelName = fusion.panelName, fusionModels = fusion.models)
+        }
+
+        streamCompletion(
+            apiKey = apiKey,
+            model = model,
+            payloadMessages = buildMessagesPayload(history, systemPrompt),
+            tools = tools,
+            params = params,
+            toolChoice = "required",
+            echo = echo,
+        ) { emit(it) }
     }.flowOn(Dispatchers.IO)
 
     /**

--- a/app/src/main/java/com/echoflow/data/ReplyNotifications.kt
+++ b/app/src/main/java/com/echoflow/data/ReplyNotifications.kt
@@ -1,0 +1,85 @@
+package com.echoflow.data
+
+import android.app.ActivityManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.echoflow.MainActivity
+import com.echoflow.R
+
+/**
+ * One-shot "your reply is ready" notifications for long cloud generations (Echo Adviser /
+ * Echo Fusion), which can take a while. While the app is minimized the reply keeps streaming
+ * via [KeepAliveService]; this posts a heads-up only when it finishes and the app is NOT in
+ * the foreground, so the user is pinged like Deep Research but never spammed while watching.
+ *
+ * Tapping carries [EXTRA_OPEN_CHAT] so MainActivity can jump straight to that conversation.
+ */
+object ReplyNotifications {
+    const val EXTRA_OPEN_CHAT = "open_chat_id"
+    private const val CHANNEL_ID = "echo_replies"
+    private const val NOTIFICATION_BASE = 7100
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Replies",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = "Tells you when a long Echo reply is ready" }
+            context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+    }
+
+    /** True only when one of this app's processes is currently in the foreground. */
+    fun isAppForeground(context: Context): Boolean {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return false
+        val procs = am.runningAppProcesses ?: return false
+        val pkg = context.packageName
+        return procs.any {
+            it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+                it.processName == pkg
+        }
+    }
+
+    /**
+     * Post a "reply ready / failed" notification for [chatId]. No-op if the app is foreground
+     * (the user is already watching) or if notifications are blocked.
+     */
+    fun notifyReplyReady(context: Context, chatId: String, title: String, text: String) {
+        if (isAppForeground(context)) return
+        ensureChannel(context)
+
+        val openIntent = Intent(context, MainActivity::class.java).apply {
+            putExtra(EXTRA_OPEN_CHAT, chatId)
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            chatId.hashCode(),
+            openIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        // notify() throws SecurityException if POST_NOTIFICATIONS was denied — degrade silently.
+        runCatching {
+            NotificationManagerCompat.from(context)
+                .notify(NOTIFICATION_BASE + (chatId.hashCode() and 0xFFFF), notification)
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -80,6 +80,13 @@ class SettingsRepository(context: Context) {
     private val _hfAccessToken = MutableStateFlow(getHfAccessTokenDirect())
     val hfAccessToken: StateFlow<String> = _hfAccessToken.asStateFlow()
 
+    // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
+    private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
+    val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
+
+    private val _echoFusionPanelId = MutableStateFlow(getEchoFusionPanelIdDirect())
+    val echoFusionPanelId: StateFlow<String> = _echoFusionPanelId.asStateFlow()
+
     // Inference parameters: one global set for on-device models, one for OpenRouter models.
     private val _localInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = true))
     val localInferenceParams: StateFlow<InferenceParams> = _localInferenceParams.asStateFlow()
@@ -214,6 +221,24 @@ class SettingsRepository(context: Context) {
     fun saveHfAccessToken(token: String) {
         prefs.edit().putString("hf_access_token", token).apply()
         _hfAccessToken.value = token
+    }
+
+    // ── Echo Adviser / Echo Fusion selection ───────────────────────────────────────────
+
+    fun getEchoAdviserProfileIdDirect(): String =
+        prefs.getString("echo_adviser_profile_id", "").orEmpty()
+
+    fun saveEchoAdviserProfileId(id: String) {
+        prefs.edit().putString("echo_adviser_profile_id", id).apply()
+        _echoAdviserProfileId.value = id
+    }
+
+    fun getEchoFusionPanelIdDirect(): String =
+        prefs.getString("echo_fusion_panel_id", "").orEmpty()
+
+    fun saveEchoFusionPanelId(id: String) {
+        prefs.edit().putString("echo_fusion_panel_id", id).apply()
+        _echoFusionPanelId.value = id
     }
 
     // ── Inference parameters ───────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -156,6 +156,54 @@ object SystemPrompts {
         """.trimIndent()
     }
 
+    // ── Echo Adviser / Echo Fusion (OpenRouter server tools, cloud only) ─────────────
+
+    /**
+     * Echo Adviser: the answering model (any cloud model) escalates hard parts to a stronger,
+     * domain-specific advisor model. Web search/fetch are also available. Cloud only.
+     */
+    fun buildEchoAdviser(advisorName: String, currentDate: String = currentDate()): String =
+        listOf(
+            identity(false),
+            "Current date: $currentDate.",
+            adviserGuidance(advisorName),
+            openRouterServerSearch(),
+            formatting(false),
+        ).joinToString("\n\n")
+
+    /**
+     * Echo Fusion: the outer model acts as the judge of a multi-model panel, invoking the
+     * fusion tool to deliberate, then synthesizing one answer. Cloud only.
+     */
+    fun buildEchoFusion(panelName: String, currentDate: String = currentDate()): String =
+        listOf(
+            identity(false),
+            "Current date: $currentDate.",
+            fusionGuidance(panelName),
+            formatting(false),
+        ).joinToString("\n\n")
+
+    private fun adviserGuidance(advisorName: String): String =
+        """
+        ## Echo Adviser
+        A higher-intelligence advisor — "$advisorName" — is available through your advisor tool. Consult it before committing to a non-obvious approach, when you are stuck or uncertain, or before declaring a hard task complete.
+
+        - Ask one focused question that describes exactly what guidance you need; the advisor can also search the web.
+        - Fold the advice into your own answer. You do not need to announce that you consulted it unless it genuinely helps the user.
+        - Do not consult for trivial steps. One good consultation usually beats several shallow ones.
+        """.trimIndent()
+
+    private fun fusionGuidance(panelName: String): String =
+        """
+        ## Echo Fusion
+        You are the judge of a multi-model panel — "$panelName". Invoke your fusion tool so the panel deliberates on the user's request, then write the single best answer yourself.
+
+        - Treat points of consensus as high-confidence.
+        - Surface genuine disagreements honestly instead of hiding them; note which view is better supported.
+        - Preserve insights only one model raised, and flag gaps the whole panel missed.
+        - Write a clean, well-structured markdown answer. The app shows the structured panel comparison and each model's full response separately, so do NOT paste the raw analysis JSON.
+        """.trimIndent()
+
     // ── Deep Research (agentic, cloud only) ──────────────────────────────────────────
 
     /**

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -24,6 +24,23 @@ sealed class StreamSegment {
         val sources: List<SearchSource>,
         val active: Boolean
     ) : StreamSegment()
+
+    /** Echo Adviser consultation: the question asked and the advice (null while pending). */
+    data class Advisor(
+        val advisorName: String,
+        val advisorModel: String,
+        val prompt: String,
+        val advice: String?,
+        val active: Boolean
+    ) : StreamSegment()
+
+    /** Echo Fusion deliberation: the panel roster and the judge's analysis (null while pending). */
+    data class Fusion(
+        val panelName: String,
+        val models: List<String>,
+        val analysis: FusionAnalysis?,
+        val active: Boolean
+    ) : StreamSegment()
 }
 
 private data class ActiveStreamState(
@@ -40,7 +57,9 @@ class ChatViewModel(
     private val settingsRepository: SettingsRepository,
     private val localModelDao: LocalModelDao,
     private val researchRunDao: ResearchRunDao,
-    private val deepResearchModelDao: DeepResearchModelDao
+    private val deepResearchModelDao: DeepResearchModelDao,
+    private val advisorProfileDao: AdvisorProfileDao,
+    private val fusionPanelDao: FusionPanelDao
 ) : AndroidViewModel(application) {
 
     private val openRouterService = OpenRouterService(application)
@@ -181,6 +200,14 @@ class ChatViewModel(
     private val _dataAgentActive = MutableStateFlow(false)
     val dataAgentActive: StateFlow<Boolean> = _dataAgentActive.asStateFlow()
 
+    // Echo Adviser / Echo Fusion: OpenRouter-only modes chosen from the "+" menu. Persist
+    // across messages (a deliberate, cost-heavy choice) until the user turns them off.
+    private val _echoAdviserActive = MutableStateFlow(false)
+    val echoAdviserActive: StateFlow<Boolean> = _echoAdviserActive.asStateFlow()
+
+    private val _echoFusionActive = MutableStateFlow(false)
+    val echoFusionActive: StateFlow<Boolean> = _echoFusionActive.asStateFlow()
+
     /** The Deep Research engine/model the user has added (built-in provider engines + agentic). */
     val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -193,23 +220,42 @@ class ChatViewModel(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    // Web Search, Deep Research and Data Agent are mutually exclusive capabilities.
+    // Web Search, Deep Research, Data Agent, Echo Adviser and Echo Fusion are mutually
+    // exclusive capabilities — turning one on clears the rest.
+    private fun clearCapabilitiesExcept(keep: MutableStateFlow<Boolean>) {
+        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive)
+            .filter { it !== keep }
+            .forEach { it.value = false }
+    }
+
     fun toggleDeepResearch() {
         val next = !_deepResearchActive.value
         _deepResearchActive.value = next
-        if (next) { _webSearchChipOn.value = false; _dataAgentActive.value = false }
+        if (next) clearCapabilitiesExcept(_deepResearchActive)
     }
 
     fun toggleWebSearchChip() {
         val next = !_webSearchChipOn.value
         _webSearchChipOn.value = next
-        if (next) { _deepResearchActive.value = false; _dataAgentActive.value = false }
+        if (next) clearCapabilitiesExcept(_webSearchChipOn)
     }
 
     fun toggleDataAgent() {
         val next = !_dataAgentActive.value
         _dataAgentActive.value = next
-        if (next) { _deepResearchActive.value = false; _webSearchChipOn.value = false }
+        if (next) clearCapabilitiesExcept(_dataAgentActive)
+    }
+
+    fun toggleEchoAdviser() {
+        val next = !_echoAdviserActive.value
+        _echoAdviserActive.value = next
+        if (next) clearCapabilitiesExcept(_echoAdviserActive)
+    }
+
+    fun toggleEchoFusion() {
+        val next = !_echoFusionActive.value
+        _echoFusionActive.value = next
+        if (next) clearCapabilitiesExcept(_echoFusionActive)
     }
 
     fun selectThread(chatId: String?) {
@@ -315,6 +361,69 @@ class ChatViewModel(
             is StreamChunk.StatusNote -> {
                 return chunk.text
             }
+            is StreamChunk.AdvisorStarted -> {
+                segments.add(
+                    StreamSegment.Advisor(
+                        advisorName = chunk.advisorName,
+                        advisorModel = chunk.advisorModel,
+                        prompt = chunk.prompt,
+                        advice = null,
+                        active = true,
+                    )
+                )
+            }
+            is StreamChunk.AdvisorResolved -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Advisor && it.active }
+                if (idx >= 0) {
+                    val seg = segments[idx] as StreamSegment.Advisor
+                    segments[idx] = seg.copy(
+                        advisorModel = chunk.advice.advisorModel.ifBlank { seg.advisorModel },
+                        prompt = seg.prompt.ifBlank { chunk.advice.prompt },
+                        advice = chunk.advice.advice,
+                        active = false,
+                    )
+                } else {
+                    segments.add(
+                        StreamSegment.Advisor(
+                            advisorName = chunk.advice.advisorName,
+                            advisorModel = chunk.advice.advisorModel,
+                            prompt = chunk.advice.prompt,
+                            advice = chunk.advice.advice,
+                            active = false,
+                        )
+                    )
+                }
+            }
+            is StreamChunk.FusionStarted -> {
+                segments.add(
+                    StreamSegment.Fusion(
+                        panelName = chunk.panelName,
+                        models = chunk.models,
+                        analysis = null,
+                        active = true,
+                    )
+                )
+            }
+            is StreamChunk.FusionResolved -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Fusion && it.active }
+                if (idx >= 0) {
+                    val seg = segments[idx] as StreamSegment.Fusion
+                    segments[idx] = seg.copy(
+                        models = seg.models.ifEmpty { chunk.analysis.models },
+                        analysis = chunk.analysis,
+                        active = false,
+                    )
+                } else {
+                    segments.add(
+                        StreamSegment.Fusion(
+                            panelName = chunk.analysis.panelName,
+                            models = chunk.analysis.models,
+                            analysis = chunk.analysis,
+                            active = false,
+                        )
+                    )
+                }
+            }
         }
         return null
     }
@@ -363,7 +472,9 @@ class ChatViewModel(
             val chipProvider = if (_webSearchChipOn.value) settingsRepository.resolveChipSearchProvider() else null
             val provider = chipProvider ?: settingsRepository.getWebSearchProviderDirect()
             val searchScope = if (chipProvider != null) "both" else settingsRepository.getWebSearchScopeDirect()
-            val isLocal = selectedModel.startsWith("local/")
+            // Echo Fusion always runs cloud models (the panel + judge), so it never uses the
+            // on-device engine even if a local model is the global selection.
+            val isLocal = selectedModel.startsWith("local/") && !_echoFusionActive.value
 
             if (isLocal && _activeStreams.value.values.any { it.isLocal }) {
                 _errorMessage.value = "The on-device model is still responding. Wait for it to finish before starting another local reply."
@@ -401,7 +512,38 @@ class ChatViewModel(
                 clientSearchReady -> provider
                 else -> "off"
             }
-            val systemPrompt = SystemPrompts.build(isLocal, effectiveProvider)
+
+            // Echo Adviser / Echo Fusion: OpenRouter-only modes. Resolve the active profile/panel
+            // here; both override the model, system prompt and response flow. Cloud models only.
+            var advisorReq: OpenRouterService.AdvisorRequest? = null
+            var fusionReq: OpenRouterService.FusionRequest? = null
+            var echoModel = selectedModel
+            var echoSystemPrompt: String? = null
+            if (_echoAdviserActive.value) {
+                if (isLocal) {
+                    _errorMessage.value = "Echo Adviser needs a cloud model. Pick one from the model selector."
+                    return@launch
+                }
+                val profile = advisorProfileDao.getById(settingsRepository.getEchoAdviserProfileIdDirect())
+                if (profile == null) {
+                    _errorMessage.value = "Pick an advisor first — set one up in Settings → Echo Adviser."
+                    return@launch
+                }
+                advisorReq = OpenRouterService.AdvisorRequest(profile.name, profile.modelId)
+                echoSystemPrompt = SystemPrompts.buildEchoAdviser(profile.name)
+            } else if (_echoFusionActive.value) {
+                val panel = fusionPanelDao.getById(settingsRepository.getEchoFusionPanelIdDirect())
+                if (panel == null || panel.models.isEmpty()) {
+                    _errorMessage.value = "Set up a Fusion panel first in Settings → Echo Fusion, then pick it."
+                    return@launch
+                }
+                val judge = panel.judgeModelId?.takeIf { it.isNotBlank() } ?: panel.models.first()
+                echoModel = judge
+                fusionReq = OpenRouterService.FusionRequest(panel.name, panel.models, panel.judgeModelId)
+                echoSystemPrompt = SystemPrompts.buildEchoFusion(panel.name)
+            }
+
+            val systemPrompt = echoSystemPrompt ?: SystemPrompts.build(isLocal, effectiveProvider)
 
             var isFirstMsgInChat = false
             var chatId = _currentChatThreadId.value
@@ -472,7 +614,8 @@ class ChatViewModel(
                 InferenceLimits.coerce(
                     settingsRepository.getInferenceParamsDirect(local = true),
                     ModelCapabilities(
-                        maxContextTokens = lm.maxTokens ?: LocalModelCatalog.maxTokensFor(lm.id, lm.fileName),
+                        maxContextTokens = (lm.maxTokens ?: LocalModelCatalog.maxTokensFor(lm.id, lm.fileName))
+                            .coerceAtMost(InferenceLimits.LOCAL_MAX_TOKENS_CEIL),
                         maxTopK = InferenceLimits.LOCAL_TOP_K_MAX,
                     ),
                     InferenceLimits.LOCAL_DEFAULTS,
@@ -487,6 +630,16 @@ class ChatViewModel(
             }
 
             val responseFlow: Flow<StreamChunk> = when {
+                advisorReq != null || fusionReq != null ->
+                    openRouterService.sendWithEchoTools(
+                        apiKey = apiKey,
+                        model = echoModel,
+                        history = fullHistory,
+                        systemPrompt = systemPrompt,
+                        advisor = advisorReq,
+                        fusion = fusionReq,
+                        params = inferenceParams,
+                    )
                 isLocal && clientSearchReady ->
                     localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey, inferenceParams)
                 isLocal ->
@@ -514,8 +667,20 @@ class ChatViewModel(
 
             val segments = mutableListOf<StreamSegment>()
             var statusNote: String? = null
+            // Echo Adviser/Fusion are cost-heavy and can take a while; label the keep-alive
+            // notification and ping the user when they finish in the background (like research).
+            val echoLabel = when {
+                advisorReq != null -> "Echo Adviser"
+                fusionReq != null -> "Echo Fusion"
+                else -> null
+            }
+            val keepAliveText = when {
+                fusionReq != null -> "Echo Fusion — the panel is deliberating…"
+                advisorReq != null -> "Echo Adviser — consulting your advisor…"
+                else -> "Generating a reply…"
+            }
             // Keep the process unfrozen so the reply keeps streaming while minimized.
-            KeepAliveService.acquire(getApplication(), "Generating a reply…")
+            KeepAliveService.acquire(getApplication(), keepAliveText)
             try {
                 responseFlow.collect { chunk ->
                     val note = reduceSegments(segments, chunk)
@@ -531,10 +696,24 @@ class ChatViewModel(
                     )
                 }
                 persistAssistantMessage(chatId, segments, interrupted = null)
+                if (echoLabel != null) {
+                    ReplyNotifications.notifyReplyReady(
+                        getApplication(), chatId,
+                        title = "$echoLabel reply is ready",
+                        text = "Tap to read the answer in EchoFlow.",
+                    )
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."
                 persistAssistantMessage(chatId, segments, interrupted = e.message)
+                if (echoLabel != null) {
+                    ReplyNotifications.notifyReplyReady(
+                        getApplication(), chatId,
+                        title = "$echoLabel couldn't finish",
+                        text = e.message ?: "The reply was interrupted. Tap to reopen.",
+                    )
+                }
             } finally {
                 KeepAliveService.release(getApplication())
                 streamJobs.remove(chatId)
@@ -714,7 +893,10 @@ class ChatViewModel(
         val normalizedSegments = normalizeAssistantSegmentsForPersistence(segments)
         val contentText = normalizedSegments.filterIsInstance<StreamSegment.Text>()
             .joinToString("\n\n") { it.text }.trim()
-        if (contentText.isEmpty()) return
+        // Keep a turn that produced only an Echo Adviser/Fusion artifact (no prose answer) so
+        // the consultation/deliberation card still persists and re-renders.
+        val hasEchoArtifact = normalizedSegments.any { it is StreamSegment.Advisor || it is StreamSegment.Fusion }
+        if (contentText.isEmpty() && !hasEchoArtifact) return
 
         val reasoningText = normalizedSegments.filterIsInstance<StreamSegment.Reasoning>()
             .joinToString("\n\n") { it.text }.trim()
@@ -740,6 +922,22 @@ class ChatViewModel(
                     ?.let { PersistedSegment(type = "reasoning", text = it) }
                 is StreamSegment.Search ->
                     PersistedSegment(type = "search", query = seg.query, sources = seg.sources)
+                is StreamSegment.Advisor ->
+                    PersistedSegment(
+                        type = "advisor",
+                        advisor = AdvisorAdvice(
+                            advisorName = seg.advisorName,
+                            advisorModel = seg.advisorModel,
+                            prompt = seg.prompt,
+                            advice = seg.advice.orEmpty(),
+                        ),
+                    )
+                is StreamSegment.Fusion ->
+                    PersistedSegment(
+                        type = "fusion",
+                        fusion = (seg.analysis ?: FusionAnalysis(panelName = seg.panelName, judgeModel = null, models = seg.models))
+                            .copy(panelName = seg.panelName, models = seg.models.ifEmpty { seg.analysis?.models ?: emptyList() }),
+                    )
                 is StreamSegment.Text -> seg.text.trim().takeIf { it.isNotEmpty() }
                     ?.let { PersistedSegment(type = "text", text = it) }
             }
@@ -970,13 +1168,15 @@ class ChatViewModel(
             settingsRepository: SettingsRepository,
             localModelDao: LocalModelDao,
             researchRunDao: ResearchRunDao,
-            deepResearchModelDao: DeepResearchModelDao
+            deepResearchModelDao: DeepResearchModelDao,
+            advisorProfileDao: AdvisorProfileDao,
+            fusionPanelDao: FusionPanelDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
-                    researchRunDao, deepResearchModelDao
+                    researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -4,11 +4,15 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.echoflow.data.AdvisorProfile
+import com.echoflow.data.AdvisorProfileDao
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.CustomModel
 import com.echoflow.data.CustomModelDao
 import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DeepResearchModelDao
+import com.echoflow.data.FusionPanel
+import com.echoflow.data.FusionPanelDao
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.InferenceParams
@@ -31,7 +35,9 @@ class SettingsViewModel(
     private val customModelDao: CustomModelDao,
     private val localModelDao: LocalModelDao,
     private val downloadManager: ModelDownloadManager,
-    private val deepResearchModelDao: DeepResearchModelDao
+    private val deepResearchModelDao: DeepResearchModelDao,
+    private val advisorProfileDao: AdvisorProfileDao,
+    private val fusionPanelDao: FusionPanelDao
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
 
@@ -70,6 +76,14 @@ class SettingsViewModel(
     val dataAgentEnabled: StateFlow<Boolean> = repository.dataAgentEnabled
     val dataAgentEngine: StateFlow<String> = repository.dataAgentEngine
     val dataAgentMaxCredits: StateFlow<Int> = repository.dataAgentMaxCredits
+
+    // Echo Adviser / Echo Fusion
+    val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
+    val echoFusionPanelId: StateFlow<String> = repository.echoFusionPanelId
+    val advisorProfiles: StateFlow<List<AdvisorProfile>> = advisorProfileDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val fusionPanels: StateFlow<List<FusionPanel>> = fusionPanelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _importError = MutableStateFlow<String?>(null)
     val importError: StateFlow<String?> = _importError.asStateFlow()
@@ -196,6 +210,76 @@ class SettingsViewModel(
     fun saveDataAgentEnabled(enabled: Boolean) = repository.saveDataAgentEnabled(enabled)
     fun saveDataAgentEngine(id: String) = repository.saveDataAgentEngine(id)
     fun saveDataAgentMaxCredits(value: Int) = repository.saveDataAgentMaxCredits(value)
+
+    // ── Echo Adviser ───────────────────────────────────────────────────────────────────
+
+    fun saveEchoAdviserProfile(id: String) = repository.saveEchoAdviserProfileId(id)
+
+    fun addAdvisorProfile(name: String, modelId: String, modelName: String) {
+        viewModelScope.launch {
+            val cleanName = name.trim().ifEmpty { "Advisor" }
+            val cleanModel = modelId.trim()
+            if (cleanModel.isEmpty()) return@launch
+            val id = java.util.UUID.randomUUID().toString()
+            advisorProfileDao.insert(
+                AdvisorProfile(
+                    id = id,
+                    name = cleanName,
+                    modelId = cleanModel,
+                    modelName = modelName.trim().ifEmpty { cleanModel.substringAfterLast("/") },
+                    createdAt = System.currentTimeMillis(),
+                )
+            )
+            // First profile becomes the active selection automatically.
+            if (repository.getEchoAdviserProfileIdDirect().isBlank()) {
+                repository.saveEchoAdviserProfileId(id)
+            }
+        }
+    }
+
+    fun deleteAdvisorProfile(id: String) {
+        viewModelScope.launch {
+            advisorProfileDao.delete(id)
+            if (repository.getEchoAdviserProfileIdDirect() == id) {
+                repository.saveEchoAdviserProfileId(advisorProfileDao.getAllSync().firstOrNull()?.id.orEmpty())
+            }
+        }
+    }
+
+    // ── Echo Fusion ────────────────────────────────────────────────────────────────────
+
+    fun saveEchoFusionPanel(id: String) = repository.saveEchoFusionPanelId(id)
+
+    fun addFusionPanel(name: String, models: List<Pair<String, String>>, judgeModelId: String?) {
+        viewModelScope.launch {
+            val cleanName = name.trim().ifEmpty { "Panel" }
+            val ids = models.map { it.first.trim() }.filter { it.isNotEmpty() }
+            if (ids.size < 2) return@launch // a panel needs at least two models
+            val id = java.util.UUID.randomUUID().toString()
+            fusionPanelDao.upsert(
+                FusionPanel(
+                    id = id,
+                    name = cleanName,
+                    modelIds = ids.joinToString("\n"),
+                    modelNames = models.map { it.second.trim().ifEmpty { it.first.substringAfterLast("/") } }.joinToString("\n"),
+                    judgeModelId = judgeModelId?.trim()?.takeIf { it.isNotEmpty() && it in ids },
+                    createdAt = System.currentTimeMillis(),
+                )
+            )
+            if (repository.getEchoFusionPanelIdDirect().isBlank()) {
+                repository.saveEchoFusionPanelId(id)
+            }
+        }
+    }
+
+    fun deleteFusionPanel(id: String) {
+        viewModelScope.launch {
+            fusionPanelDao.delete(id)
+            if (repository.getEchoFusionPanelIdDirect() == id) {
+                repository.saveEchoFusionPanelId(fusionPanelDao.getAllSync().firstOrNull()?.id.orEmpty())
+            }
+        }
+    }
 
     fun addDeepResearchModel(id: String, name: String) {
         viewModelScope.launch {
@@ -356,11 +440,13 @@ class SettingsViewModel(
             customModelDao: CustomModelDao,
             localModelDao: LocalModelDao,
             downloadManager: ModelDownloadManager,
-            deepResearchModelDao: DeepResearchModelDao
+            deepResearchModelDao: DeepResearchModelDao,
+            advisorProfileDao: AdvisorProfileDao,
+            fusionPanelDao: FusionPanelDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -1,0 +1,372 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.CompareArrows
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.FusionAnalysis
+import com.echoflow.ui.theme.RoundedPolygonShape
+import com.echoflow.ui.theme.Spacing
+
+/** Short, human label for an OpenRouter model id, e.g. "anthropic/claude-opus-4.8" → "claude-opus-4.8". */
+private fun shortModel(id: String): String = id.substringAfterLast('/').ifBlank { id }
+
+// ── Echo Adviser ────────────────────────────────────────────────────────────────────────
+
+/**
+ * One Echo Adviser consultation in the reply timeline: a tertiary-tinted side-channel card.
+ * While [active] it pulses "Consulting <name>"; once resolved it collapses to a tap-to-expand
+ * card revealing the question the model asked and the advisor's advice. This is the
+ * transparency win — the user watches the answering model escalate to a stronger mind.
+ */
+@Composable
+fun AdvisorCard(
+    advisorName: String,
+    advisorModel: String,
+    prompt: String,
+    advice: String?,
+    active: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var userToggled by remember { mutableStateOf<Boolean?>(null) }
+    val expanded = userToggled ?: active
+    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "advisor-chevron")
+    val hasBody = !prompt.isBlank() || !advice.isNullOrBlank()
+
+    Surface(
+        onClick = { if (hasBody) userToggled = !expanded },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.38f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(30.dp).clip(RoundedPolygonShape(MaterialShapes.Cookie7Sided))
+                        .background(MaterialTheme.colorScheme.tertiary),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.Psychology, null, Modifier.size(17.dp), tint = MaterialTheme.colorScheme.onTertiary) }
+                Spacer(Modifier.width(Spacing.s))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        if (active) "Consulting $advisorName" else "$advisorName advised",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    if (advisorModel.isNotBlank()) {
+                        Text(
+                            shortModel(advisorModel),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1, overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                if (active) {
+                    LoadingIndicator(color = MaterialTheme.colorScheme.tertiary, modifier = Modifier.size(18.dp))
+                } else if (hasBody) {
+                    Icon(
+                        Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand",
+                        Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            AnimatedVisibility(visible = expanded && hasBody, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                Column(Modifier.padding(top = Spacing.s)) {
+                    if (prompt.isNotBlank()) {
+                        Surface(
+                            shape = MaterialTheme.shapes.medium,
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Row(Modifier.padding(Spacing.m)) {
+                                Icon(Icons.Default.CompareArrows, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.tertiary)
+                                Spacer(Modifier.width(Spacing.s))
+                                Column {
+                                    Text("Asked", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    Text(prompt, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurface)
+                                }
+                            }
+                        }
+                    }
+                    if (!advice.isNullOrBlank()) {
+                        Spacer(Modifier.height(Spacing.s))
+                        RichMarkdown(advice, Modifier.fillMaxWidth())
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Echo Fusion ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * One Echo Fusion deliberation in the reply timeline. While [active] it shows the (real) panel
+ * roster shimmering under a staged "deliberating → synthesizing" header — we can't observe
+ * per-model completion, so the roster is honest but the timing is indeterminate. Once resolved
+ * it morphs into the structured analysis: consensus, contradictions (opposing stances),
+ * unique insights, blind spots, and an accordion of each model's full response.
+ */
+@Composable
+fun FusionCard(
+    panelName: String,
+    models: List<String>,
+    analysis: FusionAnalysis?,
+    active: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val roster = analysis?.models?.takeIf { it.isNotEmpty() } ?: models
+
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.32f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(34.dp).clip(RoundedPolygonShape(MaterialShapes.Clover4Leaf))
+                        .background(MaterialTheme.colorScheme.secondary),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.AccountTree, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSecondary) }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        if (panelName.isNotBlank()) "Fusion · $panelName" else "Echo Fusion",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        if (active) "Deliberating across ${roster.size} models" else "${roster.size} models · judged",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (active) LoadingIndicator(color = MaterialTheme.colorScheme.secondary, modifier = Modifier.size(18.dp))
+            }
+
+            Spacer(Modifier.height(Spacing.m))
+            PanelRoster(roster, shimmer = active)
+
+            if (active) {
+                Spacer(Modifier.height(Spacing.m))
+                LinearWavyProgressIndicator(
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(Spacing.s))
+                Text(
+                    "Panel deliberating → judge synthesizing…",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else if (analysis != null) {
+                FusionAnalysisBody(analysis)
+            }
+        }
+    }
+}
+
+/** The panel members as a horizontal strip of model chips; [shimmer] pulses them while deliberating. */
+@Composable
+private fun PanelRoster(models: List<String>, shimmer: Boolean) {
+    val transition = rememberInfiniteTransition(label = "roster")
+    val pulse by transition.animateFloat(
+        initialValue = 0.45f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(900), RepeatMode.Reverse),
+        label = "roster-pulse",
+    )
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        models.forEach { model ->
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.alpha(if (shimmer) pulse else 1f),
+            ) {
+                Row(
+                    Modifier.padding(start = Spacing.s, end = Spacing.m, top = 5.dp, bottom = 5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(Icons.Default.Bolt, null, Modifier.size(13.dp), tint = MaterialTheme.colorScheme.secondary)
+                    Spacer(Modifier.width(4.dp))
+                    Text(shortModel(model), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurface, maxLines = 1)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FusionAnalysisBody(analysis: FusionAnalysis) {
+    Column(Modifier.padding(top = Spacing.m), verticalArrangement = Arrangement.spacedBy(Spacing.m)) {
+        if (analysis.consensus.isNotEmpty()) {
+            FusionSection("Consensus", Icons.Default.CheckCircle, MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onPrimaryContainer) {
+                BulletList(analysis.consensus, MaterialTheme.colorScheme.onPrimaryContainer)
+            }
+        }
+        if (analysis.contradictions.isNotEmpty()) {
+            FusionSection("Disagreements", Icons.Default.CompareArrows, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer) {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    analysis.contradictions.forEach { c ->
+                        Column {
+                            Text(c.topic, style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold), color = MaterialTheme.colorScheme.onErrorContainer)
+                            c.stances.forEach { stance ->
+                                Row(Modifier.padding(top = 2.dp)) {
+                                    Text("⟂ ", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                                    Text(stance, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (analysis.uniqueInsights.isNotEmpty()) {
+            FusionSection("Unique insights", Icons.Default.Lightbulb, MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer) {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    analysis.uniqueInsights.forEach { i ->
+                        Column {
+                            if (i.model.isNotBlank()) {
+                                Text(shortModel(i.model), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
+                            }
+                            Text(i.insight, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onTertiaryContainer)
+                        }
+                    }
+                }
+            }
+        }
+        if (analysis.blindSpots.isNotEmpty()) {
+            FusionSection("Blind spots", Icons.Default.VisibilityOff, MaterialTheme.colorScheme.surfaceContainerHigh, MaterialTheme.colorScheme.onSurface) {
+                BulletList(analysis.blindSpots, MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        if (analysis.responses.isNotEmpty()) {
+            ModelResponsesDisclosure(analysis)
+        }
+        if (analysis.failedModels.isNotEmpty()) {
+            Text(
+                "Did not respond: ${analysis.failedModels.joinToString(", ") { shortModel(it) }}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        analysis.judgeModel?.takeIf { it.isNotBlank() }?.let {
+            Text("Judged by ${shortModel(it)}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun FusionSection(
+    title: String,
+    icon: ImageVector,
+    container: Color,
+    onContainer: Color,
+    content: @Composable () -> Unit,
+) {
+    Surface(shape = MaterialTheme.shapes.large, color = container, modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(icon, null, Modifier.size(16.dp), tint = onContainer)
+                Spacer(Modifier.width(Spacing.s))
+                Text(title, style = MaterialTheme.typography.labelLarge, color = onContainer)
+            }
+            Spacer(Modifier.height(Spacing.s))
+            content()
+        }
+    }
+}
+
+@Composable
+private fun BulletList(items: List<String>, color: Color) {
+    Column {
+        items.forEach { item ->
+            Row(Modifier.padding(vertical = 1.dp)) {
+                Text("•  ", style = MaterialTheme.typography.bodySmall, color = color)
+                Text(item, style = MaterialTheme.typography.bodySmall, color = color)
+            }
+        }
+    }
+}
+
+/** Collapsed accordion holding each panel model's full answer, rendered as markdown. */
+@Composable
+private fun ModelResponsesDisclosure(analysis: FusionAnalysis) {
+    var expanded by remember { mutableStateOf(false) }
+    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "fusion-resp-chevron")
+    Surface(
+        onClick = { expanded = !expanded },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.AutoAwesome, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    "Each model's answer · ${analysis.responses.size}",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand", Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            AnimatedVisibility(visible = expanded, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                Column(Modifier.padding(top = Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    analysis.responses.forEach { resp ->
+                        Column {
+                            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(bottom = 2.dp)) {
+                                Icon(Icons.Default.Bolt, null, Modifier.size(13.dp), tint = MaterialTheme.colorScheme.secondary)
+                                Spacer(Modifier.width(4.dp))
+                                Text(shortModel(resp.model), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.secondary)
+                            }
+                            RichMarkdown(resp.content, Modifier.fillMaxWidth())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -58,19 +58,23 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.echoflow.data.AdvisorProfile
 import com.echoflow.data.ChatMessage
 import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
+import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.StreamSegment
+import com.echoflow.ui.components.AdvisorCard
 import com.echoflow.ui.components.BrandMark
 import com.echoflow.ui.components.CapabilityChip
 import com.echoflow.ui.components.DataResultCard
+import com.echoflow.ui.components.FusionCard
 import com.echoflow.ui.components.EffortPill
 import com.echoflow.ui.components.MarkdownText
 import com.echoflow.ui.components.ReportCard
@@ -126,6 +130,15 @@ fun ChatScreen(
     val exaEffort by settingsViewModel.deepResearchExaEffort.collectAsState()
     val dataAgentEnabled by settingsViewModel.dataAgentEnabled.collectAsState()
     val dataAgentEngineId by settingsViewModel.dataAgentEngine.collectAsState()
+
+    val echoAdviserActive by chatViewModel.echoAdviserActive.collectAsState()
+    val echoFusionActive by chatViewModel.echoFusionActive.collectAsState()
+    val advisorProfiles by settingsViewModel.advisorProfiles.collectAsState()
+    val fusionPanels by settingsViewModel.fusionPanels.collectAsState()
+    val echoAdviserProfileId by settingsViewModel.echoAdviserProfileId.collectAsState()
+    val echoFusionPanelId by settingsViewModel.echoFusionPanelId.collectAsState()
+    val activeAdvisor = advisorProfiles.firstOrNull { it.id == echoAdviserProfileId }
+    val activePanel = fusionPanels.firstOrNull { it.id == echoFusionPanelId }
 
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
@@ -212,6 +225,8 @@ fun ChatScreen(
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
                 modelName = when {
+                    echoFusionActive -> activePanel?.name ?: "Choose panel"
+                    echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
                     dataAgentActive -> dataAgentLabel
                     deepResearchActive -> drEngineLabel
                     else -> modelShortName
@@ -239,9 +254,15 @@ fun ChatScreen(
                 webSearchChipOn = webSearchChipOn,
                 dataAgentActive = dataAgentActive,
                 dataAgentAvailable = dataAgentAvailable,
+                echoAdviserActive = echoAdviserActive,
+                echoFusionActive = echoFusionActive,
+                advisorChipLabel = activeAdvisor?.name,
+                fusionChipLabel = activePanel?.name,
                 onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
                 onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
                 onToggleDataAgent = { chatViewModel.toggleDataAgent() },
+                onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
+                onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
                 researchInProgress = researchRun != null,
                 researchEngineLabel = drEngineLabel,
                 dataAgentLabel = dataAgentLabel,
@@ -269,7 +290,26 @@ fun ChatScreen(
     }
 
     if (showModelMenu) {
-        if (dataAgentActive) {
+        if (echoFusionActive) {
+            FusionPickerSheet(
+                panels = fusionPanels,
+                selectedId = echoFusionPanelId,
+                onSelect = { settingsViewModel.saveEchoFusionPanel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoAdviserActive) {
+            AdvisorPickerSheet(
+                models = activeModelList,
+                selectedModelId = selectedModelID,
+                profiles = advisorProfiles,
+                selectedProfileId = echoAdviserProfileId,
+                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
+                onSelectProfile = { settingsViewModel.saveEchoAdviserProfile(it) },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (dataAgentActive) {
             val dataEngines = remember(firecrawlKey) {
                 if (firecrawlKey.isNotBlank()) DataAgentCatalog.engines else emptyList()
             }
@@ -450,6 +490,25 @@ private fun StreamingAssistantBubble(
                         SearchActivityCard(query = segment.query, sources = segment.sources, active = segment.active)
                         Spacer(Modifier.height(Spacing.s))
                     }
+                    is StreamSegment.Advisor -> {
+                        AdvisorCard(
+                            advisorName = segment.advisorName,
+                            advisorModel = segment.advisorModel,
+                            prompt = segment.prompt,
+                            advice = segment.advice,
+                            active = segment.active,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    is StreamSegment.Fusion -> {
+                        FusionCard(
+                            panelName = segment.panelName,
+                            models = segment.models,
+                            analysis = segment.analysis,
+                            active = segment.active,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
                     is StreamSegment.Text -> {
                         SmoothStreamingText(segment.text, Modifier.fillMaxWidth())
                         if (!isLast) Spacer(Modifier.height(Spacing.s))
@@ -593,6 +652,29 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                             "search" -> {
                                 SearchActivityCard(query = segment.query.orEmpty(), sources = segment.sources.orEmpty(), active = false)
                                 Spacer(Modifier.height(Spacing.s))
+                            }
+                            "advisor" -> {
+                                segment.advisor?.let { a ->
+                                    AdvisorCard(
+                                        advisorName = a.advisorName,
+                                        advisorModel = a.advisorModel,
+                                        prompt = a.prompt,
+                                        advice = a.advice,
+                                        active = false,
+                                    )
+                                    Spacer(Modifier.height(Spacing.s))
+                                }
+                            }
+                            "fusion" -> {
+                                segment.fusion?.let { f ->
+                                    FusionCard(
+                                        panelName = f.panelName,
+                                        models = f.models,
+                                        analysis = f,
+                                        active = false,
+                                    )
+                                    Spacer(Modifier.height(Spacing.s))
+                                }
                             }
                             // The plan is rendered as a disclosure inside the report card.
                             "plan" -> Unit
@@ -845,9 +927,15 @@ private fun InputToolbar(
     webSearchChipOn: Boolean,
     dataAgentActive: Boolean,
     dataAgentAvailable: Boolean,
+    echoAdviserActive: Boolean,
+    echoFusionActive: Boolean,
+    advisorChipLabel: String?,
+    fusionChipLabel: String?,
     onToggleDeepResearch: () -> Unit,
     onToggleWebSearch: () -> Unit,
     onToggleDataAgent: () -> Unit,
+    onToggleEchoAdviser: () -> Unit,
+    onToggleEchoFusion: () -> Unit,
     researchInProgress: Boolean,
     researchEngineLabel: String?,
     dataAgentLabel: String,
@@ -882,7 +970,7 @@ private fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -890,6 +978,20 @@ private fun InputToolbar(
             ) {
                 if (webSearchChipOn) {
                     CapabilityChip(Icons.Default.TravelExplore, "Web search", onRemove = onToggleWebSearch)
+                }
+                if (echoAdviserActive) {
+                    CapabilityChip(
+                        Icons.Default.Psychology,
+                        advisorChipLabel?.let { "Adviser · $it" } ?: "Echo Adviser",
+                        onRemove = onToggleEchoAdviser,
+                    )
+                }
+                if (echoFusionActive) {
+                    CapabilityChip(
+                        Icons.Default.AccountTree,
+                        fusionChipLabel?.let { "Fusion · $it" } ?: "Echo Fusion",
+                        onRemove = onToggleEchoFusion,
+                    )
                 }
                 if (deepResearchActive) {
                     CapabilityChip(
@@ -927,6 +1029,15 @@ private fun InputToolbar(
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
             )
         }
+        AnimatedVisibility(visible = (echoAdviserActive || echoFusionActive) && blockedReason == null) {
+            Text(
+                if (echoFusionActive) "Runs a panel of models + a judge every message · cost-heavy"
+                else "Consults a stronger advisor model each message · adds cost",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
+            )
+        }
 
         Surface(
             shape = CircleShape,
@@ -957,10 +1068,14 @@ private fun InputToolbar(
                         deepResearchOn = deepResearchActive,
                         dataAgentOn = dataAgentActive,
                         dataAgentAvailable = dataAgentAvailable,
+                        echoAdviserOn = echoAdviserActive,
+                        echoFusionOn = echoFusionActive,
                         onImage = { plusMenuOpen = false; onAttach() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
                         onToggleDeepResearch = { plusMenuOpen = false; onToggleDeepResearch() },
                         onToggleDataAgent = { plusMenuOpen = false; onToggleDataAgent() },
+                        onToggleEchoAdviser = { plusMenuOpen = false; onToggleEchoAdviser() },
+                        onToggleEchoFusion = { plusMenuOpen = false; onToggleEchoFusion() },
                     )
                 }
 
@@ -1010,10 +1125,14 @@ private fun PlusMenu(
     deepResearchOn: Boolean,
     dataAgentOn: Boolean,
     dataAgentAvailable: Boolean,
+    echoAdviserOn: Boolean,
+    echoFusionOn: Boolean,
     onImage: () -> Unit,
     onToggleWebSearch: () -> Unit,
     onToggleDeepResearch: () -> Unit,
     onToggleDataAgent: () -> Unit,
+    onToggleEchoAdviser: () -> Unit,
+    onToggleEchoFusion: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
@@ -1045,6 +1164,21 @@ private fun PlusMenu(
                 onClick = onToggleDataAgent,
             )
         }
+        HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
+        // Echo Adviser / Echo Fusion — OpenRouter-only, cost-heavy modes. Always shown; if the
+        // key or a profile/panel is missing, sending surfaces a "set it up" message.
+        DropdownMenuItem(
+            text = { Text("Echo Adviser") },
+            leadingIcon = { Icon(Icons.Default.Psychology, null) },
+            trailingIcon = { if (echoAdviserOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleEchoAdviser,
+        )
+        DropdownMenuItem(
+            text = { Text("Echo Fusion") },
+            leadingIcon = { Icon(Icons.Default.AccountTree, null) },
+            trailingIcon = { if (echoFusionOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleEchoFusion,
+        )
     }
 }
 
@@ -1193,6 +1327,114 @@ private fun ModelPickerSheet(
                         ModelRow(name, id, id == selectedId, isLocal = true) { onSelect(id) }
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Echo Fusion panel picker: each saved panel (a named roster of 2–8 models) is a selectable
+ * card showing its members. The chosen panel deliberates on every message until turned off.
+ */
+@Composable
+private fun FusionPickerSheet(
+    panels: List<FusionPanel>,
+    selectedId: String,
+    onSelect: (String) -> Unit,
+    onManage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, containerColor = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.l)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.base)) {
+                Column(Modifier.weight(1f)) {
+                    Text("Choose a fusion panel", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text("Models answer in parallel, a judge compares them", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                TextButton(onClick = onManage) {
+                    Icon(Icons.Default.Tune, null, Modifier.size(18.dp)); Spacer(Modifier.width(Spacing.s)); Text("Manage")
+                }
+            }
+            if (panels.isEmpty()) {
+                Column(Modifier.fillMaxWidth().padding(vertical = Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(Icons.Default.AccountTree, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text("No panels yet.\nTap Manage to build one in Settings.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center)
+                }
+            }
+            LazyColumn(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.s), contentPadding = PaddingValues(bottom = Spacing.xl)) {
+                items(panels, key = { it.id }) { panel ->
+                    DrEngineRow(
+                        name = panel.name,
+                        description = panel.names.joinToString(" · ").ifBlank { "${panel.models.size} models" },
+                        selected = panel.id == selectedId,
+                    ) { onSelect(panel.id) }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Echo Adviser picker: two zones — the answering model (any cloud model) and which advisor
+ * profile it escalates to. Both persist immediately; the sheet stays open so the user can set
+ * both before dismissing.
+ */
+@Composable
+private fun AdvisorPickerSheet(
+    models: List<Pair<String, String>>,
+    selectedModelId: String,
+    profiles: List<AdvisorProfile>,
+    selectedProfileId: String,
+    onSelectModel: (String) -> Unit,
+    onSelectProfile: (String) -> Unit,
+    onManage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, containerColor = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.l)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.base)) {
+                Column(Modifier.weight(1f)) {
+                    Text("Adviser setup", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text("A cloud model answers and consults your advisor", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                TextButton(onClick = onManage) {
+                    Icon(Icons.Default.Tune, null, Modifier.size(18.dp)); Spacer(Modifier.width(Spacing.s)); Text("Manage")
+                }
+            }
+
+            Box(Modifier.padding(bottom = Spacing.s)) { SectionLabel("Advisor") }
+            if (profiles.isEmpty()) {
+                Text(
+                    "No advisors yet — tap Manage to set one up.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = Spacing.s),
+                )
+            } else {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.s), modifier = Modifier.padding(bottom = Spacing.m)) {
+                    profiles.forEach { profile ->
+                        FilterChip(
+                            selected = profile.id == selectedProfileId,
+                            onClick = { onSelectProfile(profile.id) },
+                            label = { Text(profile.name) },
+                            leadingIcon = { Icon(Icons.Default.Psychology, null, Modifier.size(16.dp)) },
+                        )
+                    }
+                }
+            }
+
+            Box(Modifier.padding(bottom = Spacing.s)) { SectionLabel("Answering model") }
+            LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp), verticalArrangement = Arrangement.spacedBy(Spacing.s), contentPadding = PaddingValues(bottom = Spacing.m)) {
+                items(models, key = { it.first }) { (id, name) ->
+                    ModelRow(name, id, id == selectedModelId, isLocal = false) { onSelectModel(id) }
+                }
+            }
+
+            Button(onClick = onDismiss, shape = CircleShape, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.xl)) {
+                Text("Done")
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
@@ -48,6 +50,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.RestartAlt
@@ -80,8 +83,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
+import com.echoflow.data.AdvisorProfile
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DataAgentCatalog
+import com.echoflow.data.FusionPanel
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DownloadState
 import com.echoflow.data.InferenceLimits
@@ -131,6 +136,8 @@ private const val PageWebSearch = "web_search"
 private const val PageLocalModels = "local_models"
 private const val PageDeepResearch = "deep_research"
 private const val PageDataAgent = "data_agent"
+private const val PageEchoAdviser = "echo_adviser"
+private const val PageEchoFusion = "echo_fusion"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -182,6 +189,8 @@ fun SettingsScreen(
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageHome })
+            PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageHome })
+            PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageHome })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -207,6 +216,8 @@ private fun SettingsHomePage(
     val deepResearchModels by viewModel.deepResearchModels.collectAsState()
     val dataAgentEnabled by viewModel.dataAgentEnabled.collectAsState()
     val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
+    val advisorProfiles by viewModel.advisorProfiles.collectAsState()
+    val fusionPanels by viewModel.fusionPanels.collectAsState()
 
     val themeLabel = when (darkMode) {
         "light" -> "Light"
@@ -247,6 +258,14 @@ private fun SettingsHomePage(
         !dataAgentEnabled -> "Off"
         else -> DataAgentCatalog.byId(dataAgentEngine)?.name ?: "On"
     }
+    val echoAdviserSubtitle = when {
+        advisorProfiles.isEmpty() -> "Escalate to a stronger model · none set up"
+        else -> "${advisorProfiles.size} advisor" + (if (advisorProfiles.size == 1) "" else "s")
+    }
+    val echoFusionSubtitle = when {
+        fusionPanels.isEmpty() -> "A panel deliberates · no panels yet"
+        else -> "${fusionPanels.size} panel" + (if (fusionPanels.size == 1) "" else "s")
+    }
 
     SettingsPageScaffold(title = "Settings", subtitle = "Make EchoFlow yours", onBack = onBackClicked) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
@@ -257,7 +276,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 6,
+                index = 0, count = 8,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -267,7 +286,7 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 6,
+                index = 1, count = 8,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -277,7 +296,7 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 6,
+                index = 2, count = 8,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -287,7 +306,7 @@ private fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 3, count = 6,
+                index = 3, count = 8,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
@@ -297,8 +316,28 @@ private fun SettingsHomePage(
                 subtitle = dataAgentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 4, count = 6,
+                index = 4, count = 8,
                 onClick = { onOpen(PageDataAgent) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Psychology,
+                polygon = MaterialShapes.Cookie7Sided,
+                title = "Echo Adviser",
+                subtitle = echoAdviserSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 5, count = 8,
+                onClick = { onOpen(PageEchoAdviser) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.AccountTree,
+                polygon = BrandShapes.avatarEnd, // Clover4Leaf
+                title = "Echo Fusion",
+                subtitle = echoFusionSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 6, count = 8,
+                onClick = { onOpen(PageEchoFusion) },
             )
             SettingsNavRow(
                 icon = Icons.Default.PhoneAndroid,
@@ -307,7 +346,7 @@ private fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 6,
+                index = 7, count = 8,
                 onClick = { onOpen(PageLocalModels) },
             )
         }
@@ -1343,6 +1382,324 @@ private fun DataAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             }
         }
     }
+}
+
+// ── Echo Adviser ──────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EchoAdviserPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val apiKey by viewModel.apiKey.collectAsState()
+    val profiles by viewModel.advisorProfiles.collectAsState()
+    val selectedId by viewModel.echoAdviserProfileId.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orResults by viewModel.orModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+    var pendingModel by remember { mutableStateOf<OpenRouterModelInfo?>(null) }
+
+    SettingsPageScaffold(title = "Echo Adviser", subtitle = "Escalate hard parts to a stronger model", onBack = onBack) {
+        FormCard {
+            Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "Any cloud model answers, and consults a stronger, domain-specific advisor mid-answer — before committing to an approach or finishing a hard task. Set up advisors for different jobs (coding, maths, research), then pick one per chat from the model selector. OpenRouter only; each consult adds cost.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (apiKey.isBlank()) {
+            Spacer(Modifier.height(Spacing.m))
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Adviser.", error = true)
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Your advisors", "Tap to set the default; pick per chat from the model selector")
+        if (profiles.isEmpty()) {
+            EchoNoticeCard(Icons.Default.Psychology, "No advisors yet.\nAdd one below — e.g. a strong model for coding or maths.")
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                profiles.forEach { profile ->
+                    DrEngineSelectRow(
+                        name = profile.name,
+                        subtitle = profile.modelName.ifBlank { profile.modelId },
+                        selected = profile.id == selectedId,
+                        onClick = { viewModel.saveEchoAdviserProfile(profile.id) },
+                        onDelete = { viewModel.deleteAdvisorProfile(profile.id) },
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(Spacing.s))
+        FilledTonalButton(
+            onClick = { showDirectory = true; viewModel.loadOpenRouterDirectory() },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Add an advisor")
+        }
+    }
+
+    if (showDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = emptySet(),
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> pendingModel = info; showDirectory = false },
+            onRemove = {},
+            onDismiss = { showDirectory = false },
+        )
+    }
+    pendingModel?.let { model ->
+        EchoNamePromptDialog(
+            title = "Name this advisor",
+            supporting = model.name,
+            defaultName = "",
+            placeholder = "Coding, Maths, Research…",
+            onDismiss = { pendingModel = null },
+            onConfirm = { name ->
+                viewModel.addAdvisorProfile(name, model.id, model.name.substringAfter(": "))
+                pendingModel = null
+            },
+        )
+    }
+}
+
+// ── Echo Fusion ───────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EchoFusionPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val apiKey by viewModel.apiKey.collectAsState()
+    val panels by viewModel.fusionPanels.collectAsState()
+    val selectedId by viewModel.echoFusionPanelId.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orResults by viewModel.orModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+    val pendingModels = remember { mutableStateMapOf<String, String>() } // id -> display name
+    var nameDialog by remember { mutableStateOf(false) }
+
+    SettingsPageScaffold(title = "Echo Fusion", subtitle = "A panel of models deliberates", onBack = onBack) {
+        FormCard {
+            Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "Several models answer the same question in parallel and a judge compares them — surfacing where they agree, where they disagree, and what they all missed. Best for research, comparisons and high-stakes questions. OpenRouter only; cost-heavy — every message runs the whole panel plus a judge.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (apiKey.isBlank()) {
+            Spacer(Modifier.height(Spacing.m))
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Fusion.", error = true)
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Your panels", "Tap to set the default; pick per chat from the model selector")
+        if (panels.isEmpty()) {
+            EchoNoticeCard(Icons.Default.AccountTree, "No panels yet.\nBuild one below from 2–8 models.")
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                panels.forEach { panel ->
+                    DrEngineSelectRow(
+                        name = panel.name,
+                        subtitle = panel.names.joinToString(" · ").ifBlank { "${panel.models.size} models" },
+                        selected = panel.id == selectedId,
+                        onClick = { viewModel.saveEchoFusionPanel(panel.id) },
+                        onDelete = { viewModel.deleteFusionPanel(panel.id) },
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(Spacing.s))
+        FilledTonalButton(
+            onClick = { pendingModels.clear(); showDirectory = true; viewModel.loadOpenRouterDirectory() },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("New panel")
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            "A panel needs 2–8 models. The first model judges unless you change it later.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
+    }
+
+    if (showDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = pendingModels.keys.toSet(),
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> if (pendingModels.size < 8) pendingModels[info.id] = info.name.substringAfter(": ") },
+            onRemove = { id -> pendingModels.remove(id) },
+            onDismiss = { showDirectory = false; if (pendingModels.size >= 2) nameDialog = true },
+        )
+    }
+    if (nameDialog) {
+        FusionPanelDialog(
+            models = pendingModels.toList(),
+            onDismiss = { nameDialog = false; pendingModels.clear() },
+            onConfirm = { name, judgeId ->
+                viewModel.addFusionPanel(name, pendingModels.toList(), judgeModelId = judgeId)
+                nameDialog = false
+                pendingModels.clear()
+            },
+        )
+    }
+}
+
+/** Small info/empty slab used on the Echo Adviser/Fusion pages. */
+@Composable
+private fun EchoNoticeCard(icon: ImageVector, text: String, error: Boolean = false) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.fillMaxWidth().padding(Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(icon, null, Modifier.size(28.dp), tint = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                text,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/** Name-entry dialog used to finish creating an advisor profile or a fusion panel. */
+@Composable
+private fun EchoNamePromptDialog(
+    title: String,
+    supporting: String,
+    defaultName: String,
+    placeholder: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf(defaultName) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.AutoAwesome, null) },
+        title = { Text(title) },
+        text = {
+            Column {
+                Text(supporting, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(Modifier.height(Spacing.m))
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    singleLine = true,
+                    placeholder = { Text(placeholder) },
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(text.trim()) },
+                enabled = text.trim().isNotEmpty(),
+            ) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/**
+ * Finishes a fusion panel: a name plus a **judge** picker — the model that compares the panel
+ * and writes the final answer (defaults to the first/strongest member).
+ */
+@Composable
+private fun FusionPanelDialog(
+    models: List<Pair<String, String>>,
+    onDismiss: () -> Unit,
+    onConfirm: (String, String?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var judgeId by remember { mutableStateOf(models.firstOrNull()?.first) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.AccountTree, null) },
+        title = { Text("New fusion panel") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    singleLine = true,
+                    placeholder = { Text("Heavy hitters, Fast trio…") },
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(Spacing.m))
+                Text("Judge", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                Text(
+                    "Compares the panel and writes the final answer",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.s))
+                Column(
+                    Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
+                ) {
+                    models.forEach { (id, label) ->
+                        val selected = judgeId == id
+                        Surface(
+                            onClick = { judgeId = id },
+                            shape = MaterialTheme.shapes.medium,
+                            color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Row(
+                                Modifier.padding(end = Spacing.m),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                RadioButton(selected = selected, onClick = { judgeId = id })
+                                Text(
+                                    label,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name.trim(), judgeId) },
+                enabled = name.trim().isNotEmpty(),
+            ) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 // ── Local models ──────────────────────────────────────────────────────────────────────

--- a/app/src/test/java/com/echoflow/LocalModelCatalogTest.kt
+++ b/app/src/test/java/com/echoflow/LocalModelCatalogTest.kt
@@ -7,16 +7,16 @@ import org.junit.Test
 class LocalModelCatalogTest {
 
     @Test
-    fun gemma4LiteRtModelsUseFullThirtyTwoKContext() {
+    fun gemma4LiteRtModelsUseEightKMobileContextCap() {
         assertEquals(
-            32768,
+            8192,
             LocalModelCatalog.maxTokensFor(
                 "local/gemma-4-e2b-it",
                 "gemma-4-E2B-it.litertlm"
             )
         )
         assertEquals(
-            32768,
+            8192,
             LocalModelCatalog.maxTokensFor(
                 "local/recovered-gemma-4-e2b",
                 "gemma-4-E2B-it.litertlm"
@@ -27,7 +27,7 @@ class LocalModelCatalogTest {
     @Test
     fun contextHintsCanExposeLargerImportedModelWindows() {
         assertEquals(
-            32768,
+            8192,
             LocalModelCatalog.maxTokensFor(
                 "local/imported",
                 "Some-Model-ctx32k.litertlm"


### PR DESCRIPTION
## Echo Adviser, Echo Fusion & web_fetch

Adds three OpenRouter **server-tool** capabilities, built on the existing streaming chat path (not the Deep Research foreground-service path).

### web_fetch
Auto-attached alongside `web_search` whenever OpenRouter is the active search provider — no new setting. Mentioned only in the OpenRouter prompt branch; a fetched URL surfaces on the existing search timeline.

### Echo Adviser (`openrouter:advisor`)
A cheaper/faster cloud model answers and **escalates hard parts to a stronger, domain-specific advisor** mid-generation. Set up multiple named profiles (Coding, Maths, Research…); the chat picker selects the answering model **and** which advisor. In-chat `AdvisorCard` shows the question asked and the advice.

### Echo Fusion (`openrouter:fusion`)
A **panel of 2–8 models deliberates in parallel and a judge synthesizes**. The `FusionCard` shows the live roster, then consensus, disagreements (opposing stances), unique insights, blind spots, and an accordion of each model's full answer. **Judge is selectable** at panel creation.

### Behaviour
- Both modes are **OpenRouter-only**, mutually exclusive with the other capabilities, surfaced from the **+ menu** with cost-heavy notes, and **forced via `tool_choice: "required"`** (deliberate, cost-heavy choice).
- New **Room v8** tables (`advisor_profiles`, `fusion_panels`) + `MIGRATION_7_8`, two settings pages, and Material 3 Expressive components.
- Long Echo replies keep running in the **background** (`KeepAliveService`) and post a **tap-to-open completion notification** when finished while the app isn't in the foreground.

### Notes for review
- The exact Chat-Completions SSE shape for advisor/fusion **results** is OpenRouter beta/undocumented. Tool-call args (the question / panel) are reliable; the result parsers walk the chunk tree defensively and degrade to "consulted, no body" if keys differ — **verify against a live key in Android Studio** and adjust the key names if needed.
- Not CLI-buildable in this environment (Android Studio required).
- Also carries a few small in-progress local-model/inference tweaks that were already uncommitted on the branch.

### Verify
1. Build in Android Studio.
2. Create an advisor profile + a fusion panel (with a judge), pick them from the chat model selector.
3. Send a message in each mode; confirm the cards render and the completion notification fires when backgrounded.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Echo Adviser and Echo Fusion modes with web_fetch tool support to chat
> - Adds two new chat modes: **Echo Adviser** (consults a named AI advisor mid-response) and **Echo Fusion** (runs a panel of 2–8 models with a judge for structured analysis), both toggled via the `+` menu in the chat input toolbar.
> - Introduces `AdvisorProfile` and `FusionPanel` Room entities with DAOs and a DB migration from v7 to v8; selected profile/panel IDs are persisted in `SettingsRepository`.
> - Extends `OpenRouterService.streamCompletion` to detect and emit `AdvisorStarted`/`AdvisorResolved` and `FusionStarted`/`FusionResolved` stream chunks; adds `sendWithEchoTools` to drive adviser/fusion server-side tool calls and surfaces `web_fetch` URLs as search timeline events.
> - Adds new settings pages (`EchoAdviserPage`, `EchoFusionPage`) for creating, selecting, and deleting adviser profiles and fusion panels, with model picker and judge selection dialogs.
> - Renders adviser and fusion results in the chat timeline via new `AdvisorCard` and `FusionCard` composables, including animated loading states, expandable analysis sections, and markdown content.
> - Adds `ReplyNotifications` to post a background notification when a long adviser/fusion reply completes while the app is backgrounded, navigating back to the relevant chat on tap.
> - Reduces local inference `LOCAL_MAX_TOKENS_CEIL` from 32768 to 8192, enforced across `LocalModelCatalog`, `LocalLlmService`, and `InferenceLimits`; Echo Fusion always forces cloud model usage.
> - Risk: the 8192 local token cap is a breaking behavioral change for any local model previously using up to 32K tokens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b300cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->