### PR TITLE
Add Claude-style Artifacts (web page / document / LaTeX report)

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -106,7 +106,9 @@ class MainActivity : ComponentActivity() {
                     database.fusionPanelDao(),
                     database.agentProfileDao(),
                     database.browserSessionDao(),
-                    database.browserStepDao()
+                    database.browserStepDao(),
+                    database.artifactDao(),
+                    database.artifactVersionDao()
                 )
             )
 

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -156,6 +156,8 @@ fun MainNavigationHub(
 
     val activeBrowserSession by chatViewModel.activeBrowserSession.collectAsState()
     val browserWorkspaceChatId by chatViewModel.browserWorkspaceChatId.collectAsState()
+    val currentArtifact by chatViewModel.currentArtifact.collectAsState()
+    val artifactWorkspaceOpen by chatViewModel.artifactWorkspaceOpen.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (activeTab == "settings") {
@@ -191,6 +193,26 @@ fun MainNavigationHub(
             com.echoflow.ui.screens.BrowserWorkspaceScreen(
                 chatViewModel = chatViewModel,
                 onClose = { chatViewModel.closeBrowserWorkspace() },
+            )
+        }
+
+        // Global "artifact ready" pill — tap to reopen the workspace for the open chat's artifact.
+        val artifact = currentArtifact
+        if (artifact != null && !artifactWorkspaceOpen && browserWorkspaceChatId == null) {
+            com.echoflow.ui.components.GlobalArtifactPill(
+                title = artifact.title,
+                artifactType = artifact.type,
+                onClick = { chatViewModel.openArtifactWorkspace() },
+                modifier = Modifier.align(Alignment.BottomEnd).padding(end = 20.dp, bottom = 110.dp),
+            )
+        }
+
+        // Fullscreen Artifact Workspace overlay (preview / code / version switcher).
+        if (artifactWorkspaceOpen) {
+            BackHandler { chatViewModel.closeArtifactWorkspace() }
+            com.echoflow.ui.screens.ArtifactWorkspaceScreen(
+                chatViewModel = chatViewModel,
+                onClose = { chatViewModel.closeArtifactWorkspace() },
             )
         }
     }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -11,9 +11,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
     entities = [
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
         DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
-        AgentProfile::class, BrowserSession::class, BrowserStep::class
+        AgentProfile::class, BrowserSession::class, BrowserStep::class,
+        Artifact::class, ArtifactVersion::class
     ],
-    version = 11, // v11: Browser Flow sessions + steps (MIGRATION_10_11)
+    version = 12, // v12: artifacts + artifact_versions (MIGRATION_11_12)
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -28,6 +29,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun agentProfileDao(): AgentProfileDao
     abstract fun browserSessionDao(): BrowserSessionDao
     abstract fun browserStepDao(): BrowserStepDao
+    abstract fun artifactDao(): ArtifactDao
+    abstract fun artifactVersionDao(): ArtifactVersionDao
 
     companion object {
         @Volatile
@@ -190,6 +193,34 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS artifacts (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "chatId TEXT NOT NULL, " +
+                        "title TEXT NOT NULL, " +
+                        "type TEXT NOT NULL, " +
+                        "currentVersion INTEGER NOT NULL, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(chatId) REFERENCES chat_threads(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_artifacts_chatId ON artifacts (chatId)")
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS artifact_versions (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "artifactId TEXT NOT NULL, " +
+                        "versionNumber INTEGER NOT NULL, " +
+                        "content TEXT NOT NULL, " +
+                        "sourcePrompt TEXT NOT NULL, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(artifactId) REFERENCES artifacts(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_artifact_versions_artifactId ON artifact_versions (artifactId)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -207,6 +238,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_8_9,
                     MIGRATION_9_10,
                     MIGRATION_10_11,
+                    MIGRATION_11_12,
                 )
                 // Only pre-v2 installs (no migration path defined) fall back destructively.
                 .fallbackToDestructiveMigration()

--- a/app/src/main/java/com/echoflow/data/ArtifactExport.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactExport.kt
@@ -1,0 +1,105 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.print.PrintAttributes
+import android.print.PrintManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * Exports an artifact to PDF using Android's built-in print framework — no extra dependency and no
+ * APK weight. An HTML artifact prints as-is; a markdown/latex report is rendered to a print-ready
+ * HTML document (markdown via marked, math via KaTeX) and printed. The system print dialog lets the
+ * user "Save as PDF" or send to a printer.
+ *
+ * Note: report math uses CDN libraries, so exporting a report with equations needs a connection
+ * (the on-screen preview always uses the app's native renderer). Plain text exports work offline.
+ */
+object ArtifactExport {
+
+    // Keep transient print WebViews alive until the print adapter is done with them.
+    private val liveWebViews = mutableListOf<WebView>()
+
+    fun printArtifact(context: Context, title: String, type: String, content: String) {
+        val html = when (Artifact.normalizeType(type)) {
+            Artifact.TYPE_HTML -> content
+            else -> reportHtml(title, content)
+        }
+        val webView = WebView(context)
+        liveWebViews.add(webView)
+        webView.settings.javaScriptEnabled = true
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView, url: String?) {
+                // Give marked/KaTeX a moment to lay out before snapshotting to PDF.
+                Handler(Looper.getMainLooper()).postDelayed({
+                    runCatching {
+                        val printManager = context.getSystemService(Context.PRINT_SERVICE) as PrintManager
+                        val jobName = title.ifBlank { "Artifact" }
+                        val adapter = view.createPrintDocumentAdapter(jobName)
+                        printManager.print(
+                            jobName,
+                            adapter,
+                            PrintAttributes.Builder()
+                                .setMediaSize(PrintAttributes.MediaSize.ISO_A4)
+                                .build(),
+                        )
+                    }
+                    liveWebViews.remove(webView)
+                }, 700)
+            }
+        }
+        webView.loadDataWithBaseURL("https://localhost/", html, "text/html", "utf-8", null)
+    }
+
+    /** Wrap markdown (+ LaTeX math) in a print-tuned HTML document. */
+    private fun reportHtml(title: String, markdown: String): String {
+        // Embed the raw markdown safely in a text/plain script block.
+        val safe = markdown.replace("</script>", "<\\/script>")
+        val katex = "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist"
+        return """
+            <!DOCTYPE html>
+            <html><head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link rel="stylesheet" href="$katex/katex.min.css">
+            <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+            <script defer src="$katex/katex.min.js"></script>
+            <script defer src="$katex/contrib/auto-render.min.js"></script>
+            <style>
+              @page { margin: 18mm; }
+              body { font-family: Georgia, 'Times New Roman', serif; line-height: 1.55; color: #111; }
+              h1, h2, h3 { font-family: 'Helvetica Neue', Arial, sans-serif; line-height: 1.25; }
+              h1 { font-size: 26px; } h2 { font-size: 20px; margin-top: 1.4em; } h3 { font-size: 16px; }
+              p, li { font-size: 13px; }
+              pre, code { font-family: ui-monospace, Consolas, monospace; font-size: 12px; }
+              pre { background: #f5f5f5; padding: 10px; border-radius: 6px; overflow-x: auto; }
+              table { border-collapse: collapse; width: 100%; font-size: 12px; }
+              th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
+              blockquote { border-left: 3px solid #ccc; margin: 0; padding-left: 12px; color: #555; }
+              img { max-width: 100%; }
+            </style>
+            </head><body>
+            <div id="content"></div>
+            <script id="src" type="text/plain">$safe</script>
+            <script>
+              window.addEventListener('load', function () {
+                try {
+                  var md = document.getElementById('src').textContent;
+                  document.getElementById('content').innerHTML = marked.parse(md);
+                  if (window.renderMathInElement) {
+                    renderMathInElement(document.body, {
+                      delimiters: [
+                        { left: '${'$'}${'$'}', right: '${'$'}${'$'}', display: true },
+                        { left: '${'$'}', right: '${'$'}', display: false }
+                      ]
+                    });
+                  }
+                } catch (e) {}
+              });
+            </script>
+            </body></html>
+        """.trimIndent()
+    }
+}

--- a/app/src/main/java/com/echoflow/data/ArtifactManager.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactManager.kt
@@ -1,0 +1,77 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+/**
+ * Owns the artifact store. Mirrors how [BrowserAgentManager] fronts the browser tables: the UI
+ * observes the rows it writes. v1 keeps one artifact lineage per chat — [saveVersion] appends a new
+ * [ArtifactVersion] to the chat's existing [Artifact] (or creates the first one), preserving full
+ * version history.
+ */
+class ArtifactManager(
+    private val artifactDao: ArtifactDao,
+    private val artifactVersionDao: ArtifactVersionDao,
+) {
+    fun observeForChat(chatId: String): Flow<Artifact?> = artifactDao.observeLatestForChat(chatId)
+
+    fun observeVersions(artifactId: String): Flow<List<ArtifactVersion>> =
+        artifactVersionDao.observeForArtifact(artifactId)
+
+    suspend fun getVersion(artifactId: String, version: Int): ArtifactVersion? =
+        artifactVersionDao.getVersion(artifactId, version)
+
+    /** The latest artifact body for a chat, fed back to the model so it iterates instead of restarting. */
+    suspend fun getLatestVersionContent(chatId: String): String? {
+        val artifact = artifactDao.getLatestForChat(chatId) ?: return null
+        return artifactVersionDao.getLatest(artifact.id)?.content
+    }
+
+    /**
+     * Persist a freshly generated artifact body as a new version of the chat's lineage (creating
+     * the lineage on first use), and return a reference the timeline/card can deep-link with.
+     */
+    suspend fun saveVersion(
+        chatId: String,
+        title: String,
+        type: String,
+        content: String,
+        sourcePrompt: String,
+    ): ArtifactRef {
+        val now = System.currentTimeMillis()
+        val normalizedType = Artifact.normalizeType(type)
+        val existing = artifactDao.getLatestForChat(chatId)
+        val artifactId = existing?.id ?: UUID.randomUUID().toString()
+        val nextVersion = if (existing == null) 1 else artifactVersionDao.maxVersion(artifactId) + 1
+        val resolvedTitle = title.ifBlank { existing?.title ?: defaultTitle(normalizedType) }
+
+        artifactDao.upsert(
+            Artifact(
+                id = artifactId,
+                chatId = chatId,
+                title = resolvedTitle,
+                type = normalizedType,
+                currentVersion = nextVersion,
+                createdAt = existing?.createdAt ?: now,
+                updatedAt = now,
+            )
+        )
+        artifactVersionDao.insert(
+            ArtifactVersion(
+                id = UUID.randomUUID().toString(),
+                artifactId = artifactId,
+                versionNumber = nextVersion,
+                content = content,
+                sourcePrompt = sourcePrompt,
+                createdAt = now,
+            )
+        )
+        return ArtifactRef(artifactId = artifactId, title = resolvedTitle, type = normalizedType, version = nextVersion)
+    }
+
+    private fun defaultTitle(type: String): String = when (type) {
+        Artifact.TYPE_MARKDOWN -> "Document"
+        Artifact.TYPE_LATEX -> "Report"
+        else -> "Artifact"
+    }
+}

--- a/app/src/main/java/com/echoflow/data/ArtifactModels.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactModels.kt
@@ -1,0 +1,127 @@
+package com.echoflow.data
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A Claude-style artifact: a self-contained, rendered piece of content (a web page, a markdown
+ * document, or a printable LaTeX report) the model produced inside a chat. This is the single
+ * source of truth — the in-chat card, the global pill and the fullscreen workspace all observe
+ * this row, so an artifact survives the workspace being closed or the app being minimized.
+ *
+ * Lineage rule (v1): one artifact lineage per chat. Each artifact-mode turn that yields content
+ * appends a new [ArtifactVersion] to the chat's artifact (full version history), so "make the
+ * header blue" produces v2 of the same artifact rather than a fresh one.
+ */
+@Entity(
+    tableName = "artifacts",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatThread::class,
+            parentColumns = ["id"],
+            childColumns = ["chatId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("chatId")],
+)
+data class Artifact(
+    @PrimaryKey val id: String,
+    val chatId: String,
+    val title: String,
+    val type: String, // see TYPE_* constants
+    val currentVersion: Int, // version number of the latest ArtifactVersion
+    val createdAt: Long,
+    val updatedAt: Long,
+) {
+    val isHtml: Boolean get() = type == TYPE_HTML
+    val isMarkdown: Boolean get() = type == TYPE_MARKDOWN
+    val isReport: Boolean get() = type == TYPE_LATEX
+
+    companion object {
+        const val TYPE_HTML = "html"       // single self-contained HTML/CSS/JS, rendered in a WebView
+        const val TYPE_MARKDOWN = "markdown" // prose document, rendered natively
+        const val TYPE_LATEX = "latex"      // printable report (Markdown + LaTeX math), exportable to PDF
+
+        val ALL_TYPES = setOf(TYPE_HTML, TYPE_MARKDOWN, TYPE_LATEX)
+
+        /** Normalize a model-declared type attribute to a known type (defaults to HTML). */
+        fun normalizeType(raw: String?): String = when (raw?.trim()?.lowercase()) {
+            TYPE_MARKDOWN, "md" -> TYPE_MARKDOWN
+            TYPE_LATEX, "report", "pdf", "tex" -> TYPE_LATEX
+            else -> TYPE_HTML
+        }
+    }
+}
+
+/**
+ * One generation of an [Artifact]. Versions accrue (never overwrite) so the workspace can offer a
+ * v1 / v2 / v3 switcher and the user never loses a good earlier render to a bad iteration.
+ */
+@Entity(
+    tableName = "artifact_versions",
+    foreignKeys = [
+        ForeignKey(
+            entity = Artifact::class,
+            parentColumns = ["id"],
+            childColumns = ["artifactId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("artifactId")],
+)
+data class ArtifactVersion(
+    @PrimaryKey val id: String,
+    val artifactId: String,
+    val versionNumber: Int,
+    val content: String, // the raw artifact body (HTML, markdown, or markdown+LaTeX)
+    val sourcePrompt: String, // the user message that produced this version (for context/iteration)
+    val createdAt: Long,
+)
+
+@Dao
+interface ArtifactDao {
+    /** The most-recent artifact for one chat — drives the in-chat card and the workspace. */
+    @Query("SELECT * FROM artifacts WHERE chatId = :chatId ORDER BY updatedAt DESC LIMIT 1")
+    fun observeLatestForChat(chatId: String): Flow<Artifact?>
+
+    @Query("SELECT * FROM artifacts WHERE chatId = :chatId ORDER BY updatedAt DESC LIMIT 1")
+    suspend fun getLatestForChat(chatId: String): Artifact?
+
+    @Query("SELECT * FROM artifacts WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): Artifact?
+
+    @Query("SELECT * FROM artifacts WHERE id = :id LIMIT 1")
+    fun observeById(id: String): Flow<Artifact?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(artifact: Artifact)
+
+    @Query("DELETE FROM artifacts WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
+interface ArtifactVersionDao {
+    @Query("SELECT * FROM artifact_versions WHERE artifactId = :artifactId ORDER BY versionNumber ASC")
+    fun observeForArtifact(artifactId: String): Flow<List<ArtifactVersion>>
+
+    @Query("SELECT * FROM artifact_versions WHERE artifactId = :artifactId ORDER BY versionNumber DESC LIMIT 1")
+    suspend fun getLatest(artifactId: String): ArtifactVersion?
+
+    @Query("SELECT * FROM artifact_versions WHERE artifactId = :artifactId AND versionNumber = :version LIMIT 1")
+    suspend fun getVersion(artifactId: String, version: Int): ArtifactVersion?
+
+    @Query("SELECT COALESCE(MAX(versionNumber), 0) FROM artifact_versions WHERE artifactId = :artifactId")
+    suspend fun maxVersion(artifactId: String): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(version: ArtifactVersion)
+}

--- a/app/src/main/java/com/echoflow/data/ArtifactStreamParser.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactStreamParser.kt
@@ -1,0 +1,178 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Splits a model's reply stream into prose (kept in the chat bubble) and an artifact body (routed
+ * out to the workspace). The model is instructed (see [SystemPrompts.buildArtifact]) to wrap an
+ * artifact in a sentinel block:
+ *
+ * ```
+ * <echo:artifact type="html" title="Pricing page">
+ * ...the full artifact...
+ * </echo:artifact>
+ * ```
+ *
+ * This is a streaming state machine: everything outside the block passes through as
+ * [StreamChunk.Content]; everything inside is suppressed from the bubble and surfaced as
+ * [StreamChunk.ArtifactStarted] / [ArtifactProgress] / [ArtifactCompleted]. Tags split across
+ * chunk boundaries are handled with a holdback, and a stream that ends mid-artifact still emits a
+ * (truncated) [ArtifactCompleted] so partial work is not lost.
+ *
+ * Non-content chunks (reasoning, search, …) pass through untouched.
+ */
+fun Flow<StreamChunk>.extractArtifacts(): Flow<StreamChunk> = flow {
+    val parser = ArtifactStreamParser()
+    collect { chunk -> parser.onChunk(chunk).forEach { emit(it) } }
+    parser.onComplete().forEach { emit(it) }
+}
+
+class ArtifactStreamParser {
+
+    private enum class State { OUTSIDE, INSIDE }
+
+    private var state = State.OUTSIDE
+    private var pending = StringBuilder()      // OUTSIDE text not yet decided
+    private var artifactBuf = StringBuilder()  // INSIDE body accumulated so far
+    private var startedEmitted = false
+    private var title = ""
+    private var type = Artifact.TYPE_HTML
+
+    fun onChunk(chunk: StreamChunk): List<StreamChunk> {
+        if (chunk !is StreamChunk.Content) return listOf(chunk)
+        val out = mutableListOf<StreamChunk>()
+        if (state == State.OUTSIDE) pending.append(chunk.text) else artifactBuf.append(chunk.text)
+        drain(out)
+        return out
+    }
+
+    fun onComplete(): List<StreamChunk> {
+        val out = mutableListOf<StreamChunk>()
+        when (state) {
+            State.OUTSIDE -> {
+                // Flush any held-back tail (it never became an open tag).
+                if (pending.isNotEmpty()) {
+                    out.add(StreamChunk.Content(pending.toString()))
+                    pending.clear()
+                }
+            }
+            State.INSIDE -> {
+                // Stream ended without a closing tag — surface what we have, marked truncated.
+                out.add(
+                    StreamChunk.ArtifactCompleted(
+                        title = title,
+                        artifactType = type,
+                        content = artifactBuf.toString().trim(),
+                        truncated = true,
+                    )
+                )
+                reset()
+            }
+        }
+        return out
+    }
+
+    /** Run the state machine over whatever is currently buffered, appending emissions to [out]. */
+    private fun drain(out: MutableList<StreamChunk>) {
+        var progressed = true
+        while (progressed) {
+            progressed = false
+            if (state == State.OUTSIDE) {
+                val text = pending
+                val openAt = text.indexOf(OPEN_PREFIX)
+                if (openAt >= 0) {
+                    // Need the whole opening tag (up to '>') before we can start the artifact.
+                    val gt = text.indexOf('>', openAt)
+                    if (gt < 0) {
+                        // Open tag still arriving — emit the prose before it, keep the rest.
+                        if (openAt > 0) {
+                            out.add(StreamChunk.Content(text.substring(0, openAt)))
+                            pending = StringBuilder(text.substring(openAt))
+                        }
+                        return
+                    }
+                    // Emit prose before the tag.
+                    if (openAt > 0) out.add(StreamChunk.Content(text.substring(0, openAt)))
+                    val openTag = text.substring(openAt, gt + 1)
+                    title = attr(openTag, "title")
+                    type = Artifact.normalizeType(attr(openTag, "type"))
+                    if (!startedEmitted) {
+                        out.add(StreamChunk.ArtifactStarted(title, type))
+                        startedEmitted = true
+                    }
+                    state = State.INSIDE
+                    artifactBuf = StringBuilder(text.substring(gt + 1))
+                    pending = StringBuilder()
+                    progressed = true
+                } else {
+                    // No open tag: emit everything except a tail that could be a partial open tag.
+                    val keep = partialSuffixLen(text, OPEN_PREFIX)
+                    val emitLen = text.length - keep
+                    if (emitLen > 0) {
+                        out.add(StreamChunk.Content(text.substring(0, emitLen)))
+                        pending = StringBuilder(text.substring(emitLen))
+                    }
+                    return
+                }
+            } else { // INSIDE
+                val body = artifactBuf
+                val closeAt = body.indexOf(CLOSE_TAG)
+                if (closeAt >= 0) {
+                    val content = body.substring(0, closeAt).trim()
+                    out.add(
+                        StreamChunk.ArtifactCompleted(
+                            title = title,
+                            artifactType = type,
+                            content = content,
+                        )
+                    )
+                    val rest = body.substring(closeAt + CLOSE_TAG.length)
+                    reset()
+                    pending = StringBuilder(rest)
+                    progressed = rest.isNotEmpty()
+                } else {
+                    // No close yet — report progress, but never let a partial close tag count.
+                    val keep = partialSuffixLen(body, CLOSE_TAG)
+                    out.add(StreamChunk.ArtifactProgress(body.length - keep))
+                    return
+                }
+            }
+        }
+    }
+
+    private fun reset() {
+        state = State.OUTSIDE
+        artifactBuf = StringBuilder()
+        startedEmitted = false
+        title = ""
+        type = Artifact.TYPE_HTML
+    }
+
+    companion object {
+        private const val OPEN_PREFIX = "<echo:artifact"
+        private const val CLOSE_TAG = "</echo:artifact>"
+
+        private val ATTR_RE = Regex("""(\w+)\s*=\s*"([^"]*)"""")
+
+        private fun attr(tag: String, name: String): String =
+            ATTR_RE.findAll(tag).firstOrNull { it.groupValues[1].equals(name, ignoreCase = true) }
+                ?.groupValues?.get(2)?.trim().orEmpty()
+
+        /**
+         * Length of the longest suffix of [text] that is a (proper) prefix of [marker]. Used to
+         * hold back the tail of a buffer that might be the beginning of a tag split across chunks.
+         */
+        private fun partialSuffixLen(text: CharSequence, marker: String): Int {
+            val max = minOf(text.length, marker.length - 1)
+            for (len in max downTo 1) {
+                var match = true
+                for (i in 0 until len) {
+                    if (text[text.length - len + i] != marker[i]) { match = false; break }
+                }
+                if (match) return len
+            }
+            return 0
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -52,6 +52,27 @@ sealed class StreamChunk {
 
     /** The worker finished a delegated task. [result] carries the outcome (or an error). */
     data class SubagentResolved(val result: SubagentResult) : StreamChunk()
+
+    // ── Artifacts (sentinel-delimited, extracted from the content stream) ────────────
+    /** The model opened an artifact block; [title]/[artifactType] are known, body pending. */
+    data class ArtifactStarted(val title: String, val artifactType: String) : StreamChunk()
+
+    /** The artifact body is growing; [charCount] is how much has streamed so far (for the card). */
+    data class ArtifactProgress(val charCount: Int) : StreamChunk()
+
+    /**
+     * The artifact block closed (or the stream ended mid-artifact). [content] is the full body.
+     * [artifactId]/[version] are filled in by the ViewModel once the version is persisted, so the
+     * resulting card and timeline segment can deep-link into the workspace.
+     */
+    data class ArtifactCompleted(
+        val title: String,
+        val artifactType: String,
+        val content: String,
+        val artifactId: String? = null,
+        val version: Int = 0,
+        val truncated: Boolean = false,
+    ) : StreamChunk()
 }
 
 // ── Echo Adviser / Echo Fusion result records ──────────────────────────────────────

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -130,19 +130,28 @@ data class Citation(
     val url: String
 )
 
+/** A reference to a persisted [com.echoflow.data.Artifact] version, embedded in a reply's timeline. */
+data class ArtifactRef(
+    val artifactId: String,
+    val title: String,
+    val type: String, // Artifact.TYPE_* — selects the render view
+    val version: Int,
+)
+
 /**
  * One block of a finished reply, persisted in arrival order so the rendered timeline
  * (reason → search → reason → search → answer) survives exactly as it streamed instead
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact"
     val text: String? = null,
     val query: String? = null,
     val sources: List<SearchSource>? = null,
     val advisor: AdvisorAdvice? = null, // present when type == "advisor"
     val fusion: FusionAnalysis? = null, // present when type == "fusion"
-    val subagent: SubagentResult? = null // present when type == "subagent"
+    val subagent: SubagentResult? = null, // present when type == "subagent"
+    val artifact: ArtifactRef? = null // present when type == "artifact"
 )
 
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -87,6 +87,10 @@ class SettingsRepository(context: Context) {
     private val _browserIdleMinutes = MutableStateFlow(getBrowserIdleMinutesDirect())
     val browserIdleMinutes: StateFlow<Int> = _browserIdleMinutes.asStateFlow()
 
+    // Artifacts: when on, the artifact prompt forbids CDNs so generated HTML renders fully offline.
+    private val _artifactsOffline = MutableStateFlow(getArtifactsOfflineDirect())
+    val artifactsOffline: StateFlow<Boolean> = _artifactsOffline.asStateFlow()
+
     // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
     private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
     val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
@@ -398,6 +402,17 @@ class SettingsRepository(context: Context) {
     fun saveBrowserFlowEnabled(enabled: Boolean) {
         prefs.edit().putBoolean("browser_flow_enabled", enabled).apply()
         _browserFlowEnabled.value = enabled
+    }
+
+    // ── Artifacts ──────────────────────────────────────────────────────────────────────
+
+    /** When true, artifact HTML must be fully self-contained (no CDN) so it renders offline. */
+    fun getArtifactsOfflineDirect(): Boolean =
+        prefs.getBoolean("artifacts_offline", false)
+
+    fun saveArtifactsOffline(enabled: Boolean) {
+        prefs.edit().putBoolean("artifacts_offline", enabled).apply()
+        _artifactsOffline.value = enabled
     }
 
     /** Minutes of inactivity before Browser Flow auto-stops the session (cost guard). 0 = off. */

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -242,6 +242,151 @@ object SystemPrompts {
         - Write a clean, well-structured markdown answer. The app shows the structured panel comparison and each model's full response separately, so do NOT paste the raw analysis JSON.
         """.trimIndent()
 
+    // ── Artifacts ────────────────────────────────────────────────────────────────────
+
+    /**
+     * Artifact mode: the model produces ONE self-contained, rendered artifact (a web page, a
+     * markdown document, or a printable LaTeX report) wrapped in a sentinel block the app extracts
+     * from the stream. Works on cloud and on-device models — the on-device variant is trimmed to
+     * fit a smaller context window. [offline] forbids any network (no CDN), used when the user
+     * wants artifacts to render without a connection. [priorArtifact] is the latest version's body,
+     * present on a follow-up so the model iterates instead of starting over.
+     */
+    fun buildArtifact(
+        isLocalModel: Boolean,
+        offline: Boolean,
+        priorArtifact: String? = null,
+        currentDate: String = currentDate(),
+    ): String {
+        val sections = mutableListOf<String>()
+        sections += identity(isLocalModel)
+        sections += "Current date: $currentDate."
+        sections += artifactContract()
+        sections += artifactTypeGuidance()
+        sections += htmlDesignGuidance(isLocalModel, offline)
+        sections += reportGuidance()
+        priorArtifact?.takeIf { it.isNotBlank() }?.let { sections += artifactIterationGuidance(it) }
+        return sections.joinToString("\n\n")
+    }
+
+    private fun artifactContract(): String =
+        """
+        ## Artifacts
+        The user wants you to build an ARTIFACT — a single, complete, self-contained piece of
+        content that the app renders in its own viewer. Produce exactly ONE artifact per reply.
+
+        Output contract (critical):
+        - First, write one short line of prose to the user (e.g. "Here's a landing page for you.").
+        - Then emit the artifact wrapped EXACTLY in this sentinel block and nothing else after it:
+
+          <echo:artifact type="TYPE" title="A short human title">
+          ...the entire artifact body...
+          </echo:artifact>
+
+        - TYPE is one of: html, markdown, latex. Put NOTHING outside the tags except that one prose
+          line before the opening tag. Do not describe the code, do not repeat it, do not add a
+          closing remark after the closing tag. Always close the tag.
+        """.trimIndent()
+
+    private fun artifactTypeGuidance(): String =
+        """
+        ## Choosing the type (decide from the request)
+        - **html** — anything interactive or visual: pages, landing pages, dashboards, widgets,
+          forms, games, charts, demos, SVG art. Use when layout or JavaScript matters.
+        - **markdown** — plain prose documents: notes, READMEs, plans, structured writeups with no
+          interactivity and no heavy math.
+        - **latex** — formal, printable reports: anything math-heavy or when the user asks for a
+          report, paper, or PDF. Rendered as Markdown + LaTeX math and exportable to PDF.
+        """.trimIndent()
+
+    private fun htmlDesignGuidance(isLocalModel: Boolean, offline: Boolean): String {
+        val header = "## When type = html"
+        val core = """
+            - Single self-contained file: ALL html, css and js inline. No build step, no imports.
+            - MOBILE-FIRST — this opens in a phone-sized viewport. Include
+              <meta name="viewport" content="width=device-width, initial-scale=1">, design for a
+              ~390px-wide screen, touch targets at least 44px, and no horizontal scroll.
+            - Complete and functional: no TODOs, no placeholder lorem, no "rest of code here".
+        """.trimIndent()
+
+        val aesthetic = if (isLocalModel) {
+            // Compact: keep the anti-default rules, drop the output-inflating detail.
+            """
+            - Commit to ONE clear aesthetic direction and keep the file focused and compact.
+            - Do NOT use the generic AI look: avoid Inter/Roboto/Arial as the headline face and
+              avoid purple-gradient-on-white. Use deliberate type sizing, weight and spacing.
+            """.trimIndent()
+        } else {
+            """
+            - Before writing, commit to ONE bold aesthetic direction and execute it precisely —
+              pick an extreme (brutalist, editorial/magazine, retro-futuristic, luxury, playful,
+              art-deco, industrial). Intentionality beats intensity.
+            - Typography: a distinctive display + body pairing. NEVER Inter, Roboto, Arial or
+              system-ui as the headline face.
+            - Color: one dominant color with sharp accents via CSS variables — not a timid, evenly
+              spread palette. NEVER the purple-gradient-on-white default.
+            - Motion: CSS-only. One well-orchestrated load with staggered reveals beats scattered
+              micro-interactions. Respect prefers-reduced-motion.
+            - Depth: atmosphere over flat fills — gradient meshes, grain, layered shadows,
+              decorative borders — where they fit the direction.
+            - Match code complexity to the vision: maximalism = elaborate; minimalism = restraint
+              and precise spacing.
+            """.trimIndent()
+        }
+
+        val network = if (offline) {
+            """
+            - OFFLINE MODE — make ZERO external requests: no CDN, no <link>/@import fonts, no remote
+              scripts or images, no analytics. The file MUST render with networking OFF.
+            - You cannot download fonts. Build identity WITHOUT custom fonts: use characterful local
+              stacks (Georgia/Charter/"Times New Roman" for serif, "Courier New"/ui-monospace for
+              technical, Palatino for refined) and lean on weight contrast, scale, letter-spacing and
+              rhythm. No CSS/JS frameworks. No math libraries — render any formula as styled text or
+              inline SVG.
+            """.trimIndent()
+        } else {
+            """
+            - Fonts may load from a CDN (e.g. Google Fonts via <link>). You may use a CDN <script>
+              for a library (React, Tailwind, charts) ONLY when it genuinely helps; prefer
+              dependency-free vanilla when you can — it is more reliable.
+            """.trimIndent()
+        }
+
+        return listOf(header, core, aesthetic, network).joinToString("\n")
+    }
+
+    private fun reportGuidance(): String =
+        """
+        ## When type = markdown or latex
+        These render through the app's native Markdown engine (which has a LaTeX MATH renderer — it
+        is NOT a LaTeX compiler). Follow this exactly:
+
+        - STRUCTURE in Markdown, never LaTeX document commands: # H1 title, ## sections, ###
+          subsections, paragraphs, **bold**, *italic*, > blockquotes, - / 1. lists, and pipe tables.
+        - NEVER emit \documentclass, \usepackage, \begin{document}, \section{}, \maketitle, tikz, or
+          any full-LaTeX document command — they will NOT render.
+        - MATH (latex type especially): inline ${'$'}...${'$'}, display ${'$'}${'$'}...${'$'}${'$'}.
+          Standard math only — \frac, exponents/subscripts, \sqrt, Greek, \sum, \int, limits,
+          vectors, \begin{matrix}, \begin{aligned}, common operators. Put each nontrivial equation
+          in its own display block so pagination cannot split it.
+        - For a latex REPORT (it exports to a paginated PDF): single column; nothing wider than the
+          page; lead with a "# Title" then an *italic subtitle/date* line; use frequent ## headings
+          (they give clean page-break points); don't rely on color to carry meaning; keep code and
+          quote blocks short. Make it complete — no placeholders.
+        """.trimIndent()
+
+    private fun artifactIterationGuidance(priorArtifact: String): String =
+        """
+        ## You are revising an existing artifact
+        Below is the current version you produced earlier. Apply the user's latest request to it and
+        output the FULL updated artifact (same sentinel block) — never a diff or a fragment. Keep
+        everything the user did not ask to change. Pick the same type unless they ask otherwise.
+
+        --- CURRENT ARTIFACT ---
+        $priorArtifact
+        --- END CURRENT ARTIFACT ---
+        """.trimIndent()
+
     // ── Deep Research (agentic, cloud only) ──────────────────────────────────────────
 
     /**

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -55,6 +55,20 @@ sealed class StreamSegment {
         val error: String?,
         val active: Boolean
     ) : StreamSegment()
+
+    /**
+     * Artifact card: shown while the model builds an artifact ([building] = true, with a live
+     * [charCount]) and afterwards as a finished card carrying the persisted [artifactId]/[version].
+     */
+    data class Artifact(
+        val artifactId: String?,
+        val title: String,
+        val artifactType: String,
+        val version: Int,
+        val charCount: Int,
+        val building: Boolean,
+        val truncated: Boolean,
+    ) : StreamSegment()
 }
 
 private data class ActiveStreamState(
@@ -82,8 +96,13 @@ class ChatViewModel(
     private val fusionPanelDao: FusionPanelDao,
     private val agentProfileDao: AgentProfileDao,
     private val browserSessionDao: BrowserSessionDao,
-    private val browserStepDao: BrowserStepDao
+    private val browserStepDao: BrowserStepDao,
+    private val artifactDao: ArtifactDao,
+    private val artifactVersionDao: ArtifactVersionDao
 ) : AndroidViewModel(application) {
+
+    // Artifacts: model-built, rendered content (web page / document / report) with version history.
+    private val artifactManager = ArtifactManager(artifactDao, artifactVersionDao)
 
     private val openRouterService = OpenRouterService(application)
     private val webSearchService = WebSearchService()
@@ -240,6 +259,30 @@ class ChatViewModel(
     private val _echoAgentActive = MutableStateFlow(false)
     val echoAgentActive: StateFlow<Boolean> = _echoAgentActive.asStateFlow()
 
+    // Artifact mode: sticky like the Echo modes. While on, every turn builds/updates an artifact;
+    // follow-ups iterate the chat's current artifact (full version history).
+    private val _artifactActive = MutableStateFlow(false)
+    val artifactActive: StateFlow<Boolean> = _artifactActive.asStateFlow()
+
+    /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentArtifact: StateFlow<Artifact?> = _currentChatThreadId
+        .flatMapLatest { id -> if (id == null) flowOf(null) else artifactManager.observeForChat(id) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    /** All versions of the current artifact (drives the workspace version switcher). */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentArtifactVersions: StateFlow<List<ArtifactVersion>> = currentArtifact
+        .flatMapLatest { a -> if (a == null) flowOf(emptyList()) else artifactManager.observeVersions(a.id) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** True while the fullscreen Artifact Workspace overlay is open. */
+    private val _artifactWorkspaceOpen = MutableStateFlow(false)
+    val artifactWorkspaceOpen: StateFlow<Boolean> = _artifactWorkspaceOpen.asStateFlow()
+
+    fun openArtifactWorkspace() { if (currentArtifact.value != null) _artifactWorkspaceOpen.value = true }
+    fun closeArtifactWorkspace() { _artifactWorkspaceOpen.value = false }
+
     // Browser Flow igniter chip. Unlike Echo modes it is NOT sticky: it only *starts* a session;
     // once a session exists, the session row (not this flag) captures the owning chat's routing.
     private val _browserFlowActive = MutableStateFlow(false)
@@ -302,9 +345,15 @@ class ChatViewModel(
     // Web Search, Deep Research, Data Agent, Echo Adviser and Echo Fusion are mutually
     // exclusive capabilities — turning one on clears the rest.
     private fun clearCapabilitiesExcept(keep: MutableStateFlow<Boolean>) {
-        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive, _browserFlowActive)
+        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive, _browserFlowActive, _artifactActive)
             .filter { it !== keep }
             .forEach { it.value = false }
+    }
+
+    fun toggleArtifact() {
+        val next = !_artifactActive.value
+        _artifactActive.value = next
+        if (next) clearCapabilitiesExcept(_artifactActive)
     }
 
     fun toggleDeepResearch() {
@@ -606,6 +655,39 @@ class ChatViewModel(
                     )
                 }
             }
+            is StreamChunk.ArtifactStarted -> {
+                segments.add(
+                    StreamSegment.Artifact(
+                        artifactId = null,
+                        title = chunk.title,
+                        artifactType = chunk.artifactType,
+                        version = 0,
+                        charCount = 0,
+                        building = true,
+                        truncated = false,
+                    )
+                )
+            }
+            is StreamChunk.ArtifactProgress -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Artifact && it.building }
+                if (idx >= 0) {
+                    val seg = segments[idx] as StreamSegment.Artifact
+                    segments[idx] = seg.copy(charCount = chunk.charCount)
+                }
+            }
+            is StreamChunk.ArtifactCompleted -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Artifact && it.building }
+                val finished = StreamSegment.Artifact(
+                    artifactId = chunk.artifactId,
+                    title = chunk.title,
+                    artifactType = chunk.artifactType,
+                    version = chunk.version,
+                    charCount = chunk.content.length,
+                    building = false,
+                    truncated = chunk.truncated,
+                )
+                if (idx >= 0) segments[idx] = finished else segments.add(finished)
+            }
         }
         return null
     }
@@ -755,7 +837,16 @@ class ChatViewModel(
                 echoSystemPrompt = SystemPrompts.buildEchoFusion(panel.name)
             }
 
-            val systemPrompt = echoSystemPrompt ?: SystemPrompts.build(isLocal, effectiveProvider)
+            // Artifact mode: override the system prompt with the artifact builder. Feed the chat's
+            // current artifact back so a follow-up revises it. On-device implies offline (no CDN).
+            val artifactMode = _artifactActive.value
+            val artifactSystemPrompt = if (artifactMode) {
+                val prior = _currentChatThreadId.value?.let { artifactManager.getLatestVersionContent(it) }
+                val offline = settingsRepository.getArtifactsOfflineDirect() || isLocal
+                SystemPrompts.buildArtifact(isLocal, offline, prior)
+            } else null
+
+            val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: SystemPrompts.build(isLocal, effectiveProvider)
 
             var isFirstMsgInChat = false
             var chatId = _currentChatThreadId.value
@@ -841,7 +932,7 @@ class ChatViewModel(
                 )
             }
 
-            val responseFlow: Flow<StreamChunk> = when {
+            val baseResponseFlow: Flow<StreamChunk> = when {
                 agentReq != null ->
                     openRouterService.sendWithAgentTools(
                         apiKey = apiKey,
@@ -851,6 +942,12 @@ class ChatViewModel(
                         agent = agentReq,
                         params = inferenceParams,
                     )
+                // Artifact mode runs the plain streaming path (no search); the parser extracts the
+                // <echo:artifact> block from the content stream.
+                artifactMode && isLocal ->
+                    localLlmService.generate(localModel!!, chatId, fullHistory, systemPrompt, inferenceParams)
+                artifactMode ->
+                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false, params = inferenceParams)
                 advisorReq != null || fusionReq != null ->
                     openRouterService.sendWithEchoTools(
                         apiKey = apiKey,
@@ -874,6 +971,11 @@ class ChatViewModel(
                 else ->
                     openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false, params = inferenceParams)
             }
+
+            // In artifact mode, route the <echo:artifact> block out of the chat bubble into
+            // artifact events; otherwise pass the stream through untouched.
+            val responseFlow: Flow<StreamChunk> =
+                if (artifactMode) baseResponseFlow.extractArtifacts() else baseResponseFlow
 
             // Begin Streaming Assistant response
             setStreamState(
@@ -905,7 +1007,19 @@ class ChatViewModel(
             // Keep the process unfrozen so the reply keeps streaming while minimized.
             KeepAliveService.acquire(getApplication(), keepAliveText)
             try {
-                responseFlow.collect { chunk ->
+                responseFlow.collect { rawChunk ->
+                    // Persist a completed artifact version before reducing, so the card/segment
+                    // carry a real artifactId/version to deep-link the workspace.
+                    val chunk = if (rawChunk is StreamChunk.ArtifactCompleted && rawChunk.content.isNotBlank()) {
+                        val ref = artifactManager.saveVersion(
+                            chatId = chatId,
+                            title = rawChunk.title,
+                            type = rawChunk.artifactType,
+                            content = rawChunk.content,
+                            sourcePrompt = prompt,
+                        )
+                        rawChunk.copy(artifactId = ref.artifactId, artifactType = ref.type, version = ref.version)
+                    } else rawChunk
                     val note = reduceSegments(segments, chunk)
                     if (note != null) statusNote = note
                     setStreamState(
@@ -1184,7 +1298,10 @@ class ChatViewModel(
             .joinToString("\n\n") { it.text }.trim()
         // Keep a turn that produced only an Echo Adviser/Fusion artifact (no prose answer) so
         // the consultation/deliberation card still persists and re-renders.
-        val hasEchoArtifact = normalizedSegments.any { it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent }
+        val hasEchoArtifact = normalizedSegments.any {
+            it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent ||
+                (it is StreamSegment.Artifact && it.artifactId != null)
+        }
         if (contentText.isEmpty() && !hasEchoArtifact) return
 
         val reasoningText = normalizedSegments.filterIsInstance<StreamSegment.Reasoning>()
@@ -1238,6 +1355,17 @@ class ChatViewModel(
                             error = seg.error,
                         ),
                     )
+                is StreamSegment.Artifact -> seg.artifactId?.let { id ->
+                    PersistedSegment(
+                        type = "artifact",
+                        artifact = ArtifactRef(
+                            artifactId = id,
+                            title = seg.title,
+                            type = seg.artifactType,
+                            version = seg.version,
+                        ),
+                    )
+                }
                 // Transient waiting indicator — never persisted.
                 is StreamSegment.AgentRun -> null
                 is StreamSegment.Text -> seg.text.trim().takeIf { it.isNotEmpty() }
@@ -1475,14 +1603,16 @@ class ChatViewModel(
             fusionPanelDao: FusionPanelDao,
             agentProfileDao: AgentProfileDao,
             browserSessionDao: BrowserSessionDao,
-            browserStepDao: BrowserStepDao
+            browserStepDao: BrowserStepDao,
+            artifactDao: ArtifactDao,
+            artifactVersionDao: ArtifactVersionDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
-                    agentProfileDao, browserSessionDao, browserStepDao
+                    agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -89,6 +89,9 @@ class SettingsViewModel(
     val browserFlowEnabled: StateFlow<Boolean> = repository.browserFlowEnabled
     val browserIdleMinutes: StateFlow<Int> = repository.browserIdleMinutes
 
+    // Artifacts
+    val artifactsOffline: StateFlow<Boolean> = repository.artifactsOffline
+
     // Echo Adviser / Echo Fusion
     val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
     val echoFusionPanelId: StateFlow<String> = repository.echoFusionPanelId
@@ -227,6 +230,7 @@ class SettingsViewModel(
     fun saveDataAgentEnabled(enabled: Boolean) = repository.saveDataAgentEnabled(enabled)
     fun saveBrowserFlowEnabled(enabled: Boolean) = repository.saveBrowserFlowEnabled(enabled)
     fun saveBrowserIdleMinutes(value: Int) = repository.saveBrowserIdleMinutes(value)
+    fun saveArtifactsOffline(enabled: Boolean) = repository.saveArtifactsOffline(enabled)
     fun saveEchoAdviserEnabled(enabled: Boolean) = repository.saveEchoAdviserEnabled(enabled)
     fun saveEchoFusionEnabled(enabled: Boolean) = repository.saveEchoFusionEnabled(enabled)
     fun saveEchoAgentEnabled(enabled: Boolean) = repository.saveEchoAgentEnabled(enabled)

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -1,0 +1,126 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.OpenInFull
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.Artifact
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The in-chat artifact card. While [building] it shows a live "Building…" header with a wavy
+ * progress bar and a streaming character count (the code never appears in the bubble). Once
+ * finished it becomes a tappable card — title, type badge, version — with an Open button that
+ * launches the fullscreen Artifact Workspace.
+ */
+@Composable
+fun ArtifactCard(
+    title: String,
+    artifactType: String,
+    version: Int,
+    building: Boolean,
+    charCount: Int,
+    truncated: Boolean,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val (icon, typeLabel) = artifactGlyph(artifactType)
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.40f),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(40.dp).clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.tertiary),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(icon, null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onTertiary) }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.tertiary) {
+                        Text(
+                            if (building) "BUILDING ARTIFACT" else "ARTIFACT · $typeLabel",
+                            Modifier.padding(horizontal = Spacing.s, vertical = 2.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onTertiary,
+                        )
+                    }
+                    Spacer(Modifier.height(3.dp))
+                    Text(
+                        title.ifBlank { typeLabel },
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        when {
+                            building && charCount > 0 -> "Writing… ${charCount} characters"
+                            building -> "Starting…"
+                            truncated -> "Version $version · incomplete (stream cut off)"
+                            else -> "Version $version · tap Open to view"
+                        },
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (!building) {
+                    Spacer(Modifier.width(Spacing.s))
+                    FilledTonalButton(onClick = onOpen) {
+                        Icon(Icons.Default.OpenInFull, null, Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("Open")
+                    }
+                }
+            }
+            if (building) {
+                Spacer(Modifier.height(Spacing.m))
+                LinearWavyProgressIndicator(
+                    color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+private fun artifactGlyph(type: String): Pair<ImageVector, String> = when (type) {
+    Artifact.TYPE_MARKDOWN -> Icons.AutoMirrored.Filled.Article to "Document"
+    Artifact.TYPE_LATEX -> Icons.Default.PictureAsPdf to "Report"
+    else -> Icons.Default.Code to "Web page"
+}

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -119,6 +119,43 @@ fun ArtifactCard(
     }
 }
 
+/**
+ * Floating pill shown across the app while an artifact exists in the open chat and the workspace is
+ * closed — a quick way back into the fullscreen viewer. Mirrors the Browser Flow global pill.
+ */
+@Composable
+fun GlobalArtifactPill(
+    title: String,
+    artifactType: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val (icon, _) = artifactGlyph(artifactType)
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.tertiary,
+        shadowElevation = 8.dp,
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.m, top = 10.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            Icon(icon, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onTertiary)
+            Text(
+                title.ifBlank { "Artifact" },
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onTertiary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
 private fun artifactGlyph(type: String): Pair<ImageVector, String> = when (type) {
     Artifact.TYPE_MARKDOWN -> Icons.AutoMirrored.Filled.Article to "Document"
     Artifact.TYPE_LATEX -> Icons.Default.PictureAsPdf to "Report"

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
@@ -1,0 +1,318 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material.icons.filled.Preview
+import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.echoflow.data.Artifact
+import com.echoflow.data.ArtifactExport
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.components.RichMarkdown
+import com.echoflow.ui.theme.Spacing
+
+private enum class ArtifactViewMode { PREVIEW, CODE }
+
+/**
+ * The fullscreen Artifact Workspace — a stripped-down viewer for the chat's current artifact.
+ * No address bar and no command composer (iteration happens back in chat): just a minimize action,
+ * a Preview/Code mode switcher, a version selector, and per-type actions (Export PDF for reports,
+ * Copy source). HTML renders in a sandboxed WebView; markdown/latex render with the native engine.
+ */
+@Composable
+fun ArtifactWorkspaceScreen(
+    chatViewModel: ChatViewModel,
+    onClose: () -> Unit,
+) {
+    val artifact by chatViewModel.currentArtifact.collectAsState()
+    val versions by chatViewModel.currentArtifactVersions.collectAsState()
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+
+    // Leave if the artifact vanishes (e.g. chat deleted).
+    LaunchedEffect(artifact == null) { if (artifact == null) onClose() }
+    val a = artifact ?: return
+
+    var mode by remember { mutableStateOf(ArtifactViewMode.PREVIEW) }
+    var selectedVersion by remember(a.id) { mutableIntStateOf(a.currentVersion) }
+    // Follow the latest version as new ones stream in, unless the user pinned an older one.
+    LaunchedEffect(a.currentVersion) {
+        if (selectedVersion < a.currentVersion && selectedVersion == a.currentVersion - 1) {
+            selectedVersion = a.currentVersion
+        }
+    }
+    val content = remember(versions, selectedVersion) {
+        (versions.firstOrNull { it.versionNumber == selectedVersion } ?: versions.lastOrNull())?.content.orEmpty()
+    }
+
+    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+        Column(Modifier.fillMaxSize()) {
+            ArtifactTopBar(
+                artifact = a,
+                versions = versions.map { it.versionNumber },
+                selectedVersion = selectedVersion,
+                onSelectVersion = { selectedVersion = it },
+                mode = mode,
+                onMode = { mode = it },
+                onClose = onClose,
+                onExport = { ArtifactExport.printArtifact(context, a.title, a.type, content) },
+                onCopy = { clipboard.setText(AnnotatedString(content)) },
+            )
+
+            Box(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .background(
+                        if (a.isHtml && mode == ArtifactViewMode.PREVIEW) Color.White
+                        else MaterialTheme.colorScheme.surface
+                    ),
+            ) {
+                when {
+                    mode == ArtifactViewMode.CODE -> CodeView(content)
+                    a.isHtml -> ArtifactWebView(html = content, modifier = Modifier.fillMaxSize())
+                    else -> Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(Spacing.base)) {
+                        RichMarkdown(content, Modifier.fillMaxWidth())
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtifactTopBar(
+    artifact: Artifact,
+    versions: List<Int>,
+    selectedVersion: Int,
+    onSelectVersion: (Int) -> Unit,
+    mode: ArtifactViewMode,
+    onMode: (ArtifactViewMode) -> Unit,
+    onClose: () -> Unit,
+    onExport: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.KeyboardArrowDown, "Minimize to chat", Modifier.size(26.dp))
+                }
+                Text(
+                    artifact.title.ifBlank { "Artifact" },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (versions.size > 1) VersionMenu(versions, selectedVersion, onSelectVersion)
+                IconButton(onClick = onCopy) { Icon(Icons.Default.ContentCopy, "Copy source", Modifier.size(20.dp)) }
+                // Export to PDF — reports/docs render their math; an HTML artifact prints as a page.
+                FilledTonalIconButton(onClick = onExport) {
+                    Icon(Icons.Default.PictureAsPdf, "Export PDF", Modifier.size(20.dp))
+                }
+            }
+            // Preview / Code segmented switcher.
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                ModeTab(
+                    label = if (artifact.isHtml) "Preview" else "Reading",
+                    icon = Icons.Default.Preview,
+                    selected = mode == ArtifactViewMode.PREVIEW,
+                    onClick = { onMode(ArtifactViewMode.PREVIEW) },
+                    modifier = Modifier.weight(1f),
+                )
+                ModeTab(
+                    label = if (artifact.isHtml) "Code" else "Source",
+                    icon = Icons.Default.Code,
+                    selected = mode == ArtifactViewMode.CODE,
+                    onClick = { onMode(ArtifactViewMode.CODE) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModeTab(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                icon, null, Modifier.size(18.dp),
+                tint = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                label,
+                style = MaterialTheme.typography.labelLarge,
+                color = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VersionMenu(versions: List<Int>, selected: Int, onSelect: (Int) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    Box {
+        Surface(
+            onClick = { open = true },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ) {
+            Row(
+                Modifier.padding(horizontal = Spacing.s, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text("v$selected", style = MaterialTheme.typography.labelLarge)
+                Icon(Icons.Default.UnfoldMore, "Pick version", Modifier.size(16.dp))
+            }
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            versions.sortedDescending().forEach { v ->
+                DropdownMenuItem(
+                    text = { Text("Version $v") },
+                    trailingIcon = { if (v == selected) Icon(Icons.Default.Check, "Selected", tint = MaterialTheme.colorScheme.primary) },
+                    onClick = { onSelect(v); open = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CodeView(code: String) {
+    SelectionContainer {
+        Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(Spacing.base)) {
+            Text(
+                code,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.size(Spacing.xl))
+        }
+    }
+}
+
+/**
+ * Sandboxed WebView for an HTML artifact. Loaded with a null base URL (opaque origin) and with file
+ * access disabled — the artifact is untrusted, model-generated code, so it gets no path to the app.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun ArtifactWebView(html: String, modifier: Modifier = Modifier) {
+    var lastHtml by remember { mutableStateOf<String?>(null) }
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            WebView(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.allowFileAccess = false
+                settings.allowContentAccess = false
+                @Suppress("DEPRECATION")
+                settings.allowFileAccessFromFileURLs = false
+                @Suppress("DEPRECATION")
+                settings.allowUniversalAccessFromFileURLs = false
+                settings.useWideViewPort = true
+                settings.loadWithOverviewMode = true
+                webViewClient = WebViewClient()
+                loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+                lastHtml = html
+            }
+        },
+        update = { web ->
+            if (lastHtml != html) {
+                web.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+                lastHtml = html
+            }
+        },
+        onRelease = { web ->
+            web.stopLoading()
+            web.loadUrl("about:blank")
+            web.destroy()
+        },
+    )
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -74,6 +74,7 @@ import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.AdvisorCard
 import com.echoflow.ui.components.AgentDeployingCard
 import com.echoflow.ui.components.BrandMark
+import com.echoflow.ui.components.ArtifactCard
 import com.echoflow.ui.components.CapabilityChip
 import com.echoflow.ui.components.DataResultCard
 import com.echoflow.ui.components.FusionCard
@@ -154,6 +155,7 @@ fun ChatScreen(
     val echoFusionEnabled by settingsViewModel.echoFusionEnabled.collectAsState()
     val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
 
+    val artifactActive by chatViewModel.artifactActive.collectAsState()
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -276,6 +278,7 @@ fun ChatScreen(
                         topInset = topBarInset,
                         bottomInset = messageBottomInset,
                         onCopy = { clipboard.setText(AnnotatedString(it)) },
+                        onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
                     )
                 }
             }
@@ -335,6 +338,8 @@ fun ChatScreen(
                 browserFlowActive = browserFlowActive,
                 browserFlowAvailable = browserFlowAvailable,
                 onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
+                artifactActive = artifactActive,
+                onToggleArtifact = { chatViewModel.toggleArtifact() },
                 browserSession = browserSession,
                 browserSteps = browserSteps,
                 onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },
@@ -496,6 +501,7 @@ private fun MessagesPane(
     topInset: Dp = Spacing.l,
     bottomInset: Dp = Spacing.l,
     onCopy: (String) -> Unit,
+    onArtifactOpen: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     var autoFollow by remember { mutableStateOf(true) }
@@ -533,7 +539,7 @@ private fun MessagesPane(
         contentPadding = PaddingValues(start = Spacing.base, end = Spacing.base, top = topInset, bottom = bottomInset),
     ) {
         items(messages, key = { it.id }) { msg ->
-            MessageBubble(msg) { onCopy(msg.content) }
+            MessageBubble(msg, onCopy = { onCopy(msg.content) }, onArtifactOpen = onArtifactOpen)
         }
         researchRun?.let { run ->
             item(key = "research") { ResearchProgressCard(run = run, onCancel = onCancelResearch) }
@@ -544,7 +550,7 @@ private fun MessagesPane(
             item { ThinkingRow() }
         }
         if (segments.isNotEmpty()) item(key = "streaming") {
-            StreamingAssistantBubble(segments = segments, statusNote = statusNote, isStreaming = isStreaming)
+            StreamingAssistantBubble(segments = segments, statusNote = statusNote, isStreaming = isStreaming, onArtifactOpen = onArtifactOpen)
         }
     }
 }
@@ -591,6 +597,7 @@ private fun StreamingAssistantBubble(
     segments: List<StreamSegment>,
     statusNote: String?,
     isStreaming: Boolean,
+    onArtifactOpen: () -> Unit = {},
 ) {
     Column(Modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -643,6 +650,18 @@ private fun StreamingAssistantBubble(
                             outcome = segment.outcome,
                             error = segment.error,
                             active = segment.active,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    is StreamSegment.Artifact -> {
+                        ArtifactCard(
+                            title = segment.title,
+                            artifactType = segment.artifactType,
+                            version = segment.version,
+                            building = segment.building,
+                            charCount = segment.charCount,
+                            truncated = segment.truncated,
+                            onOpen = onArtifactOpen,
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }
@@ -733,7 +752,7 @@ private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
 }
 
 @Composable
-private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, streaming: Boolean = false, onCopy: () -> Unit) {
+private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, streaming: Boolean = false, onArtifactOpen: () -> Unit = {}, onCopy: () -> Unit) {
     val isUser = message.role == "user"
     if (isUser) {
         Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -834,6 +853,20 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                                         active = false,
                                     )
                                     Spacer(Modifier.height(Spacing.s))
+                                }
+                            }
+                            "artifact" -> {
+                                segment.artifact?.let { a ->
+                                    ArtifactCard(
+                                        title = a.title,
+                                        artifactType = a.type,
+                                        version = a.version,
+                                        building = false,
+                                        charCount = 0,
+                                        truncated = false,
+                                        onOpen = onArtifactOpen,
+                                    )
+                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
                             }
                             // The plan is rendered as a disclosure inside the report card.
@@ -1149,6 +1182,8 @@ private fun InputToolbar(
     browserFlowActive: Boolean,
     browserFlowAvailable: Boolean,
     onToggleBrowserFlow: () -> Unit,
+    artifactActive: Boolean,
+    onToggleArtifact: () -> Unit,
     browserSession: com.echoflow.data.BrowserSession?,
     browserSteps: List<com.echoflow.data.BrowserStep>,
     onBrowserOpen: () -> Unit,
@@ -1217,7 +1252,7 @@ private fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -1228,6 +1263,9 @@ private fun InputToolbar(
                 }
                 if (browserFlowActive) {
                     CapabilityChip(Icons.Default.Language, "Browser Flow", onRemove = onToggleBrowserFlow)
+                }
+                if (artifactActive) {
+                    CapabilityChip(Icons.Default.AutoAwesome, "Artifact", onRemove = onToggleArtifact)
                 }
                 if (echoAdviserActive) {
                     CapabilityChip(
@@ -1317,6 +1355,7 @@ private fun InputToolbar(
                         echoAgentAvailable = echoAgentAvailable,
                         browserFlowOn = browserFlowActive,
                         browserFlowAvailable = browserFlowAvailable,
+                        artifactOn = artifactActive,
                         onImage = { plusMenuOpen = false; onAttach() },
                         onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
@@ -1326,6 +1365,7 @@ private fun InputToolbar(
                         onToggleEchoFusion = { plusMenuOpen = false; onToggleEchoFusion() },
                         onToggleEchoAgent = { plusMenuOpen = false; onToggleEchoAgent() },
                         onToggleBrowserFlow = { plusMenuOpen = false; onToggleBrowserFlow() },
+                        onToggleArtifact = { plusMenuOpen = false; onToggleArtifact() },
                     )
                 }
 
@@ -1339,6 +1379,7 @@ private fun InputToolbar(
                                 browserFlowActive -> "Open a site & say what to do…"
                                 dataAgentActive -> "Describe the data to extract…"
                                 deepResearchActive -> "Research a topic…"
+                                artifactActive -> "Describe an artifact to build…"
                                 else -> "Ask anything…"
                             }
                         )
@@ -1387,6 +1428,7 @@ private fun PlusMenu(
     echoAgentAvailable: Boolean,
     browserFlowOn: Boolean,
     browserFlowAvailable: Boolean,
+    artifactOn: Boolean,
     onImage: () -> Unit,
     onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
@@ -1396,6 +1438,7 @@ private fun PlusMenu(
     onToggleEchoFusion: () -> Unit,
     onToggleEchoAgent: () -> Unit,
     onToggleBrowserFlow: () -> Unit,
+    onToggleArtifact: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
@@ -1424,6 +1467,13 @@ private fun PlusMenu(
             leadingIcon = { Icon(Icons.Default.Science, null) },
             trailingIcon = { if (deepResearchOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleDeepResearch,
+        )
+        // Artifacts — build a rendered web page, document or report (model picks the type).
+        DropdownMenuItem(
+            text = { Text("Artifact") },
+            leadingIcon = { Icon(Icons.Default.AutoAwesome, null) },
+            trailingIcon = { if (artifactOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleArtifact,
         )
         // Data Agent only appears once it's enabled in Settings and a Firecrawl key exists.
         if (dataAgentAvailable) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -1385,6 +1385,32 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
                 onClick = { onOpen(PageBrowserFlow) },
             )
         }
+
+        val artifactsOffline by viewModel.artifactsOffline.collectAsState()
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Artifacts", "How generated web artifacts handle the network")
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text("Offline artifacts", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Build HTML artifacts with no CDN so they render without a connection. " +
+                            "Reports and documents already work offline.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(
+                    checked = artifactsOffline,
+                    onCheckedChange = { viewModel.saveArtifactsOffline(it) },
+                )
+            }
+        }
     }
 }
 

--- a/app/src/test/java/com/echoflow/ArtifactStreamParserTest.kt
+++ b/app/src/test/java/com/echoflow/ArtifactStreamParserTest.kt
@@ -1,0 +1,74 @@
+package com.echoflow
+
+import com.echoflow.data.Artifact
+import com.echoflow.data.ArtifactStreamParser
+import com.echoflow.data.StreamChunk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Drives the parser synchronously by feeding content in arbitrary chunk splits. */
+class ArtifactStreamParserTest {
+
+    private fun run(vararg chunks: String): List<StreamChunk> {
+        val parser = ArtifactStreamParser()
+        val out = mutableListOf<StreamChunk>()
+        chunks.forEach { out += parser.onChunk(StreamChunk.Content(it)) }
+        out += parser.onComplete()
+        return out
+    }
+
+    private fun proseOf(chunks: List<StreamChunk>) =
+        chunks.filterIsInstance<StreamChunk.Content>().joinToString("") { it.text }
+
+    @Test
+    fun `prose without an artifact passes straight through`() {
+        val out = run("Hello ", "world")
+        assertEquals("Hello world", proseOf(out))
+        assertTrue(out.none { it is StreamChunk.ArtifactStarted })
+    }
+
+    @Test
+    fun `extracts a single artifact and keeps surrounding prose`() {
+        val out = run(
+            "Here you go: ",
+            "<echo:artifact type=\"html\" title=\"Page\">",
+            "<h1>Hi</h1>",
+            "</echo:artifact>",
+            " done",
+        )
+        assertEquals("Here you go:  done", proseOf(out))
+        val started = out.filterIsInstance<StreamChunk.ArtifactStarted>().single()
+        assertEquals("Page", started.title)
+        assertEquals(Artifact.TYPE_HTML, started.artifactType)
+        val done = out.filterIsInstance<StreamChunk.ArtifactCompleted>().single()
+        assertEquals("<h1>Hi</h1>", done.content)
+        assertTrue(!done.truncated)
+    }
+
+    @Test
+    fun `handles an open tag split across chunk boundaries`() {
+        val out = run("intro <echo:art", "ifact type=\"markdown\" title=\"Doc\">body", "</echo:artifact>")
+        assertEquals("intro ", proseOf(out))
+        val started = out.filterIsInstance<StreamChunk.ArtifactStarted>().single()
+        assertEquals(Artifact.TYPE_MARKDOWN, started.artifactType)
+        assertEquals("body", out.filterIsInstance<StreamChunk.ArtifactCompleted>().single().content)
+    }
+
+    @Test
+    fun `handles a close tag split across chunk boundaries`() {
+        val out = run("<echo:artifact type=\"latex\" title=\"R\">x=1</echo:art", "ifact>tail")
+        assertEquals("tail", proseOf(out))
+        val done = out.filterIsInstance<StreamChunk.ArtifactCompleted>().single()
+        assertEquals("x=1", done.content)
+        assertEquals(Artifact.TYPE_LATEX, done.artifactType)
+    }
+
+    @Test
+    fun `unterminated artifact is surfaced as truncated`() {
+        val out = run("<echo:artifact type=\"html\" title=\"P\">partial code never closed")
+        val done = out.filterIsInstance<StreamChunk.ArtifactCompleted>().single()
+        assertEquals("partial code never closed", done.content)
+        assertTrue(done.truncated)
+    }
+}


### PR DESCRIPTION
## What

Adds an **Artifact** mode: the model builds one self-contained, rendered artifact — an interactive **web page** (HTML/CSS/JS), a **markdown document**, or a printable **LaTeX report** — shown in an in-chat card and opened in a fullscreen workspace. The model picks the type from the prompt. Built to reuse the existing Browser Flow / Echo-mode patterns end-to-end.

Turn it on from the **+ menu → Artifact**. It's a sticky capability (like the Echo modes); follow-up messages iterate the chat's current artifact, and every generation is kept as a **version** (full history).

## How it works

- **Sentinel extraction** — the model wraps the artifact in `<echo:artifact type="…" title="…">…</echo:artifact>`. A streaming state-machine parser (`extractArtifacts`) routes the body out of the chat bubble into artifact events, so the code never floods the conversation. Handles tags split across chunk boundaries and surfaces an unterminated stream as *truncated*. Unit-tested.
- **System prompt** (`SystemPrompts.buildArtifact`) — sentinel output contract, type selection, and a stripped-down version of Anthropic's frontend-design guidance (full for cloud, compact for on-device). Detailed Markdown+LaTeX report rules tuned for the app's native renderer (Markdown for structure, LaTeX only for math — it is **not** a LaTeX compiler). An iteration block feeds the prior version back for revisions.
- **Local + cloud** — works on both. On-device models get the compact prompt and are forced offline.
- **Offline (no-CDN) setting** — Settings → Echo Labs → *Offline artifacts*. When on (auto-forced for on-device models), the HTML prompt forbids CDNs so pages render with no connection; reports/docs are offline regardless (native renderer).
- **Workspace** — stripped-down fullscreen viewer: minimize, **Preview/Code** switcher, **version selector**, **Copy**, **Export PDF**. No address bar, no command composer (iteration is chat-driven). HTML renders in a **sandboxed WebView** (null base URL, file access off); markdown/latex render natively. A global "artifact ready" pill gives quick re-entry.
- **PDF export** — Android's built-in print framework (no new dependency). HTML prints as a page; reports render via marked + KaTeX. *(Report math uses CDN at export time; the on-screen preview always uses the native renderer.)*

## Data

- Room **v12** (`MIGRATION_11_12`): `artifacts` + `artifact_versions`. One lineage per chat, versions accrue.
- New `PersistedSegment` type `artifact` (carries an `ArtifactRef`) so finished replies re-render the card.

## Commits (built in parts)

1. Data layer (Room v12) · 2. Stream chunks + parser (+tests) · 3. `buildArtifact` prompt · 4. Offline setting · 5. ViewModel wiring · 6. Chat card / chip / + menu · 7. Workspace + PDF export + pill

## Verification

⚠️ Not compiled from CLI (per project constraints: build/verify in **Android Studio**). Please confirm: Room v12 migration, the artifact stream parser against real model output, the sandboxed WebView render, and PDF export on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude-style Artifacts feature for web pages, documents, and LaTeX reports
> - Introduces an end-to-end artifact pipeline: users toggle "Artifact" mode from the chat plus menu, which sends a specialized system prompt instructing the model to produce sentinel-wrapped (`<echo:artifact>`) content.
> - A streaming state machine in [`ArtifactStreamParser`](https://github.com/adityavardhansharma/EchoFlow/pull/42/files#diff-00e81e039ccaf4ac971949b7ef720d0c5fbf0ff510c4011c17a70df7c5fce451) intercepts artifact blocks in real time, emitting `ArtifactStarted`, `ArtifactProgress`, and `ArtifactCompleted` events while keeping artifact bodies out of chat bubbles.
> - Completed artifacts are persisted via a new [`ArtifactManager`](https://github.com/adityavardhansharma/EchoFlow/pull/42/files#diff-2c840fbc4c6a32441b2419d21c9ea7923c61fd8d47c0d9a39c34db5dd85282b5) backed by two new Room tables (`artifacts`, `artifact_versions`) added in DB migration 11→12.
> - A fullscreen [`ArtifactWorkspaceScreen`](https://github.com/adityavardhansharma/EchoFlow/pull/42/files#diff-22b0a67de891471d5b5fe7ea23412af4b866a6e22218b3e1b8d29ca6e9349a81) lets users switch between preview and code views, browse version history, copy source, and export to PDF via Android's `PrintManager`.
> - HTML artifacts render in a sandboxed `WebView`; markdown and LaTeX render via `RichMarkdown`. A settings toggle controls offline mode for HTML artifact generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40d3133.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Artifact generation mode supporting HTML, Markdown, and LaTeX content types
  * Fullscreen Artifact Workspace with version history and multiple view modes
  * PDF export functionality for generated artifacts
  * Offline rendering mode for artifact assets
  * Artifact mode toggle in chat input toolbar with visual indicators

* **Tests**
  * Added comprehensive test coverage for artifact stream parsing and boundary conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->