### PR TITLE
Add Browser Flow session support

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -103,7 +104,9 @@ class MainActivity : ComponentActivity() {
                     database.deepResearchModelDao(),
                     database.advisorProfileDao(),
                     database.fusionPanelDao(),
-                    database.agentProfileDao()
+                    database.agentProfileDao(),
+                    database.browserSessionDao(),
+                    database.browserStepDao()
                 )
             )
 
@@ -149,6 +152,9 @@ fun MainNavigationHub(
 ) {
     var activeTab by remember { mutableStateOf("chat") }
 
+    val activeBrowserSession by chatViewModel.activeBrowserSession.collectAsState()
+    val browserWorkspaceChatId by chatViewModel.browserWorkspaceChatId.collectAsState()
+
     Box(modifier = Modifier.fillMaxSize()) {
         if (activeTab == "settings") {
             // Intercept the system back gesture/button so it returns to chat
@@ -163,6 +169,26 @@ fun MainNavigationHub(
                 chatViewModel = chatViewModel,
                 settingsViewModel = settingsViewModel,
                 onSettingsClicked = { activeTab = "settings" }
+            )
+        }
+
+        // Global "remote browser active" pill — visible across tabs while a session is live and
+        // the workspace is closed. Tapping it returns to the owning chat's workspace.
+        val pillSession = activeBrowserSession
+        if (pillSession != null && browserWorkspaceChatId == null) {
+            com.echoflow.ui.components.GlobalBrowserPill(
+                session = pillSession,
+                onClick = { chatViewModel.openBrowserWorkspace(pillSession.chatId) },
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 110.dp),
+            )
+        }
+
+        // Fullscreen Browser Workspace overlay (the native mini-browser).
+        if (browserWorkspaceChatId != null) {
+            BackHandler { chatViewModel.closeBrowserWorkspace() }
+            com.echoflow.ui.screens.BrowserWorkspaceScreen(
+                chatViewModel = chatViewModel,
+                onClose = { chatViewModel.closeBrowserWorkspace() },
             )
         }
     }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -11,9 +11,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
     entities = [
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
         DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
-        AgentProfile::class
+        AgentProfile::class, BrowserSession::class, BrowserStep::class
     ],
-    version = 10, // v10: Echo Agent profiles (MIGRATION_9_10)
+    version = 11, // v11: Browser Flow sessions + steps (MIGRATION_10_11)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -26,6 +26,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun advisorProfileDao(): AdvisorProfileDao
     abstract fun fusionPanelDao(): FusionPanelDao
     abstract fun agentProfileDao(): AgentProfileDao
