### PR TITLE
Add Echo Agents (openrouter:subagent) as a third Echo mode

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -87,7 +87,8 @@ class MainActivity : ComponentActivity() {
                     modelDownloadManager,
                     database.deepResearchModelDao(),
                     database.advisorProfileDao(),
-                    database.fusionPanelDao()
+                    database.fusionPanelDao(),
+                    database.agentProfileDao()
                 )
             )
 
@@ -101,7 +102,8 @@ class MainActivity : ComponentActivity() {
                     database.researchRunDao(),
                     database.deepResearchModelDao(),
                     database.advisorProfileDao(),
-                    database.fusionPanelDao()
+                    database.fusionPanelDao(),
+                    database.agentProfileDao()
                 )
             )
 

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -10,9 +10,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 @Database(
     entities = [
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
-        DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class
+        DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
+        AgentProfile::class
     ],
-    version = 8, // v8: advisor_profiles + fusion_panels — Echo Adviser / Echo Fusion (MIGRATION_7_8)
+    version = 10, // v10: Echo Agent profiles (MIGRATION_9_10)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -24,6 +25,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun researchRunDao(): ResearchRunDao
     abstract fun advisorProfileDao(): AdvisorProfileDao
     abstract fun fusionPanelDao(): FusionPanelDao
+    abstract fun agentProfileDao(): AgentProfileDao
 
     companion object {
         @Volatile
@@ -124,6 +126,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN localAttachmentUri TEXT")
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN localAttachmentMimeType TEXT")
+                db.execSQL("ALTER TABLE research_runs ADD COLUMN localAttachmentName TEXT")
+            }
+        }
+
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS agent_profiles (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "workerModelId TEXT NOT NULL, " +
+                        "workerModelName TEXT NOT NULL, " +
+                        "maxToolCalls INTEGER NOT NULL, " +
+                        "createdAt INTEGER NOT NULL)"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -131,7 +155,16 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "local_chat_database"
                 )
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+                .addMigrations(
+                    MIGRATION_2_3,
+                    MIGRATION_3_4,
+                    MIGRATION_4_5,
+                    MIGRATION_5_6,
+                    MIGRATION_6_7,
+                    MIGRATION_7_8,
+                    MIGRATION_8_9,
+                    MIGRATION_9_10,
+                )
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()
                 .build()

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -40,6 +40,14 @@ sealed class StreamChunk {
 
     /** The fusion judge returned its structured analysis (and per-model responses). */
     data class FusionResolved(val analysis: FusionAnalysis) : StreamChunk()
+
+    // ── Echo Agent (openrouter:subagent) ───────────────────────────────────────────
+    /** The orchestrator delegated a self-contained task to its worker; the brief is known,
+     *  the worker's outcome is pending. Fires once per delegation (there may be several). */
+    data class SubagentStarted(val taskName: String, val taskDescription: String, val workerModel: String) : StreamChunk()
+
+    /** The worker finished a delegated task. [result] carries the outcome (or an error). */
+    data class SubagentResolved(val result: SubagentResult) : StreamChunk()
 }
 
 // ── Echo Adviser / Echo Fusion result records ──────────────────────────────────────
@@ -50,6 +58,15 @@ data class AdvisorAdvice(
     val advisorModel: String, // the OpenRouter model id that served as advisor
     val prompt: String, // the question the answering model asked
     val advice: String, // the advice text (may be blank if not captured from the stream)
+)
+
+/** One Echo Agent delegation: the task the orchestrator handed off and what the worker returned. */
+data class SubagentResult(
+    val taskName: String, // the orchestrator's short label for the task
+    val taskDescription: String = "", // the full brief the worker was given (worker sees only this)
+    val workerModel: String, // the OpenRouter model id that did the work
+    val outcome: String, // the worker's result text (blank on error)
+    val error: String? = null, // present when the delegation failed
 )
 
 /** One panel model's full answer in a fusion deliberation. */
@@ -115,12 +132,13 @@ data class Citation(
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent"
     val text: String? = null,
     val query: String? = null,
     val sources: List<SearchSource>? = null,
     val advisor: AdvisorAdvice? = null, // present when type == "advisor"
-    val fusion: FusionAnalysis? = null // present when type == "fusion"
+    val fusion: FusionAnalysis? = null, // present when type == "fusion"
+    val subagent: SubagentResult? = null // present when type == "subagent"
 )
 
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -110,6 +110,24 @@ interface FusionPanelDao {
 }
 
 @Dao
