### PR TITLE
Fix Browser Flow release compile on main

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -154,7 +154,7 @@ fun BrowserWorkspaceScreen(
                 }
 
                 // Transient phase overlay while the agent is driving.
-                AnimatedVisibility(visible = busy, modifier = Modifier.align(Alignment.TopCenter)) {
+                androidx.compose.animation.AnimatedVisibility(visible = busy, modifier = Modifier.align(Alignment.TopCenter)) {
                     Surface(
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.inverseSurface,


### PR DESCRIPTION
## Summary
- Qualifies the Browser Workspace phase overlay AnimatedVisibility call so Compose does not resolve the ColumnScope overload inside the live browser Box.

## Testing
- ./gradlew.bat :app:compileReleaseKotlin

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release compile error in `BrowserWorkspaceScreen` by qualifying `AnimatedVisibility`
> Replaces the unqualified `AnimatedVisibility` call with the fully qualified `androidx.compose.animation.AnimatedVisibility` in [BrowserWorkspaceScreen.kt](https://github.com/adityavardhansharma/EchoFlow/pull/35/files#diff-a02559b724fdf634aa7cf3c9b1a19e767ac8e185ac7eeffcf22b51a0ee18e219) to resolve an ambiguous reference compile error on the main branch release build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ce1a42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->