### PR TITLE
Browser/artifact polish + working Stop button

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -10,6 +10,12 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
@@ -207,8 +213,13 @@ fun MainNavigationHub(
             )
         }
 
-        // Fullscreen Artifact Workspace overlay (preview / code / version switcher).
-        if (artifactWorkspaceOpen) {
+        // Fullscreen Artifact Workspace overlay (preview / code / version switcher). It slides up
+        // and fades in so tapping "Open" reads as a smooth sheet transition rather than a pop.
+        AnimatedVisibility(
+            visible = artifactWorkspaceOpen,
+            enter = slideInVertically(animationSpec = tween(320)) { it } + fadeIn(tween(220)),
+            exit = slideOutVertically(animationSpec = tween(260)) { it } + fadeOut(tween(180)),
+        ) {
             BackHandler { chatViewModel.closeArtifactWorkspace() }
             com.echoflow.ui.screens.ArtifactWorkspaceScreen(
                 chatViewModel = chatViewModel,

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -162,7 +162,6 @@ fun MainNavigationHub(
 
     val activeBrowserSession by chatViewModel.activeBrowserSession.collectAsState()
     val browserWorkspaceChatId by chatViewModel.browserWorkspaceChatId.collectAsState()
-    val currentArtifact by chatViewModel.currentArtifact.collectAsState()
     val artifactWorkspaceOpen by chatViewModel.artifactWorkspaceOpen.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -199,17 +198,6 @@ fun MainNavigationHub(
             com.echoflow.ui.screens.BrowserWorkspaceScreen(
                 chatViewModel = chatViewModel,
                 onClose = { chatViewModel.closeBrowserWorkspace() },
-            )
-        }
-
-        // Global "artifact ready" pill — tap to reopen the workspace for the open chat's artifact.
-        val artifact = currentArtifact
-        if (artifact != null && !artifactWorkspaceOpen && browserWorkspaceChatId == null) {
-            com.echoflow.ui.components.GlobalArtifactPill(
-                title = artifact.title,
-                artifactType = artifact.type,
-                onClick = { chatViewModel.openArtifactWorkspace() },
-                modifier = Modifier.align(Alignment.BottomEnd).padding(end = 20.dp, bottom = 110.dp),
             )
         }
 

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -9,10 +9,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.echoflow.data.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.UUID
 import kotlin.coroutines.coroutineContext
 
@@ -1040,6 +1043,13 @@ class ChatViewModel(
                         text = "Tap to read the answer in EchoFlow.",
                     )
                 }
+            } catch (e: CancellationException) {
+                // User tapped Stop — keep whatever streamed so far and surface no error banner.
+                // The persist runs under NonCancellable so it isn't skipped by the cancellation.
+                withContext(NonCancellable) {
+                    persistAssistantMessage(chatId, segments, interrupted = null)
+                }
+                throw e
             } catch (e: Exception) {
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -3,7 +3,6 @@
 package com.echoflow.ui.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -115,43 +114,6 @@ fun ArtifactCard(
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-        }
-    }
-}
-
-/**
- * Floating pill shown across the app while an artifact exists in the open chat and the workspace is
- * closed — a quick way back into the fullscreen viewer. Mirrors the Browser Flow global pill.
- */
-@Composable
-fun GlobalArtifactPill(
-    title: String,
-    artifactType: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val (icon, _) = artifactGlyph(artifactType)
-    Surface(
-        onClick = onClick,
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.tertiary,
-        shadowElevation = 8.dp,
-        modifier = modifier,
-    ) {
-        Row(
-            Modifier.padding(start = Spacing.base, end = Spacing.m, top = 10.dp, bottom = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-        ) {
-            Icon(icon, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onTertiary)
-            Text(
-                title.ifBlank { "Artifact" },
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onTertiary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
@@ -180,9 +180,13 @@ private fun ArtifactTopBar(
                 )
                 if (versions.size > 1) VersionMenu(versions, selectedVersion, onSelectVersion)
                 IconButton(onClick = onCopy) { Icon(Icons.Default.ContentCopy, "Copy source", Modifier.size(20.dp)) }
-                // Export to PDF — reports/docs render their math; an HTML artifact prints as a page.
-                FilledTonalIconButton(onClick = onExport) {
-                    Icon(Icons.Default.PictureAsPdf, "Export PDF", Modifier.size(20.dp))
+                // Export to PDF only for documents/reports (markdown/LaTeX), where it renders the
+                // math/prose to a page. HTML pages aren't meant to be flattened to a PDF, so the
+                // action is hidden for them.
+                if (!artifact.isHtml) {
+                    FilledTonalIconButton(onClick = onExport) {
+                        Icon(Icons.Default.PictureAsPdf, "Export PDF", Modifier.size(20.dp))
+                    }
                 }
             }
             // Preview / Code segmented switcher.

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
@@ -121,13 +121,22 @@ fun ArtifactWorkspaceScreen(
                     .weight(1f)
                     .fillMaxWidth()
                     .background(
-                        if (a.isHtml && mode == ArtifactViewMode.PREVIEW) Color.White
+                        if (a.isHtml) Color.White
                         else MaterialTheme.colorScheme.surface
                     ),
             ) {
                 when {
+                    a.isHtml -> {
+                        // Keep the WebView mounted across Preview/Code so toggling modes doesn't
+                        // destroy and reload it (which flashes black). The Code view overlays it.
+                        ArtifactWebView(html = content, modifier = Modifier.fillMaxSize())
+                        if (mode == ArtifactViewMode.CODE) {
+                            Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+                                CodeView(content)
+                            }
+                        }
+                    }
                     mode == ArtifactViewMode.CODE -> CodeView(content)
-                    a.isHtml -> ArtifactWebView(html = content, modifier = Modifier.fillMaxSize())
                     else -> Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(Spacing.base)) {
                         RichMarkdown(content, Modifier.fillMaxWidth())
                     }
@@ -298,6 +307,8 @@ private fun ArtifactWebView(html: String, modifier: Modifier = Modifier) {
                 settings.allowUniversalAccessFromFileURLs = false
                 settings.useWideViewPort = true
                 settings.loadWithOverviewMode = true
+                // Opaque white base so the view never paints a black frame while (re)loading.
+                setBackgroundColor(android.graphics.Color.WHITE)
                 webViewClient = WebViewClient()
                 loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
                 lastHtml = html

--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -116,7 +116,11 @@ fun BrowserWorkspaceScreen(
         runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
     }
 
-    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+    Surface(
+        Modifier.fillMaxSize(),
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) {
         Column(Modifier.fillMaxSize()) {
             WorkspaceTopBar(
                 session = s,
@@ -243,7 +247,10 @@ private fun WorkspaceTopBar(
     onClose: () -> Unit,
     onStop: () -> Unit,
 ) {
-    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    ) {
         Column(
             Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -362,6 +362,7 @@ fun ChatScreen(
                     else -> null
                 },
                 onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
+                onStop = { chatViewModel.stopStreaming() },
             )
 
             // Error banner floats just below the top bar.
@@ -1201,6 +1202,7 @@ private fun InputToolbar(
     onSelectEffort: (String) -> Unit,
     blockedReason: String? = null,
     onSend: () -> Unit,
+    onStop: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -1401,7 +1403,7 @@ private fun InputToolbar(
                 val hasText = text.trim().isNotEmpty()
                 val hasContent = hasText || (pendingUri != null && !researchMode)
                 val canSend = hasContent && !isStreaming && !researchInProgress && blockedReason == null
-                SendButton(enabled = canSend, isStreaming = isStreaming, research = researchMode) {
+                SendButton(enabled = canSend, isStreaming = isStreaming, research = researchMode, onStop = onStop) {
                     if (canSend) onSend()
                 }
             }
@@ -1526,12 +1528,24 @@ private fun PlusMenu(
 }
 
 @Composable
-private fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolean = false, onClick: () -> Unit) {
+private fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolean = false, onStop: () -> Unit = {}, onClick: () -> Unit) {
     if (isStreaming) {
+        // Tappable Stop — cancels the in-flight reply (cloud stream or on-device generation).
         Box(
-            Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+                .clickable(onClick = onStop),
             contentAlignment = Alignment.Center,
-        ) { LoadingIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp)) }
+        ) {
+            Icon(
+                Icons.Default.Stop,
+                "Stop generating",
+                Modifier.size(22.dp),
+                tint = MaterialTheme.colorScheme.onPrimary,
+            )
+        }
     } else {
         // The hero action gets the boldest shape — a "Sunny" that morphs to a rounder cookie on
         // press with an expressive (bouncy) spring. In research mode it starts the investigation.


### PR DESCRIPTION
Four small fixes, one commit each.

## Changes

1. **Round the Browser Workspace top corners** (`3d866e1`)
   The fullscreen browser overlay had a hard rectangular top that read as boxy over the chat. The outer surface and the top bar now share matching 28dp rounded top corners, so the workspace reads as a rounded sheet.

2. **Animate the Artifact Workspace open/close** (`5ee0487`)
   Opening an artifact popped in abruptly. The overlay is now wrapped in `AnimatedVisibility` and slides up + fades in (reversing on close), so tapping **Open** on an artifact card is a smooth sheet transition.

3. **Remove the global artifact pill near the input box** (`3cb39be`)
   The floating pill showing the artifact title sat just above the composer and duplicated the in-chat artifact card. Removed the pill usage, its state collection, and the now-dead `GlobalArtifactPill` composable.

4. **Make the composer Stop button actually cancel streaming** (`831b1e6`)
   While a reply streamed, the send button showed a non-interactive spinner — tapping it did nothing, so OpenRouter cloud replies couldn't be stopped. It is now a tappable **Stop** control wired to `stopStreaming()`. The resulting `CancellationException` is handled by persisting the partial reply under `NonCancellable` with no error banner.

> Note: this branch also carries the earlier `86f2598` release-build fix that it was originally cut for.

## Testing
UI/Compose changes — please verify in Android Studio per the project build constraints (no CLI Gradle/SDK build available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add working Stop button and fix artifact/browser workspace polish
> - The `SendButton` in the chat toolbar becomes a tappable Stop button during streaming; tapping it cancels generation and persists any partial assistant content already received.
> - HTML artifact previews no longer flash black or reload the WebView when switching between Preview and Code modes; the WebView stays mounted and a surface overlay displays code instead.
> - The Export PDF button is hidden for HTML artifacts, and the WebView background is set to white to prevent black frames during load.
> - The browser workspace and its top bar now have 28dp rounded top corners.
> - The Artifact Workspace animates in and out with a slide+fade transition; the global artifact pill is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa11336.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact workspace now transitions smoothly with slide-up and fade-in animations on open, slide-down and fade-out on close.
  * Interactive "Stop generating" button during chat streaming for improved user control.

* **Bug Fixes**
  * Enhanced handling of chat generation interruptions to preserve previously streamed content.

* **Style**
  * Browser workspace now displays with rounded top corners for a polished appearance.
  * Removed floating artifact pill from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->