### PR TITLE
Fix release build + redesign Browser Workspace

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -1593,7 +1593,6 @@ private fun BrowserFlowPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
 // ── Echo Adviser ──────────────────────────────────────────────────────────────────────
 
-@Composable
 /** Master on/off card shown at the top of each Echo Labs feature page. */
 @Composable
 private fun LabMasterToggle(title: String, subtitle: String, enabled: Boolean, onToggle: (Boolean) -> Unit) {


### PR DESCRIPTION
Two changes, both on top of the merged Echo Labs work.

## 1. Build fix (critical)

PR #39 merged at a commit that predated the build fix, so `main` currently fails:

```
SettingsScreen.kt:1598 This annotation is not repeatable.
> Task :app:compileReleaseKotlin FAILED
```

The `LabMasterToggle` helper insertion left an orphaned `@Composable` stacked on it. This removes the duplicate (one-line change).

## 2. Browser Workspace redesign

Reworks the mini-browser chrome to feel native and Material 3 Expressive — no gimmick shapes:

- **Top bar**: a minimize chevron, a rounded **address bar** (lock + domain + status pill), and a tonal stop button, with a privacy/cost strip underneath.
- **Viewport**: the live page sits in a rounded container with a browser-style **wavy load bar** (`LinearWavyProgressIndicator`) pinned to the top edge, and a floating phase chip using the expressive `LoadingIndicator`.
- **Opening state**: expressive `LoadingIndicator` + "Opening <domain>…".
- **Composer**: now mirrors the chat message bar (outlined pill + filled circular send button).
- **Activity drawer**: grabber handle, rounded top, count badge, and role-tagged ("You / Agent / System") timeline rows.

## Reviewer notes
- Logic (session routing, WebView lifecycle, pause flows) is unchanged — visual layer only for #2.
- Per the repo setup this isn't CLI-compiled; the GitHub Actions release build verifies it. Uses the Expressive APIs already used elsewhere (`LoadingIndicator`, `LinearWavyProgressIndicator`) under a file-level `@OptIn(ExperimentalMaterial3ExpressiveApi)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)