### PR TITLE
Group experimental modes under Echo Labs settings

### DIFF
--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -97,6 +97,17 @@ class SettingsRepository(context: Context) {
     private val _echoAgentProfileId = MutableStateFlow(getEchoAgentProfileIdDirect())
     val echoAgentProfileId: StateFlow<String> = _echoAgentProfileId.asStateFlow()
 
+    // Echo Labs master switches: each experimental mode can be turned off entirely (hides it
+    // from the in-chat "+" menu). Stable modes default on; the beta one (Browser Flow) is opt-in.
+    private val _echoAdviserEnabled = MutableStateFlow(getEchoAdviserEnabledDirect())
+    val echoAdviserEnabled: StateFlow<Boolean> = _echoAdviserEnabled.asStateFlow()
+
+    private val _echoFusionEnabled = MutableStateFlow(getEchoFusionEnabledDirect())
+    val echoFusionEnabled: StateFlow<Boolean> = _echoFusionEnabled.asStateFlow()
+
+    private val _echoAgentEnabled = MutableStateFlow(getEchoAgentEnabledDirect())
+    val echoAgentEnabled: StateFlow<Boolean> = _echoAgentEnabled.asStateFlow()
+
     // Inference parameters: one global set for on-device models, one for OpenRouter models.
     private val _localInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = true))
     val localInferenceParams: StateFlow<InferenceParams> = _localInferenceParams.asStateFlow()
@@ -359,10 +370,30 @@ class SettingsRepository(context: Context) {
         _dataAgentMaxCredits.value = value
     }
 
-    // ── Browser Flow ───────────────────────────────────────────────────────────────────
+    // ── Echo Labs master switches ──────────────────────────────────────────────────────
+
+    fun getEchoAdviserEnabledDirect(): Boolean = prefs.getBoolean("echo_adviser_enabled", true)
+    fun saveEchoAdviserEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("echo_adviser_enabled", enabled).apply()
+        _echoAdviserEnabled.value = enabled
+    }
+
+    fun getEchoFusionEnabledDirect(): Boolean = prefs.getBoolean("echo_fusion_enabled", true)
+    fun saveEchoFusionEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("echo_fusion_enabled", enabled).apply()
+        _echoFusionEnabled.value = enabled
+    }
+
+    fun getEchoAgentEnabledDirect(): Boolean = prefs.getBoolean("echo_agent_enabled", true)
+    fun saveEchoAgentEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("echo_agent_enabled", enabled).apply()
+        _echoAgentEnabled.value = enabled
+    }
+
+    // ── Browser Flow (beta) ────────────────────────────────────────────────────────────
 
     fun getBrowserFlowEnabledDirect(): Boolean =
