### PR TITLE
Feat/echo agents

### DIFF
--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -42,6 +42,10 @@ sealed class StreamChunk {
     data class FusionResolved(val analysis: FusionAnalysis) : StreamChunk()
 
     // ── Echo Agent (openrouter:subagent) ───────────────────────────────────────────
+    /** Echo Agents run kicked off — a branded "deploying agents" banner shows while the
+     *  (non-streaming) request is in flight, before any delegation/reasoning/answer arrives. */
+    object AgentRunStarted : StreamChunk()
+
     /** The orchestrator delegated a self-contained task to its worker; the brief is known,
      *  the worker's outcome is pending. Fires once per delegation (there may be several). */
     data class SubagentStarted(val taskName: String, val taskDescription: String, val workerModel: String) : StreamChunk()

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -777,14 +777,18 @@ class OpenRouterService(private val context: Context) {
     data class AgentRequest(val workerModel: String, val workerModelName: String, val maxToolCalls: Int)
 
     /**
-     * Echo Agent. The selected cloud model orchestrates a full toolbox on the **streaming** path:
-     * `openrouter:web_search`, `openrouter:web_fetch`, and `openrouter:subagent` (a cheaper worker
-     * model it can delegate self-contained tasks to). tool_choice is left to the model (auto): it
-     * decides which tools to use and in what order, possibly several times, chaining them freely.
-     * All three execute server-side and surface here as SearchStarted/SearchSources and
-     * SubagentStarted/SubagentResolved chunks. Uses the long-timeout [echoClient] because a worker
-     * delegation can stall the stream for a while. Unlike advisor/fusion, the subagent result shape
-     * is documented (`{status, model, task_name, outcome}`), so its parsing is exact.
+     * Echo Agents. The selected cloud model orchestrates a full toolbox: `openrouter:web_search`,
+     * `openrouter:web_fetch`, and `openrouter:subagent` (a cheaper agent it delegates self-contained
+     * tasks to). tool_choice is auto — the model decides whether/how often to delegate.
+     *
+     * "Option B" hybrid: the request IS streamed, but only so the UI can react the instant a
+     * delegation happens (SubagentStarted/Resolved + web-search activity ping straight through).
+     * The reasoning and answer deltas are swallowed and accumulate in the [TurnResult], then are
+     * replayed once the run finishes — reasoning first, then the answer as a paced reveal — so the
+     * answer reads as non-streamed and reasoning can never trail it. A reconcile pass guarantees a
+     * card for every delegation even if its start/result never surfaced as a delta (the subagent
+     * SSE shape is beta). Uses the long-timeout [echoClient] because a delegation can stall the
+     * stream while the agent works.
      */
     fun sendWithAgentTools(
         apiKey: String,
@@ -798,11 +802,11 @@ class OpenRouterService(private val context: Context) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
         val tools = mutableListOf<Map<String, Any>>()
-        tools.addAll(openRouterWebTools()) // the orchestrator's own web_search + web_fetch
+        tools.addAll(openRouterWebTools()) // the main model's own web_search + web_fetch
         val subagentParams = mutableMapOf<String, Any>(
             "model" to agent.workerModel,
             "max_tool_calls" to agent.maxToolCalls.coerceIn(1, 25),
-            // The worker gets its own web toolbox so it can research while doing the task.
+            // The agent gets its own web toolbox so it can research while doing the task.
             "tools" to listOf(
                 mapOf("type" to "openrouter:web_search"),
                 mapOf("type" to "openrouter:web_fetch"),
@@ -811,7 +815,16 @@ class OpenRouterService(private val context: Context) {
         tools.add(mapOf("type" to "openrouter:subagent", "parameters" to subagentParams))
 
         val hasPdf = historyHasPdfAttachment(history)
-        streamCompletion(
+
+        // Option B: we DO stream the request, but only to catch the live "an agent was called"
+        // event the instant the delegate tool-call appears — that pings SubagentStarted/Resolved
+        // straight through to the UI. Reasoning and answer chunks are swallowed here (they
+        // accumulate in the returned TurnResult) and replayed AFTER the run in a controlled order,
+        // so the answer reads as non-streamed and reasoning can never trail it. tool_choice stays
+        // auto — the main model decides whether/how often to delegate.
+        val announced = mutableSetOf<String>()
+        val resolvedNames = mutableSetOf<String>()
+        val result = streamCompletion(
             apiKey = apiKey,
             model = model,
             payloadMessages = buildMessagesPayload(history, systemPrompt),
@@ -820,7 +833,41 @@ class OpenRouterService(private val context: Context) {
             agentWorkerModel = agent.workerModel,
             pdfPluginEnabled = hasPdf,
             httpClient = echoClient,
-        ) { emit(it) }
+        ) { chunk ->
+            when (chunk) {
+                is StreamChunk.SubagentStarted -> { announced.add(chunk.taskName); emit(chunk) }
+                is StreamChunk.SubagentResolved -> { resolvedNames.add(chunk.result.taskName); emit(chunk) }
+                is StreamChunk.SearchStarted, is StreamChunk.SearchSources, is StreamChunk.StatusNote -> emit(chunk)
+                else -> {} // swallow reasoning + content; replayed below in controlled order
+            }
+        }
+
+        // Reconcile: make sure every delegation has a card even if its start/result never surfaced
+        // as a stream delta (the subagent SSE shape is beta). The completed tool-calls carry the
+        // task briefs; an outcome that didn't stream shows as "ran, no result text".
+        result.toolCalls.filter { it.name.contains("subagent") }.forEach { call ->
+            val (name, desc) = parseTaskArgs(call.arguments) ?: ("Task" to "")
+            if (announced.add(name)) emit(StreamChunk.SubagentStarted(name, desc, agent.workerModel))
+            if (resolvedNames.add(name)) {
+                emit(StreamChunk.SubagentResolved(SubagentResult(name, desc, agent.workerModel, outcome = "")))
+            }
+        }
+
+        // Now replay reasoning (so it sits above the answer), then the answer as a paced reveal.
+        if (result.reasoning.isNotBlank()) emit(StreamChunk.Reasoning(result.reasoning))
+        if (result.content.isNotBlank()) {
+            val answer = result.content
+            val step = 18
+            var idx = 0
+            while (idx < answer.length) {
+                val end = (idx + step).coerceAtMost(answer.length)
+                emit(StreamChunk.Content(answer.substring(idx, end)))
+                idx = end
+                delay(14)
+            }
+        } else if (announced.isEmpty()) {
+            throw Exception("No response content received.")
+        }
     }.flowOn(Dispatchers.IO)
 
     /** Config for one Echo Adviser consult: which profile (display name) and advisor model. */
@@ -985,6 +1032,23 @@ class OpenRouterService(private val context: Context) {
             return dynamicAdapter.fromJson(responseString) as? Map<*, *>
                 ?: throw Exception("OpenRouter returned an unreadable response.")
         }
+    }
+
+    /** Each subagent delegation's (task_name, task_description), from the assistant's tool_calls. */
+    private fun extractSubagentDelegations(message: Map<*, *>?): List<Pair<String, String>> {
+        val calls = message?.get("tool_calls") as? List<*> ?: return emptyList()
+        val out = mutableListOf<Pair<String, String>>()
+        for (raw in calls) {
+            val m = raw as? Map<*, *> ?: continue
+            val type = (m["type"] as? String).orEmpty()
+            val fn = m["function"] as? Map<*, *>
+            val name = (fn?.get("name") as? String).orEmpty()
+            val looksAgent = type.contains("subagent") || name.contains("subagent") || name.contains("delegate")
+            if (!looksAgent) continue
+            val args = fn?.get("arguments") as? String ?: continue
+            parseTaskArgs(args)?.let { out.add(it) }
+        }
+        return out
     }
 
     /** The prompt the answering model sent its advisor, from the assistant message's tool_calls. */

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -207,7 +207,9 @@ object SystemPrompts {
 
         When to hand off a task:
         - Offload mechanical or bounded work — summarizing a long source, extracting structured data, reformatting, drafting boilerplate, or running a focused lookup — so you stay focused on the reasoning and the final answer.
-        - You may hand off several tasks (in sequence or for different parts) and combine the results.
+        - When a request breaks into several independent, self-contained parts (write N items, summarize N sources, draft N variations), prefer to hand off each part as its own task, then combine the results.
+
+        Actually use the tool — this is critical: when you decide to delegate, you MUST make a real call to the delegate tool. Never just write in your reasoning that you are "delegating" or "sending to a subagent" and then produce the content yourself. If you did not make a tool call, no delegation happened. Saying it is not doing it.
 
         How to write a good task:
         - The helper sees ONLY the task description you write — never the chat history. Make every task fully self-contained: include all inputs, the exact output format you want, and any constraints.

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -43,6 +43,9 @@ sealed class StreamSegment {
         val active: Boolean
     ) : StreamSegment()
 
+    /** Transient "Echo Agents are deploying…" banner shown while the non-streaming request runs. */
+    object AgentRun : StreamSegment()
+
     /** Echo Agent delegation: a task handed to the worker and its outcome (null while running). */
     data class Subagent(
         val taskName: String,
@@ -350,7 +353,15 @@ class ChatViewModel(
     // -------------------------------------------------------------------------------
 
     private fun reduceSegments(segments: MutableList<StreamSegment>, chunk: StreamChunk): String? {
+        // The "deploying agents" banner is only a waiting indicator: clear it the moment any real
+        // reply content (a delegation, reasoning, the answer, …) starts to arrive.
+        if (chunk !is StreamChunk.AgentRunStarted && chunk !is StreamChunk.StatusNote) {
+            segments.removeAll { it is StreamSegment.AgentRun }
+        }
         when (chunk) {
+            is StreamChunk.AgentRunStarted -> {
+                if (segments.none { it is StreamSegment.AgentRun }) segments.add(StreamSegment.AgentRun)
+            }
             is StreamChunk.Reasoning -> {
                 val last = segments.lastOrNull()
                 if (last is StreamSegment.Reasoning) {
@@ -1063,6 +1074,8 @@ class ChatViewModel(
                             error = seg.error,
                         ),
                     )
+                // Transient waiting indicator — never persisted.
+                is StreamSegment.AgentRun -> null
                 is StreamSegment.Text -> seg.text.trim().takeIf { it.isNotEmpty() }
                     ?.let { PersistedSegment(type = "text", text = it) }
             }

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -319,6 +319,50 @@ fun SubagentCard(
     }
 }
 
+/**
+ * Branded waiting state for an Echo Agents run. The request is non-streaming, so this card
+ * animates through the whole wait — the user sees "Echo Agents are deploying…" instead of a bare
+ * thinking row — and is replaced by the delegation cards, reasoning and answer once they arrive.
+ */
+@Composable
+fun AgentDeployingCard(modifier: Modifier = Modifier) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.40f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(38.dp).clip(RoundedPolygonShape(MaterialShapes.Pentagon))
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.Hub, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimary) }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    ModeBadge("ECHO AGENTS", MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.onPrimary)
+                    Spacer(Modifier.height(3.dp))
+                    Text(
+                        "Deploying agents…",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        "The main model is planning, delegating and gathering results",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.height(Spacing.m))
+            LinearWavyProgressIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
 // ── Echo Fusion ─────────────────────────────────────────────────────────────────────────
 
 /**

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -72,6 +72,7 @@ import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.AdvisorCard
+import com.echoflow.ui.components.AgentDeployingCard
 import com.echoflow.ui.components.BrandMark
 import com.echoflow.ui.components.CapabilityChip
 import com.echoflow.ui.components.DataResultCard
@@ -565,6 +566,10 @@ private fun StreamingAssistantBubble(
                             analysis = segment.analysis,
                             active = segment.active,
                         )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    is StreamSegment.AgentRun -> {
+                        AgentDeployingCard()
                         Spacer(Modifier.height(Spacing.s))
                     }
                     is StreamSegment.Subagent -> {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Echo Agents deploying banner and deferred streaming replay to agent runs
- Adds a new `AgentRunStarted` stream event and a transient `StreamSegment.AgentRun` UI state that renders an `AgentDeployingCard` branded waiting indicator while an agent run is in progress.
- Rewrites `OpenRouterService.sendWithAgentTools` to emit only delegation and web-search/status events live during the run, then replay accumulated reasoning followed by paced answer content (18-char chunks, 14ms delay) after completion.
- Adds a reconcile pass over `result.toolCalls` to emit synthetic `SubagentStarted`/`SubagentResolved` cards for any delegations that did not surface as streaming deltas.
- Strengthens the Echo Agents system prompt to require real `delegate` tool calls rather than stating delegation only in reasoning.
- `AgentRun` segments are transient and not persisted to chat history.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb2835.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual "deploying agents" status indicator displayed while agent delegation is in progress.
  
* **Improvements**
  * Enhanced agent delegation workflow to better track and organize subagent tasks and results.
  * Refined agent guidance to improve delegation accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->