### PR TITLE
Redesign Browser Workspace with a native browser shell

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package com.echoflow.ui.screens
 
 import android.annotation.SuppressLint
@@ -7,7 +9,12 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,15 +38,20 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.OpenInNew
-import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -55,6 +67,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -70,9 +83,10 @@ import com.echoflow.ui.theme.Spacing
 
 /**
  * The native, fullscreen Browser Workspace — a mini-browser inside EchoFlow wrapped around the
- * live Firecrawl browser stream ([BrowserSession.interactiveLiveViewUrl]). Browser-dominant: the
- * WebView fills the screen, a command composer sits at the bottom, and a pull-up drawer shows the
- * activity timeline. The live page is itself the progress indicator while the agent works.
+ * live Firecrawl browser stream ([BrowserSession.interactiveLiveViewUrl]). Browser-dominant: a
+ * browser-style address bar on top, the live page in a rounded viewport, a pull-up activity
+ * drawer, and a chat-style command composer. The live page is itself the progress indicator
+ * while the agent works.
  */
 @Composable
 fun BrowserWorkspaceScreen(
@@ -102,96 +116,74 @@ fun BrowserWorkspaceScreen(
         runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
     }
 
-    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
         Column(Modifier.fillMaxSize()) {
-            // ── Top bar ────────────────────────────────────────────────────────────────
-            Surface(color = MaterialTheme.colorScheme.surfaceContainer, shadowElevation = 2.dp) {
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .windowInsetsPadding(WindowInsets.statusBars)
-                        .padding(horizontal = Spacing.s, vertical = Spacing.s),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onClose) { Icon(Icons.Default.Close, "Close workspace") }
-                    Column(Modifier.weight(1f)) {
-                        Text(
-                            BrowserResolver.domainOf(s.resolvedUrl).ifBlank { "Browser Flow" },
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            "Temporary · nothing saved · ~${BrowserSession.CREDITS_PER_MINUTE} cr/min",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    BrowserStatusPill(s)
-                    Spacer(Modifier.width(Spacing.xs))
-                    IconButton(onClick = { chatViewModel.browserStop(s.id) }) {
-                        Icon(Icons.Default.Stop, "Stop session", tint = MaterialTheme.colorScheme.error)
-                    }
-                }
-            }
+            WorkspaceTopBar(
+                session = s,
+                onClose = onClose,
+                onStop = { chatViewModel.browserStop(s.id) },
+            )
 
-            // ── Live browser ───────────────────────────────────────────────────────────
-            Box(Modifier.weight(1f).fillMaxWidth()) {
+            // ── Live browser viewport ────────────────────────────────────────────────────
+            Box(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.s)
+                    .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp, bottomStart = 12.dp, bottomEnd = 12.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
+            ) {
                 if (liveUrl != null) {
                     LiveBrowserWebView(url = liveUrl, modifier = Modifier.fillMaxSize())
                 } else {
-                    Column(
-                        Modifier.fillMaxSize().padding(Spacing.l),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            if (busy) "Opening the browser…" else "Live view isn't available.",
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    }
+                    OpeningState(domain = BrowserResolver.domainOf(s.resolvedUrl), busy = busy, phase = s.phase)
                 }
 
-                // Transient phase overlay while the agent is driving.
-                androidx.compose.animation.AnimatedVisibility(visible = busy, modifier = Modifier.align(Alignment.TopCenter)) {
-                    Surface(
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.inverseSurface,
-                        modifier = Modifier.padding(top = Spacing.s),
-                    ) {
+                // Thin browser-style load bar pinned to the top edge of the page.
+                AnimatedVisibility(busy, Modifier.align(Alignment.TopCenter), enter = fadeIn(), exit = fadeOut()) {
+                    LinearWavyProgressIndicator(Modifier.fillMaxWidth())
+                }
+
+                // Floating phase chip — the agent is driving.
+                AnimatedVisibility(
+                    visible = busy && liveUrl != null,
+                    modifier = Modifier.align(Alignment.TopCenter).padding(top = Spacing.base),
+                    enter = scaleIn() + fadeIn(),
+                    exit = scaleOut() + fadeOut(),
+                ) {
+                    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.inverseSurface, shadowElevation = 6.dp) {
                         Row(
-                            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                            Modifier.padding(start = Spacing.s, end = Spacing.base, top = 6.dp, bottom = 6.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                         ) {
-                            LinearProgressIndicator(Modifier.width(40.dp))
+                            LoadingIndicator(
+                                modifier = Modifier.size(22.dp),
+                                color = MaterialTheme.colorScheme.inversePrimary,
+                            )
                             Text(
                                 s.phase ?: "Working…",
-                                style = MaterialTheme.typography.labelMedium,
+                                style = MaterialTheme.typography.labelLarge,
                                 color = MaterialTheme.colorScheme.inverseOnSurface,
                             )
                         }
                     }
                 }
 
-                // External-browser escape hatch (WebView fallback).
+                // Take-over-in-Chrome escape hatch.
                 if (liveUrl != null) {
-                    Surface(
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.s).clickable { openExternal() },
+                    FilledTonalIconButton(
+                        onClick = { openExternal() },
+                        modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        ),
                     ) {
-                        Icon(
-                            Icons.Default.OpenInNew, "Open in external browser",
-                            Modifier.padding(Spacing.s).size(20.dp),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        )
+                        Icon(Icons.Default.OpenInNew, "Open in external browser", Modifier.size(20.dp))
                     }
                 }
             }
 
-            // ── Pause action bar (needs-you states) ──────────────────────────────────────
             BrowserPauseBar(
                 session = s,
                 onPick = { chatViewModel.browserResolveCandidate(s.id, it) },
@@ -201,79 +193,186 @@ fun BrowserWorkspaceScreen(
                 onOpenExternal = { openExternal() },
             )
 
-            // ── Activity drawer (pull-up timeline) ───────────────────────────────────────
-            Surface(color = MaterialTheme.colorScheme.surfaceContainerLow) {
-                Column(Modifier.fillMaxWidth()) {
+            ActivityDrawer(steps = steps, open = drawerOpen, onToggle = { drawerOpen = !drawerOpen })
+
+            CommandComposer(
+                value = command,
+                onValue = { command = it },
+                busy = busy,
+                onSend = {
+                    val t = command.trim()
+                    if (t.isNotEmpty()) { command = ""; chatViewModel.sendMessage(t) }
+                },
+            )
+        }
+    }
+}
+
+// ── Top bar (browser chrome) ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun WorkspaceTopBar(
+    session: BrowserSession,
+    onClose: () -> Unit,
+    onStop: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.KeyboardArrowDown, "Minimize to chat", Modifier.size(26.dp))
+                }
+                // The address bar — favicon stand-in (lock = secure/temporary) + domain + status.
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    modifier = Modifier.weight(1f),
+                ) {
                     Row(
-                        Modifier.fillMaxWidth().clickable { drawerOpen = !drawerOpen }.padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                        Modifier.padding(start = Spacing.base, end = 6.dp, top = 8.dp, bottom = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                     ) {
-                        Text("Activity", style = MaterialTheme.typography.labelLarge, modifier = Modifier.weight(1f))
-                        Text("${steps.size}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        Icon(if (drawerOpen) Icons.Default.ExpandMore else Icons.Default.ExpandLess, null)
-                    }
-                    AnimatedVisibility(visible = drawerOpen) {
-                        LazyColumn(Modifier.fillMaxWidth().heightIn(max = 220.dp).padding(horizontal = Spacing.base)) {
-                            items(steps.reversed(), key = { it.id }) { step -> TimelineRow(step) }
-                        }
+                        Icon(Icons.Default.Lock, null, Modifier.size(15.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(
+                            BrowserResolver.domainOf(session.resolvedUrl).ifBlank { "Browser Flow" },
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        BrowserStatusPill(session)
                     }
                 }
+                FilledTonalIconButton(
+                    onClick = onStop,
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    ),
+                ) { Icon(Icons.Default.PowerSettingsNew, "Stop session", Modifier.size(20.dp)) }
             }
+            // Privacy / cost strip.
+            Row(
+                Modifier.padding(start = Spacing.base),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Box(Modifier.size(5.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
+                Text(
+                    "Temporary · nothing saved · ~${BrowserSession.CREDITS_PER_MINUTE} cr/min while open",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
 
-            // ── Command composer ─────────────────────────────────────────────────────────
-            Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
-                Column(
-                    Modifier
-                        .fillMaxWidth()
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .imePadding()
-                        .padding(Spacing.s),
+// ── Opening / no-live-view state ──────────────────────────────────────────────────────────
+
+@Composable
+private fun OpeningState(domain: String, busy: Boolean, phase: String?) {
+    Column(
+        Modifier.fillMaxSize().padding(Spacing.l),
+        verticalArrangement = Arrangement.spacedBy(Spacing.base, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (busy) {
+            LoadingIndicator(modifier = Modifier.size(56.dp), color = MaterialTheme.colorScheme.primary)
+            Text(
+                if (domain.isNotBlank()) "Opening $domain…" else (phase ?: "Opening the browser…"),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "Starting a temporary, private browser session",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Icon(Icons.Default.OpenInNew, null, Modifier.size(40.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("Live view isn't available", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+// ── Command composer (mirrors the chat message bar) ──────────────────────────────────────
+
+@Composable
+private fun CommandComposer(
+    value: String,
+    onValue: (String) -> Unit,
+    busy: Boolean,
+    onSend: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .imePadding()
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+        ) {
+            AnimatedVisibility(busy, enter = fadeIn(), exit = fadeOut()) {
+                Row(
+                    Modifier.padding(start = Spacing.base, bottom = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 ) {
-                    if (busy) {
-                        Text(
-                            "Agent is driving — please wait…",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(start = Spacing.s, bottom = 4.dp),
-                        )
-                    }
+                    LoadingIndicator(modifier = Modifier.size(16.dp), color = MaterialTheme.colorScheme.primary)
+                    Text(
+                        "Agent is driving — please wait…",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape),
+            ) {
+                Row(Modifier.padding(start = Spacing.base, end = Spacing.xs, top = Spacing.xs, bottom = Spacing.xs), verticalAlignment = Alignment.CenterVertically) {
+                    TextField(
+                        value = value,
+                        onValueChange = onValue,
+                        enabled = !busy,
+                        placeholder = { Text("Command the browser…") },
+                        maxLines = 4,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent,
+                        ),
+                        textStyle = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    val canSend = value.trim().isNotEmpty() && !busy
                     Surface(
                         shape = CircleShape,
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        modifier = Modifier.fillMaxWidth(),
+                        color = if (canSend) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHighest,
+                        modifier = Modifier.size(44.dp).clickable(enabled = canSend, onClick = onSend),
                     ) {
-                        Row(Modifier.padding(Spacing.xs), verticalAlignment = Alignment.CenterVertically) {
-                            TextField(
-                                value = command,
-                                onValueChange = { command = it },
-                                enabled = !busy,
-                                placeholder = { Text("Command the browser…") },
-                                maxLines = 4,
-                                colors = TextFieldDefaults.colors(
-                                    focusedContainerColor = Color.Transparent,
-                                    unfocusedContainerColor = Color.Transparent,
-                                    disabledContainerColor = Color.Transparent,
-                                    focusedIndicatorColor = Color.Transparent,
-                                    unfocusedIndicatorColor = Color.Transparent,
-                                    disabledIndicatorColor = Color.Transparent,
-                                ),
-                                modifier = Modifier.weight(1f),
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Send,
+                                "Send command",
+                                Modifier.size(20.dp),
+                                tint = if (canSend) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            val canSend = command.trim().isNotEmpty() && !busy
-                            IconButton(
-                                onClick = {
-                                    val t = command.trim()
-                                    command = ""
-                                    chatViewModel.sendMessage(t)
-                                },
-                                enabled = canSend,
-                            ) {
-                                Icon(
-                                    Icons.AutoMirrored.Filled.Send,
-                                    "Send command",
-                                    tint = if (canSend) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
                         }
                     }
                 }
@@ -281,6 +380,81 @@ fun BrowserWorkspaceScreen(
         }
     }
 }
+
+// ── Activity drawer (pull-up timeline) ────────────────────────────────────────────────────
+
+@Composable
+private fun ActivityDrawer(steps: List<BrowserStep>, open: Boolean, onToggle: () -> Unit) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+    ) {
+        Column(Modifier.fillMaxWidth()) {
+            // Grabber handle.
+            Box(
+                Modifier
+                    .padding(top = Spacing.s)
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 32.dp, height = 4.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.outlineVariant),
+            )
+            Row(
+                Modifier.fillMaxWidth().clickable(onClick = onToggle).padding(horizontal = Spacing.base, vertical = Spacing.s),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Activity", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.secondaryContainer) {
+                    Text(
+                        "${steps.size}",
+                        Modifier.padding(horizontal = Spacing.s, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Icon(if (open) Icons.Default.ExpandMore else Icons.Default.ExpandLess, null)
+            }
+            AnimatedVisibility(visible = open) {
+                LazyColumn(
+                    Modifier.fillMaxWidth().heightIn(max = 240.dp).padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                ) {
+                    items(steps.reversed(), key = { it.id }) { step -> TimelineRow(step) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineRow(step: BrowserStep) {
+    val (label, color) = when (step.role) {
+        "user" -> "You" to MaterialTheme.colorScheme.primary
+        "agent" -> "Agent" to MaterialTheme.colorScheme.tertiary
+        else -> "System" to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+        Surface(shape = CircleShape, color = color.copy(alpha = 0.14f), modifier = Modifier.width(54.dp)) {
+            Text(
+                label,
+                Modifier.padding(vertical = 3.dp),
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Text(
+            step.text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+// ── Pause action bar (needs-you states) ───────────────────────────────────────────────────
 
 @Composable
 private fun BrowserPauseBar(
@@ -292,7 +466,11 @@ private fun BrowserPauseBar(
     onOpenExternal: () -> Unit,
 ) {
     if (session.status != BrowserSession.STATUS_AWAITING_USER) return
-    Surface(color = MaterialTheme.colorScheme.tertiaryContainer) {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s, vertical = Spacing.xs),
+    ) {
         Column(Modifier.fillMaxWidth().padding(Spacing.base), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
             when (session.pendingKind) {
                 BrowserSession.PENDING_DISAMBIGUATION -> {
@@ -334,19 +512,6 @@ private fun BrowserPauseBar(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun TimelineRow(step: BrowserStep) {
-    val color = when (step.role) {
-        "user" -> MaterialTheme.colorScheme.primary
-        "agent" -> MaterialTheme.colorScheme.onSurface
-        else -> MaterialTheme.colorScheme.onSurfaceVariant
-    }
-    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
-        Box(Modifier.padding(top = 6.dp).size(6.dp).background(color, CircleShape))
-        Text(step.text, style = MaterialTheme.typography.bodySmall, color = color, modifier = Modifier.weight(1f))
     }
 }
 


### PR DESCRIPTION
## Why

The workspace redesign was pushed to PR #40's branch *after* that PR had already merged (it merged at the build-fix commit), so it never reached `main`. This PR carries just that change — one file, the `BrowserWorkspaceScreen` visual layer.

## What

Reworks the mini-browser chrome to feel native and Material 3 Expressive — no gimmick shapes:

- **Top bar**: a minimize chevron, a rounded **address bar** (lock + domain + status pill), and a tonal stop button, with a privacy/cost strip underneath.
- **Viewport**: the live page sits in a rounded container with a browser-style **wavy load bar** (`LinearWavyProgressIndicator`) pinned to the top edge, and a floating phase chip using the expressive `LoadingIndicator`.
- **Opening state**: expressive `LoadingIndicator` + "Opening <domain>…".
- **Composer**: now mirrors the chat message bar (outlined pill + filled circular send button).
- **Activity drawer**: grabber handle, rounded top, count badge, and role-tagged ("You / Agent / System") timeline rows.

## Reviewer notes
- Visual layer only — session routing, WebView lifecycle and the pause/handoff flows are unchanged.
- Uses Expressive APIs already used elsewhere in the app (`LoadingIndicator`, `LinearWavyProgressIndicator`) under a file-level `@OptIn(ExperimentalMaterial3ExpressiveApi)`.
- Not CLI-compiled per the repo setup; the GitHub Actions release build verifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign BrowserWorkspaceScreen with a native browser shell
> - Replaces the inline browser workspace layout with dedicated composables: `WorkspaceTopBar` (address bar, lock icon, domain, stop button, cost strip), `ActivityDrawer` (grabber, step count pill, expandable timeline), `CommandComposer` (busy banner, circular send button), and `OpeningState` (spinner/unavailable messaging).
> - The live browser viewport is now padded and clipped with asymmetric rounded corners; a `LinearWavyProgressIndicator` appears at the top while busy, and a floating phase chip shows the current agent phase.
> - `TimelineRow` now renders labeled, color-coded chips ('You', 'Agent', 'System') replacing the previous dot-based styling.
> - `BrowserPauseBar` gains rounded corners and inset padding with no functional changes.
> - Behavioral Change: Opts in to `ExperimentalMaterial3ExpressiveApi` at file level; replaces `LinearProgressIndicator` and `LoadingIndicator` usages with Material3 expressive equivalents, and swaps Close/Stop icons for `KeyboardArrowDown` and `PowerSettingsNew`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21540d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined workspace visual styling with improved layout consistency
  * Enhanced activity status indicators for clearer operational awareness
  * Improved timeline display with explicit action attribution (You, Agent, System)
  * Redesigned activity panel with better spacing and visual hierarchy

* **Bug Fixes**
  * Improved WebView resource management and lifecycle handling for increased stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->