### PR TITLE
Fix Browser Flow site resolution startup

### DIFF
--- a/app/src/main/java/com/echoflow/data/BrowserAgentManager.kt
+++ b/app/src/main/java/com/echoflow/data/BrowserAgentManager.kt
@@ -97,7 +97,7 @@ class BrowserAgentManager(
     fun sendCommand(chatId: String, text: String) {
         scope.launch {
             val session = sessionDao.getActiveForChat(chatId) ?: return@launch
-            if (session.status == STATUS_RESOLVING || session.status == STATUS_STARTING || session.status == STATUS_RUNNING) {
+            if (session.status == STATUS_STARTING || session.status == STATUS_RUNNING) {
                 addStep(session.id, "system", "Still working on the previous command.")
                 return@launch
             }

--- a/app/src/main/java/com/echoflow/data/FirecrawlBrowserService.kt
+++ b/app/src/main/java/com/echoflow/data/FirecrawlBrowserService.kt
@@ -59,13 +59,13 @@ class FirecrawlBrowserService {
             ),
         )
         val data = json["data"] as? Map<*, *>
-        val scrapeId = firstString(json, data, listOf("scrapeId", "id", "sessionId"))
-            ?: throw Exception("Firecrawl did not return a browser session id.")
         val metadata = data?.get("metadata") as? Map<*, *>
+        val scrapeId = firstString(json, data, metadata, listOf("scrapeId", "id", "sessionId"))
+            ?: throw Exception("Firecrawl did not return a browser session id.")
         StartResult(
             scrapeId = scrapeId,
-            liveViewUrl = firstString(json, data, listOf("liveViewUrl")),
-            interactiveLiveViewUrl = firstString(json, data, listOf("interactiveLiveViewUrl")),
+            liveViewUrl = firstString(json, data, metadata, listOf("liveViewUrl")),
+            interactiveLiveViewUrl = firstString(json, data, metadata, listOf("interactiveLiveViewUrl")),
             title = (metadata?.get("title") as? String),
         )
     }
@@ -82,12 +82,13 @@ class FirecrawlBrowserService {
                 ),
             )
             val data = json["data"] as? Map<*, *>
-            val output = firstString(json, data, listOf("output", "result", "stdout"))?.trim().orEmpty()
+            val metadata = data?.get("metadata") as? Map<*, *>
+            val output = firstString(json, data, metadata, listOf("output", "result", "stdout"))?.trim().orEmpty()
             InteractResult(
                 success = (json["success"] as? Boolean) ?: output.isNotBlank(),
                 output = output,
-                liveViewUrl = firstString(json, data, listOf("liveViewUrl")),
-                interactiveLiveViewUrl = firstString(json, data, listOf("interactiveLiveViewUrl")),
+                liveViewUrl = firstString(json, data, metadata, listOf("liveViewUrl")),
+                interactiveLiveViewUrl = firstString(json, data, metadata, listOf("interactiveLiveViewUrl")),
             )
         }
 
@@ -129,11 +130,12 @@ class FirecrawlBrowserService {
         }
     }
 
-    /** First non-blank string for any of [keys], checking the top-level then the nested data map. */
-    private fun firstString(top: Map<*, *>, data: Map<*, *>?, keys: List<String>): String? {
+    /** First non-blank string for any of [keys], checking top-level, data, then metadata. */
+    private fun firstString(top: Map<*, *>, data: Map<*, *>?, metadata: Map<*, *>?, keys: List<String>): String? {
         for (k in keys) {
             (top[k] as? String)?.takeIf { it.isNotBlank() }?.let { return it }
             (data?.get(k) as? String)?.takeIf { it.isNotBlank() }?.let { return it }
+            (metadata?.get(k) as? String)?.takeIf { it.isNotBlank() }?.let { return it }
         }
         return null
     }


### PR DESCRIPTION
## Summary
- Allow typed site answers during Browser Flow's pre-browser resolving state instead of treating them as blocked commands.
- Parse Firecrawl scrape metadata for scrapeId/live-view URLs so Browser Flow can open the interact session from v2 scrape responses.

## Testing
- ./gradlew.bat :app:compileReleaseKotlin

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Browser Flow site resolution by reading fields from nested metadata map
> - Updates `FirecrawlBrowserService.firstString` to also search a nested `metadata` map, so `scrapeId`, `liveViewUrl`, and `interactiveLiveViewUrl` in both `start` and `interact` can be resolved even when absent at the top level or in `data`.
> - Removes `STATUS_RESOLVING` from the early-return gate in `BrowserAgentManager.sendCommand`, so commands are no longer blocked with "Still working on the previous command." during site resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9c2271.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->