+    abstract fun browserSessionDao(): BrowserSessionDao
+    abstract fun browserStepDao(): BrowserStepDao
 
     companion object {
         @Volatile
@@ -148,6 +150,46 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS browser_sessions (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "chatId TEXT NOT NULL, " +
+                        "goal TEXT NOT NULL, " +
+                        "resolvedUrl TEXT, " +
+                        "scrapeId TEXT, " +
+                        "liveViewUrl TEXT, " +
+                        "interactiveLiveViewUrl TEXT, " +
+                        "status TEXT NOT NULL, " +
+                        "phase TEXT, " +
+                        "pendingKind TEXT, " +
+                        "pendingInstruction TEXT, " +
+                        "pendingDraft TEXT, " +
+                        "candidatesJson TEXT, " +
+                        "lastOutput TEXT, " +
+                        "error TEXT, " +
+                        "openedAt INTEGER, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL, " +
+                        "lastActivityAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(chatId) REFERENCES chat_threads(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_browser_sessions_chatId ON browser_sessions (chatId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_browser_sessions_status ON browser_sessions (status)")
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS browser_steps (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "sessionId TEXT NOT NULL, " +
+                        "role TEXT NOT NULL, " +
+                        "text TEXT NOT NULL, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(sessionId) REFERENCES browser_sessions(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_browser_steps_sessionId ON browser_steps (sessionId)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -164,6 +206,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_7_8,
                     MIGRATION_8_9,
                     MIGRATION_9_10,
+                    MIGRATION_10_11,
                 )
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()

--- a/app/src/main/java/com/echoflow/data/BrowserAgentManager.kt
+++ b/app/src/main/java/com/echoflow/data/BrowserAgentManager.kt
@@ -1,0 +1,544 @@
+package com.echoflow.data
+
+import com.echoflow.data.BrowserSession.Companion.PENDING_CONFIRM_DOMAIN
+import com.echoflow.data.BrowserSession.Companion.PENDING_DISAMBIGUATION
+import com.echoflow.data.BrowserSession.Companion.PENDING_DRAFT_CONFIRM
+import com.echoflow.data.BrowserSession.Companion.PENDING_HANDOFF
+import com.echoflow.data.BrowserSession.Companion.STATUS_AWAITING_INSTRUCTION
+import com.echoflow.data.BrowserSession.Companion.STATUS_AWAITING_USER
+import com.echoflow.data.BrowserSession.Companion.STATUS_COMPLETED
+import com.echoflow.data.BrowserSession.Companion.STATUS_EXPIRED
+import com.echoflow.data.BrowserSession.Companion.STATUS_FAILED
+import com.echoflow.data.BrowserSession.Companion.STATUS_RESOLVING
+import com.echoflow.data.BrowserSession.Companion.STATUS_RUNNING
+import com.echoflow.data.BrowserSession.Companion.STATUS_STARTING
+import com.echoflow.data.BrowserSession.Companion.STATUS_STOPPED
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/**
+ * Orchestrates Browser Flow: the stateful, multi-turn Firecrawl browser session controlled
+ * through chat. It is the only writer to [BrowserSession]/[BrowserStep]; the UI observes those
+ * rows. Each turn is one request/response `/interact` call (no streaming) — the live browser
+ * WebView is the real-time feedback channel.
+ *
+ * Lifecycle decisions (see design notes): per-turn work runs in the supplied [scope]
+ * (viewModelScope) — no foreground service. Firecrawl's TTL caps billing; on relaunch
+ * [sweepOrphans] conservatively expires any session left active by a previous process, and an
+ * [idleWatcher] auto-closes idle sessions as a cost guard.
+ */
+class BrowserAgentManager(
+    private val chatDao: ChatDao,
+    private val messageDao: MessageDao,
+    private val sessionDao: BrowserSessionDao,
+    private val stepDao: BrowserStepDao,
+    private val settings: SettingsRepository,
+    private val webSearch: WebSearchService,
+    private val scope: CoroutineScope,
+) {
+    private val firecrawl = FirecrawlBrowserService()
+
+    /** The single app-wide live session (the start-a-session lock + the global pill). */
+    val activeSession: StateFlow<BrowserSession?> =
+        sessionDao.observeAnyActive().stateIn(scope, SharingStarted.Eagerly, null)
+
+    /** Auto-open request: set when a session goes live so the workspace can pop open. */
+    private val _openWorkspaceFor = MutableStateFlow<String?>(null)
+    val openWorkspaceFor: StateFlow<String?> = _openWorkspaceFor.asStateFlow()
+
+    fun requestOpenWorkspace(chatId: String) { _openWorkspaceFor.value = chatId }
+    fun clearWorkspaceRequest() { _openWorkspaceFor.value = null }
+
+    fun observeForChat(chatId: String) = sessionDao.observeActiveForChat(chatId)
+    fun observeSteps(sessionId: String) = stepDao.observeForSession(sessionId)
+
+    init {
+        scope.launch { sweepOrphans() }
+        scope.launch { idleWatcher() }
+    }
+
+    // ── Public entry points ────────────────────────────────────────────────────────────
+
+    /** Ignite a new session in [chatId] from the first [instruction]. */
+    fun startSession(chatId: String, instruction: String) {
+        scope.launch {
+            val now = System.currentTimeMillis()
+            val sessionId = UUID.randomUUID().toString()
+            insertUser(chatId, instruction)
+            val session = BrowserSession(
+                id = sessionId,
+                chatId = chatId,
+                goal = instruction,
+                status = STATUS_RESOLVING,
+                phase = "Finding site…",
+                createdAt = now,
+                updatedAt = now,
+                lastActivityAt = now,
+            )
+            save(session)
+            addStep(sessionId, "system", "Browser Flow started.")
+            addStep(sessionId, "user", instruction)
+            if (settings.getSearchApiKeyDirect("firecrawl").isBlank()) {
+                fail(session, "Add your Firecrawl API key in Settings → Web search.")
+                return@launch
+            }
+            resolveAndProceed(session, instruction)
+        }
+    }
+
+    /** A message in the owning chat: continue the same session (or answer a pending question). */
+    fun sendCommand(chatId: String, text: String) {
+        scope.launch {
+            val session = sessionDao.getActiveForChat(chatId) ?: return@launch
+            if (session.status == STATUS_RESOLVING || session.status == STATUS_STARTING || session.status == STATUS_RUNNING) {
+                addStep(session.id, "system", "Still working on the previous command.")
+                return@launch
+            }
+            insertUser(chatId, text)
+            addStep(session.id, "user", text)
+            val touched = session.copy(lastActivityAt = System.currentTimeMillis())
+            if (session.status == STATUS_AWAITING_USER &&
+                (session.pendingKind == PENDING_DISAMBIGUATION || session.pendingKind == PENDING_CONFIRM_DOMAIN)
+            ) {
+                // A typed reply during site-resolution is itself a URL/name to resolve.
+                save(touched.copy(status = STATUS_RESOLVING, phase = "Finding site…"))
+                resolveAndProceed(touched, text)
+            } else {
+                runTurn(touched, text)
+            }
+        }
+    }
+
+    /** Disambiguation chip tapped. */
+    fun resolveCandidate(sessionId: String, url: String) {
+        scope.launch {
+            val s = sessionDao.getById(sessionId) ?: return@launch
+            addStep(sessionId, "user", "Use ${BrowserResolver.domainOf(url)}")
+            if (BrowserResolver.isSensitive(url)) askConfirmDomain(s, url)
+            else beginScrape(s.copy(resolvedUrl = url), s.goal)
+        }
+    }
+
+    /** Sensitive-site confirmation accepted. */
+    fun confirmDomain(sessionId: String) {
+        scope.launch {
+            val s = sessionDao.getById(sessionId) ?: return@launch
+            if (s.resolvedUrl == null) return@launch
+            addStep(sessionId, "user", "Confirmed — open ${BrowserResolver.domainOf(s.resolvedUrl)}")
+            beginScrape(s, s.goal)
+        }
+    }
+
+    /** Draft message approved — actually send it. */
+    fun confirmSend(sessionId: String) {
+        scope.launch {
+            val s = sessionDao.getById(sessionId) ?: return@launch
+            val draft = s.pendingDraft ?: return@launch
+            val scrapeId = s.scrapeId ?: run { softFail(s, "Lost the browser session."); return@launch }
+            addStep(sessionId, "user", "Approved — send it")
+            val cleared = s.copy(status = STATUS_RUNNING, phase = "Sending…", pendingKind = null, pendingDraft = null)
+            save(cleared)
+            try {
+                val r = firecrawl.interact(
+                    settings.getSearchApiKeyDirect("firecrawl"),
+                    scrapeId,
+                    SystemPrompts.browserSendConfirmedPrompt(draft),
+                )
+                val out = r.output.ifBlank { "Sent." }
+                save(
+                    cleared.copy(
+                        status = STATUS_AWAITING_INSTRUCTION,
+                        phase = "Waiting for next instruction",
+                        lastOutput = out,
+                        lastActivityAt = System.currentTimeMillis(),
+                        liveViewUrl = r.liveViewUrl ?: s.liveViewUrl,
+                        interactiveLiveViewUrl = r.interactiveLiveViewUrl ?: s.interactiveLiveViewUrl,
+                    )
+                )
+                addStep(sessionId, "agent", out)
+                insertAssistant(s.chatId, out)
+            } catch (e: Exception) {
+                softFail(cleared, e.message ?: "Sending failed.")
+            }
+        }
+    }
+
+    /** Cancel a pending confirmation/handoff. Keeps the browser open if one exists. */
+    fun cancelPending(sessionId: String) {
+        scope.launch {
+            val s = sessionDao.getById(sessionId) ?: return@launch
+            if (!s.hasLiveBrowser) { stopInternal(s, expired = false); return@launch }
+            addStep(sessionId, "user", "Cancelled.")
+            save(
+                s.copy(
+                    status = STATUS_AWAITING_INSTRUCTION,
+                    phase = "Waiting for next instruction",
+                    pendingKind = null,
+                    pendingDraft = null,
+                    lastActivityAt = System.currentTimeMillis(),
+                )
+            )
+        }
+    }
+
+    /** Finish: ask for a closing summary, save it, then close the session. */
+    fun finish(sessionId: String) { scope.launch { finishNow(sessionId) } }
+
+    suspend fun finishNow(sessionId: String) {
+        val s = sessionDao.getById(sessionId) ?: return
+        if (s.isTerminal) return
+        save(s.copy(status = STATUS_RUNNING, phase = "Wrapping up…"))
+        if (s.hasLiveBrowser) {
+            val key = settings.getSearchApiKeyDirect("firecrawl")
+            runCatching {
+                val r = firecrawl.interact(key, s.scrapeId!!, SystemPrompts.browserFinishPrompt())
+                if (r.output.isNotBlank()) {
+                    addStep(sessionId, "agent", r.output)
+                    insertAssistant(s.chatId, r.output)
+                }
+            }
+            firecrawl.stop(key, s.scrapeId!!)
+        }
+        addStep(sessionId, "system", "Session finished.")
+        save(s.copy(status = STATUS_COMPLETED, phase = "Finished", pendingKind = null, pendingDraft = null))
+        if (_openWorkspaceFor.value == s.chatId) _openWorkspaceFor.value = null
+    }
+
+    /** Stop now: close immediately, no summary. */
+    fun stop(sessionId: String) {
+        scope.launch {
+            val s = sessionDao.getById(sessionId) ?: return@launch
+            stopInternal(s, expired = false)
+        }
+    }
+
+    // ── Resolution ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Resolve a website from [searchText] (a URL, the first instruction, or a typed reply during
+     * disambiguation). The *task* to run once a browser opens is always [BrowserSession.goal], so
+     * the original objective survives any number of resolution round-trips.
+     */
+    private suspend fun resolveAndProceed(session: BrowserSession, searchText: String) {
+        BrowserResolver.extractUrl(searchText)?.let { direct ->
+            if (BrowserResolver.isSensitive(direct)) askConfirmDomain(session, direct)
+            else beginScrape(session.copy(resolvedUrl = direct), session.goal)
+            return
+        }
+
+        val provider = settings.resolveChipSearchProvider()?.takeIf { it in CLIENT_SEARCH_PROVIDERS }
+        val searchKey = provider?.let { settings.getSearchApiKeyDirect(it) }.orEmpty()
+        if (provider == null || searchKey.isBlank()) {
+            askForUrl(session, "I can't look that up — no web-search key is set. Paste the website URL.")
+            return
+        }
+
+        val results = runCatching { webSearch.search(provider, searchKey, websiteQuery(searchText), 6) }
+            .getOrNull().orEmpty()
+        val candidates = BrowserResolver.rankCandidates(results, searchText)
+        val top = candidates.firstOrNull()
+        when {
+            top == null -> askForUrl(session, "I couldn't find that site. Paste the URL or type the exact name.")
+            isConfident(top, searchText) -> {
+                if (BrowserResolver.isSensitive(top.url)) askConfirmDomain(session, top.url)
+                else beginScrape(session.copy(resolvedUrl = top.url), session.goal)
+            }
+            else -> askDisambiguation(session, candidates)
+        }
+    }
+
+    private suspend fun askForUrl(session: BrowserSession, message: String) {
+        addStep(session.id, "system", message)
+        save(
+            session.copy(
+                status = STATUS_AWAITING_USER,
+                pendingKind = PENDING_DISAMBIGUATION,
+                candidatesJson = null,
+                phase = "Which site?",
+            )
+        )
+    }
+
+    private suspend fun askDisambiguation(session: BrowserSession, candidates: List<BrowserCandidate>) {
+        addStep(session.id, "system", "Found a few sites — choose which one to open.")
+        save(
+            session.copy(
+                status = STATUS_AWAITING_USER,
+                pendingKind = PENDING_DISAMBIGUATION,
+                candidatesJson = BrowserJson.candidatesToJson(candidates),
+                phase = "Which site?",
+            )
+        )
+    }
+
+    private suspend fun askConfirmDomain(session: BrowserSession, url: String) {
+        addStep(session.id, "system", "${BrowserResolver.domainOf(url)} looks sensitive — confirm before I open it.")
+        save(
+            session.copy(
+                status = STATUS_AWAITING_USER,
+                pendingKind = PENDING_CONFIRM_DOMAIN,
+                resolvedUrl = url,
+                candidatesJson = null,
+                phase = "Confirm sensitive site",
+            )
+        )
+    }
+
+    // ── Browser open + interact ─────────────────────────────────────────────────────────
+
+    private suspend fun beginScrape(session: BrowserSession, instruction: String) {
+        val url = session.resolvedUrl ?: return
+        save(
+            session.copy(
+                status = STATUS_STARTING,
+                phase = "Opening browser…",
+                pendingKind = null,
+                pendingInstruction = null,
+                candidatesJson = null,
+            )
+        )
+        addStep(session.id, "system", "Opening ${BrowserResolver.domainOf(url)}…")
+        try {
+            val start = firecrawl.startSession(settings.getSearchApiKeyDirect("firecrawl"), url)
+            val now = System.currentTimeMillis()
+            val opened = session.copy(
+                status = STATUS_RUNNING,
+                phase = "Running instruction…",
+                scrapeId = start.scrapeId,
+                liveViewUrl = start.liveViewUrl,
+                interactiveLiveViewUrl = start.interactiveLiveViewUrl,
+                resolvedUrl = url,
+                openedAt = now,
+                pendingKind = null,
+                pendingInstruction = null,
+                candidatesJson = null,
+                lastActivityAt = now,
+            )
+            save(opened)
+            requestOpenWorkspace(session.chatId) // auto-open on first start
+            runInteract(opened, instruction, isFirst = true)
+        } catch (e: Exception) {
+            fail(session, e.message ?: "Couldn't open the browser.")
+        }
+    }
+
+    private suspend fun runTurn(session: BrowserSession, text: String) {
+        if (!session.hasLiveBrowser) {
+            softFail(session, "The browser session is no longer available. Start a new one.")
+            return
+        }
+        when (BrowserResolver.classifyInstruction(text)) {
+            BrowserResolver.RiskKind.HARD -> handoff(
+                session,
+                "This step looks like a payment or an irreversible action. Open the live browser and " +
+                    "complete it yourself — I won't automate payments, checkout or account changes.",
+            )
+            BrowserResolver.RiskKind.SEND -> runInteract(session, text, isFirst = false, draftMode = true)
+            null -> runInteract(session, text, isFirst = false)
+        }
+    }
+
+    private suspend fun runInteract(session: BrowserSession, instruction: String, isFirst: Boolean, draftMode: Boolean = false) {
+        val scrapeId = session.scrapeId ?: run { softFail(session, "Lost the browser session."); return }
+        save(
+            session.copy(
+                status = STATUS_RUNNING,
+                phase = if (draftMode) "Composing…" else if (isFirst) "Running instruction…" else "Running…",
+                lastActivityAt = System.currentTimeMillis(),
+            )
+        )
+        try {
+            val r = firecrawl.interact(
+                settings.getSearchApiKeyDirect("firecrawl"),
+                scrapeId,
+                SystemPrompts.browserInteractPrompt(instruction, draftMode),
+            )
+            val out = r.output.ifBlank { "Done." }
+            val withUrls = session.copy(
+                liveViewUrl = r.liveViewUrl ?: session.liveViewUrl,
+                interactiveLiveViewUrl = r.interactiveLiveViewUrl ?: session.interactiveLiveViewUrl,
+                lastActivityAt = System.currentTimeMillis(),
+            )
+            val blocker = BrowserResolver.detectBlocker(out)
+            when {
+                draftMode -> {
+                    save(
+                        withUrls.copy(
+                            status = STATUS_AWAITING_USER,
+                            pendingKind = PENDING_DRAFT_CONFIRM,
+                            pendingDraft = out,
+                            phase = "Confirm before sending",
+                            lastOutput = out,
+                        )
+                    )
+                    addStep(session.id, "agent", "Drafted a message — awaiting your confirmation.")
+                }
+                blocker != null -> handoff(withUrls.copy(lastOutput = out), blocker)
+                else -> {
+                    save(
+                        withUrls.copy(
+                            status = STATUS_AWAITING_INSTRUCTION,
+                            phase = "Waiting for next instruction",
+                            pendingKind = null,
+                            pendingDraft = null,
+                            lastOutput = out,
+                            error = null,
+                        )
+                    )
+                    addStep(session.id, "agent", out)
+                    insertAssistant(session.chatId, out)
+                }
+            }
+        } catch (e: Exception) {
+            softFail(session, e.message ?: "The browser action failed.")
+        }
+    }
+
+    private suspend fun handoff(session: BrowserSession, message: String) {
+        save(
+            session.copy(
+                status = STATUS_AWAITING_USER,
+                pendingKind = PENDING_HANDOFF,
+                phase = "Needs you",
+                lastOutput = message,
+                lastActivityAt = System.currentTimeMillis(),
+            )
+        )
+        addStep(session.id, "system", message)
+        insertAssistant(session.chatId, message)
+    }
+
+    // ── Termination + housekeeping ──────────────────────────────────────────────────────
+
+    private suspend fun stopInternal(session: BrowserSession, expired: Boolean) {
+        if (session.hasLiveBrowser) {
+            val key = settings.getSearchApiKeyDirect("firecrawl")
+            if (key.isNotBlank()) firecrawl.stop(key, session.scrapeId!!)
+        }
+        addStep(session.id, "system", if (expired) "Session expired or was interrupted." else "Session stopped.")
+        save(
+            session.copy(
+                status = if (expired) STATUS_EXPIRED else STATUS_STOPPED,
+                phase = if (expired) "Expired" else "Stopped",
+                pendingKind = null,
+                pendingDraft = null,
+            )
+        )
+        if (_openWorkspaceFor.value == session.chatId) _openWorkspaceFor.value = null
+    }
+
+    /** Terminal failure (no browser, or session gone): close and mark failed. */
+    private suspend fun fail(session: BrowserSession, message: String) {
+        if (session.hasLiveBrowser) {
+            val key = settings.getSearchApiKeyDirect("firecrawl")
+            if (key.isNotBlank()) runCatching { firecrawl.stop(key, session.scrapeId!!) }
+        }
+        addStep(session.id, "system", "Error: $message")
+        save(session.copy(status = STATUS_FAILED, phase = "Failed", error = message, pendingKind = null, pendingDraft = null))
+        if (_openWorkspaceFor.value == session.chatId) _openWorkspaceFor.value = null
+    }
+
+    /** Transient action failure: keep the live browser open unless the session is gone. */
+    private suspend fun softFail(session: BrowserSession, message: String) {
+        val sessionGone = message.contains("expired", ignoreCase = true) ||
+            message.contains("start a new", ignoreCase = true)
+        if (sessionGone || !session.hasLiveBrowser) {
+            fail(session, message)
+            return
+        }
+        addStep(session.id, "system", "Action failed: $message")
+        insertAssistant(session.chatId, "That action failed: $message. Try again, or open the live browser to do it yourself.")
+        save(
+            session.copy(
+                status = STATUS_AWAITING_INSTRUCTION,
+                phase = "Waiting for next instruction",
+                error = message,
+                pendingKind = null,
+                pendingDraft = null,
+                lastActivityAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    /** On relaunch: never auto-resume — best-effort close + mark any leftover session expired. */
+    private suspend fun sweepOrphans() {
+        val key = settings.getSearchApiKeyDirect("firecrawl")
+        sessionDao.getAllActive().forEach { s ->
+            if (s.hasLiveBrowser && key.isNotBlank()) runCatching { firecrawl.stop(key, s.scrapeId!!) }
+            addStep(s.id, "system", "Previous browser session expired or was interrupted.")
+            save(s.copy(status = STATUS_EXPIRED, phase = "Expired", pendingKind = null, pendingDraft = null))
+        }
+    }
+
+    /** Cost guard: auto-stop a session idling at awaiting_instruction past the configured timeout. */
+    private suspend fun idleWatcher() {
+        while (true) {
+            delay(30_000)
+            val s = activeSession.value ?: continue
+            val minutes = settings.getBrowserIdleMinutesDirect()
+            if (minutes <= 0 || s.status != STATUS_AWAITING_INSTRUCTION) continue
+            if (System.currentTimeMillis() - s.lastActivityAt > minutes * 60_000L) {
+                addStep(s.id, "system", "Closed after $minutes min of inactivity.")
+                stopInternal(s, expired = false)
+            }
+        }
+    }
+
+    // ── small helpers ───────────────────────────────────────────────────────────────────
+
+    private suspend fun save(session: BrowserSession) {
+        sessionDao.upsert(session.copy(updatedAt = System.currentTimeMillis()))
+    }
+
+    private suspend fun addStep(sessionId: String, role: String, text: String) {
+        if (text.isBlank()) return
+        stepDao.insert(BrowserStep(UUID.randomUUID().toString(), sessionId, role, text.trim(), System.currentTimeMillis()))
+    }
+
+    private suspend fun insertUser(chatId: String, text: String) {
+        messageDao.insertMessage(ChatMessage(UUID.randomUUID().toString(), chatId, "user", text, System.currentTimeMillis()))
+        touchThread(chatId)
+    }
+
+    private suspend fun insertAssistant(chatId: String, text: String) {
+        if (text.isBlank()) return
+        messageDao.insertMessage(ChatMessage(UUID.randomUUID().toString(), chatId, "assistant", text, System.currentTimeMillis()))
+        touchThread(chatId)
+    }
+
+    private suspend fun touchThread(chatId: String) {
+        chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = System.currentTimeMillis())) }
+    }
+
+    private fun websiteQuery(instruction: String): String {
+        val cleaned = instruction.replace(
+            Regex("^(go to|open|visit|check|navigate to|browse|launch|head to)\\s+", RegexOption.IGNORE_CASE), ""
+        )
+        val name = cleaned.split(Regex("\\s+(and|then|to find|find|search|,)\\s+", RegexOption.IGNORE_CASE))
+            .firstOrNull()?.trim().orEmpty()
+        val base = if (name.length in 2..40) name else cleaned.take(40)
+        return "$base official website"
+    }
+
+    private fun isConfident(top: BrowserCandidate, instruction: String): Boolean {
+        if (BrowserResolver.isDispreferred(top.url)) return false
+        val tokens = instruction.lowercase().split(Regex("[^a-z0-9]+"))
+            .filter { it.length > 2 && it !in STOPWORDS }
+        return tokens.any { top.domain.contains(it) }
+    }
+
+    companion object {
+        private val CLIENT_SEARCH_PROVIDERS = setOf("exa", "parallel", "firecrawl")
+        private val STOPWORDS = setOf(
+            "go", "to", "the", "open", "visit", "find", "and", "check", "on", "for", "of",
+            "in", "me", "please", "navigate", "search", "website", "site", "official",
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/data/BrowserModels.kt
+++ b/app/src/main/java/com/echoflow/data/BrowserModels.kt
@@ -1,0 +1,178 @@
+package com.echoflow.data
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A durable, stateful Browser Flow session: one live Firecrawl browser (`scrapeId`) controlled
+ * through chat over many turns. This is the single source of truth — the chat card, the global
+ * pill and the fullscreen workspace all observe this row, so the session survives the workspace
+ * being closed, the app being minimized, or a process kill (resolved conservatively on relaunch).
+ *
+ * Routing rule: while a session is non-[isTerminal] it **owns** its [chatId] — every message in
+ * that chat drives `/interact` on this [scrapeId]. Only one non-terminal session may exist
+ * app-wide at a time (the start-a-session lock); other chats stay normal.
+ */
+@Entity(
+    tableName = "browser_sessions",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatThread::class,
+            parentColumns = ["id"],
+            childColumns = ["chatId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("chatId"), Index("status")],
+)
+data class BrowserSession(
+    @PrimaryKey val id: String,
+    val chatId: String,
+    val goal: String, // the first instruction that started the session
+    val resolvedUrl: String? = null,
+    val scrapeId: String? = null,
+    val liveViewUrl: String? = null, // read-only browser stream
+    val interactiveLiveViewUrl: String? = null, // user-controllable stream (the WebView source)
+    val status: String = STATUS_RESOLVING, // see STATUS_* constants
+    val phase: String? = null, // human progress line, e.g. "Running instruction…"
+    val pendingKind: String? = null, // when awaiting_user: what we're waiting for (PENDING_*)
+    val pendingInstruction: String? = null, // instruction held across a disambiguation/confirm
+    val pendingDraft: String? = null, // composed message awaiting the user's send-confirmation
+    val candidatesJson: String? = null, // JSON List<BrowserCandidate> for disambiguation
+    val lastOutput: String? = null, // latest agent output (for the card summary)
+    val error: String? = null,
+    val openedAt: Long? = null, // when the Firecrawl browser actually opened (for cost/elapsed)
+    val createdAt: Long,
+    val updatedAt: Long,
+    val lastActivityAt: Long, // drives the idle auto-finish timer
+) {
+    val isTerminal: Boolean get() = status in TERMINAL_STATUSES
+    val isActive: Boolean get() = !isTerminal
+    val hasLiveBrowser: Boolean get() = !scrapeId.isNullOrBlank()
+    val candidates: List<BrowserCandidate> get() = BrowserJson.candidatesFromJson(candidatesJson)
+
+    companion object {
+        const val STATUS_RESOLVING = "resolving"
+        const val STATUS_STARTING = "starting"
+        const val STATUS_RUNNING = "running"
+        const val STATUS_AWAITING_USER = "awaiting_user"
+        const val STATUS_AWAITING_INSTRUCTION = "awaiting_instruction"
+        const val STATUS_COMPLETED = "completed"
+        const val STATUS_FAILED = "failed"
+        const val STATUS_STOPPED = "stopped"
+        const val STATUS_EXPIRED = "expired"
+
+        // What an awaiting_user pause is about.
+        const val PENDING_DISAMBIGUATION = "disambiguation" // pick a site (chips + Other)
+        const val PENDING_CONFIRM_DOMAIN = "confirm_domain" // sensitive site — confirm before opening
+        const val PENDING_HANDOFF = "handoff"               // login/CAPTCHA/payment — drive it yourself
+        const val PENDING_DRAFT_CONFIRM = "draft_confirm"   // confirm an outgoing message before send
+
+        val TERMINAL_STATUSES = setOf(STATUS_COMPLETED, STATUS_FAILED, STATUS_STOPPED, STATUS_EXPIRED)
+
+        // Firecrawl billing for prompt-driven interact (shown to the user for trust).
+        const val CREDITS_PER_MINUTE = 7
+    }
+}
+
+/**
+ * One entry in a session's timeline (the activity log shown in the card / workspace drawer).
+ * Roles: "user" (a command/answer), "agent" (an output) or "system" (a status/handoff note).
+ * Meaningful agent results are *also* mirrored into the chat thread as assistant messages; the
+ * timeline keeps the full mechanical record.
+ */
+@Entity(
+    tableName = "browser_steps",
+    foreignKeys = [
+        ForeignKey(
+            entity = BrowserSession::class,
+            parentColumns = ["id"],
+            childColumns = ["sessionId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("sessionId")],
+)
+data class BrowserStep(
+    @PrimaryKey val id: String,
+    val sessionId: String,
+    val role: String, // "user" | "agent" | "system"
+    val text: String,
+    val createdAt: Long,
+)
+
+/** A candidate website surfaced during resolution (for the disambiguation chips). */
+data class BrowserCandidate(
+    val title: String,
+    val url: String,
+    val domain: String,
+)
+
+/** Moshi (de)serialization for the small embedded lists, mirroring [ResearchJson]. */
+object BrowserJson {
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val candidateListType = Types.newParameterizedType(List::class.java, BrowserCandidate::class.java)
+    private val candidateAdapter = moshi.adapter<List<BrowserCandidate>>(candidateListType)
+
+    fun candidatesToJson(list: List<BrowserCandidate>): String = candidateAdapter.toJson(list)
+
+    fun candidatesFromJson(json: String?): List<BrowserCandidate> =
+        if (json.isNullOrBlank()) emptyList()
+        else runCatching { candidateAdapter.fromJson(json) }.getOrNull().orEmpty()
+}
+
+@Dao
+interface BrowserSessionDao {
+    /** The live (non-terminal) session for one chat, if any — drives the in-chat card. */
+    @Query(
+        "SELECT * FROM browser_sessions WHERE chatId = :chatId " +
+            "AND status NOT IN ('completed','failed','stopped','expired') " +
+            "ORDER BY createdAt DESC LIMIT 1"
+    )
+    fun observeActiveForChat(chatId: String): Flow<BrowserSession?>
+
+    /** The single app-wide live session (start-a-session lock + global pill). */
+    @Query(
+        "SELECT * FROM browser_sessions WHERE status NOT IN ('completed','failed','stopped','expired') " +
+            "ORDER BY createdAt DESC LIMIT 1"
+    )
+    fun observeAnyActive(): Flow<BrowserSession?>
+
+    @Query("SELECT * FROM browser_sessions WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): BrowserSession?
+
+    @Query(
+        "SELECT * FROM browser_sessions WHERE chatId = :chatId " +
+            "AND status NOT IN ('completed','failed','stopped','expired') " +
+            "ORDER BY createdAt DESC LIMIT 1"
+    )
+    suspend fun getActiveForChat(chatId: String): BrowserSession?
+
+    @Query("SELECT * FROM browser_sessions WHERE status NOT IN ('completed','failed','stopped','expired')")
+    suspend fun getAllActive(): List<BrowserSession>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(session: BrowserSession)
+
+    @Query("DELETE FROM browser_sessions WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
+interface BrowserStepDao {
+    @Query("SELECT * FROM browser_steps WHERE sessionId = :sessionId ORDER BY createdAt ASC")
+    fun observeForSession(sessionId: String): Flow<List<BrowserStep>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(step: BrowserStep)
+}

--- a/app/src/main/java/com/echoflow/data/FirecrawlBrowserService.kt
+++ b/app/src/main/java/com/echoflow/data/FirecrawlBrowserService.kt
@@ -1,0 +1,267 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
+
+/**
+ * Thin client for Firecrawl Interact (the stateful browser session behind Browser Flow):
+ *  - [startSession]  POST /v2/scrape                      → opens a browser, returns scrapeId + live URLs
+ *  - [interact]      POST /v2/scrape/{scrapeId}/interact  → drives the same browser with a prompt
+ *  - [stop]          DELETE /v2/scrape/{scrapeId}/interact → closes the session (billing/cleanup)
+ *
+ * Sessions are deliberately ephemeral: no `profile` is ever sent, so Firecrawl keeps no cookies
+ * or login state. Interact is request/response (no token streaming); a prompt call can take up to
+ * Firecrawl's 300s timeout, hence the long read/call timeouts.
+ */
+class FirecrawlBrowserService {
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        // A single interact action can run up to Firecrawl's 300s cap; give headroom.
+        .readTimeout(330, TimeUnit.SECONDS)
+        .writeTimeout(45, TimeUnit.SECONDS)
+        .callTimeout(360, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val anyAdapter = moshi.adapter(Any::class.java)
+
+    data class StartResult(
+        val scrapeId: String,
+        val liveViewUrl: String?,
+        val interactiveLiveViewUrl: String?,
+        val title: String?,
+    )
+
+    data class InteractResult(
+        val success: Boolean,
+        val output: String,
+        val liveViewUrl: String?,
+        val interactiveLiveViewUrl: String?,
+    )
+
+    /** Open a browser on [url]. Temporary session (no profile is sent). */
+    suspend fun startSession(apiKey: String, url: String): StartResult = withContext(Dispatchers.IO) {
+        val json = post(
+            url = "https://api.firecrawl.dev/v2/scrape",
+            apiKey = apiKey,
+            body = mapOf(
+                "url" to url,
+                "formats" to listOf("markdown"),
+                "actions" to emptyList<Any>(),
+            ),
+        )
+        val data = json["data"] as? Map<*, *>
+        val scrapeId = firstString(json, data, listOf("scrapeId", "id", "sessionId"))
+            ?: throw Exception("Firecrawl did not return a browser session id.")
+        val metadata = data?.get("metadata") as? Map<*, *>
+        StartResult(
+            scrapeId = scrapeId,
+            liveViewUrl = firstString(json, data, listOf("liveViewUrl")),
+            interactiveLiveViewUrl = firstString(json, data, listOf("interactiveLiveViewUrl")),
+            title = (metadata?.get("title") as? String),
+        )
+    }
+
+    /** Drive the same browser with a natural-language [prompt]. */
+    suspend fun interact(apiKey: String, scrapeId: String, prompt: String): InteractResult =
+        withContext(Dispatchers.IO) {
+            val json = post(
+                url = "https://api.firecrawl.dev/v2/scrape/$scrapeId/interact",
+                apiKey = apiKey,
+                body = mapOf(
+                    "prompt" to prompt,
+                    "timeout" to 280,
+                ),
+            )
+            val data = json["data"] as? Map<*, *>
+            val output = firstString(json, data, listOf("output", "result", "stdout"))?.trim().orEmpty()
+            InteractResult(
+                success = (json["success"] as? Boolean) ?: output.isNotBlank(),
+                output = output,
+                liveViewUrl = firstString(json, data, listOf("liveViewUrl")),
+                interactiveLiveViewUrl = firstString(json, data, listOf("interactiveLiveViewUrl")),
+            )
+        }
+
+    /** Close the session. Best-effort — failures are swallowed; Firecrawl's TTL is the backstop. */
+    suspend fun stop(apiKey: String, scrapeId: String) = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url("https://api.firecrawl.dev/v2/scrape/$scrapeId/interact")
+                .addHeader("Authorization", "Bearer $apiKey")
+                .delete()
+                .build()
+            client.newCall(request).execute().use { /* ignore body/code */ }
+        }
+        Unit
+    }
+
+    private fun post(url: String, apiKey: String, body: Map<String, Any?>): Map<*, *> {
+        val reqBody = anyAdapter.toJson(body).toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .post(reqBody)
+            .build()
+        client.newCall(request).execute().use { response ->
+            val str = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                val message = when (response.code) {
+                    401, 403 -> "Invalid Firecrawl API key — check Settings."
+                    402 -> "Firecrawl credits exhausted — top up to keep browsing."
+                    404 -> "The browser session expired. Start a new one."
+                    429 -> "Firecrawl rate limit reached — try again shortly."
+                    else -> "Firecrawl browser request failed (HTTP ${response.code})."
+                }
+                throw Exception(message)
+            }
+            return anyAdapter.fromJson(str) as? Map<*, *>
+                ?: throw Exception("Firecrawl returned an unreadable response.")
+        }
+    }
+
+    /** First non-blank string for any of [keys], checking the top-level then the nested data map. */
+    private fun firstString(top: Map<*, *>, data: Map<*, *>?, keys: List<String>): String? {
+        for (k in keys) {
+            (top[k] as? String)?.takeIf { it.isNotBlank() }?.let { return it }
+            (data?.get(k) as? String)?.takeIf { it.isNotBlank() }?.let { return it }
+        }
+        return null
+    }
+}
+
+/**
+ * Pure, testable helpers for Browser Flow's website resolution and safety gating. No network —
+ * the manager owns the actual web search and Firecrawl calls.
+ */
+object BrowserResolver {
+
+    private val URL_REGEX = Regex("""\b((https?://)?([a-z0-9-]+\.)+[a-z]{2,}(/[^\s]*)?)""", RegexOption.IGNORE_CASE)
+
+    /** Sites we treat as sensitive — confirm with the user before opening. */
+    private val SENSITIVE_HINTS = listOf(
+        "bank", "icici", "hdfc", "sbi", "axis", "kotak", "paypal", "stripe", "razorpay",
+        "paytm", "phonepe", "gov", "irctc", "uidai", "incometax", "nsdl", "health", "hospital",
+        "insurance", "aadhaar", "passport", "wallet", "crypto", "binance", "coinbase",
+    )
+
+    /** Domains we avoid auto-picking during name resolution unless the user asked for them. */
+    private val DISPREFERRED_HOSTS = listOf(
+        "wikipedia.org", "facebook.com", "instagram.com", "twitter.com", "x.com",
+        "youtube.com", "play.google.com", "apps.apple.com", "linkedin.com", "pinterest.com",
+        "reddit.com", "tiktok.com", "amazon.com/dp", "quora.com",
+    )
+
+    enum class RiskKind {
+        /** Payment / checkout / booking / irreversible account change — hard handoff, never automate. */
+        HARD,
+
+        /** Sending a message/email/post — draft then confirm before it leaves. */
+        SEND,
+    }
+
+    private val HARD_KEYWORDS = listOf(
+        "pay", "payment", "checkout", "check out", "buy now", "purchase", "place order",
+        "place the order", "complete the order", "book ticket", "book the", "booking", "reserve",
+        "confirm purchase", "confirm order", "delete account", "close account", "transfer money",
+        "wire", "subscribe", "renew", "add card", "card number", "cvv",
+    )
+
+    private val SEND_KEYWORDS = listOf(
+        "send email", "send an email", "send mail", "send message", "send a message",
+        "send dm", "reply to", "post a", "post this", "submit the form", "submit form",
+        "send it", "email them", "message them",
+    )
+
+    private val BLOCKER_HINTS = mapOf(
+        "login" to "A login is required. Open the live browser to sign in yourself, then tell me to continue.",
+        "log in" to "A login is required. Open the live browser to sign in yourself, then tell me to continue.",
+        "sign in" to "A sign-in is required. Open the live browser to sign in yourself, then tell me to continue.",
+        "captcha" to "A CAPTCHA appeared. Open the live browser to solve it, then tell me to continue.",
+        "verify you are human" to "A human-verification step appeared. Open the live browser to complete it, then tell me to continue.",
+        "payment" to "This step involves payment. Open the live browser and complete it yourself — I won't automate payments.",
+        "enter your card" to "This step asks for card details. Open the live browser and complete it yourself.",
+        "otp" to "A one-time password is needed. Open the live browser to enter it, then tell me to continue.",
+    )
+
+    fun extractUrl(text: String): String? {
+        val match = URL_REGEX.find(text)?.value?.trim()?.trimEnd('.', ',', ')') ?: return null
+        // Ignore bare "x.y" that's really a sentence fragment (require a known-ish TLD length already in regex).
+        return if (match.contains('.')) normalizeUrl(match) else null
+    }
+
+    fun normalizeUrl(raw: String): String {
+        val trimmed = raw.trim()
+        return if (trimmed.startsWith("http://", true) || trimmed.startsWith("https://", true)) trimmed
+        else "https://$trimmed"
+    }
+
+    fun domainOf(url: String?): String {
+        if (url.isNullOrBlank()) return ""
+        return url.trim()
+            .removePrefix("https://").removePrefix("http://")
+            .removePrefix("www.")
+            .substringBefore('/')
+            .substringBefore('?')
+    }
+
+    fun isSensitive(url: String?): Boolean {
+        val host = domainOf(url).lowercase()
+        if (host.isBlank()) return false
+        return SENSITIVE_HINTS.any { host.contains(it) }
+    }
+
+    fun isDispreferred(url: String?): Boolean {
+        val u = (url ?: "").lowercase()
+        return DISPREFERRED_HOSTS.any { u.contains(it) }
+    }
+
+    /** Classify an instruction's risk, or null if it's ordinary navigation/reading. */
+    fun classifyInstruction(text: String): RiskKind? {
+        val t = text.lowercase()
+        if (SEND_KEYWORDS.any { t.contains(it) }) return RiskKind.SEND
+        if (HARD_KEYWORDS.any { t.contains(it) }) return RiskKind.HARD
+        return null
+    }
+
+    /** If the agent's output indicates a blocker (login/CAPTCHA/payment), return a handoff message. */
+    fun detectBlocker(output: String): String? {
+        val t = output.lowercase()
+        for ((hint, message) in BLOCKER_HINTS) {
+            if (t.contains(hint)) return message
+        }
+        return null
+    }
+
+    /** Rank web-search hits into resolution candidates, official-looking domains first. */
+    fun rankCandidates(sources: List<SearchSource>, query: String): List<BrowserCandidate> {
+        val tokens = query.lowercase().split(Regex("\\s+")).filter { it.length > 2 }
+        return sources
+            .asSequence()
+            .filter { it.url.startsWith("http") }
+            .map { src ->
+                val domain = domainOf(src.url)
+                var score = 0
+                if (!isDispreferred(src.url)) score += 3
+                // A homepage (no deep path) is more likely the official site.
+                if (src.url.trimEnd('/').count { it == '/' } <= 2) score += 2
+                if (tokens.any { domain.contains(it) }) score += 4
+                if (domain.endsWith(".com") || domain.endsWith(".in") || domain.endsWith(".org") || domain.endsWith(".net")) score += 1
+                BrowserCandidate(title = src.title.ifBlank { domain }, url = src.url, domain = domain) to score
+            }
+            .sortedByDescending { it.second }
+            .map { it.first }
+            .distinctBy { it.domain }
+            .take(4)
+            .toList()
+    }
+}

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -80,6 +80,13 @@ class SettingsRepository(context: Context) {
     private val _hfAccessToken = MutableStateFlow(getHfAccessTokenDirect())
     val hfAccessToken: StateFlow<String> = _hfAccessToken.asStateFlow()
 
+    // Browser Flow (Firecrawl Interact stateful browser; gated additionally on a Firecrawl key)
+    private val _browserFlowEnabled = MutableStateFlow(getBrowserFlowEnabledDirect())
+    val browserFlowEnabled: StateFlow<Boolean> = _browserFlowEnabled.asStateFlow()
+
+    private val _browserIdleMinutes = MutableStateFlow(getBrowserIdleMinutesDirect())
+    val browserIdleMinutes: StateFlow<Int> = _browserIdleMinutes.asStateFlow()
+
     // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
     private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
     val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
@@ -350,6 +357,25 @@ class SettingsRepository(context: Context) {
     fun saveDataAgentMaxCredits(value: Int) {
         prefs.edit().putInt("data_agent_max_credits", value).apply()
         _dataAgentMaxCredits.value = value
+    }
+
+    // ── Browser Flow ───────────────────────────────────────────────────────────────────
+
+    fun getBrowserFlowEnabledDirect(): Boolean =
+        prefs.getBoolean("browser_flow_enabled", false)
+
+    fun saveBrowserFlowEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("browser_flow_enabled", enabled).apply()
+        _browserFlowEnabled.value = enabled
+    }
+
+    /** Minutes of inactivity before Browser Flow auto-stops the session (cost guard). 0 = off. */
+    fun getBrowserIdleMinutesDirect(): Int =
+        prefs.getInt("browser_idle_minutes", 3)
+
+    fun saveBrowserIdleMinutes(value: Int) {
+        prefs.edit().putInt("browser_idle_minutes", value).apply()
+        _browserIdleMinutes.value = value
     }
 
     companion object {

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -311,6 +311,42 @@ object SystemPrompts {
             "item. Prefer many short, specific fields over a single long text field, and use " +
             "concise human-readable field names."
 
+    // ── Browser Flow ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Safety preamble EchoFlow prepends to every Browser Flow `/interact` call (no LLM planner
+     * in v1). Keeps the agent on the current session and forbids irreversible actions: it must
+     * stop and report rather than pay, submit accounts changes, or send anything on its own.
+     */
+    fun browserInteractPrompt(instruction: String, draftMode: Boolean): String = buildString {
+        append("You are controlling a live web browser on the user's behalf, continuing from the current page and session. ")
+        append("Do the task, then briefly report what you did and what is now on screen.\n\n")
+        append("Rules:\n")
+        append("- Do NOT save logins, cookies or credentials. This is a temporary session.\n")
+        append("- NEVER complete payments, checkout, place orders, book/confirm purchases, transfer money, or change/delete account settings. ")
+        append("If the task needs that, STOP and reply that the user must do it themselves in the live browser.\n")
+        append("- If you hit a login, CAPTCHA, OTP, paywall or human-verification step, STOP and say exactly which one — do not attempt to bypass it.\n")
+        if (draftMode) {
+            append("- The user wants to send a message/email. COMPOSE it but DO NOT send or submit it. ")
+            append("Return the exact final text you would send, clearly, so the user can confirm first.\n")
+        } else {
+            append("- Do not send messages, emails or form submissions unless the task explicitly says to, and even then only non-sensitive ones.\n")
+        }
+        append("\nTask: ")
+        append(instruction.trim())
+    }
+
+    /** Final-turn prompt used by Finish: summarize the session before it is closed. */
+    fun browserFinishPrompt(): String =
+        "Summarize what was accomplished in this browser session and the final state of the page " +
+            "(key items, prices, links or results found). Be concise and useful. Do not take any " +
+            "further action — this is the closing summary."
+
+    /** Prompt to actually send a message the user already reviewed and confirmed. */
+    fun browserSendConfirmedPrompt(draft: String): String =
+        "The user has reviewed and approved the following message. Send/submit it exactly as written, " +
+            "then confirm it was sent.\n\nApproved message:\n" + draft.trim()
+
     private fun formatting(isLocalModel: Boolean): String = buildString {
         append(
             "## Style\n" +

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -64,6 +64,12 @@ private data class ActiveStreamState(
     val isLocal: Boolean = false
 )
 
+data class BrowserStartConflict(
+    val activeSession: BrowserSession,
+    val targetChatId: String?,
+    val pendingPrompt: String,
+)
+
 class ChatViewModel(
     application: Application,
     private val chatDao: ChatDao,
@@ -74,12 +80,20 @@ class ChatViewModel(
     private val deepResearchModelDao: DeepResearchModelDao,
     private val advisorProfileDao: AdvisorProfileDao,
     private val fusionPanelDao: FusionPanelDao,
-    private val agentProfileDao: AgentProfileDao
+    private val agentProfileDao: AgentProfileDao,
+    private val browserSessionDao: BrowserSessionDao,
+    private val browserStepDao: BrowserStepDao
 ) : AndroidViewModel(application) {
 
     private val openRouterService = OpenRouterService(application)
     private val webSearchService = WebSearchService()
     private val localLlmService = LocalLlmService(application)
+
+    // Browser Flow: stateful Firecrawl browser controlled through chat. The manager owns all
+    // orchestration and writes session/step rows; the UI observes them.
+    private val browserAgent = BrowserAgentManager(
+        chatDao, messageDao, browserSessionDao, browserStepDao, settingsRepository, webSearchService, viewModelScope
+    )
 
     val allThreads: StateFlow<List<ChatThread>> = chatDao.getAllThreads()
         .stateIn(
@@ -226,6 +240,53 @@ class ChatViewModel(
     private val _echoAgentActive = MutableStateFlow(false)
     val echoAgentActive: StateFlow<Boolean> = _echoAgentActive.asStateFlow()
 
+    // Browser Flow igniter chip. Unlike Echo modes it is NOT sticky: it only *starts* a session;
+    // once a session exists, the session row (not this flag) captures the owning chat's routing.
+    private val _browserFlowActive = MutableStateFlow(false)
+    val browserFlowActive: StateFlow<Boolean> = _browserFlowActive.asStateFlow()
+
+    /** The single app-wide live browser session (start-lock + global pill). */
+    val activeBrowserSession: StateFlow<BrowserSession?> = browserAgent.activeSession
+
+    /** The live browser session owning the open chat, if any (drives the in-chat card/capture). */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentBrowserSession: StateFlow<BrowserSession?> = _currentChatThreadId
+        .flatMapLatest { chatId -> if (chatId == null) flowOf(null) else browserAgent.observeForChat(chatId) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    /** Timeline steps for the open chat's session. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentBrowserSteps: StateFlow<List<BrowserStep>> = currentBrowserSession
+        .flatMapLatest { s -> if (s == null) flowOf(emptyList()) else browserAgent.observeSteps(s.id) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** Browser Flow is offered when enabled in Settings and a Firecrawl key exists. */
+    val browserFlowAvailable: StateFlow<Boolean> = combine(
+        settingsRepository.browserFlowEnabled, settingsRepository.firecrawlApiKey
+    ) { enabled, key -> enabled && key.isNotBlank() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    /** Which chat's Browser Workspace should be open fullscreen (null = closed). */
+    private val _browserWorkspaceChatId = MutableStateFlow<String?>(null)
+    val browserWorkspaceChatId: StateFlow<String?> = _browserWorkspaceChatId.asStateFlow()
+
+    /** Set when the user tries to start a 2nd session while one is already live elsewhere. */
+    private val _browserStartConflict = MutableStateFlow<BrowserStartConflict?>(null)
+    val browserStartConflict: StateFlow<BrowserStartConflict?> = _browserStartConflict.asStateFlow()
+
+    init {
+        // Auto-open the workspace when a session goes live (the manager requests it).
+        viewModelScope.launch {
+            browserAgent.openWorkspaceFor.collect { chatId ->
+                if (chatId != null) {
+                    _currentChatThreadId.value = chatId
+                    _browserWorkspaceChatId.value = chatId
+                    browserAgent.clearWorkspaceRequest()
+                }
+            }
+        }
+    }
+
     /** The Deep Research engine/model the user has added (built-in provider engines + agentic). */
     val deepResearchModels: StateFlow<List<DeepResearchModel>> = deepResearchModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -241,7 +302,7 @@ class ChatViewModel(
     // Web Search, Deep Research, Data Agent, Echo Adviser and Echo Fusion are mutually
     // exclusive capabilities — turning one on clears the rest.
     private fun clearCapabilitiesExcept(keep: MutableStateFlow<Boolean>) {
-        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive)
+        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive, _browserFlowActive)
             .filter { it !== keep }
             .forEach { it.value = false }
     }
@@ -280,6 +341,52 @@ class ChatViewModel(
         val next = !_echoAgentActive.value
         _echoAgentActive.value = next
         if (next) clearCapabilitiesExcept(_echoAgentActive)
+    }
+
+    fun toggleBrowserFlow() {
+        val next = !_browserFlowActive.value
+        _browserFlowActive.value = next
+        if (next) clearCapabilitiesExcept(_browserFlowActive)
+    }
+
+    // ── Browser Flow actions (delegate to the manager; the card/workspace observe its rows) ──
+
+    fun openBrowserWorkspace(chatId: String) {
+        _currentChatThreadId.value = chatId
+        clearError()
+        _browserWorkspaceChatId.value = chatId
+    }
+
+    fun closeBrowserWorkspace() {
+        _browserWorkspaceChatId.value = null
+        browserAgent.clearWorkspaceRequest()
+    }
+
+    fun browserResolveCandidate(sessionId: String, url: String) = browserAgent.resolveCandidate(sessionId, url)
+    fun browserConfirmDomain(sessionId: String) = browserAgent.confirmDomain(sessionId)
+    fun browserConfirmSend(sessionId: String) = browserAgent.confirmSend(sessionId)
+    fun browserCancelPending(sessionId: String) = browserAgent.cancelPending(sessionId)
+    fun browserStop(sessionId: String) {
+        browserAgent.stop(sessionId)
+        if (_browserWorkspaceChatId.value != null) closeBrowserWorkspace()
+    }
+    fun browserFinish(sessionId: String) = browserAgent.finish(sessionId)
+
+    fun dismissBrowserConflict() { _browserStartConflict.value = null }
+
+    fun browserReturnToActive() {
+        _browserStartConflict.value?.let { openBrowserWorkspace(it.activeSession.chatId) }
+        _browserStartConflict.value = null
+    }
+
+    /** Finish the currently-active session, then start a new one in the chat that requested it. */
+    fun browserFinishActiveThenStart() {
+        val conflict = _browserStartConflict.value ?: return
+        _browserStartConflict.value = null
+        viewModelScope.launch {
+            browserAgent.finishNow(conflict.activeSession.id)
+            startBrowserSession(conflict.pendingPrompt, force = true, targetChatId = conflict.targetChatId)
+        }
     }
 
     fun selectThread(chatId: String?) {
@@ -529,6 +636,18 @@ class ChatViewModel(
         }
         if (_dataAgentActive.value && prompt.isNotEmpty()) {
             startDataAgent(prompt)
+            return
+        }
+        // Browser Flow: the owning chat is captured — every message drives the same live browser.
+        val activeBrowser = currentBrowserSession.value
+        if (activeBrowser != null && prompt.isNotEmpty()) {
+            clearPendingAttachment()
+            browserAgent.sendCommand(activeBrowser.chatId, prompt)
+            return
+        }
+        // Igniter: the "+ → Browser Flow" chip starts a new session, then turns itself off.
+        if (_browserFlowActive.value && prompt.isNotEmpty()) {
+            startBrowserSession(prompt)
             return
         }
 
@@ -946,6 +1065,51 @@ class ChatViewModel(
     }
 
     /** Start a Firecrawl Data Agent run (structured extraction). */
+    private fun startBrowserSession(prompt: String, force: Boolean = false, targetChatId: String? = null) {
+        viewModelScope.launch {
+            clearError()
+            if (!settingsRepository.getBrowserFlowEnabledDirect()) {
+                _errorMessage.value = "Turn on Browser Flow in Settings first."
+                return@launch
+            }
+            if (settingsRepository.getSearchApiKeyDirect("firecrawl").isBlank()) {
+                _errorMessage.value = "Add your Firecrawl API key in Settings → Web search."
+                return@launch
+            }
+            // One live browser session app-wide — block starting a second.
+            if (!force) {
+                browserAgent.activeSession.value?.let { existing ->
+                    _browserStartConflict.value = BrowserStartConflict(
+                        activeSession = existing,
+                        targetChatId = _currentChatThreadId.value,
+                        pendingPrompt = prompt,
+                    )
+                    return@launch
+                }
+            }
+
+            val now = System.currentTimeMillis()
+            var chatId = targetChatId ?: _currentChatThreadId.value
+            if (chatId == null) {
+                chatId = UUID.randomUUID().toString()
+                chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
+                _currentChatThreadId.value = chatId
+            } else {
+                _currentChatThreadId.value = chatId
+            }
+            // Title a fresh thread from the instruction (manager writes the message rows).
+            chatDao.getThreadById(chatId)?.let { thread ->
+                if (thread.title == "New Conversation") {
+                    val words = prompt.split("\\s+".toRegex())
+                    val title = words.take(5).joinToString(" ") + if (words.size > 5) "…" else ""
+                    chatDao.updateThread(thread.copy(title = title.ifBlank { "Browser session" }))
+                }
+            }
+            _browserFlowActive.value = false // igniter consumed
+            browserAgent.startSession(chatId, prompt)
+        }
+    }
+
     private fun startDataAgent(topic: String) {
         viewModelScope.launch {
             clearError()
@@ -1309,14 +1473,16 @@ class ChatViewModel(
             deepResearchModelDao: DeepResearchModelDao,
             advisorProfileDao: AdvisorProfileDao,
             fusionPanelDao: FusionPanelDao,
-            agentProfileDao: AgentProfileDao
+            agentProfileDao: AgentProfileDao,
+            browserSessionDao: BrowserSessionDao,
+            browserStepDao: BrowserStepDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
-                    agentProfileDao
+                    agentProfileDao, browserSessionDao, browserStepDao
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -80,6 +80,10 @@ class SettingsViewModel(
     val dataAgentEngine: StateFlow<String> = repository.dataAgentEngine
     val dataAgentMaxCredits: StateFlow<Int> = repository.dataAgentMaxCredits
 
+    // Browser Flow
+    val browserFlowEnabled: StateFlow<Boolean> = repository.browserFlowEnabled
+    val browserIdleMinutes: StateFlow<Int> = repository.browserIdleMinutes
+
     // Echo Adviser / Echo Fusion
     val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
     val echoFusionPanelId: StateFlow<String> = repository.echoFusionPanelId
@@ -216,6 +220,8 @@ class SettingsViewModel(
     fun saveDeepResearchExaEffort(value: String) = repository.saveDeepResearchExaEffort(value)
 
     fun saveDataAgentEnabled(enabled: Boolean) = repository.saveDataAgentEnabled(enabled)
+    fun saveBrowserFlowEnabled(enabled: Boolean) = repository.saveBrowserFlowEnabled(enabled)
+    fun saveBrowserIdleMinutes(value: Int) = repository.saveBrowserIdleMinutes(value)
     fun saveDataAgentEngine(id: String) = repository.saveDataAgentEngine(id)
     fun saveDataAgentMaxCredits(value: Int) = repository.saveDataAgentMaxCredits(value)
 

--- a/app/src/main/java/com/echoflow/ui/components/BrowserComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/BrowserComponents.kt
@@ -1,0 +1,338 @@
+package com.echoflow.ui.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.BrowserResolver
+import com.echoflow.data.BrowserSession
+import com.echoflow.data.BrowserStep
+import com.echoflow.ui.theme.Spacing
+
+/** Short, legible status label for the pill (collapses the 9 internal statuses). */
+fun browserStatusLabel(session: BrowserSession): String = when (session.status) {
+    BrowserSession.STATUS_RESOLVING -> "Finding site"
+    BrowserSession.STATUS_STARTING -> "Opening"
+    BrowserSession.STATUS_RUNNING -> "Running"
+    BrowserSession.STATUS_AWAITING_USER -> if (session.pendingKind == BrowserSession.PENDING_DRAFT_CONFIRM) "Confirm" else "Needs you"
+    BrowserSession.STATUS_AWAITING_INSTRUCTION -> "Live"
+    BrowserSession.STATUS_COMPLETED -> "Done"
+    BrowserSession.STATUS_STOPPED -> "Stopped"
+    BrowserSession.STATUS_EXPIRED -> "Expired"
+    BrowserSession.STATUS_FAILED -> "Error"
+    else -> session.status
+}
+
+@Composable
+private fun browserStatusColor(session: BrowserSession): Color = when (session.status) {
+    BrowserSession.STATUS_AWAITING_USER -> MaterialTheme.colorScheme.tertiary
+    BrowserSession.STATUS_FAILED -> MaterialTheme.colorScheme.error
+    BrowserSession.STATUS_STOPPED, BrowserSession.STATUS_EXPIRED -> MaterialTheme.colorScheme.outline
+    else -> MaterialTheme.colorScheme.primary
+}
+
+private fun browserBusy(session: BrowserSession): Boolean =
+    session.status == BrowserSession.STATUS_RESOLVING ||
+        session.status == BrowserSession.STATUS_STARTING ||
+        session.status == BrowserSession.STATUS_RUNNING
+
+@Composable
+fun BrowserStatusPill(session: BrowserSession, modifier: Modifier = Modifier) {
+    val color = browserStatusColor(session)
+    Surface(
+        shape = CircleShape,
+        color = color.copy(alpha = 0.14f),
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            PulsingDot(color = color, animate = browserBusy(session) || session.status == BrowserSession.STATUS_AWAITING_INSTRUCTION)
+            Text(
+                browserStatusLabel(session),
+                style = MaterialTheme.typography.labelMedium,
+                color = color,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PulsingDot(color: Color, animate: Boolean, size: androidx.compose.ui.unit.Dp = 8.dp) {
+    val alpha = if (animate) {
+        val t = rememberInfiniteTransition(label = "dot")
+        val a by t.animateFloat(
+            initialValue = 0.35f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(tween(900), RepeatMode.Reverse),
+            label = "dotAlpha",
+        )
+        a
+    } else 1f
+    Box(Modifier.size(size).background(color.copy(alpha = alpha), CircleShape))
+}
+
+/**
+ * The floating "remote browser active" pill shown app-wide while a session is live and the
+ * workspace is closed. Privacy-first: the user is never unaware a remote browser is running.
+ */
+@Composable
+fun GlobalBrowserPill(
+    session: BrowserSession,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.inverseSurface,
+        shadowElevation = 8.dp,
+        modifier = modifier.clickable(onClick = onClick),
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            PulsingDot(color = MaterialTheme.colorScheme.error, animate = true)
+            Column {
+                Text(
+                    "Remote browser active",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                val domain = BrowserResolver.domainOf(session.resolvedUrl)
+                Text(
+                    if (domain.isNotBlank()) "$domain · ${browserStatusLabel(session)}" else browserStatusLabel(session),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.8f),
+                )
+            }
+            Spacer(Modifier.width(Spacing.xs))
+            Icon(Icons.Default.OpenInNew, "Open", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.inverseOnSurface)
+        }
+    }
+}
+
+/**
+ * The persistent in-chat Browser Flow card: status, domain, the current pause's controls
+ * (disambiguation / confirm / handoff / draft) and the Open/Finish/Stop actions.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun BrowserSessionCard(
+    session: BrowserSession,
+    steps: List<BrowserStep>,
+    onOpen: () -> Unit,
+    onFinish: () -> Unit,
+    onStop: () -> Unit,
+    onPickCandidate: (String) -> Unit,
+    onConfirmDomain: () -> Unit,
+    onConfirmSend: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+            // Header
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primaryContainer, modifier = Modifier.size(36.dp)) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(Icons.Default.Language, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimaryContainer)
+                    }
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Column(Modifier.weight(1f)) {
+                    Text("Browser Flow", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    val domain = BrowserResolver.domainOf(session.resolvedUrl)
+                    Text(
+                        domain.ifBlank { session.phase ?: "Starting…" },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                BrowserStatusPill(session)
+            }
+
+            if (browserBusy(session)) {
+                LinearProgressIndicator(Modifier.fillMaxWidth())
+                session.phase?.let { Text(it, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            }
+
+            // Pause controls
+            when {
+                session.status == BrowserSession.STATUS_AWAITING_USER &&
+                    session.pendingKind == BrowserSession.PENDING_DISAMBIGUATION -> {
+                    Text("Which site should I open?", style = MaterialTheme.typography.bodyMedium)
+                    if (session.candidates.isEmpty()) {
+                        Text(
+                            "Type the website URL or exact name in the message box below.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                            session.candidates.forEach { c ->
+                                AssistChip(
+                                    onClick = { onPickCandidate(c.url) },
+                                    label = { Text(c.domain, maxLines = 1) },
+                                    leadingIcon = { Icon(Icons.Default.Language, null, Modifier.size(16.dp)) },
+                                )
+                            }
+                        }
+                        Text(
+                            "Not listed? Type the URL in the message box (Other).",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                session.status == BrowserSession.STATUS_AWAITING_USER &&
+                    session.pendingKind == BrowserSession.PENDING_CONFIRM_DOMAIN -> {
+                    Text(
+                        "${BrowserResolver.domainOf(session.resolvedUrl)} looks sensitive (banking/payments/account). Open it?",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onConfirmDomain) { Text("Open it") }
+                        OutlinedButton(onClick = onCancel) { Text("Cancel") }
+                    }
+                }
+
+                session.status == BrowserSession.STATUS_AWAITING_USER &&
+                    session.pendingKind == BrowserSession.PENDING_HANDOFF -> {
+                    Text(session.lastOutput ?: "This step needs you.", style = MaterialTheme.typography.bodyMedium)
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onOpen) {
+                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
+                        }
+                        OutlinedButton(onClick = onCancel) { Text("Skip") }
+                    }
+                    Text(
+                        "When you're done, type \"continue\" to resume.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                session.status == BrowserSession.STATUS_AWAITING_USER &&
+                    session.pendingKind == BrowserSession.PENDING_DRAFT_CONFIRM -> {
+                    Text("Review before sending:", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+                    Surface(
+                        shape = RoundedCornerShape(14.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            session.pendingDraft.orEmpty(),
+                            Modifier.padding(Spacing.s),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onConfirmSend) {
+                            Icon(Icons.AutoMirrored.Filled.Send, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Send")
+                        }
+                        OutlinedButton(onClick = onCancel) { Text("Don't send") }
+                    }
+                }
+
+                session.status == BrowserSession.STATUS_AWAITING_INSTRUCTION -> {
+                    session.lastOutput?.let {
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // Privacy/cost footer
+            if (session.hasLiveBrowser && !session.isTerminal) {
+                Text(
+                    "Temporary · nothing saved · ~${BrowserSession.CREDITS_PER_MINUTE} cr/min while open",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // Actions
+            if (!session.isTerminal) {
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                    if (session.hasLiveBrowser) {
+                        Button(onClick = onOpen, modifier = Modifier.weight(1f)) {
+                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open browser")
+                        }
+                    }
+                    OutlinedButton(
+                        onClick = onFinish,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.Default.DoneAll, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Finish")
+                    }
+                    OutlinedButton(
+                        onClick = onStop,
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                    ) {
+                        Icon(Icons.Default.Stop, "Stop", Modifier.size(18.dp))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -1,0 +1,387 @@
+package com.echoflow.ui.screens
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.echoflow.data.BrowserResolver
+import com.echoflow.data.BrowserSession
+import com.echoflow.data.BrowserStep
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.components.BrowserStatusPill
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The native, fullscreen Browser Workspace — a mini-browser inside EchoFlow wrapped around the
+ * live Firecrawl browser stream ([BrowserSession.interactiveLiveViewUrl]). Browser-dominant: the
+ * WebView fills the screen, a command composer sits at the bottom, and a pull-up drawer shows the
+ * activity timeline. The live page is itself the progress indicator while the agent works.
+ */
+@Composable
+fun BrowserWorkspaceScreen(
+    chatViewModel: ChatViewModel,
+    onClose: () -> Unit,
+) {
+    val session by chatViewModel.currentBrowserSession.collectAsState()
+    val steps by chatViewModel.currentBrowserSteps.collectAsState()
+    val context = LocalContext.current
+
+    // If the session ends (Finish/Stop/expire), leave the workspace.
+    LaunchedEffect(session?.isTerminal, session == null) {
+        if (session == null || session?.isTerminal == true) onClose()
+    }
+    val s = session ?: return
+
+    var command by remember { mutableStateOf("") }
+    var drawerOpen by remember { mutableStateOf(false) }
+
+    val busy = s.status == BrowserSession.STATUS_RUNNING ||
+        s.status == BrowserSession.STATUS_STARTING ||
+        s.status == BrowserSession.STATUS_RESOLVING
+    val liveUrl = s.interactiveLiveViewUrl ?: s.liveViewUrl
+
+    fun openExternal() {
+        val url = s.interactiveLiveViewUrl ?: s.liveViewUrl ?: return
+        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
+    }
+
+    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Column(Modifier.fillMaxSize()) {
+            // ── Top bar ────────────────────────────────────────────────────────────────
+            Surface(color = MaterialTheme.colorScheme.surfaceContainer, shadowElevation = 2.dp) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .padding(horizontal = Spacing.s, vertical = Spacing.s),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(onClick = onClose) { Icon(Icons.Default.Close, "Close workspace") }
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            BrowserResolver.domainOf(s.resolvedUrl).ifBlank { "Browser Flow" },
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            "Temporary · nothing saved · ~${BrowserSession.CREDITS_PER_MINUTE} cr/min",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    BrowserStatusPill(s)
+                    Spacer(Modifier.width(Spacing.xs))
+                    IconButton(onClick = { chatViewModel.browserStop(s.id) }) {
+                        Icon(Icons.Default.Stop, "Stop session", tint = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+
+            // ── Live browser ───────────────────────────────────────────────────────────
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                if (liveUrl != null) {
+                    LiveBrowserWebView(url = liveUrl, modifier = Modifier.fillMaxSize())
+                } else {
+                    Column(
+                        Modifier.fillMaxSize().padding(Spacing.l),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            if (busy) "Opening the browser…" else "Live view isn't available.",
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+
+                // Transient phase overlay while the agent is driving.
+                AnimatedVisibility(visible = busy, modifier = Modifier.align(Alignment.TopCenter)) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.inverseSurface,
+                        modifier = Modifier.padding(top = Spacing.s),
+                    ) {
+                        Row(
+                            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                        ) {
+                            LinearProgressIndicator(Modifier.width(40.dp))
+                            Text(
+                                s.phase ?: "Working…",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.inverseOnSurface,
+                            )
+                        }
+                    }
+                }
+
+                // External-browser escape hatch (WebView fallback).
+                if (liveUrl != null) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.s).clickable { openExternal() },
+                    ) {
+                        Icon(
+                            Icons.Default.OpenInNew, "Open in external browser",
+                            Modifier.padding(Spacing.s).size(20.dp),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+            }
+
+            // ── Pause action bar (needs-you states) ──────────────────────────────────────
+            BrowserPauseBar(
+                session = s,
+                onPick = { chatViewModel.browserResolveCandidate(s.id, it) },
+                onConfirmDomain = { chatViewModel.browserConfirmDomain(s.id) },
+                onConfirmSend = { chatViewModel.browserConfirmSend(s.id) },
+                onCancel = { chatViewModel.browserCancelPending(s.id) },
+                onOpenExternal = { openExternal() },
+            )
+
+            // ── Activity drawer (pull-up timeline) ───────────────────────────────────────
+            Surface(color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(Modifier.fillMaxWidth()) {
+                    Row(
+                        Modifier.fillMaxWidth().clickable { drawerOpen = !drawerOpen }.padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("Activity", style = MaterialTheme.typography.labelLarge, modifier = Modifier.weight(1f))
+                        Text("${steps.size}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Icon(if (drawerOpen) Icons.Default.ExpandMore else Icons.Default.ExpandLess, null)
+                    }
+                    AnimatedVisibility(visible = drawerOpen) {
+                        LazyColumn(Modifier.fillMaxWidth().heightIn(max = 220.dp).padding(horizontal = Spacing.base)) {
+                            items(steps.reversed(), key = { it.id }) { step -> TimelineRow(step) }
+                        }
+                    }
+                }
+            }
+
+            // ── Command composer ─────────────────────────────────────────────────────────
+            Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .imePadding()
+                        .padding(Spacing.s),
+                ) {
+                    if (busy) {
+                        Text(
+                            "Agent is driving — please wait…",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = Spacing.s, bottom = 4.dp),
+                        )
+                    }
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(Modifier.padding(Spacing.xs), verticalAlignment = Alignment.CenterVertically) {
+                            TextField(
+                                value = command,
+                                onValueChange = { command = it },
+                                enabled = !busy,
+                                placeholder = { Text("Command the browser…") },
+                                maxLines = 4,
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    disabledContainerColor = Color.Transparent,
+                                    focusedIndicatorColor = Color.Transparent,
+                                    unfocusedIndicatorColor = Color.Transparent,
+                                    disabledIndicatorColor = Color.Transparent,
+                                ),
+                                modifier = Modifier.weight(1f),
+                            )
+                            val canSend = command.trim().isNotEmpty() && !busy
+                            IconButton(
+                                onClick = {
+                                    val t = command.trim()
+                                    command = ""
+                                    chatViewModel.sendMessage(t)
+                                },
+                                enabled = canSend,
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.Send,
+                                    "Send command",
+                                    tint = if (canSend) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowserPauseBar(
+    session: BrowserSession,
+    onPick: (String) -> Unit,
+    onConfirmDomain: () -> Unit,
+    onConfirmSend: () -> Unit,
+    onCancel: () -> Unit,
+    onOpenExternal: () -> Unit,
+) {
+    if (session.status != BrowserSession.STATUS_AWAITING_USER) return
+    Surface(color = MaterialTheme.colorScheme.tertiaryContainer) {
+        Column(Modifier.fillMaxWidth().padding(Spacing.base), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+            when (session.pendingKind) {
+                BrowserSession.PENDING_DISAMBIGUATION -> {
+                    Text("Which site? Tap one, or type a URL below.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onTertiaryContainer)
+                    session.candidates.forEach { c ->
+                        OutlinedButton(onClick = { onPick(c.url) }, modifier = Modifier.fillMaxWidth()) {
+                            Text(c.domain, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                    }
+                }
+                BrowserSession.PENDING_CONFIRM_DOMAIN -> {
+                    Text("${BrowserResolver.domainOf(session.resolvedUrl)} looks sensitive. Open it?", color = MaterialTheme.colorScheme.onTertiaryContainer)
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onConfirmDomain) { Text("Open it") }
+                        OutlinedButton(onClick = onCancel) { Text("Cancel") }
+                    }
+                }
+                BrowserSession.PENDING_HANDOFF -> {
+                    Text(session.lastOutput ?: "This step needs you.", color = MaterialTheme.colorScheme.onTertiaryContainer)
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onOpenExternal) {
+                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
+                        }
+                        OutlinedButton(onClick = onCancel) { Text("Skip") }
+                    }
+                    Text("Then type \"continue\" below.", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onTertiaryContainer)
+                }
+                BrowserSession.PENDING_DRAFT_CONFIRM -> {
+                    Text("Review before sending:", fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onTertiaryContainer)
+                    Surface(shape = RoundedCornerShape(12.dp), color = MaterialTheme.colorScheme.surface) {
+                        Text(session.pendingDraft.orEmpty(), Modifier.padding(Spacing.s), style = MaterialTheme.typography.bodyMedium)
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                        Button(onClick = onConfirmSend) {
+                            Icon(Icons.AutoMirrored.Filled.Send, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Send")
+                        }
+                        OutlinedButton(onClick = onCancel) { Text("Don't send") }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineRow(step: BrowserStep) {
+    val color = when (step.role) {
+        "user" -> MaterialTheme.colorScheme.primary
+        "agent" -> MaterialTheme.colorScheme.onSurface
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+        Box(Modifier.padding(top = 6.dp).size(6.dp).background(color, CircleShape))
+        Text(step.text, style = MaterialTheme.typography.bodySmall, color = color, modifier = Modifier.weight(1f))
+    }
+}
+
+/** WebView showing the live remote browser. Created on enter, destroyed on leave (lean). */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun LiveBrowserWebView(url: String, modifier: Modifier = Modifier) {
+    var lastUrl by remember { mutableStateOf<String?>(null) }
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            WebView(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.mediaPlaybackRequiresUserGesture = false
+                settings.useWideViewPort = true
+                settings.loadWithOverviewMode = true
+                webViewClient = WebViewClient()
+                loadUrl(url)
+                lastUrl = url
+            }
+        },
+        update = { web ->
+            if (lastUrl != url) {
+                web.loadUrl(url)
+                lastUrl = url
+            }
+        },
+        onRelease = { web ->
+            web.stopLoading()
+            web.loadUrl("about:blank")
+            web.destroy()
+        },
+    )
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -149,6 +149,19 @@ fun ChatScreen(
     val echoAgentProfileId by settingsViewModel.echoAgentProfileId.collectAsState()
     val activeAgent = agentProfiles.firstOrNull { it.id == echoAgentProfileId }
 
+    val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
+    val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
+    val browserSession by chatViewModel.currentBrowserSession.collectAsState()
+    val browserSteps by chatViewModel.currentBrowserSteps.collectAsState()
+    val browserStartConflict by chatViewModel.browserStartConflict.collectAsState()
+    // The owning chat is "captured" while a session is live — every message drives the browser.
+    val browserCaptured = browserSession != null
+    val browserBusy = browserSession?.let {
+        it.status == com.echoflow.data.BrowserSession.STATUS_RUNNING ||
+            it.status == com.echoflow.data.BrowserSession.STATUS_STARTING ||
+            it.status == com.echoflow.data.BrowserSession.STATUS_RESOLVING
+    } == true
+
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
 
@@ -311,6 +324,18 @@ fun ChatScreen(
                 onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
                 onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
                 onToggleEchoAgent = { chatViewModel.toggleEchoAgent() },
+                browserFlowActive = browserFlowActive,
+                browserFlowAvailable = browserFlowAvailable,
+                onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
+                browserSession = browserSession,
+                browserSteps = browserSteps,
+                onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },
+                onBrowserFinish = { browserSession?.let { chatViewModel.browserFinish(it.id) } },
+                onBrowserStop = { browserSession?.let { chatViewModel.browserStop(it.id) } },
+                onBrowserPick = { url -> browserSession?.let { chatViewModel.browserResolveCandidate(it.id, url) } },
+                onBrowserConfirmDomain = { browserSession?.let { chatViewModel.browserConfirmDomain(it.id) } },
+                onBrowserConfirmSend = { browserSession?.let { chatViewModel.browserConfirmSend(it.id) } },
+                onBrowserCancel = { browserSession?.let { chatViewModel.browserCancelPending(it.id) } },
                 researchInProgress = researchRun != null,
                 researchEngineLabel = drEngineLabel,
                 dataAgentLabel = dataAgentLabel,
@@ -318,6 +343,7 @@ fun ChatScreen(
                 exaEffort = exaEffort,
                 onSelectEffort = { settingsViewModel.saveDeepResearchExaEffort(it) },
                 blockedReason = when {
+                    browserBusy -> "Browser is working — please wait…"
                     researchRun != null -> "A run is in progress — see the card above"
                     localSendBlocked -> "On-device model is busy in another chat"
                     else -> null
@@ -333,6 +359,35 @@ fun ChatScreen(
                 exit = shrinkVertically() + fadeOut(),
             ) {
                 errorMessage?.let { ErrorBanner(it) { chatViewModel.clearError() } }
+            }
+
+            // One live browser session app-wide: starting a second is blocked with a choice.
+            browserStartConflict?.let { conflict ->
+                AlertDialog(
+                    onDismissRequest = { chatViewModel.dismissBrowserConflict() },
+                    title = { Text("A browser session is already active") },
+                    text = {
+                        Text(
+                            "Browser Flow is running in \"${conflict.activeSession.goal.take(40)}\". " +
+                                "Finish it before starting another, or return to it.",
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { chatViewModel.browserReturnToActive() }) { Text("Return to browser") }
+                    },
+                    dismissButton = {
+                        Row {
+                            TextButton(
+                                onClick = {
+                                    textInput = ""
+                                    chatViewModel.browserFinishActiveThenStart()
+                                },
+                                enabled = conflict.pendingPrompt.isNotEmpty(),
+                            ) { Text("Finish & start new") }
+                            TextButton(onClick = { chatViewModel.dismissBrowserConflict() }) { Text("Cancel") }
+                        }
+                    },
+                )
             }
         }
     }
@@ -1080,6 +1135,18 @@ private fun InputToolbar(
     onToggleEchoAdviser: () -> Unit,
     onToggleEchoFusion: () -> Unit,
     onToggleEchoAgent: () -> Unit,
+    browserFlowActive: Boolean,
+    browserFlowAvailable: Boolean,
+    onToggleBrowserFlow: () -> Unit,
+    browserSession: com.echoflow.data.BrowserSession?,
+    browserSteps: List<com.echoflow.data.BrowserStep>,
+    onBrowserOpen: () -> Unit,
+    onBrowserFinish: () -> Unit,
+    onBrowserStop: () -> Unit,
+    onBrowserPick: (String) -> Unit,
+    onBrowserConfirmDomain: () -> Unit,
+    onBrowserConfirmSend: () -> Unit,
+    onBrowserCancel: () -> Unit,
     researchInProgress: Boolean,
     researchEngineLabel: String?,
     dataAgentLabel: String,
@@ -1096,6 +1163,22 @@ private fun InputToolbar(
             .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
             .padding(horizontal = Spacing.base, vertical = Spacing.m),
     ) {
+        // Persistent Browser Flow card — the in-chat anchor/control surface for the live session.
+        browserSession?.let { session ->
+            com.echoflow.ui.components.BrowserSessionCard(
+                session = session,
+                steps = browserSteps,
+                onOpen = onBrowserOpen,
+                onFinish = onBrowserFinish,
+                onStop = onBrowserStop,
+                onPickCandidate = onBrowserPick,
+                onConfirmDomain = onBrowserConfirmDomain,
+                onConfirmSend = onBrowserConfirmSend,
+                onCancel = onBrowserCancel,
+                modifier = Modifier.padding(bottom = Spacing.s),
+            )
+        }
+
         AnimatedVisibility(visible = pendingUri != null) {
             pendingUri?.let { uri ->
                 Surface(
@@ -1123,7 +1206,7 @@ private fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -1131,6 +1214,9 @@ private fun InputToolbar(
             ) {
                 if (webSearchChipOn) {
                     CapabilityChip(Icons.Default.TravelExplore, "Web search", onRemove = onToggleWebSearch)
+                }
+                if (browserFlowActive) {
+                    CapabilityChip(Icons.Default.Language, "Browser Flow", onRemove = onToggleBrowserFlow)
                 }
                 if (echoAdviserActive) {
                     CapabilityChip(
@@ -1204,7 +1290,9 @@ private fun InputToolbar(
 
         Surface(
             shape = CircleShape,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            // Tint the composer while the chat is captured by a live browser session.
+            color = if (browserSession != null) MaterialTheme.colorScheme.primaryContainer
+            else MaterialTheme.colorScheme.surfaceContainerHigh,
             tonalElevation = 3.dp,
             shadowElevation = 8.dp,
             modifier = Modifier.fillMaxWidth(),
@@ -1235,6 +1323,8 @@ private fun InputToolbar(
                         echoAdviserOn = echoAdviserActive,
                         echoFusionOn = echoFusionActive,
                         echoAgentOn = echoAgentActive,
+                        browserFlowOn = browserFlowActive,
+                        browserFlowAvailable = browserFlowAvailable,
                         onImage = { plusMenuOpen = false; onAttach() },
                         onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
@@ -1243,6 +1333,7 @@ private fun InputToolbar(
                         onToggleEchoAdviser = { plusMenuOpen = false; onToggleEchoAdviser() },
                         onToggleEchoFusion = { plusMenuOpen = false; onToggleEchoFusion() },
                         onToggleEchoAgent = { plusMenuOpen = false; onToggleEchoAgent() },
+                        onToggleBrowserFlow = { plusMenuOpen = false; onToggleBrowserFlow() },
                     )
                 }
 
@@ -1252,6 +1343,8 @@ private fun InputToolbar(
                     placeholder = {
                         Text(
                             when {
+                                browserSession != null -> "Command the browser…"
+                                browserFlowActive -> "Open a site & say what to do…"
                                 dataAgentActive -> "Describe the data to extract…"
                                 deepResearchActive -> "Research a topic…"
                                 else -> "Ask anything…"
@@ -1297,6 +1390,8 @@ private fun PlusMenu(
     echoAdviserOn: Boolean,
     echoFusionOn: Boolean,
     echoAgentOn: Boolean,
+    browserFlowOn: Boolean,
+    browserFlowAvailable: Boolean,
     onImage: () -> Unit,
     onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
@@ -1305,6 +1400,7 @@ private fun PlusMenu(
     onToggleEchoAdviser: () -> Unit,
     onToggleEchoFusion: () -> Unit,
     onToggleEchoAgent: () -> Unit,
+    onToggleBrowserFlow: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
@@ -1341,6 +1437,15 @@ private fun PlusMenu(
                 leadingIcon = { Icon(Icons.Default.Dataset, null) },
                 trailingIcon = { if (dataAgentOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
                 onClick = onToggleDataAgent,
+            )
+        }
+        // Browser Flow — a live, stateful browser controlled through chat (needs a Firecrawl key).
+        if (browserFlowAvailable) {
+            DropdownMenuItem(
+                text = { Text("Browser Flow") },
+                leadingIcon = { Icon(Icons.Default.Language, null) },
+                trailingIcon = { if (browserFlowOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+                onClick = onToggleBrowserFlow,
             )
         }
         HorizontalDivider(Modifier.padding(vertical = Spacing.xs))

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.BrightnessAuto
@@ -138,6 +139,7 @@ private const val PageWebSearch = "web_search"
 private const val PageLocalModels = "local_models"
 private const val PageDeepResearch = "deep_research"
 private const val PageDataAgent = "data_agent"
+private const val PageBrowserFlow = "browser_flow"
 private const val PageEchoAdviser = "echo_adviser"
 private const val PageEchoFusion = "echo_fusion"
 private const val PageEchoAgent = "echo_agent"
@@ -192,6 +194,7 @@ fun SettingsScreen(
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageHome })
+            PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageHome })
             PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageHome })
             PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageHome })
             PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageHome })
@@ -220,6 +223,8 @@ private fun SettingsHomePage(
     val deepResearchModels by viewModel.deepResearchModels.collectAsState()
     val dataAgentEnabled by viewModel.dataAgentEnabled.collectAsState()
     val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
+    val browserFlowEnabled by viewModel.browserFlowEnabled.collectAsState()
+    val firecrawlKeyHome by viewModel.firecrawlApiKey.collectAsState()
     val advisorProfiles by viewModel.advisorProfiles.collectAsState()
     val fusionPanels by viewModel.fusionPanels.collectAsState()
     val agentProfiles by viewModel.agentProfiles.collectAsState()
@@ -263,6 +268,11 @@ private fun SettingsHomePage(
         !dataAgentEnabled -> "Off"
         else -> DataAgentCatalog.byId(dataAgentEngine)?.name ?: "On"
     }
+    val browserFlowSubtitle = when {
+        !browserFlowEnabled -> "Off"
+        firecrawlKeyHome.isBlank() -> "On · add a Firecrawl key"
+        else -> "Live browser · controlled by chat"
+    }
     val echoAdviserSubtitle = when {
         advisorProfiles.isEmpty() -> "Escalate to a stronger model · none set up"
         else -> "${advisorProfiles.size} advisor" + (if (advisorProfiles.size == 1) "" else "s")
@@ -285,7 +295,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 9,
+                index = 0, count = 10,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -295,7 +305,7 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 9,
+                index = 1, count = 10,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -305,7 +315,7 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 9,
+                index = 2, count = 10,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -315,7 +325,7 @@ private fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 3, count = 9,
+                index = 3, count = 10,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
@@ -325,7 +335,7 @@ private fun SettingsHomePage(
                 subtitle = dataAgentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 4, count = 9,
+                index = 4, count = 10,
                 onClick = { onOpen(PageDataAgent) },
             )
             SettingsNavRow(
@@ -335,7 +345,7 @@ private fun SettingsHomePage(
                 subtitle = echoAdviserSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 9,
+                index = 5, count = 10,
                 onClick = { onOpen(PageEchoAdviser) },
             )
             SettingsNavRow(
@@ -345,7 +355,7 @@ private fun SettingsHomePage(
                 subtitle = echoFusionSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 6, count = 9,
+                index = 6, count = 10,
                 onClick = { onOpen(PageEchoFusion) },
             )
             SettingsNavRow(
@@ -355,7 +365,7 @@ private fun SettingsHomePage(
                 subtitle = echoAgentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 7, count = 9,
+                index = 7, count = 10,
                 onClick = { onOpen(PageEchoAgent) },
             )
             SettingsNavRow(
@@ -365,8 +375,18 @@ private fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 8, count = 9,
+                index = 8, count = 10,
                 onClick = { onOpen(PageLocalModels) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Language,
+                polygon = MaterialShapes.Cookie4Sided,
+                title = "Browser Flow",
+                subtitle = browserFlowSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 9, count = 10,
+                onClick = { onOpen(PageBrowserFlow) },
             )
         }
     }
@@ -1397,6 +1417,82 @@ private fun DataAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                     options = listOf("1000" to "Low", "2500" to "Standard", "10000" to "High"),
                     selected = maxCredits.toString(),
                     onSelect = { viewModel.saveDataAgentMaxCredits(it.toInt()) },
+                )
+            }
+        }
+    }
+}
+
+// ── Browser Flow ──────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val enabled by viewModel.browserFlowEnabled.collectAsState()
+    val idleMinutes by viewModel.browserIdleMinutes.collectAsState()
+    val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
+
+    SettingsPageScaffold(title = "Browser Flow", subtitle = "A live browser, controlled by chat", onBack = onBack) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text("Browser Flow", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Open a real website and steer it with chat messages",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(checked = enabled, onCheckedChange = viewModel::saveBrowserFlowEnabled)
+            }
+        }
+
+        AnimatedVisibility(visible = enabled, enter = sectionEnter(), exit = sectionExit()) {
+            Column {
+                Spacer(Modifier.height(Spacing.xl))
+                FormCard {
+                    Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(
+                        "Tell it to open a site, then keep sending instructions — it controls the same live " +
+                            "Firecrawl browser until you Finish or Stop. You can watch and take over any time. " +
+                            "Sessions are temporary (no saved logins). It never automates payments or checkout, " +
+                            "and asks before sending messages. Uses Firecrawl credits (~${com.echoflow.data.BrowserSession.CREDITS_PER_MINUTE} per minute while open).",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                if (firecrawlKey.isBlank()) {
+                    Spacer(Modifier.height(Spacing.xl))
+                    Surface(
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(Modifier.fillMaxWidth().padding(Spacing.xl), horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(Icons.Default.Key, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Spacer(Modifier.height(Spacing.s))
+                            Text(
+                                "Add your Firecrawl API key in Settings → Web search to use Browser Flow.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Auto-close when idle", "Closes the session after this long with no activity (saves credits)")
+                ConnectedToggleRow(
+                    options = listOf("2" to "2 min", "3" to "3 min", "5" to "5 min", "0" to "Off"),
+                    selected = idleMinutes.toString(),
+                    onSelect = { viewModel.saveBrowserIdleMinutes(it.toInt()) },
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Add Browser Flow session and step persistence, including a Room migration for the new tables
- Wire chat navigation, composer state, and conflict handling to the live browser session
- Add Browser Flow settings, prompts, and UI entry points for the workspace and session card

## Testing
- Not run (not requested)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Browser Flow feature for AI-controlled remote browser sessions in chat
> - Introduces a full Browser Flow feature that lets users direct an AI agent to open, navigate, and interact with websites via a Firecrawl-backed remote browser session, with all state and steps persisted to Room DB.
> - Adds `BrowserAgentManager` to orchestrate session lifecycle: URL resolution, Firecrawl session start/interact/stop, risk classification, blocker detection, draft confirmation, and idle auto-expiry.
> - Adds two new Room entities (`BrowserSession`, `BrowserStep`) with a DB migration from v10 to v11, including foreign keys and indexes.
> - Integrates into `ChatScreen` and `ChatViewModel` so user prompts are routed as browser commands when a session is active, with conflict handling when a second session is attempted.
> - Adds a `BrowserWorkspaceScreen` with an in-app WebView for the live browser stream, pause/confirmation UI, activity timeline, and a command composer.
> - Adds a Settings page for Browser Flow to enable the feature, configure idle timeout (2/3/5 min or off), and surface missing Firecrawl API key warnings.
> - Risk: Browser Flow requires a Firecrawl API key and consumes credits per session; sessions left active consume resources until idle timeout expires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a53f71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* **Browser Flow**: Automate web tasks directly via chat commands with real-time interaction
* **Browser Workspace**: Full-screen native mini-browser view for monitoring and controlling automation
* **Session Management**: Track browser session status, steps, and progress with in-chat session cards
* **Safety Confirmations**: Domain verification, blocker detection (login/CAPTCHA/payment), and draft message review before execution
* **Browser Settings**: Enable/disable Browser Flow and configure auto-close idle timeout
* **Global Browser Indicator**: "Remote browser active" pill for quick workspace access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->