+interface AgentProfileDao {
+    @Query("SELECT * FROM agent_profiles ORDER BY createdAt ASC")
+    fun getAll(): Flow<List<AgentProfile>>
+
+    @Query("SELECT * FROM agent_profiles ORDER BY createdAt ASC")
+    suspend fun getAllSync(): List<AgentProfile>
+
+    @Query("SELECT * FROM agent_profiles WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): AgentProfile?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(profile: AgentProfile)
+
+    @Query("DELETE FROM agent_profiles WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
 interface ResearchRunDao {
     @Query("SELECT * FROM research_runs WHERE chatId = :chatId AND status NOT IN ('completed','failed','cancelled') ORDER BY createdAt DESC LIMIT 1")
     fun observeActiveForChat(chatId: String): Flow<ResearchRun?>

--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -72,10 +72,11 @@ class DeepResearchEngine(
         existing: ResearchRun?,
     ): Flow<ResearchEvent> = flow {
         try {
+            val attachment = existing?.localAttachmentForOpenRouter()
             when (config.engineKind) {
                 "provider" -> runProvider(config, topic, searchKey, existing)
                 "data-agent" -> runDataAgent(config, topic, searchKey, existing)
-                else -> runAgent(config, topic, openRouterKey, searchKey, existing)
+                else -> runAgent(config, topic, openRouterKey, searchKey, existing, attachment)
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
@@ -433,6 +434,7 @@ class DeepResearchEngine(
         openRouterKey: String,
         searchKey: String,
         existing: ResearchRun?,
+        attachment: OpenRouterService.LocalAttachment?,
     ) {
         if (openRouterKey.isBlank()) {
             emit(ResearchEvent.Failed("OpenRouter API key is missing — add it in Settings → Cloud models."))
@@ -448,16 +450,20 @@ class DeepResearchEngine(
         val resumedSources = ResearchJson.sourcesFromJson(existing?.sourcesJson)
         if (existing != null && resumedSources.isNotEmpty() && existing.report.isNullOrBlank()) {
             emit(ResearchEvent.Phase(ResearchRun.STATUS_SYNTHESIZING, "Writing the report…"))
-            emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, resumedSources)))
+            emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, resumedSources, attachment)))
             return
         }
 
         emit(ResearchEvent.Phase(ResearchRun.STATUS_PLANNING, "Planning the research…"))
+        val planningPrompt = if (attachment != null) {
+            "User research request: $topic\n\nUse the attached PDF as primary context while planning the research."
+        } else topic
         val planRaw = openRouterService.complete(
             apiKey = openRouterKey,
             model = config.provider,
             systemPrompt = SystemPrompts.deepResearchPlanner(topic, config.maxSearches),
-            userPrompt = topic,
+            userPrompt = planningPrompt,
+            attachment = attachment,
         )
         val steps = parsePlan(planRaw, config.maxSearches)
         if (steps.isEmpty()) {
@@ -492,7 +498,7 @@ class DeepResearchEngine(
         }
 
         emit(ResearchEvent.Phase(ResearchRun.STATUS_SYNTHESIZING, "Writing the report…"))
-        emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, gathered.values.toList())))
+        emit(ResearchEvent.Report(synthesize(config.provider, openRouterKey, topic, gathered.values.toList(), attachment)))
     }
 
     private suspend fun synthesize(
@@ -500,12 +506,29 @@ class DeepResearchEngine(
         apiKey: String,
         topic: String,
         sources: List<SearchSource>,
+        attachment: OpenRouterService.LocalAttachment?,
     ): String = openRouterService.complete(
         apiKey = apiKey,
         model = model,
         systemPrompt = SystemPrompts.deepResearchSynthesis(topic),
-        userPrompt = "Numbered search results:\n\n" + formatSearchResultsForModel(sources),
+        userPrompt = buildString {
+            append("User research request: ")
+            append(topic)
+            append("\n\n")
+            if (attachment != null) {
+                append("Use the attached PDF as primary context and combine it with these numbered search results.\n\n")
+            }
+            append("Numbered search results:\n\n")
+            append(formatSearchResultsForModel(sources))
+        },
+        attachment = attachment,
     )
+
+    private fun ResearchRun.localAttachmentForOpenRouter(): OpenRouterService.LocalAttachment? {
+        val uri = localAttachmentUri ?: return null
+        if (!localAttachmentMimeType.equals("application/pdf", ignoreCase = true)) return null
+        return OpenRouterService.LocalAttachment(uri, localAttachmentMimeType, localAttachmentName)
+    }
 
     private fun parsePlan(raw: String, max: Int): List<String> =
         raw.lineSequence()

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -102,6 +102,23 @@ data class FusionPanel(
 }
 
 /**
+ * One Echo Agent profile: a named orchestration setup whose **worker model** is the cheap,
+ * fast model that the answering (orchestrator) model delegates self-contained subtasks to via
+ * the `openrouter:subagent` server tool. The orchestrator itself is whichever cloud model is
+ * selected in chat; this profile only pins the worker and how many tool-calling steps it may
+ * take per delegation.
+ */
+@Entity(tableName = "agent_profiles")
+data class AgentProfile(
+    @PrimaryKey val id: String, // UUID
+    val name: String, // "Fast worker", "Cheap drone", …
+    val workerModelId: String, // the worker OpenRouter model id
+    val workerModelName: String, // human label for the worker model
+    val maxToolCalls: Int = 8, // worker tool-calling budget per delegation (1–25)
+    val createdAt: Long,
+)
+
+/**
  * The durable record of one Deep Research run. This is the single source of truth: the
  * foreground service writes progress here and the UI observes it, so a run survives the
  * Activity/ViewModel being destroyed and can be resumed after the app is force-killed
@@ -135,6 +152,9 @@ data class ResearchRun(
     val report: String? = null, // final report markdown (or partial on cancel)
     val error: String? = null,
     val assistantMessageId: String? = null, // the chat_messages row holding the final report
+    val localAttachmentUri: String? = null,
+    val localAttachmentMimeType: String? = null,
+    val localAttachmentName: String? = null,
     val createdAt: Long,
     val updatedAt: Long
 ) {

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -41,8 +41,14 @@ class OpenRouterService(private val context: Context) {
 
     private val dynamicAdapter = moshi.adapter(Any::class.java)
 
+    data class LocalAttachment(
+        val uri: String,
+        val mimeType: String?,
+        val name: String?,
+    )
+
     /**
-     * Converts an image URI to standard raw Base64 string.
+     * Converts a local attachment URI to standard raw Base64 string.
      */
     private fun getBase64FromUri(uriString: String?): String? {
         if (uriString == null) return null
@@ -60,6 +66,22 @@ class OpenRouterService(private val context: Context) {
         }
     }
 
+    private fun isPdfMime(mime: String?): Boolean = mime.equals("application/pdf", ignoreCase = true)
+
+    private fun pdfPlugins(): List<Map<String, Any>> = listOf(
+        mapOf(
+            "id" to "file-parser",
+            "pdf" to mapOf("engine" to "cloudflare-ai"),
+        )
+    )
+
+    private fun historyHasPdfAttachment(history: List<ChatMessage>): Boolean =
+        history.any { it.role == "user" && it.localAttachmentUri != null && isPdfMime(it.localAttachmentMimeType) }
+
+    private fun addPdfPluginIfNeeded(requestMap: MutableMap<String, Any>, hasPdf: Boolean) {
+        if (hasPdf) requestMap["plugins"] = pdfPlugins()
+    }
+
     /**
      * Transforms database messages into OpenRouter compliant multi-modal format structure.
      * The system prompt (when present) is prepended for the request only — never persisted.
@@ -74,14 +96,25 @@ class OpenRouterService(private val context: Context) {
             payload.add(
                 if (base64 != null && msg.role == "user") {
                     val mime = msg.localAttachmentMimeType ?: "image/jpeg"
+                    val attachmentPart = if (isPdfMime(mime)) {
+                        mapOf(
+                            "type" to "file",
+                            "file" to mapOf(
+                                "filename" to (msg.localAttachmentName?.takeIf { it.isNotBlank() } ?: "document.pdf"),
+                                "file_data" to "data:application/pdf;base64,$base64",
+                            )
+                        )
+                    } else {
+                        mapOf(
+                            "type" to "image_url",
+                            "image_url" to mapOf("url" to "data:$mime;base64,$base64")
+                        )
+                    }
                     mapOf(
                         "role" to msg.role,
                         "content" to listOf(
                             mapOf("type" to "text", "text" to msg.content),
-                            mapOf(
-                                "type" to "image_url",
-                                "image_url" to mapOf("url" to "data:$mime;base64,$base64")
-                            )
+                            attachmentPart
                         )
                     )
                 } else {
@@ -134,6 +167,7 @@ class OpenRouterService(private val context: Context) {
             "messages" to buildMessagesPayload(history),
             "stream" to false
         )
+        addPdfPluginIfNeeded(requestMap, historyHasPdfAttachment(history))
 
         val jsonPayload = dynamicAdapter.toJson(requestMap)
         val request = buildHttpRequest(apiKey, jsonPayload)
@@ -172,19 +206,30 @@ class OpenRouterService(private val context: Context) {
         apiKey: String,
         model: String,
         systemPrompt: String,
-        userPrompt: String
+        userPrompt: String,
+        attachment: LocalAttachment? = null,
     ): String = withContext(Dispatchers.IO) {
         if (apiKey.isBlank()) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
+        val promptHistory = listOf(
+            ChatMessage(
+                id = "completion_user",
+                chatId = "completion",
+                role = "user",
+                content = userPrompt,
+                createdAt = System.currentTimeMillis(),
+                localAttachmentUri = attachment?.uri,
+                localAttachmentMimeType = attachment?.mimeType,
+                localAttachmentName = attachment?.name,
+            )
+        )
         val requestMap = mutableMapOf<String, Any>(
             "model" to model,
-            "messages" to listOf(
-                mapOf("role" to "system", "content" to systemPrompt),
-                mapOf("role" to "user", "content" to userPrompt)
-            ),
+            "messages" to buildMessagesPayload(promptHistory, systemPrompt),
             "stream" to false
         )
+        addPdfPluginIfNeeded(requestMap, attachment != null && isPdfMime(attachment.mimeType))
         val jsonPayload = dynamicAdapter.toJson(requestMap)
         val request = buildHttpRequest(apiKey, jsonPayload)
 
@@ -234,6 +279,7 @@ class OpenRouterService(private val context: Context) {
         fun looksLikeWebFetch(): Boolean = mentions("web_fetch")
         fun looksLikeAdvisor(): Boolean = mentions("advisor")
         fun looksLikeFusion(): Boolean = mentions("fusion")
+        fun looksLikeSubagent(): Boolean = mentions("subagent")
     }
 
     /**
@@ -276,6 +322,16 @@ class OpenRouterService(private val context: Context) {
         null
     }
 
+    /** Parse a subagent tool call's arguments `{task_name, task_description}`. */
+    private fun parseTaskArgs(argsJson: String): Pair<String, String>? = try {
+        val map = dynamicAdapter.fromJson(argsJson) as? Map<*, *>
+        val name = (map?.get("task_name") as? String)?.takeIf { it.isNotBlank() }
+        val desc = (map?.get("task_description") as? String).orEmpty()
+        if (name != null) name to desc else null
+    } catch (e: Exception) {
+        null
+    }
+
     /** Parse a string only if it looks like a JSON object/array (some tool results are stringified). */
     private fun parseMaybeJson(s: String): Any? {
         val t = s.trim()
@@ -299,6 +355,36 @@ class OpenRouterService(private val context: Context) {
             is List<*> -> for (v in node) scanForAdvisorResult(v, depth + 1)?.let { return it }
         }
         return null
+    }
+
+    /**
+     * Walks an SSE chunk for subagent results `{status, model, task_name, outcome}` (or an
+     * `{status:"error", task_name, error}`). Appends every distinct one found to [out]; the
+     * caller dedupes by task_name. The shape is documented (unlike advisor/fusion), so this is
+     * a straightforward keyed scan rather than a guess.
+     */
+    private fun scanForSubagentResults(node: Any?, depth: Int = 0, out: MutableList<SubagentResult>) {
+        if (depth > 8) return
+        when (node) {
+            is Map<*, *> -> {
+                val taskName = (node["task_name"] as? String)?.takeIf { it.isNotBlank() }
+                val hasOutcome = node.containsKey("outcome")
+                val errorMsg = (node["error"] as? String)?.takeIf { it.isNotBlank() }
+                if (taskName != null && (hasOutcome || errorMsg != null)) {
+                    out.add(
+                        SubagentResult(
+                            taskName = taskName,
+                            workerModel = (node["model"] as? String).orEmpty(),
+                            outcome = (node["outcome"] as? String).orEmpty(),
+                            error = errorMsg?.takeIf { (node["status"] as? String) == "error" || !hasOutcome },
+                        )
+                    )
+                }
+                (node["content"] as? String)?.let { c -> parseMaybeJson(c)?.let { scanForSubagentResults(it, depth + 1, out) } }
+                for (v in node.values) scanForSubagentResults(v, depth + 1, out)
+            }
+            is List<*> -> for (v in node) scanForSubagentResults(v, depth + 1, out)
+        }
     }
 
     private fun isFusionResponseList(list: List<*>?): Boolean =
@@ -389,6 +475,9 @@ class OpenRouterService(private val context: Context) {
         params: InferenceParams?,
         toolChoice: String? = null,
         echo: EchoContext? = null,
+        agentWorkerModel: String? = null,
+        pdfPluginEnabled: Boolean = false,
+        httpClient: OkHttpClient = client,
         onChunk: suspend (StreamChunk) -> Unit
     ): TurnResult {
         val requestMap = mutableMapOf<String, Any>(
@@ -400,6 +489,7 @@ class OpenRouterService(private val context: Context) {
             "include_reasoning" to true,
             "reasoning" to mapOf("enabled" to true)
         )
+        addPdfPluginIfNeeded(requestMap, pdfPluginEnabled)
         if (tools != null) {
             requestMap["tools"] = tools
         }
@@ -436,7 +526,12 @@ class OpenRouterService(private val context: Context) {
         var fusionAnnounced = false
         var fusionResolved = false
 
-        client.newCall(request).execute().use { response ->
+        // Echo Agent: the orchestrator may delegate several tasks per turn, so these track
+        // per-tool-call (announce) and per-task-name (resolve) rather than a single flag.
+        val subagentAnnounced = mutableMapOf<Int, Boolean>()
+        val subagentResolved = mutableSetOf<String>()
+
+        httpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 val errorString = response.body?.string().orEmpty()
                 val parsedErrorMsg = parseErrorMessage(errorString)
@@ -523,6 +618,14 @@ class OpenRouterService(private val context: Context) {
                             fusionAnnounced = true
                             onChunk(StreamChunk.FusionStarted(echo.fusionPanelName, echo.fusionModels))
                         }
+                        // Echo Agent delegation: announce the moment the task brief parses, then
+                        // the worker runs server-side and its outcome arrives as a tool result.
+                        if (agentWorkerModel != null && subagentAnnounced[index] != true && builder.looksLikeSubagent()) {
+                            parseTaskArgs(builder.args.toString())?.let { (name, desc) ->
+                                subagentAnnounced[index] = true
+                                onChunk(StreamChunk.SubagentStarted(name, desc, agentWorkerModel))
+                            }
+                        }
                     }
 
                     // url_citation annotations may arrive on the delta or on a message object.
@@ -584,6 +687,18 @@ class OpenRouterService(private val context: Context) {
                         }
                     }
 
+                    // Echo Agent: a worker delegation finished somewhere in this chunk. Emit each
+                    // distinct result once (keyed by task_name) so its card flips from running.
+                    if (agentWorkerModel != null && map != null) {
+                        val found = mutableListOf<SubagentResult>()
+                        scanForSubagentResults(map, out = found)
+                        found.forEach { r ->
+                            if (subagentResolved.add(r.taskName)) {
+                                onChunk(StreamChunk.SubagentResolved(r.copy(workerModel = r.workerModel.ifBlank { agentWorkerModel })))
+                            }
+                        }
+                    }
+
                     (choice?.get("finish_reason") as? String)?.let { finishReason = it }
                 } catch (e: Exception) {
                     // Resilient inline SSE fail ignores
@@ -629,8 +744,9 @@ class OpenRouterService(private val context: Context) {
         }
 
         val tools = if (serverWebSearch) openRouterWebTools() else null
+        val hasPdf = historyHasPdfAttachment(history)
 
-        streamCompletion(apiKey, model, buildMessagesPayload(history, systemPrompt), tools, params) { emit(it) }
+        streamCompletion(apiKey, model, buildMessagesPayload(history, systemPrompt), tools, params, pdfPluginEnabled = hasPdf) { emit(it) }
     }.flowOn(Dispatchers.IO)
 
     /**
@@ -656,6 +772,56 @@ class OpenRouterService(private val context: Context) {
             )
         )
     )
+
+    /** Config for one Echo Agent turn: the worker (subagent) model and its tool-call budget. */
+    data class AgentRequest(val workerModel: String, val workerModelName: String, val maxToolCalls: Int)
+
+    /**
+     * Echo Agent. The selected cloud model orchestrates a full toolbox on the **streaming** path:
+     * `openrouter:web_search`, `openrouter:web_fetch`, and `openrouter:subagent` (a cheaper worker
+     * model it can delegate self-contained tasks to). tool_choice is left to the model (auto): it
+     * decides which tools to use and in what order, possibly several times, chaining them freely.
+     * All three execute server-side and surface here as SearchStarted/SearchSources and
+     * SubagentStarted/SubagentResolved chunks. Uses the long-timeout [echoClient] because a worker
+     * delegation can stall the stream for a while. Unlike advisor/fusion, the subagent result shape
+     * is documented (`{status, model, task_name, outcome}`), so its parsing is exact.
+     */
+    fun sendWithAgentTools(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        agent: AgentRequest,
+        params: InferenceParams? = null,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) {
+            throw Exception("API key is missing! Please configure it in your Settings.")
+        }
+        val tools = mutableListOf<Map<String, Any>>()
+        tools.addAll(openRouterWebTools()) // the orchestrator's own web_search + web_fetch
+        val subagentParams = mutableMapOf<String, Any>(
+            "model" to agent.workerModel,
+            "max_tool_calls" to agent.maxToolCalls.coerceIn(1, 25),
+            // The worker gets its own web toolbox so it can research while doing the task.
+            "tools" to listOf(
+                mapOf("type" to "openrouter:web_search"),
+                mapOf("type" to "openrouter:web_fetch"),
+            ),
+        )
+        tools.add(mapOf("type" to "openrouter:subagent", "parameters" to subagentParams))
+
+        val hasPdf = historyHasPdfAttachment(history)
+        streamCompletion(
+            apiKey = apiKey,
+            model = model,
+            payloadMessages = buildMessagesPayload(history, systemPrompt),
+            tools = tools,
+            params = params,
+            agentWorkerModel = agent.workerModel,
+            pdfPluginEnabled = hasPdf,
+            httpClient = echoClient,
+        ) { emit(it) }
+    }.flowOn(Dispatchers.IO)
 
     /** Config for one Echo Adviser consult: which profile (display name) and advisor model. */
     data class AdvisorRequest(val name: String, val model: String)
@@ -716,6 +882,7 @@ class OpenRouterService(private val context: Context) {
             emit(StreamChunk.FusionStarted(fusion.panelName, fusion.models))
         }
 
+        val hasPdf = historyHasPdfAttachment(history)
         val requestMap = mutableMapOf<String, Any>(
             "model" to model,
             "messages" to buildMessagesPayload(history, systemPrompt),
@@ -725,6 +892,7 @@ class OpenRouterService(private val context: Context) {
             "tools" to tools,
             "tool_choice" to "required",
         )
+        addPdfPluginIfNeeded(requestMap, hasPdf)
         if (params != null) {
             requestMap["temperature"] = params.temperature
             requestMap["top_p"] = params.topP
@@ -848,6 +1016,7 @@ class OpenRouterService(private val context: Context) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
 
+        val hasPdf = historyHasPdfAttachment(history)
         val messages: MutableList<Map<String, Any>> = buildMessagesPayload(history, systemPrompt)
         val toolSpec = listOf(
             mapOf(
@@ -880,7 +1049,7 @@ class OpenRouterService(private val context: Context) {
             // Once the budget is spent (or on the last round) drop the tool so the model
             // is forced to answer with what it has.
             val tools = if (searchesUsed >= maxSearches || round == maxRounds - 1) null else toolSpec
-            val result = streamCompletion(apiKey, model, messages, tools, params) { emit(it) }
+            val result = streamCompletion(apiKey, model, messages, tools, params, pdfPluginEnabled = hasPdf) { emit(it) }
 
             val searchCalls = result.toolCalls
             if (result.finishReason != "tool_calls" || searchCalls.isEmpty()) break

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -87,6 +87,9 @@ class SettingsRepository(context: Context) {
     private val _echoFusionPanelId = MutableStateFlow(getEchoFusionPanelIdDirect())
     val echoFusionPanelId: StateFlow<String> = _echoFusionPanelId.asStateFlow()
 
+    private val _echoAgentProfileId = MutableStateFlow(getEchoAgentProfileIdDirect())
+    val echoAgentProfileId: StateFlow<String> = _echoAgentProfileId.asStateFlow()
+
     // Inference parameters: one global set for on-device models, one for OpenRouter models.
     private val _localInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = true))
     val localInferenceParams: StateFlow<InferenceParams> = _localInferenceParams.asStateFlow()
@@ -239,6 +242,14 @@ class SettingsRepository(context: Context) {
     fun saveEchoFusionPanelId(id: String) {
         prefs.edit().putString("echo_fusion_panel_id", id).apply()
         _echoFusionPanelId.value = id
+    }
+
+    fun getEchoAgentProfileIdDirect(): String =
+        prefs.getString("echo_agent_profile_id", "").orEmpty()
+
+    fun saveEchoAgentProfileId(id: String) {
+        prefs.edit().putString("echo_agent_profile_id", id).apply()
+        _echoAgentProfileId.value = id
     }
 
     // ── Inference parameters ───────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -183,6 +183,42 @@ object SystemPrompts {
             formatting(false),
         ).joinToString("\n\n")
 
+    /**
+     * Echo Agent: the answering model is an orchestrator with a full toolbox — web search, web
+     * fetch, and a subagent (worker) it can delegate self-contained tasks to. It decides which
+     * tool to use, in any order, as many times as the work needs. Cloud only.
+     */
+    fun buildEchoAgent(workerName: String, currentDate: String = currentDate()): String =
+        listOf(
+            identity(false),
+            "Current date: $currentDate.",
+            agentGuidance(workerName),
+            formatting(false),
+        ).joinToString("\n\n")
+
+    private fun agentGuidance(workerName: String): String =
+        """
+        ## Your tools
+        You decide, on your own, which tools to use and in what order — you may chain them freely (e.g. search the web, hand off a task, then search again to verify).
+
+        - **web_search** — search the web for current, factual, or niche information.
+        - **web_fetch** — pull the full content of a specific URL when you need the whole page.
+        - **delegate** — hand a self-contained task to a faster, cheaper helper model ("$workerName"). The helper can itself search and fetch the web.
+
+        When to hand off a task:
+        - Offload mechanical or bounded work — summarizing a long source, extracting structured data, reformatting, drafting boilerplate, or running a focused lookup — so you stay focused on the reasoning and the final answer.
+        - You may hand off several tasks (in sequence or for different parts) and combine the results.
+
+        How to write a good task:
+        - The helper sees ONLY the task description you write — never the chat history. Make every task fully self-contained: include all inputs, the exact output format you want, and any constraints.
+        - Give each task a short, descriptive task_name.
+        - Do NOT hand off the core judgement, the final decision, or the synthesis — that is your job.
+
+        Using results:
+        - Fold tool and helper results into one coherent answer. Verify anything important rather than trusting a single source or a single pass.
+        - Cite web-backed claims inline as markdown links, e.g. ([Reuters](https://example.com)). Never append a separate "Sources" list — the app shows sources separately.
+        """.trimIndent()
+
     private fun adviserGuidance(advisorName: String): String =
         """
         ## Echo Adviser

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1,6 +1,7 @@
 package com.echoflow.ui
 
 import android.app.Application
+import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.lifecycle.AndroidViewModel
@@ -41,6 +42,16 @@ sealed class StreamSegment {
         val analysis: FusionAnalysis?,
         val active: Boolean
     ) : StreamSegment()
+
+    /** Echo Agent delegation: a task handed to the worker and its outcome (null while running). */
+    data class Subagent(
+        val taskName: String,
+        val taskDescription: String,
+        val workerModel: String,
+        val outcome: String?,
+        val error: String?,
+        val active: Boolean
+    ) : StreamSegment()
 }
 
 private data class ActiveStreamState(
@@ -59,7 +70,8 @@ class ChatViewModel(
     private val researchRunDao: ResearchRunDao,
     private val deepResearchModelDao: DeepResearchModelDao,
     private val advisorProfileDao: AdvisorProfileDao,
-    private val fusionPanelDao: FusionPanelDao
+    private val fusionPanelDao: FusionPanelDao,
+    private val agentProfileDao: AgentProfileDao
 ) : AndroidViewModel(application) {
 
     private val openRouterService = OpenRouterService(application)
@@ -208,6 +220,9 @@ class ChatViewModel(
     private val _echoFusionActive = MutableStateFlow(false)
     val echoFusionActive: StateFlow<Boolean> = _echoFusionActive.asStateFlow()
 
+    private val _echoAgentActive = MutableStateFlow(false)
+    val echoAgentActive: StateFlow<Boolean> = _echoAgentActive.asStateFlow()
+
     /** The Deep Research engine/model the user has added (built-in provider engines + agentic). */
     val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -223,7 +238,7 @@ class ChatViewModel(
     // Web Search, Deep Research, Data Agent, Echo Adviser and Echo Fusion are mutually
     // exclusive capabilities — turning one on clears the rest.
     private fun clearCapabilitiesExcept(keep: MutableStateFlow<Boolean>) {
-        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive)
+        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive)
             .filter { it !== keep }
             .forEach { it.value = false }
     }
@@ -258,6 +273,12 @@ class ChatViewModel(
         if (next) clearCapabilitiesExcept(_echoFusionActive)
     }
 
+    fun toggleEchoAgent() {
+        val next = !_echoAgentActive.value
+        _echoAgentActive.value = next
+        if (next) clearCapabilitiesExcept(_echoAgentActive)
+    }
+
     fun selectThread(chatId: String?) {
         _currentChatThreadId.value = chatId
         clearPendingAttachment()
@@ -268,14 +289,18 @@ class ChatViewModel(
         _errorMessage.value = null
     }
 
-    fun setPendingAttachment(uri: Uri) {
+    fun setPendingAttachment(uri: Uri, fallbackMimeType: String? = null) {
         viewModelScope.launch {
             _pendingAttachmentUri.value = uri
             val resolver = getApplication<Application>().contentResolver
-            _pendingAttachmentMimeType.value = resolver.getType(uri) ?: "image/jpeg"
+            runCatching {
+                resolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val mimeType = resolver.getType(uri) ?: fallbackMimeType ?: "image/jpeg"
+            _pendingAttachmentMimeType.value = mimeType
 
             // Get display name
-            var displayName = "Attached Image"
+            var displayName = if (mimeType.equals("application/pdf", ignoreCase = true)) "Attached PDF" else "Attached Image"
             resolver.query(uri, null, null, null, null)?.use { cursor ->
                 val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
                 if (nameIndex != -1 && cursor.moveToFirst()) {
@@ -424,6 +449,45 @@ class ChatViewModel(
                     )
                 }
             }
+            is StreamChunk.SubagentStarted -> {
+                segments.add(
+                    StreamSegment.Subagent(
+                        taskName = chunk.taskName,
+                        taskDescription = chunk.taskDescription,
+                        workerModel = chunk.workerModel,
+                        outcome = null,
+                        error = null,
+                        active = true,
+                    )
+                )
+            }
+            is StreamChunk.SubagentResolved -> {
+                val r = chunk.result
+                // Match the running delegation by task name; fall back to the last active one.
+                val idx = segments.indexOfLast {
+                    it is StreamSegment.Subagent && it.active && (it.taskName == r.taskName || r.taskName.isBlank())
+                }.takeIf { it >= 0 } ?: segments.indexOfLast { it is StreamSegment.Subagent && it.active }
+                if (idx >= 0) {
+                    val seg = segments[idx] as StreamSegment.Subagent
+                    segments[idx] = seg.copy(
+                        workerModel = r.workerModel.ifBlank { seg.workerModel },
+                        outcome = r.outcome,
+                        error = r.error,
+                        active = false,
+                    )
+                } else {
+                    segments.add(
+                        StreamSegment.Subagent(
+                            taskName = r.taskName,
+                            taskDescription = r.taskDescription,
+                            workerModel = r.workerModel,
+                            outcome = r.outcome,
+                            error = r.error,
+                            active = false,
+                        )
+                    )
+                }
+            }
         }
         return null
     }
@@ -449,7 +513,7 @@ class ChatViewModel(
         // Deep Research and Data Agent are different pipelines (foreground service +
         // provider/agent orchestration), so they short-circuit the normal streaming send.
         if (_deepResearchActive.value && prompt.isNotEmpty()) {
-            startDeepResearch(prompt)
+            startDeepResearch(prompt, attachmentUri, attachmentMime, attachmentName)
             return
         }
         if (_dataAgentActive.value && prompt.isNotEmpty()) {
@@ -478,6 +542,11 @@ class ChatViewModel(
 
             if (isLocal && _activeStreams.value.values.any { it.isLocal }) {
                 _errorMessage.value = "The on-device model is still responding. Wait for it to finish before starting another local reply."
+                return@launch
+            }
+
+            if (isLocal && attachmentMime.equals("application/pdf", ignoreCase = true)) {
+                _errorMessage.value = "PDF files work with OpenRouter models only. Pick a cloud model to attach this PDF."
                 return@launch
             }
 
@@ -517,9 +586,22 @@ class ChatViewModel(
             // here; both override the model, system prompt and response flow. Cloud models only.
             var advisorReq: OpenRouterService.AdvisorRequest? = null
             var fusionReq: OpenRouterService.FusionRequest? = null
+            var agentReq: OpenRouterService.AgentRequest? = null
             var echoModel = selectedModel
             var echoSystemPrompt: String? = null
-            if (_echoAdviserActive.value) {
+            if (_echoAgentActive.value) {
+                if (isLocal) {
+                    _errorMessage.value = "Echo Agents needs a cloud main model. Pick one from the model selector."
+                    return@launch
+                }
+                val profile = agentProfileDao.getById(settingsRepository.getEchoAgentProfileIdDirect())
+                if (profile == null) {
+                    _errorMessage.value = "Set up an Echo Agent first in Settings → Echo Agents, then pick it."
+                    return@launch
+                }
+                agentReq = OpenRouterService.AgentRequest(profile.workerModelId, profile.workerModelName, profile.maxToolCalls)
+                echoSystemPrompt = SystemPrompts.buildEchoAgent(profile.name)
+            } else if (_echoAdviserActive.value) {
                 if (isLocal) {
                     _errorMessage.value = "Echo Adviser needs a cloud model. Pick one from the model selector."
                     return@launch
@@ -630,6 +712,15 @@ class ChatViewModel(
             }
 
             val responseFlow: Flow<StreamChunk> = when {
+                agentReq != null ->
+                    openRouterService.sendWithAgentTools(
+                        apiKey = apiKey,
+                        model = echoModel,
+                        history = fullHistory,
+                        systemPrompt = systemPrompt,
+                        agent = agentReq,
+                        params = inferenceParams,
+                    )
                 advisorReq != null || fusionReq != null ->
                     openRouterService.sendWithEchoTools(
                         apiKey = apiKey,
@@ -670,11 +761,13 @@ class ChatViewModel(
             // Echo Adviser/Fusion are cost-heavy and can take a while; label the keep-alive
             // notification and ping the user when they finish in the background (like research).
             val echoLabel = when {
+                agentReq != null -> "Echo Agents"
                 advisorReq != null -> "Echo Adviser"
                 fusionReq != null -> "Echo Fusion"
                 else -> null
             }
             val keepAliveText = when {
+                agentReq != null -> "Echo Agents — handing tasks to your Echo Agent…"
                 fusionReq != null -> "Echo Fusion — the panel is deliberating…"
                 advisorReq != null -> "Echo Adviser — consulting your advisor…"
                 else -> "Generating a reply…"
@@ -730,7 +823,12 @@ class ChatViewModel(
      * Validates the configured Deep Research engine, records the user's question, creates a
      * durable [ResearchRun], and hands off to the foreground service which owns execution.
      */
-    private fun startDeepResearch(topic: String) {
+    private fun startDeepResearch(
+        topic: String,
+        attachmentUri: String?,
+        attachmentMime: String?,
+        attachmentName: String?,
+    ) {
         viewModelScope.launch {
             clearError()
             if (currentResearchRun.value != null) {
@@ -746,6 +844,15 @@ class ChatViewModel(
             val isProvider = DeepResearchCatalog.isProviderEngine(engineId)
             val maxSearches = settingsRepository.getDeepResearchMaxSearchesDirect()
             val maxSources = settingsRepository.getDeepResearchMaxSourcesDirect()
+            val hasPdfAttachment = attachmentUri != null && attachmentMime.equals("application/pdf", ignoreCase = true)
+            if (attachmentUri != null && !hasPdfAttachment) {
+                _errorMessage.value = "Deep Research can attach PDFs only."
+                return@launch
+            }
+            if (hasPdfAttachment && isProvider) {
+                _errorMessage.value = "PDF files are available for OpenRouter Deep Research models only. Pick one of your research models instead of a provider-native engine."
+                return@launch
+            }
 
             var searchProvider: String? = null
             val engineLabel: String
@@ -793,6 +900,9 @@ class ChatViewModel(
                     role = "user",
                     content = topic,
                     createdAt = now,
+                    localAttachmentUri = attachmentUri,
+                    localAttachmentMimeType = attachmentMime,
+                    localAttachmentName = attachmentName,
                 )
             )
             chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = now)) }
@@ -811,11 +921,15 @@ class ChatViewModel(
                     maxSearches = maxSearches,
                     maxSources = maxSources,
                     status = ResearchRun.STATUS_QUEUED,
+                    localAttachmentUri = attachmentUri,
+                    localAttachmentMimeType = attachmentMime,
+                    localAttachmentName = attachmentName,
                     createdAt = now,
                     updatedAt = now,
                 )
             )
             DeepResearchForegroundService.start(getApplication(), runId)
+            clearPendingAttachment()
             _deepResearchActive.value = false // deliberate, per-question opt-in
         }
     }
@@ -895,7 +1009,7 @@ class ChatViewModel(
             .joinToString("\n\n") { it.text }.trim()
         // Keep a turn that produced only an Echo Adviser/Fusion artifact (no prose answer) so
         // the consultation/deliberation card still persists and re-renders.
-        val hasEchoArtifact = normalizedSegments.any { it is StreamSegment.Advisor || it is StreamSegment.Fusion }
+        val hasEchoArtifact = normalizedSegments.any { it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent }
         if (contentText.isEmpty() && !hasEchoArtifact) return
 
         val reasoningText = normalizedSegments.filterIsInstance<StreamSegment.Reasoning>()
@@ -937,6 +1051,17 @@ class ChatViewModel(
                         type = "fusion",
                         fusion = (seg.analysis ?: FusionAnalysis(panelName = seg.panelName, judgeModel = null, models = seg.models))
                             .copy(panelName = seg.panelName, models = seg.models.ifEmpty { seg.analysis?.models ?: emptyList() }),
+                    )
+                is StreamSegment.Subagent ->
+                    PersistedSegment(
+                        type = "subagent",
+                        subagent = SubagentResult(
+                            taskName = seg.taskName,
+                            taskDescription = seg.taskDescription,
+                            workerModel = seg.workerModel,
+                            outcome = seg.outcome.orEmpty(),
+                            error = seg.error,
+                        ),
                     )
                 is StreamSegment.Text -> seg.text.trim().takeIf { it.isNotEmpty() }
                     ?.let { PersistedSegment(type = "text", text = it) }
@@ -1170,13 +1295,15 @@ class ChatViewModel(
             researchRunDao: ResearchRunDao,
             deepResearchModelDao: DeepResearchModelDao,
             advisorProfileDao: AdvisorProfileDao,
-            fusionPanelDao: FusionPanelDao
+            fusionPanelDao: FusionPanelDao,
+            agentProfileDao: AgentProfileDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
-                    researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao
+                    researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
+                    agentProfileDao
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.echoflow.data.AdvisorProfile
 import com.echoflow.data.AdvisorProfileDao
+import com.echoflow.data.AgentProfile
+import com.echoflow.data.AgentProfileDao
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.CustomModel
 import com.echoflow.data.CustomModelDao
@@ -37,7 +39,8 @@ class SettingsViewModel(
     private val downloadManager: ModelDownloadManager,
     private val deepResearchModelDao: DeepResearchModelDao,
     private val advisorProfileDao: AdvisorProfileDao,
-    private val fusionPanelDao: FusionPanelDao
+    private val fusionPanelDao: FusionPanelDao,
+    private val agentProfileDao: AgentProfileDao
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
 
@@ -83,6 +86,11 @@ class SettingsViewModel(
     val advisorProfiles: StateFlow<List<AdvisorProfile>> = advisorProfileDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     val fusionPanels: StateFlow<List<FusionPanel>> = fusionPanelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Echo Agent
+    val echoAgentProfileId: StateFlow<String> = repository.echoAgentProfileId
+    val agentProfiles: StateFlow<List<AgentProfile>> = agentProfileDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _importError = MutableStateFlow<String?>(null)
@@ -281,6 +289,42 @@ class SettingsViewModel(
         }
     }
 
+    // ── Echo Agent ───────────────────────────────────────────────────────────────────────
+
+    fun saveEchoAgentProfile(id: String) = repository.saveEchoAgentProfileId(id)
+
+    fun addAgentProfile(name: String, workerModelId: String, workerModelName: String, maxToolCalls: Int) {
+        viewModelScope.launch {
+            val cleanName = name.trim().ifEmpty { "Agent" }
+            val cleanModel = workerModelId.trim()
+            if (cleanModel.isEmpty()) return@launch
+            val id = java.util.UUID.randomUUID().toString()
+            agentProfileDao.insert(
+                AgentProfile(
+                    id = id,
+                    name = cleanName,
+                    workerModelId = cleanModel,
+                    workerModelName = workerModelName.trim().ifEmpty { cleanModel.substringAfterLast("/") },
+                    maxToolCalls = maxToolCalls.coerceIn(1, 25),
+                    createdAt = System.currentTimeMillis(),
+                )
+            )
+            // First profile becomes the active selection automatically.
+            if (repository.getEchoAgentProfileIdDirect().isBlank()) {
+                repository.saveEchoAgentProfileId(id)
+            }
+        }
+    }
+
+    fun deleteAgentProfile(id: String) {
+        viewModelScope.launch {
+            agentProfileDao.delete(id)
+            if (repository.getEchoAgentProfileIdDirect() == id) {
+                repository.saveEchoAgentProfileId(agentProfileDao.getAllSync().firstOrNull()?.id.orEmpty())
+            }
+        }
+    }
+
     fun addDeepResearchModel(id: String, name: String) {
         viewModelScope.launch {
             val cleanId = id.trim()
@@ -442,11 +486,12 @@ class SettingsViewModel(
             downloadManager: ModelDownloadManager,
             deepResearchModelDao: DeepResearchModelDao,
             advisorProfileDao: AdvisorProfileDao,
-            fusionPanelDao: FusionPanelDao
+            fusionPanelDao: FusionPanelDao,
+            agentProfileDao: AgentProfileDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -20,11 +20,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Assignment
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.CompareArrows
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Gavel
+import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Psychology
@@ -176,6 +179,139 @@ fun AdvisorCard(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Echo Agent ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * One Echo Agent delegation in the reply timeline — a primary-accented card (distinct from the
+ * tertiary Adviser and secondary Fusion cards) that makes the orchestrator's task decomposition
+ * visible. While [active] it shows the task the model handed off and a wavy "running on the
+ * worker" indicator; once resolved it reveals the worker's outcome (or an error). The
+ * orchestrator may spin off several of these in one answer, each its own card.
+ */
+@Composable
+fun SubagentCard(
+    taskName: String,
+    taskDescription: String,
+    workerModel: String,
+    outcome: String?,
+    error: String?,
+    active: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val hasOutcome = !outcome.isNullOrBlank()
+    val hasError = !error.isNullOrBlank()
+    var userToggled by remember { mutableStateOf<Boolean?>(null) }
+    // Default: open while running and once the result lands (the brief + result are the point).
+    val expanded = userToggled ?: (active || hasOutcome || hasError)
+    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "subagent-chevron")
+    val canToggle = taskDescription.isNotBlank() || hasOutcome || hasError
+
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.40f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Surface(
+                onClick = { if (canToggle) userToggled = !expanded },
+                color = Color.Transparent,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        Modifier.size(38.dp).clip(RoundedPolygonShape(MaterialShapes.Pentagon))
+                            .background(MaterialTheme.colorScheme.primary),
+                        contentAlignment = Alignment.Center,
+                    ) { Icon(Icons.Default.Hub, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimary) }
+                    Spacer(Modifier.width(Spacing.m))
+                    Column(Modifier.weight(1f)) {
+                        ModeBadge("ECHO AGENT", MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.onPrimary)
+                        Spacer(Modifier.height(3.dp))
+                        Text(
+                            if (active) "${taskName.ifBlank { "Delegating" }}…" else taskName.ifBlank { "Delegated task" },
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 2, overflow = TextOverflow.Ellipsis,
+                        )
+                        if (workerModel.isNotBlank()) {
+                            Text(
+                                "Echo Agent · ${shortModel(workerModel)}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    if (!active && canToggle) {
+                        Icon(
+                            Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand",
+                            Modifier.size(22.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            if (active) {
+                Spacer(Modifier.height(Spacing.m))
+                LinearWavyProgressIndicator(
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            AnimatedVisibility(visible = expanded && canToggle, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                Column(Modifier.padding(top = Spacing.m)) {
+                    if (taskDescription.isNotBlank()) {
+                        Surface(
+                            shape = MaterialTheme.shapes.large,
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Row(Modifier.padding(Spacing.m)) {
+                                Icon(Icons.Default.Assignment, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                                Spacer(Modifier.width(Spacing.s))
+                                Column {
+                                    Text("Task brief", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    Spacer(Modifier.height(2.dp))
+                                    Text(taskDescription, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurface)
+                                }
+                            }
+                        }
+                    }
+                    when {
+                        hasError -> {
+                            if (taskDescription.isNotBlank()) Spacer(Modifier.height(Spacing.m))
+                            Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.errorContainer, modifier = Modifier.fillMaxWidth()) {
+                                Row(Modifier.padding(Spacing.m), verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(Icons.Default.ErrorOutline, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onErrorContainer)
+                                    Spacer(Modifier.width(Spacing.s))
+                                    Text(error!!, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer)
+                                }
+                            }
+                        }
+                        hasOutcome -> {
+                            if (taskDescription.isNotBlank()) Spacer(Modifier.height(Spacing.m))
+                            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(bottom = Spacing.xs)) {
+                                Icon(Icons.Default.AutoAwesome, null, Modifier.size(15.dp), tint = MaterialTheme.colorScheme.primary)
+                                Spacer(Modifier.width(Spacing.xs))
+                                Text("Result", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                            }
+                            RichMarkdown(outcome!!, Modifier.fillMaxWidth())
+                        }
+                        !active -> {
+                            Text(
+                                "The Echo Agent ran; no result text was returned separately.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.echoflow.data.AdvisorProfile
+import com.echoflow.data.AgentProfile
 import com.echoflow.data.ChatMessage
 import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.DeepResearchCatalog
@@ -82,6 +83,7 @@ import com.echoflow.ui.components.ResearchProgressCard
 import com.echoflow.ui.components.RichMarkdown
 import com.echoflow.ui.components.SearchActivityCard
 import com.echoflow.ui.components.SectionLabel
+import com.echoflow.ui.components.SubagentCard
 import com.echoflow.ui.theme.BrandShapes
 import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.Spacing
@@ -111,6 +113,7 @@ fun ChatScreen(
     val errorMessage by chatViewModel.errorMessage.collectAsState()
 
     val pendingUri by chatViewModel.pendingAttachmentUri.collectAsState()
+    val pendingMime by chatViewModel.pendingAttachmentMimeType.collectAsState()
     val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
     val selectedModelID by settingsViewModel.selectedModel.collectAsState()
     val customModelsList by settingsViewModel.customModels.collectAsState()
@@ -140,6 +143,11 @@ fun ChatScreen(
     val activeAdvisor = advisorProfiles.firstOrNull { it.id == echoAdviserProfileId }
     val activePanel = fusionPanels.firstOrNull { it.id == echoFusionPanelId }
 
+    val echoAgentActive by chatViewModel.echoAgentActive.collectAsState()
+    val agentProfiles by settingsViewModel.agentProfiles.collectAsState()
+    val echoAgentProfileId by settingsViewModel.echoAgentProfileId.collectAsState()
+    val activeAgent = agentProfiles.firstOrNull { it.id == echoAgentProfileId }
+
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
 
@@ -161,8 +169,36 @@ fun ChatScreen(
                 ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
         } else true
     }
-    LaunchedEffect(imageAttachAllowed) {
-        if (!imageAttachAllowed) chatViewModel.clearPendingAttachment()
+    val imageAttachAvailable = imageAttachAllowed && !deepResearchActive && !dataAgentActive
+    val selectedModelIsOpenRouter = remember(selectedModelID) { !selectedModelID.startsWith("local/") }
+    val deepResearchUsesOpenRouter = remember(deepResearchActive, drModelId) {
+        deepResearchActive && drModelId.isNotBlank() && !DeepResearchCatalog.isProviderEngine(drModelId)
+    }
+    val pdfAttachAllowed = remember(
+        selectedModelIsOpenRouter,
+        deepResearchActive,
+        deepResearchUsesOpenRouter,
+        dataAgentActive,
+        echoAdviserActive,
+        echoFusionActive,
+        echoAgentActive,
+    ) {
+        when {
+            dataAgentActive -> false
+            deepResearchActive -> deepResearchUsesOpenRouter
+            echoFusionActive -> true
+            echoAdviserActive -> selectedModelIsOpenRouter
+            echoAgentActive -> selectedModelIsOpenRouter
+            else -> selectedModelIsOpenRouter
+        }
+    }
+    LaunchedEffect(pendingUri, pendingMime, imageAttachAvailable, pdfAttachAllowed) {
+        if (pendingUri != null) {
+            val pendingIsPdf = pendingMime.equals("application/pdf", ignoreCase = true)
+            if ((pendingIsPdf && !pdfAttachAllowed) || (!pendingIsPdf && !imageAttachAvailable)) {
+                chatViewModel.clearPendingAttachment()
+            }
+        }
     }
 
     val activeModelList = remember(customModelsList) {
@@ -182,6 +218,10 @@ fun ChatScreen(
     val imagePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri) },
+    )
+    val pdfPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri, "application/pdf") },
     )
 
     // Measure the floating input's height so the message list always pads exactly enough to clear
@@ -227,6 +267,7 @@ fun ChatScreen(
                 modelName = when {
                     echoFusionActive -> activePanel?.name ?: "Choose panel"
                     echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
+                    echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
                     dataAgentActive -> dataAgentLabel
                     deepResearchActive -> drEngineLabel
                     else -> modelShortName
@@ -245,10 +286,13 @@ fun ChatScreen(
                 text = textInput,
                 onText = { textInput = it },
                 pendingUri = pendingUri?.toString(),
+                pendingMime = pendingMime,
                 pendingName = pendingName,
                 onClearAttachment = { chatViewModel.clearPendingAttachment() },
                 onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
-                imageAttachEnabled = imageAttachAllowed,
+                onAttachPdf = { pdfPicker.launch(arrayOf("application/pdf")) },
+                imageAttachEnabled = imageAttachAvailable,
+                pdfAttachEnabled = pdfAttachAllowed,
                 isStreaming = isStreaming,
                 deepResearchActive = deepResearchActive,
                 webSearchChipOn = webSearchChipOn,
@@ -256,13 +300,16 @@ fun ChatScreen(
                 dataAgentAvailable = dataAgentAvailable,
                 echoAdviserActive = echoAdviserActive,
                 echoFusionActive = echoFusionActive,
+                echoAgentActive = echoAgentActive,
                 advisorChipLabel = activeAdvisor?.name,
                 fusionChipLabel = activePanel?.name,
+                agentChipLabel = activeAgent?.name,
                 onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
                 onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
                 onToggleDataAgent = { chatViewModel.toggleDataAgent() },
                 onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
                 onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
+                onToggleEchoAgent = { chatViewModel.toggleEchoAgent() },
                 researchInProgress = researchRun != null,
                 researchEngineLabel = drEngineLabel,
                 dataAgentLabel = dataAgentLabel,
@@ -306,6 +353,17 @@ fun ChatScreen(
                 selectedProfileId = echoAdviserProfileId,
                 onSelectModel = { settingsViewModel.saveSelectedModel(it) },
                 onSelectProfile = { settingsViewModel.saveEchoAdviserProfile(it) },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoAgentActive) {
+            AgentPickerSheet(
+                models = activeModelList,
+                selectedModelId = selectedModelID,
+                profiles = agentProfiles,
+                selectedProfileId = echoAgentProfileId,
+                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
+                onSelectProfile = { settingsViewModel.saveEchoAgentProfile(it) },
                 onManage = { showModelMenu = false; onSettingsClicked() },
                 onDismiss = { showModelMenu = false },
             )
@@ -509,6 +567,17 @@ private fun StreamingAssistantBubble(
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }
+                    is StreamSegment.Subagent -> {
+                        SubagentCard(
+                            taskName = segment.taskName,
+                            taskDescription = segment.taskDescription,
+                            workerModel = segment.workerModel,
+                            outcome = segment.outcome,
+                            error = segment.error,
+                            active = segment.active,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
                     is StreamSegment.Text -> {
                         SmoothStreamingText(segment.text, Modifier.fillMaxWidth())
                         if (!isLast) Spacer(Modifier.height(Spacing.s))
@@ -601,8 +670,13 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
     if (isUser) {
         Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
             Column(horizontalAlignment = Alignment.End, modifier = Modifier.widthIn(max = 320.dp)) {
-                message.localAttachmentUri?.let {
-                    AsyncImage(it, null, Modifier.padding(bottom = Spacing.s).size(200.dp).clip(MaterialTheme.shapes.large), contentScale = ContentScale.Crop)
+                message.localAttachmentUri?.let { uri ->
+                    MessageAttachmentPreview(
+                        uri = uri,
+                        mimeType = message.localAttachmentMimeType,
+                        name = message.localAttachmentName,
+                        modifier = Modifier.padding(bottom = Spacing.s),
+                    )
                 }
                 Surface(
                     shape = RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp),
@@ -628,8 +702,13 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
             // streamed with instead of merging all reasoning into one block.
             val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
 
-            message.localAttachmentUri?.let {
-                AsyncImage(it, null, Modifier.padding(bottom = Spacing.s).size(200.dp).clip(MaterialTheme.shapes.large), contentScale = ContentScale.Crop)
+            message.localAttachmentUri?.let { uri ->
+                MessageAttachmentPreview(
+                    uri = uri,
+                    mimeType = message.localAttachmentMimeType,
+                    name = message.localAttachmentName,
+                    modifier = Modifier.padding(bottom = Spacing.s),
+                )
             }
 
             when {
@@ -671,6 +750,19 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                                         panelName = f.panelName,
                                         models = f.models,
                                         analysis = f,
+                                        active = false,
+                                    )
+                                    Spacer(Modifier.height(Spacing.s))
+                                }
+                            }
+                            "subagent" -> {
+                                segment.subagent?.let { s ->
+                                    SubagentCard(
+                                        taskName = s.taskName,
+                                        taskDescription = s.taskDescription,
+                                        workerModel = s.workerModel,
+                                        outcome = s.outcome,
+                                        error = s.error,
                                         active = false,
                                     )
                                     Spacer(Modifier.height(Spacing.s))
@@ -914,14 +1006,58 @@ private fun AssistPill(icon: ImageVector, label: String, container: Color, onCon
 }
 
 @Composable
+private fun MessageAttachmentPreview(
+    uri: String,
+    mimeType: String?,
+    name: String?,
+    modifier: Modifier = Modifier,
+) {
+    if (mimeType.equals("application/pdf", ignoreCase = true)) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            modifier = modifier.widthIn(max = 280.dp),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.PictureAsPdf,
+                    null,
+                    Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    name ?: "PDF file",
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    } else {
+        AsyncImage(
+            uri,
+            null,
+            modifier.size(200.dp).clip(MaterialTheme.shapes.large),
+            contentScale = ContentScale.Crop,
+        )
+    }
+}
+
+@Composable
 private fun InputToolbar(
     text: String,
     onText: (String) -> Unit,
     pendingUri: String?,
+    pendingMime: String?,
     pendingName: String?,
     onClearAttachment: () -> Unit,
     onAttach: () -> Unit,
+    onAttachPdf: () -> Unit,
     imageAttachEnabled: Boolean,
+    pdfAttachEnabled: Boolean,
     isStreaming: Boolean,
     deepResearchActive: Boolean,
     webSearchChipOn: Boolean,
@@ -929,13 +1065,16 @@ private fun InputToolbar(
     dataAgentAvailable: Boolean,
     echoAdviserActive: Boolean,
     echoFusionActive: Boolean,
+    echoAgentActive: Boolean,
     advisorChipLabel: String?,
     fusionChipLabel: String?,
+    agentChipLabel: String?,
     onToggleDeepResearch: () -> Unit,
     onToggleWebSearch: () -> Unit,
     onToggleDataAgent: () -> Unit,
     onToggleEchoAdviser: () -> Unit,
     onToggleEchoFusion: () -> Unit,
+    onToggleEchoAgent: () -> Unit,
     researchInProgress: Boolean,
     researchEngineLabel: String?,
     dataAgentLabel: String,
@@ -960,7 +1099,16 @@ private fun InputToolbar(
                     modifier = Modifier.padding(bottom = Spacing.s),
                 ) {
                     Row(Modifier.padding(Spacing.s), verticalAlignment = Alignment.CenterVertically) {
-                        AsyncImage(uri, null, Modifier.size(40.dp).clip(MaterialTheme.shapes.medium), contentScale = ContentScale.Crop)
+                        if (pendingMime.equals("application/pdf", ignoreCase = true)) {
+                            Icon(
+                                Icons.Default.PictureAsPdf,
+                                null,
+                                Modifier.size(40.dp),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        } else {
+                            AsyncImage(uri, null, Modifier.size(40.dp).clip(MaterialTheme.shapes.medium), contentScale = ContentScale.Crop)
+                        }
                         Spacer(Modifier.width(Spacing.m))
                         Text(pendingName ?: "Attachment", maxLines = 1, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSecondaryContainer, modifier = Modifier.weight(1f))
                         IconButton(onClick = onClearAttachment, modifier = Modifier.size(28.dp)) { Icon(Icons.Default.Close, "Remove", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
@@ -970,7 +1118,7 @@ private fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -991,6 +1139,13 @@ private fun InputToolbar(
                         Icons.Default.AccountTree,
                         fusionChipLabel?.let { "Fusion · $it" } ?: "Echo Fusion",
                         onRemove = onToggleEchoFusion,
+                    )
+                }
+                if (echoAgentActive) {
+                    CapabilityChip(
+                        Icons.Default.Hub,
+                        agentChipLabel?.let { "Echo Agent · $it" } ?: "Echo Agents",
+                        onRemove = onToggleEchoAgent,
                     )
                 }
                 if (deepResearchActive) {
@@ -1029,10 +1184,13 @@ private fun InputToolbar(
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
             )
         }
-        AnimatedVisibility(visible = (echoAdviserActive || echoFusionActive) && blockedReason == null) {
+        AnimatedVisibility(visible = (echoAdviserActive || echoFusionActive || echoAgentActive) && blockedReason == null) {
             Text(
-                if (echoFusionActive) "Runs a panel of models + a judge every message · cost-heavy"
-                else "Consults a stronger advisor model each message · adds cost",
+                when {
+                    echoFusionActive -> "Runs a panel of models + a judge every message · cost-heavy"
+                    echoAgentActive -> "The main model hands tasks to your Echo Agent each message · adds cost"
+                    else -> "Consults a stronger advisor model each message · adds cost"
+                },
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
@@ -1064,18 +1222,22 @@ private fun InputToolbar(
                         expanded = plusMenuOpen,
                         onDismiss = { plusMenuOpen = false },
                         showImage = imageAttachEnabled,
+                        showFiles = pdfAttachEnabled,
                         webSearchOn = webSearchChipOn,
                         deepResearchOn = deepResearchActive,
                         dataAgentOn = dataAgentActive,
                         dataAgentAvailable = dataAgentAvailable,
                         echoAdviserOn = echoAdviserActive,
                         echoFusionOn = echoFusionActive,
+                        echoAgentOn = echoAgentActive,
                         onImage = { plusMenuOpen = false; onAttach() },
+                        onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
                         onToggleDeepResearch = { plusMenuOpen = false; onToggleDeepResearch() },
                         onToggleDataAgent = { plusMenuOpen = false; onToggleDataAgent() },
                         onToggleEchoAdviser = { plusMenuOpen = false; onToggleEchoAdviser() },
                         onToggleEchoFusion = { plusMenuOpen = false; onToggleEchoFusion() },
+                        onToggleEchoAgent = { plusMenuOpen = false; onToggleEchoAgent() },
                     )
                 }
 
@@ -1105,7 +1267,8 @@ private fun InputToolbar(
                 )
 
                 val researchMode = deepResearchActive || dataAgentActive
-                val hasContent = text.trim().isNotEmpty() || (pendingUri != null && !researchMode)
+                val hasText = text.trim().isNotEmpty()
+                val hasContent = hasText || (pendingUri != null && !researchMode)
                 val canSend = hasContent && !isStreaming && !researchInProgress && blockedReason == null
                 SendButton(enabled = canSend, isStreaming = isStreaming, research = researchMode) {
                     if (canSend) onSend()
@@ -1121,18 +1284,22 @@ private fun PlusMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
     showImage: Boolean,
+    showFiles: Boolean,
     webSearchOn: Boolean,
     deepResearchOn: Boolean,
     dataAgentOn: Boolean,
     dataAgentAvailable: Boolean,
     echoAdviserOn: Boolean,
     echoFusionOn: Boolean,
+    echoAgentOn: Boolean,
     onImage: () -> Unit,
+    onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
     onToggleDeepResearch: () -> Unit,
     onToggleDataAgent: () -> Unit,
     onToggleEchoAdviser: () -> Unit,
     onToggleEchoFusion: () -> Unit,
+    onToggleEchoAgent: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
@@ -1141,6 +1308,13 @@ private fun PlusMenu(
                 text = { Text("Image") },
                 leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
                 onClick = onImage,
+            )
+        }
+        if (showFiles) {
+            DropdownMenuItem(
+                text = { Text("Files") },
+                leadingIcon = { Icon(Icons.Default.PictureAsPdf, null) },
+                onClick = onFiles,
             )
         }
         DropdownMenuItem(
@@ -1178,6 +1352,12 @@ private fun PlusMenu(
             leadingIcon = { Icon(Icons.Default.AccountTree, null) },
             trailingIcon = { if (echoFusionOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleEchoFusion,
+        )
+        DropdownMenuItem(
+            text = { Text("Echo Agents") },
+            leadingIcon = { Icon(Icons.Default.Hub, null) },
+            trailingIcon = { if (echoAgentOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleEchoAgent,
         )
     }
 }
@@ -1427,6 +1607,70 @@ private fun AdvisorPickerSheet(
             }
 
             Box(Modifier.padding(bottom = Spacing.s)) { SectionLabel("Answering model") }
+            LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp), verticalArrangement = Arrangement.spacedBy(Spacing.s), contentPadding = PaddingValues(bottom = Spacing.m)) {
+                items(models, key = { it.first }) { (id, name) ->
+                    ModelRow(name, id, id == selectedModelId, isLocal = false) { onSelectModel(id) }
+                }
+            }
+
+            Button(onClick = onDismiss, shape = CircleShape, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.xl)) {
+                Text("Done")
+            }
+        }
+    }
+}
+
+/**
+ * Echo Agent picker: two zones — the orchestrator (any cloud model, which drives the toolbox)
+ * and which agent profile (the worker model it delegates to). Both persist immediately; the
+ * sheet stays open so the user can set both before dismissing.
+ */
+@Composable
+private fun AgentPickerSheet(
+    models: List<Pair<String, String>>,
+    selectedModelId: String,
+    profiles: List<AgentProfile>,
+    selectedProfileId: String,
+    onSelectModel: (String) -> Unit,
+    onSelectProfile: (String) -> Unit,
+    onManage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, containerColor = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.l)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.base)) {
+                Column(Modifier.weight(1f)) {
+                    Text("Echo Agents", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Text("Your main model uses tools and hands tasks to your Echo Agent", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                TextButton(onClick = onManage) {
+                    Icon(Icons.Default.Tune, null, Modifier.size(18.dp)); Spacer(Modifier.width(Spacing.s)); Text("Manage")
+                }
+            }
+
+            Box(Modifier.padding(bottom = Spacing.s)) { SectionLabel("Echo Agent") }
+            if (profiles.isEmpty()) {
+                Text(
+                    "No Echo Agents yet — tap Manage to set one up.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = Spacing.s),
+                )
+            } else {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.s), modifier = Modifier.padding(bottom = Spacing.m)) {
+                    profiles.forEach { profile ->
+                        FilterChip(
+                            selected = profile.id == selectedProfileId,
+                            onClick = { onSelectProfile(profile.id) },
+                            label = { Text(profile.name) },
+                            leadingIcon = { Icon(Icons.Default.Hub, null, Modifier.size(16.dp)) },
+                        )
+                    }
+                }
+            }
+
+            Box(Modifier.padding(bottom = Spacing.s)) { SectionLabel("Main model") }
             LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp), verticalArrangement = Arrangement.spacedBy(Spacing.s), contentPadding = PaddingValues(bottom = Spacing.m)) {
                 items(models, key = { it.first }) { (id, name) ->
                     ModelRow(name, id, id == selectedModelId, isLocal = false) { onSelectModel(id) }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.LightMode
@@ -84,6 +85,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
 import com.echoflow.data.AdvisorProfile
+import com.echoflow.data.AgentProfile
 import com.echoflow.data.CatalogEntry
 import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.FusionPanel
@@ -138,6 +140,7 @@ private const val PageDeepResearch = "deep_research"
 private const val PageDataAgent = "data_agent"
 private const val PageEchoAdviser = "echo_adviser"
 private const val PageEchoFusion = "echo_fusion"
+private const val PageEchoAgent = "echo_agent"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -191,6 +194,7 @@ fun SettingsScreen(
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageHome })
             PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageHome })
             PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageHome })
+            PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageHome })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -218,6 +222,7 @@ private fun SettingsHomePage(
     val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
     val advisorProfiles by viewModel.advisorProfiles.collectAsState()
     val fusionPanels by viewModel.fusionPanels.collectAsState()
+    val agentProfiles by viewModel.agentProfiles.collectAsState()
 
     val themeLabel = when (darkMode) {
         "light" -> "Light"
@@ -266,6 +271,10 @@ private fun SettingsHomePage(
         fusionPanels.isEmpty() -> "A panel deliberates · no panels yet"
         else -> "${fusionPanels.size} panel" + (if (fusionPanels.size == 1) "" else "s")
     }
+    val echoAgentSubtitle = when {
+        agentProfiles.isEmpty() -> "Main model hands tasks to your Echo Agents · none yet"
+        else -> "${agentProfiles.size} Echo Agent" + (if (agentProfiles.size == 1) "" else "s")
+    }
 
     SettingsPageScaffold(title = "Settings", subtitle = "Make EchoFlow yours", onBack = onBackClicked) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
@@ -276,7 +285,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 8,
+                index = 0, count = 9,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -286,7 +295,7 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 8,
+                index = 1, count = 9,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -296,7 +305,7 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 8,
+                index = 2, count = 9,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -306,7 +315,7 @@ private fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 3, count = 8,
+                index = 3, count = 9,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
@@ -316,7 +325,7 @@ private fun SettingsHomePage(
                 subtitle = dataAgentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 4, count = 8,
+                index = 4, count = 9,
                 onClick = { onOpen(PageDataAgent) },
             )
             SettingsNavRow(
@@ -326,7 +335,7 @@ private fun SettingsHomePage(
                 subtitle = echoAdviserSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 8,
+                index = 5, count = 9,
                 onClick = { onOpen(PageEchoAdviser) },
             )
             SettingsNavRow(
@@ -336,8 +345,18 @@ private fun SettingsHomePage(
                 subtitle = echoFusionSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 6, count = 8,
+                index = 6, count = 9,
                 onClick = { onOpen(PageEchoFusion) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Hub,
+                polygon = MaterialShapes.Pentagon,
+                title = "Echo Agents",
+                subtitle = echoAgentSubtitle,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                index = 7, count = 9,
+                onClick = { onOpen(PageEchoAgent) },
             )
             SettingsNavRow(
                 icon = Icons.Default.PhoneAndroid,
@@ -346,7 +365,7 @@ private fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 7, count = 8,
+                index = 8, count = 9,
                 onClick = { onOpen(PageLocalModels) },
             )
         }
@@ -1695,6 +1714,155 @@ private fun FusionPanelDialog(
         confirmButton = {
             TextButton(
                 onClick = { onConfirm(name.trim(), judgeId) },
+                enabled = name.trim().isNotEmpty(),
+            ) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+// ── Echo Agent ────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EchoAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val apiKey by viewModel.apiKey.collectAsState()
+    val profiles by viewModel.agentProfiles.collectAsState()
+    val selectedId by viewModel.echoAgentProfileId.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orResults by viewModel.orModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+    var pendingModel by remember { mutableStateOf<OpenRouterModelInfo?>(null) }
+
+    SettingsPageScaffold(title = "Echo Agents", subtitle = "Your main model hands work to an Echo Agent", onBack = onBack) {
+        FormCard {
+            Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "Your main model gets a full toolbox — web search, web fetch, and an Echo Agent (a faster, cheaper model) it can hand self-contained tasks to. It decides which tools to use and in what order, chaining them freely. Pick the main model per chat from the model selector; choose the Echo Agent here. OpenRouter only; each message can add cost.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (apiKey.isBlank()) {
+            Spacer(Modifier.height(Spacing.m))
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Agents.", error = true)
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Your Echo Agents", "Tap to set the default; pick per chat from the model selector")
+        if (profiles.isEmpty()) {
+            EchoNoticeCard(Icons.Default.Hub, "No Echo Agents yet.\nAdd one below — a fast, cheap model works best.")
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                profiles.forEach { profile ->
+                    DrEngineSelectRow(
+                        name = profile.name,
+                        subtitle = "${profile.workerModelName.ifBlank { profile.workerModelId }} · up to ${profile.maxToolCalls} steps",
+                        selected = profile.id == selectedId,
+                        onClick = { viewModel.saveEchoAgentProfile(profile.id) },
+                        onDelete = { viewModel.deleteAgentProfile(profile.id) },
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(Spacing.s))
+        FilledTonalButton(
+            onClick = { showDirectory = true; viewModel.loadOpenRouterDirectory() },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Add an Echo Agent")
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            "Your Echo Agent can search and fetch the web while doing its task. It never sees the chat history — only the task the main model gives it.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
+    }
+
+    if (showDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = emptySet(),
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> pendingModel = info; showDirectory = false },
+            onRemove = {},
+            onDismiss = { showDirectory = false },
+        )
+    }
+    pendingModel?.let { model ->
+        AgentProfileDialog(
+            workerName = model.name,
+            onDismiss = { pendingModel = null },
+            onConfirm = { name, maxCalls ->
+                viewModel.addAgentProfile(name, model.id, model.name.substringAfter(": "), maxCalls)
+                pendingModel = null
+            },
+        )
+    }
+}
+
+/**
+ * Finishes an Echo Agent profile: a name plus the agent's per-task tool-call budget (how many
+ * tool-calling steps the agent may take while completing one delegated task).
+ */
+@Composable
+private fun AgentProfileDialog(
+    workerName: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String, Int) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var maxCalls by remember { mutableStateOf(8) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Hub, null) },
+        title = { Text("New Echo Agent") },
+        text = {
+            Column {
+                Text(workerName, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(Modifier.height(Spacing.m))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    singleLine = true,
+                    placeholder = { Text("Fast agent, Cheap drone…") },
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(Spacing.m))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Echo Agent tool budget", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+                    Text("$maxCalls steps", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+                }
+                Text(
+                    "Max tool-calling steps the Echo Agent may take per task",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Slider(
+                    value = maxCalls.toFloat(),
+                    onValueChange = { maxCalls = it.toInt().coerceIn(1, 25) },
+                    valueRange = 1f..25f,
+                    steps = 23,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name.trim(), maxCalls) },
                 enabled = name.trim().isNotEmpty(),
             ) { Text("Create") }
         },


### PR DESCRIPTION
## Echo Agents

Adds **Echo Agents** — a third Echo mode alongside Adviser and Fusion. The selected cloud model (the **main model**) gets a full toolbox and decides, on its own, which tools to use and in what order, chaining them freely:

- `web_search` + `web_fetch` (the main model's own web tools)
- **delegate** → hands a self-contained task to an **Echo Agent**: a faster, cheaper worker model (`openrouter:subagent`) that can itself search/fetch the web

Unlike Adviser/Fusion (forced single tool, non-streaming), Echo Agents rides the **streaming** path with **auto** tool-choice, so the main model can delegate zero-to-many tasks per answer and interleave them with web search. Each delegation renders its own live card (running → task brief → result/error).

### Notes
- **One Echo Agent per turn.** Per OpenRouter, the subagent tool's worker is fixed by the tool definition (no `name` field to disambiguate multiple), so the main model can fire many tasks but all to the one selected agent. "Echo Agents" is the saved roster; you pick one per chat like Echo Adviser.
- Worker inner tokens are not streamed (the outcome arrives whole), same as advisor advice.
- Cloud-only; mutually exclusive with the other capabilities.

### Changes (3 commits)
1. **Data & service** — `AgentProfile` + DAO + Room v10 migration, `echo_agent_profile_id`, `SubagentResult`/stream chunks/persisted segment, `buildEchoAgent` prompt, `sendWithAgentTools`. Also threads PDF attachment context through the Deep Research agentic path.
2. **View-models & DI** — `StreamSegment.Subagent`, reducer, toggle, routing, persistence; settings flows; factory wiring.
3. **UI** — `SubagentCard`, "+" menu entry, capability chip, `AgentPickerSheet`, Echo Agents settings page + tool-budget dialog.

### Verification
Per repo constraint, this was not built from the CLI — **needs a build + live-key check in Android Studio**. The subagent result shape is documented (`{status, model, task_name, outcome}`); if results don't parse against the live stream, cards degrade gracefully to "the Echo Agent ran; no result text" plus the main model's answer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Echo Agent delegation enables task delegation to worker models with results displayed in conversation timeline.
  * Local PDF attachment support for chat and research operations.
  * Agent profile management to configure worker models and tool-call budgets.
  * New Echo Agents settings interface for managing agent configurations and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Echo Agents (openrouter:subagent) as a third Echo mode
> - Introduces Echo Agent mode, where an orchestrator model delegates subtasks to a cheaper worker model via the `openrouter:subagent` server tool, emitting `SubagentStarted`/`SubagentResolved` stream events rendered as animated `SubagentCard` components in the chat.
> - Adds an `AgentPickerSheet` for selecting an agent profile and main model, and an `EchoAgentPage` in Settings for creating, selecting, and deleting `AgentProfile` entries (name + max tool-calls budget).
> - Extends `OpenRouterService` with `sendWithAgentTools`, PDF attachment support (base64 file parts + Cloudflare file-parser plugin), and subagent result scanning from SSE chunks.
> - Migrates the Room database from version 8→9→10, adding `localAttachmentUri/MimeType/Name` to `research_runs` and creating a new `agent_profiles` table.
> - Deep Research runs on OpenRouter models can now include a PDF attachment passed through planning and synthesis steps.
> - Risk: Database schema bumps require both migrations to run successfully; apps skipping version 9 must pass through it sequentially.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ebbb65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->