-        prefs.getBoolean("browser_flow_enabled", false)
+        prefs.getBoolean("browser_flow_enabled", false) // beta — opt-in
 
     fun saveBrowserFlowEnabled(enabled: Boolean) {
         prefs.edit().putBoolean("browser_flow_enabled", enabled).apply()

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -80,7 +80,12 @@ class SettingsViewModel(
     val dataAgentEngine: StateFlow<String> = repository.dataAgentEngine
     val dataAgentMaxCredits: StateFlow<Int> = repository.dataAgentMaxCredits
 
-    // Browser Flow
+    // Echo Labs master switches
+    val echoAdviserEnabled: StateFlow<Boolean> = repository.echoAdviserEnabled
+    val echoFusionEnabled: StateFlow<Boolean> = repository.echoFusionEnabled
+    val echoAgentEnabled: StateFlow<Boolean> = repository.echoAgentEnabled
+
+    // Browser Flow (beta)
     val browserFlowEnabled: StateFlow<Boolean> = repository.browserFlowEnabled
     val browserIdleMinutes: StateFlow<Int> = repository.browserIdleMinutes
 
@@ -222,6 +227,9 @@ class SettingsViewModel(
     fun saveDataAgentEnabled(enabled: Boolean) = repository.saveDataAgentEnabled(enabled)
     fun saveBrowserFlowEnabled(enabled: Boolean) = repository.saveBrowserFlowEnabled(enabled)
     fun saveBrowserIdleMinutes(value: Int) = repository.saveBrowserIdleMinutes(value)
+    fun saveEchoAdviserEnabled(enabled: Boolean) = repository.saveEchoAdviserEnabled(enabled)
+    fun saveEchoFusionEnabled(enabled: Boolean) = repository.saveEchoFusionEnabled(enabled)
+    fun saveEchoAgentEnabled(enabled: Boolean) = repository.saveEchoAgentEnabled(enabled)
     fun saveDataAgentEngine(id: String) = repository.saveDataAgentEngine(id)
     fun saveDataAgentMaxCredits(value: Int) = repository.saveDataAgentMaxCredits(value)
 

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -149,6 +149,11 @@ fun ChatScreen(
     val echoAgentProfileId by settingsViewModel.echoAgentProfileId.collectAsState()
     val activeAgent = agentProfiles.firstOrNull { it.id == echoAgentProfileId }
 
+    // Echo Labs master switches gate which experimental modes appear in the "+" menu.
+    val echoAdviserEnabled by settingsViewModel.echoAdviserEnabled.collectAsState()
+    val echoFusionEnabled by settingsViewModel.echoFusionEnabled.collectAsState()
+    val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
+
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -324,6 +329,9 @@ fun ChatScreen(
                 onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
                 onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
                 onToggleEchoAgent = { chatViewModel.toggleEchoAgent() },
+                echoAdviserAvailable = echoAdviserEnabled,
+                echoFusionAvailable = echoFusionEnabled,
+                echoAgentAvailable = echoAgentEnabled,
                 browserFlowActive = browserFlowActive,
                 browserFlowAvailable = browserFlowAvailable,
                 onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
@@ -1135,6 +1143,9 @@ private fun InputToolbar(
     onToggleEchoAdviser: () -> Unit,
     onToggleEchoFusion: () -> Unit,
     onToggleEchoAgent: () -> Unit,
+    echoAdviserAvailable: Boolean,
+    echoFusionAvailable: Boolean,
+    echoAgentAvailable: Boolean,
     browserFlowActive: Boolean,
     browserFlowAvailable: Boolean,
     onToggleBrowserFlow: () -> Unit,
@@ -1266,28 +1277,6 @@ private fun InputToolbar(
                 modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
             )
         }
-        AnimatedVisibility(visible = (deepResearchActive || dataAgentActive) && blockedReason == null) {
-            Text(
-                if (dataAgentActive) "Collects data into a table · runs in the background"
-                else "Runs in the background · multiple searches · a few minutes",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
-            )
-        }
-        AnimatedVisibility(visible = (echoAdviserActive || echoFusionActive || echoAgentActive) && blockedReason == null) {
-            Text(
-                when {
-                    echoFusionActive -> "Runs a panel of models + a judge every message · cost-heavy"
-                    echoAgentActive -> "The main model hands tasks to your Echo Agent each message · adds cost"
-                    else -> "Consults a stronger advisor model each message · adds cost"
-                },
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
-            )
-        }
-
         Surface(
             shape = CircleShape,
             // Tint the composer while the chat is captured by a live browser session.
@@ -1323,6 +1312,9 @@ private fun InputToolbar(
                         echoAdviserOn = echoAdviserActive,
                         echoFusionOn = echoFusionActive,
                         echoAgentOn = echoAgentActive,
+                        echoAdviserAvailable = echoAdviserAvailable,
+                        echoFusionAvailable = echoFusionAvailable,
+                        echoAgentAvailable = echoAgentAvailable,
                         browserFlowOn = browserFlowActive,
                         browserFlowAvailable = browserFlowAvailable,
                         onImage = { plusMenuOpen = false; onAttach() },
@@ -1390,6 +1382,9 @@ private fun PlusMenu(
     echoAdviserOn: Boolean,
     echoFusionOn: Boolean,
     echoAgentOn: Boolean,
+    echoAdviserAvailable: Boolean,
+    echoFusionAvailable: Boolean,
+    echoAgentAvailable: Boolean,
     browserFlowOn: Boolean,
     browserFlowAvailable: Boolean,
     onImage: () -> Unit,
@@ -1448,27 +1443,35 @@ private fun PlusMenu(
                 onClick = onToggleBrowserFlow,
             )
         }
-        HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
-        // Echo Adviser / Echo Fusion — OpenRouter-only, cost-heavy modes. Always shown; if the
-        // key or a profile/panel is missing, sending surfaces a "set it up" message.
-        DropdownMenuItem(
-            text = { Text("Echo Adviser") },
-            leadingIcon = { Icon(Icons.Default.Psychology, null) },
-            trailingIcon = { if (echoAdviserOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
-            onClick = onToggleEchoAdviser,
-        )
-        DropdownMenuItem(
-            text = { Text("Echo Fusion") },
-            leadingIcon = { Icon(Icons.Default.AccountTree, null) },
-            trailingIcon = { if (echoFusionOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
-            onClick = onToggleEchoFusion,
-        )
-        DropdownMenuItem(
-            text = { Text("Echo Agents") },
-            leadingIcon = { Icon(Icons.Default.Hub, null) },
-            trailingIcon = { if (echoAgentOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
-            onClick = onToggleEchoAgent,
-        )
+        // Echo Labs modes — only shown when enabled in Settings → Echo Labs. If the key or a
+        // profile/panel is missing, sending surfaces a "set it up" message.
+        if (echoAdviserAvailable || echoFusionAvailable || echoAgentAvailable) {
+            HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
+        }
+        if (echoAdviserAvailable) {
+            DropdownMenuItem(
+                text = { Text("Echo Adviser") },
+                leadingIcon = { Icon(Icons.Default.Psychology, null) },
+                trailingIcon = { if (echoAdviserOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+                onClick = onToggleEchoAdviser,
+            )
+        }
+        if (echoFusionAvailable) {
+            DropdownMenuItem(
+                text = { Text("Echo Fusion") },
+                leadingIcon = { Icon(Icons.Default.AccountTree, null) },
+                trailingIcon = { if (echoFusionOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+                onClick = onToggleEchoFusion,
+            )
+        }
+        if (echoAgentAvailable) {
+            DropdownMenuItem(
+                text = { Text("Echo Agents") },
+                leadingIcon = { Icon(Icons.Default.Hub, null) },
+                trailingIcon = { if (echoAgentOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+                onClick = onToggleEchoAgent,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -140,6 +140,7 @@ private const val PageLocalModels = "local_models"
 private const val PageDeepResearch = "deep_research"
 private const val PageDataAgent = "data_agent"
 private const val PageBrowserFlow = "browser_flow"
+private const val PageEchoLabs = "echo_labs"
 private const val PageEchoAdviser = "echo_adviser"
 private const val PageEchoFusion = "echo_fusion"
 private const val PageEchoAgent = "echo_agent"
@@ -193,11 +194,12 @@ fun SettingsScreen(
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
-            PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageHome })
-            PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageHome })
-            PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageHome })
-            PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageHome })
-            PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageHome })
+            PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = { page = PageHome })
+            PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageEchoLabs })
+            PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageEchoLabs })
+            PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageEchoLabs })
+            PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageEchoLabs })
+            PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageEchoLabs })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -224,6 +226,9 @@ private fun SettingsHomePage(
     val dataAgentEnabled by viewModel.dataAgentEnabled.collectAsState()
     val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
     val browserFlowEnabled by viewModel.browserFlowEnabled.collectAsState()
+    val echoAdviserEnabled by viewModel.echoAdviserEnabled.collectAsState()
+    val echoFusionEnabled by viewModel.echoFusionEnabled.collectAsState()
+    val echoAgentEnabled by viewModel.echoAgentEnabled.collectAsState()
     val firecrawlKeyHome by viewModel.firecrawlApiKey.collectAsState()
     val advisorProfiles by viewModel.advisorProfiles.collectAsState()
     val fusionPanels by viewModel.fusionPanels.collectAsState()
@@ -273,6 +278,9 @@ private fun SettingsHomePage(
         firecrawlKeyHome.isBlank() -> "On · add a Firecrawl key"
         else -> "Live browser · controlled by chat"
     }
+    val labsOnCount = listOf(dataAgentEnabled, echoAdviserEnabled, echoFusionEnabled, echoAgentEnabled, browserFlowEnabled).count { it }
+    val echoLabsSubtitle =
+        if (labsOnCount == 0) "Experimental modes · all off" else "Experimental modes · $labsOnCount on"
     val echoAdviserSubtitle = when {
         advisorProfiles.isEmpty() -> "Escalate to a stronger model · none set up"
         else -> "${advisorProfiles.size} advisor" + (if (advisorProfiles.size == 1) "" else "s")
@@ -295,7 +303,7 @@ private fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 10,
+                index = 0, count = 6,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -305,8 +313,18 @@ private fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 10,
+                index = 1, count = 6,
                 onClick = { onOpen(PageCloudModels) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.PhoneAndroid,
+                polygon = BrandShapes.avatarStart, // Cookie9Sided
+                title = "Local models",
+                subtitle = localSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 2, count = 6,
+                onClick = { onOpen(PageLocalModels) },
             )
             SettingsNavRow(
                 icon = Icons.Default.Search,
@@ -315,7 +333,7 @@ private fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 2, count = 10,
+                index = 3, count = 6,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -325,68 +343,18 @@ private fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 3, count = 10,
+                index = 4, count = 6,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
-                icon = Icons.Default.Dataset,
-                polygon = BrandShapes.avatarEnd, // Clover4Leaf
-                title = "Data Agent",
-                subtitle = dataAgentSubtitle,
-                container = MaterialTheme.colorScheme.tertiaryContainer,
-                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 4, count = 10,
-                onClick = { onOpen(PageDataAgent) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.Psychology,
-                polygon = MaterialShapes.Cookie7Sided,
-                title = "Echo Adviser",
-                subtitle = echoAdviserSubtitle,
-                container = MaterialTheme.colorScheme.primaryContainer,
-                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 10,
-                onClick = { onOpen(PageEchoAdviser) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.AccountTree,
-                polygon = BrandShapes.avatarEnd, // Clover4Leaf
-                title = "Echo Fusion",
-                subtitle = echoFusionSubtitle,
-                container = MaterialTheme.colorScheme.secondaryContainer,
-                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 6, count = 10,
-                onClick = { onOpen(PageEchoFusion) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.Hub,
+                icon = Icons.Default.AutoAwesome,
                 polygon = MaterialShapes.Pentagon,
-                title = "Echo Agents",
-                subtitle = echoAgentSubtitle,
+                title = "Echo Labs",
+                subtitle = echoLabsSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 7, count = 10,
-                onClick = { onOpen(PageEchoAgent) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.PhoneAndroid,
-                polygon = BrandShapes.avatarStart, // Cookie9Sided
-                title = "Local models",
-                subtitle = localSubtitle,
-                container = MaterialTheme.colorScheme.primaryContainer,
-                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 8, count = 10,
-                onClick = { onOpen(PageLocalModels) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.Language,
-                polygon = MaterialShapes.Cookie4Sided,
-                title = "Browser Flow",
-                subtitle = browserFlowSubtitle,
-                container = MaterialTheme.colorScheme.primaryContainer,
-                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 9, count = 10,
-                onClick = { onOpen(PageBrowserFlow) },
+                index = 5, count = 6,
+                onClick = { onOpen(PageEchoLabs) },
             )
         }
     }
@@ -1334,6 +1302,92 @@ private fun DrEngineSelectRow(
     }
 }
 
+// ── Echo Labs (hub) ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit, onBack: () -> Unit) {
+    val dataAgentEnabled by viewModel.dataAgentEnabled.collectAsState()
+    val dataAgentEngine by viewModel.dataAgentEngine.collectAsState()
+    val echoAdviserEnabled by viewModel.echoAdviserEnabled.collectAsState()
+    val echoFusionEnabled by viewModel.echoFusionEnabled.collectAsState()
+    val echoAgentEnabled by viewModel.echoAgentEnabled.collectAsState()
+    val browserFlowEnabled by viewModel.browserFlowEnabled.collectAsState()
+    val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
+    val advisorProfiles by viewModel.advisorProfiles.collectAsState()
+    val fusionPanels by viewModel.fusionPanels.collectAsState()
+    val agentProfiles by viewModel.agentProfiles.collectAsState()
+
+    val dataAgentSubtitle = if (!dataAgentEnabled) "Off" else DataAgentCatalog.byId(dataAgentEngine)?.name ?: "On"
+    val adviserSubtitle = if (!echoAdviserEnabled) "Off" else "${advisorProfiles.size} advisor" + (if (advisorProfiles.size == 1) "" else "s")
+    val fusionSubtitle = if (!echoFusionEnabled) "Off" else "${fusionPanels.size} panel" + (if (fusionPanels.size == 1) "" else "s")
+    val agentSubtitle = if (!echoAgentEnabled) "Off" else "${agentProfiles.size} Echo Agent" + (if (agentProfiles.size == 1) "" else "s")
+    val browserSubtitle = when {
+        !browserFlowEnabled -> "Off"
+        firecrawlKey.isBlank() -> "On · add a Firecrawl key"
+        else -> "Live browser · chat-controlled"
+    }
+
+    SettingsPageScaffold(title = "Echo Labs", subtitle = "Experimental modes · turn on what you need", onBack = onBack) {
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            SettingsNavRow(
+                icon = Icons.Default.Dataset,
+                polygon = BrandShapes.avatarEnd,
+                title = "Data Agent",
+                subtitle = dataAgentSubtitle,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                index = 0, count = 4,
+                onClick = { onOpen(PageDataAgent) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Psychology,
+                polygon = MaterialShapes.Cookie7Sided,
+                title = "Echo Adviser",
+                subtitle = adviserSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 1, count = 4,
+                onClick = { onOpen(PageEchoAdviser) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.AccountTree,
+                polygon = BrandShapes.avatarEnd,
+                title = "Echo Fusion",
+                subtitle = fusionSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 2, count = 4,
+                onClick = { onOpen(PageEchoFusion) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Hub,
+                polygon = MaterialShapes.Pentagon,
+                title = "Echo Agents",
+                subtitle = agentSubtitle,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
+                index = 3, count = 4,
+                onClick = { onOpen(PageEchoAgent) },
+            )
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Beta", "Experimental · may break · uses Firecrawl credits while open")
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            SettingsNavRow(
+                icon = Icons.Default.Language,
+                polygon = MaterialShapes.Cookie4Sided,
+                title = "Browser Flow",
+                subtitle = browserSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 0, count = 1,
+                onClick = { onOpen(PageBrowserFlow) },
+            )
+        }
+    }
+}
+
 // ── Data Agent ────────────────────────────────────────────────────────────────────────
 
 @Composable
@@ -1430,6 +1484,7 @@ private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val enabled by viewModel.browserFlowEnabled.collectAsState()
     val idleMinutes by viewModel.browserIdleMinutes.collectAsState()
     val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
+    var showBetaWarning by remember { mutableStateOf(false) }
 
     SettingsPageScaffold(title = "Browser Flow", subtitle = "A live browser, controlled by chat", onBack = onBack) {
         Surface(
@@ -1439,7 +1494,18 @@ private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
         ) {
             Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
                 Column(Modifier.weight(1f)) {
-                    Text("Browser Flow", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("Browser Flow", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.width(Spacing.s))
+                        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.tertiaryContainer) {
+                            Text(
+                                "BETA",
+                                Modifier.padding(horizontal = Spacing.s, vertical = 2.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        }
+                    }
                     Text(
                         "Open a real website and steer it with chat messages",
                         style = MaterialTheme.typography.bodySmall,
@@ -1447,8 +1513,34 @@ private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                     )
                 }
                 Spacer(Modifier.width(Spacing.s))
-                Switch(checked = enabled, onCheckedChange = viewModel::saveBrowserFlowEnabled)
+                Switch(
+                    checked = enabled,
+                    // Turning it on is a beta opt-in — confirm first; off is immediate.
+                    onCheckedChange = { on -> if (on) showBetaWarning = true else viewModel.saveBrowserFlowEnabled(false) },
+                )
             }
+        }
+
+        if (showBetaWarning) {
+            AlertDialog(
+                onDismissRequest = { showBetaWarning = false },
+                icon = { Icon(Icons.Default.Science, null) },
+                title = { Text("Browser Flow is in beta") },
+                text = {
+                    Text(
+                        "This drives a real remote browser through Firecrawl. It's experimental and may " +
+                            "break or behave unexpectedly, and it uses Firecrawl credits (~7 per minute while " +
+                            "a session is open). It never automates payments or checkout, and asks before " +
+                            "sending messages. Turn it on?",
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = { viewModel.saveBrowserFlowEnabled(true); showBetaWarning = false }) {
+                        Text("Turn on")
+                    }
+                },
+                dismissButton = { TextButton(onClick = { showBetaWarning = false }) { Text("Cancel") } },
+            )
         }
 
         AnimatedVisibility(visible = enabled, enter = sectionEnter(), exit = sectionExit()) {
@@ -1502,6 +1594,26 @@ private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 // ── Echo Adviser ──────────────────────────────────────────────────────────────────────
 
 @Composable
+/** Master on/off card shown at the top of each Echo Labs feature page. */
+@Composable
+private fun LabMasterToggle(title: String, subtitle: String, enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Spacer(Modifier.width(Spacing.s))
+            Switch(checked = enabled, onCheckedChange = onToggle)
+        }
+    }
+}
+
+@Composable
 private fun EchoAdviserPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     val apiKey by viewModel.apiKey.collectAsState()
     val profiles by viewModel.advisorProfiles.collectAsState()
@@ -1515,6 +1627,9 @@ private fun EchoAdviserPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     var pendingModel by remember { mutableStateOf<OpenRouterModelInfo?>(null) }
 
     SettingsPageScaffold(title = "Echo Adviser", subtitle = "Escalate hard parts to a stronger model", onBack = onBack) {
+        val adviserEnabled by viewModel.echoAdviserEnabled.collectAsState()
+        LabMasterToggle("Echo Adviser", "Show this mode in the chat + menu", adviserEnabled, viewModel::saveEchoAdviserEnabled)
+        Spacer(Modifier.height(Spacing.m))
         FormCard {
             Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
             Spacer(Modifier.height(Spacing.s))
@@ -1605,6 +1720,9 @@ private fun EchoFusionPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     var nameDialog by remember { mutableStateOf(false) }
 
     SettingsPageScaffold(title = "Echo Fusion", subtitle = "A panel of models deliberates", onBack = onBack) {
+        val fusionEnabled by viewModel.echoFusionEnabled.collectAsState()
+        LabMasterToggle("Echo Fusion", "Show this mode in the chat + menu", fusionEnabled, viewModel::saveEchoFusionEnabled)
+        Spacer(Modifier.height(Spacing.m))
         FormCard {
             Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
             Spacer(Modifier.height(Spacing.s))
@@ -1833,6 +1951,9 @@ private fun EchoAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     var pendingModel by remember { mutableStateOf<OpenRouterModelInfo?>(null) }
 
     SettingsPageScaffold(title = "Echo Agents", subtitle = "Your main model hands work to an Echo Agent", onBack = onBack) {
+        val agentEnabled by viewModel.echoAgentEnabled.collectAsState()
+        LabMasterToggle("Echo Agents", "Show this mode in the chat + menu", agentEnabled, viewModel::saveEchoAgentEnabled)
+        Spacer(Modifier.height(Spacing.m))
         FormCard {
             Text("What it does", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
             Spacer(Modifier.height(Spacing.s))

--- a/app/src/main/java/com/echoflow/ui/theme/ExpressiveShapes.kt
+++ b/app/src/main/java/com/echoflow/ui/theme/ExpressiveShapes.kt
@@ -49,7 +49,12 @@ class RoundedPolygonShape(private val polygon: RoundedPolygon) : Shape {
         matrix.reset()
         val b = polygon.bounds()
         val maxDim = max(b.width, b.height).takeIf { it > 0f } ?: 1f
-        matrix.scale(size.width / maxDim, size.height / maxDim)
+        val scaleX = size.width / maxDim
+        val scaleY = size.height / maxDim
+        // Centre the (uniformly scaled) shape: a non-square polygon would otherwise sit flush to
+        // the top-left, making centred content (e.g. an icon) look off-centre.
+        matrix.translate((size.width - b.width * scaleX) / 2f, (size.height - b.height * scaleY) / 2f)
+        matrix.scale(scaleX, scaleY)
         matrix.translate(-b.left, -b.top)
         path.transform(matrix)
         return Outline.Generic(path)
@@ -94,8 +99,13 @@ class MorphPolygonShape(
         val path: Path = morph.toPath(progress = progress).asComposePath()
         val b = path.getBounds()
         val maxDim = max(b.width, b.height).takeIf { it > 0f } ?: 1f
+        val scaleX = size.width / maxDim
+        val scaleY = size.height / maxDim
         matrix.reset()
-        matrix.scale(size.width / maxDim, size.height / maxDim)
+        // Centre the morphed shape so centred content (the icon) stays visually centred even when
+        // the morph's bounds aren't square.
+        matrix.translate((size.width - b.width * scaleX) / 2f, (size.height - b.height * scaleY) / 2f)
+        matrix.scale(scaleX, scaleY)
         matrix.translate(-b.left, -b.top)
         path.transform(matrix)
         return Outline.Generic(path)


### PR DESCRIPTION
## What

Reorganizes Settings so experimental modes live under a single **Echo Labs** hub, and makes each one an optional on/off toggle.

**New Settings order (home):** Appearance · Cloud models · Local models · Web search · Deep Research · **Echo Labs**.

**Echo Labs hub** contains: Data Agent · Echo Adviser · Echo Fusion · Echo Agents, then a **Beta** section with **Browser Flow**.

## Changes

- **Master on/off switches** for Echo Adviser / Echo Fusion / Echo Agents (`echo_adviser_enabled` / `echo_fusion_enabled` / `echo_agent_enabled`, default **on**). A `LabMasterToggle` card sits at the top of each page, and the in-chat `+` menu items are now gated on these switches.
- **Browser Flow is now opt-in beta**: defaults **off**, badged `BETA` under Echo Labs → Beta, and enabling it shows a warning dialog (experimental, may break, ~7 Firecrawl credits/min while open; never automates payments/checkout, asks before sending).
- **Removed the descriptive helper text above the input bar** ("runs in the background", "cost-heavy", "consults a stronger advisor"…). The active chips plus the Settings descriptions already cover this; only the functional blocked-reason line remains.

## Files
- `data/SettingsRepository.kt` — 3 new master-switch prefs + getters/setters.
- `ui/SettingsViewModel.kt` — exposers + savers for the new switches.
- `ui/screens/SettingsScreen.kt` — home reorder, `EchoLabsPage` hub + Beta section, `LabMasterToggle` on the three Echo pages, Browser Flow beta dialog.
- `ui/screens/ChatScreen.kt` — `+` menu gating on the master switches; removal of input-bar helper text.

## Reviewer notes
- Defaults preserve current behavior for the stable Echo modes (on); only Browser Flow flips to opt-in.
- Per the repo build setup, this hasn't been compiled from CLI — please verify the build in **Android Studio**. The home page has a few now-unused subtitle `val`s (harmless warnings) that can be pruned in a follow-up if a warning-free build is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group experimental modes under a new Echo Labs settings hub
> - Adds a new Echo Labs hub page in settings that consolidates Data Agent, Echo Adviser, Echo Fusion, and Echo Agents; the home screen now shows a single Echo Labs entry with a summary of enabled modes instead of individual rows.
> - Adds per-feature master toggle cards (`LabMasterToggle`) on each feature's settings page, backed by new `StateFlow` properties in `SettingsRepository` persisted via `SharedPreferences`.
> - Echo Labs items in the `+` menu (`PlusMenu`) are now conditionally hidden when their corresponding master switch is off.
> - Browser Flow is marked as beta and now requires a confirmation dialog before enabling; disabling remains immediate.
> - Behavioral Change: feature settings pages now back-navigate to the Echo Labs hub rather than the home screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31abf6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added master toggle controls for Echo Labs features (Echo Adviser, Echo Fusion, Echo Agents)
  * Reorganized Settings with a dedicated Echo Labs hub page containing sub-pages for each feature
  * Echo Labs menu items now conditionally display based on enabled features
  * Added confirmation dialog for Browser Flow beta opt-in

<!-- end of auto-generated comment: release notes by coderabbit.ai -->