### PR TITLE
Fix release build: AnimatedVisibility overload in BrowserWorkspaceScreen

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -125,64 +125,16 @@ fun BrowserWorkspaceScreen(
             )
 
             // ── Live browser viewport ────────────────────────────────────────────────────
-            Box(
-                Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = Spacing.s)
-                    .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp, bottomStart = 12.dp, bottomEnd = 12.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
-            ) {
-                if (liveUrl != null) {
-                    LiveBrowserWebView(url = liveUrl, modifier = Modifier.fillMaxSize())
-                } else {
-                    OpeningState(domain = BrowserResolver.domainOf(s.resolvedUrl), busy = busy, phase = s.phase)
-                }
-
-                // Thin browser-style load bar pinned to the top edge of the page.
-                AnimatedVisibility(busy, Modifier.align(Alignment.TopCenter), enter = fadeIn(), exit = fadeOut()) {
-                    LinearWavyProgressIndicator(Modifier.fillMaxWidth())
-                }
-
-                // Floating phase chip — the agent is driving.
-                AnimatedVisibility(
-                    visible = busy && liveUrl != null,
-                    modifier = Modifier.align(Alignment.TopCenter).padding(top = Spacing.base),
-                    enter = scaleIn() + fadeIn(),
-                    exit = scaleOut() + fadeOut(),
-                ) {
-                    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.inverseSurface, shadowElevation = 6.dp) {
-                        Row(
-                            Modifier.padding(start = Spacing.s, end = Spacing.base, top = 6.dp, bottom = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-                        ) {
-                            LoadingIndicator(
-                                modifier = Modifier.size(22.dp),
-                                color = MaterialTheme.colorScheme.inversePrimary,
-                            )
-                            Text(
-                                s.phase ?: "Working…",
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.inverseOnSurface,
-                            )
-                        }
-                    }
-                }
-
-                // Take-over-in-Chrome escape hatch.
-                if (liveUrl != null) {
-                    FilledTonalIconButton(
-                        onClick = { openExternal() },
-                        modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        ),
-                    ) {
-                        Icon(Icons.Default.OpenInNew, "Open in external browser", Modifier.size(20.dp))
-                    }
-                }
-            }
+            // Extracted to its own composable so the enclosing ColumnScope does not leak in: the
+            // overlay AnimatedVisibility calls would otherwise resolve to ColumnScope.AnimatedVisibility
+            // (whose receiver isn't available here) instead of the plain Box-friendly overload.
+            BrowserViewport(
+                session = s,
+                busy = busy,
+                liveUrl = liveUrl,
+                onOpenExternal = { openExternal() },
+                modifier = Modifier.weight(1f),
+            )
 
             BrowserPauseBar(
                 session = s,
@@ -204,6 +156,81 @@ fun BrowserWorkspaceScreen(
                     if (t.isNotEmpty()) { command = ""; chatViewModel.sendMessage(t) }
                 },
             )
+        }
+    }
+}
+
+// ── Live viewport ────────────────────────────────────────────────────────────────────────
+
+/**
+ * The live page viewport plus its overlays (load bar, phase chip, take-over button). Kept as a
+ * standalone composable (not a ColumnScope extension) so `AnimatedVisibility` inside the [Box]
+ * resolves to the plain overload rather than the leaked-in `ColumnScope` one. The caller supplies
+ * the `weight(1f)` via [modifier] from the enclosing Column.
+ */
+@Composable
+private fun BrowserViewport(
+    session: BrowserSession,
+    busy: Boolean,
+    liveUrl: String?,
+    onOpenExternal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.s)
+            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp, bottomStart = 12.dp, bottomEnd = 12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow),
+    ) {
+        if (liveUrl != null) {
+            LiveBrowserWebView(url = liveUrl, modifier = Modifier.fillMaxSize())
+        } else {
+            OpeningState(domain = BrowserResolver.domainOf(session.resolvedUrl), busy = busy, phase = session.phase)
+        }
+
+        // Thin browser-style load bar pinned to the top edge of the page.
+        AnimatedVisibility(busy, Modifier.align(Alignment.TopCenter), enter = fadeIn(), exit = fadeOut()) {
+            LinearWavyProgressIndicator(Modifier.fillMaxWidth())
+        }
+
+        // Floating phase chip — the agent is driving.
+        AnimatedVisibility(
+            visible = busy && liveUrl != null,
+            modifier = Modifier.align(Alignment.TopCenter).padding(top = Spacing.base),
+            enter = scaleIn() + fadeIn(),
+            exit = scaleOut() + fadeOut(),
+        ) {
+            Surface(shape = CircleShape, color = MaterialTheme.colorScheme.inverseSurface, shadowElevation = 6.dp) {
+                Row(
+                    Modifier.padding(start = Spacing.s, end = Spacing.base, top = 6.dp, bottom = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                ) {
+                    LoadingIndicator(
+                        modifier = Modifier.size(22.dp),
+                        color = MaterialTheme.colorScheme.inversePrimary,
+                    )
+                    Text(
+                        session.phase ?: "Working…",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                }
+            }
+        }
+
+        // Take-over-in-Chrome escape hatch.
+        if (liveUrl != null) {
+            FilledTonalIconButton(
+                onClick = onOpenExternal,
+                modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                ),
+            ) {
+                Icon(Icons.Default.OpenInNew, "Open in external browser", Modifier.size(20.dp))
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`compileReleaseKotlin` fails:

```
BrowserWorkspaceScreen.kt:143 'fun ColumnScope.AnimatedVisibility(...)' cannot be called
in this context with an implicit receiver. Use an explicit receiver if necessary.
BrowserWorkspaceScreen.kt:148 ... (same)
```

The live-viewport overlays (load bar + phase chip) call `AnimatedVisibility` inside a `Box` that is nested in the screen's outer `Column`. The enclosing `ColumnScope` leaks in as a non-nearest implicit receiver, so overload resolution picks `ColumnScope.AnimatedVisibility` — whose receiver isn't actually available at that point — instead of the plain `Box`-friendly overload.

## Fix

Extract the viewport `Box` and its overlays into a standalone `BrowserViewport` composable (not a `ColumnScope` extension). With no `ColumnScope` in scope there, `AnimatedVisibility` resolves to the plain overload. The `weight(1f)` is passed in via `modifier` from the caller's `Column`, so layout is unchanged. No behavior or visual change.

## Verification

⚠️ Not CLI-compiled (project builds in Android Studio). The change is a pure refactor of one composable to remove the leaked-scope ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release build by extracting live viewport into a `BrowserViewport` composable
> Extracts the inline Box-based live viewport from `BrowserWorkspaceScreen` into a new private `BrowserViewport` composable in [BrowserWorkspaceScreen.kt](https://github.com/adityavardhansharma/EchoFlow/pull/43/files#diff-a02559b724fdf634aa7cf3c9b1a19e767ac8e185ac7eeffcf22b51a0ee18e219). This resolves a build failure caused by an `AnimatedVisibility` overload conflict. The new composable encapsulates the same logic: rendering `LiveBrowserWebView` or `OpeningState`, showing a progress indicator and floating phase chip when busy, and displaying an external open button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86f2598.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->