### PR TITLE
Fix artifact Open doing nothing (regression from #44)

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -10,12 +10,6 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
@@ -201,13 +195,10 @@ fun MainNavigationHub(
             )
         }
 
-        // Fullscreen Artifact Workspace overlay (preview / code / version switcher). It slides up
-        // and fades in so tapping "Open" reads as a smooth sheet transition rather than a pop.
-        AnimatedVisibility(
-            visible = artifactWorkspaceOpen,
-            enter = slideInVertically(animationSpec = tween(320)) { it } + fadeIn(tween(220)),
-            exit = slideOutVertically(animationSpec = tween(260)) { it } + fadeOut(tween(180)),
-        ) {
+        // Fullscreen Artifact Workspace overlay (preview / code / version switcher). The smooth
+        // slide-up/fade on open is animated inside the screen itself (see ArtifactWorkspaceScreen)
+        // so its presence is never gated behind a transition — keeping "Open" reliable.
+        if (artifactWorkspaceOpen) {
             BackHandler { chatViewModel.closeArtifactWorkspace() }
             com.echoflow.ui.screens.ArtifactWorkspaceScreen(
                 chatViewModel = chatViewModel,

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
@@ -6,6 +6,8 @@ import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -54,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -102,7 +105,26 @@ fun ArtifactWorkspaceScreen(
         (versions.firstOrNull { it.versionNumber == selectedVersion } ?: versions.lastOrNull())?.content.orEmpty()
     }
 
-    Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+    // Smooth open: the screen is always present (so "Open" is reliable); we just slide it up from
+    // the bottom and fade it in on first appearance via a graphics layer, then reverse none — the
+    // parent removes it on close. Driven by a flag flipped one frame after entering composition.
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val openProgress by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        animationSpec = tween(durationMillis = 320),
+        label = "artifact-open",
+    )
+
+    Surface(
+        Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                translationY = (1f - openProgress) * size.height
+                alpha = openProgress
+            },
+        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) {
         Column(Modifier.fillMaxSize()) {
             ArtifactTopBar(
                 artifact = a,


### PR DESCRIPTION
## Problem

After #44, tapping **Open** on an artifact card did nothing — the fullscreen Artifact Workspace never appeared.

The cause was the open animation added in #44: the overlay was wrapped in a `BoxScope` `AnimatedVisibility`, which gated the screen's *presence* behind the transition. For a `fillMaxSize` fullscreen overlay inside a `Box`, that stopped it from showing at all.

## Fix

- **Restore reliable presence** in `MainActivity`: the workspace is shown with the plain `if (artifactWorkspaceOpen)` guard again (same pattern as the Browser Workspace), so Open always renders.
- **Keep the smooth open** by animating *inside* `ArtifactWorkspaceScreen` instead: the root `Surface` slides up from the bottom and fades in on first appearance via a `graphicsLayer` (`translationY` + `alpha`), driven by a flag flipped one frame after entering composition. This is purely visual, so it can never block the screen from showing or gate Open.

Net effect: Open works again **and** still opens with a smooth slide-up/fade.

## Testing
Compose UI change — please verify in Android Studio per the project build constraints (no CLI Gradle/SDK build here): tapping Open on an artifact card shows the workspace with a slide-up animation, and Back/minimize still closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix artifact workspace open doing nothing by moving animation into ArtifactWorkspaceScreen
> - Removes the `AnimatedVisibility` wrapper in `MainNavigationHub` that was blocking the artifact workspace from opening (regression from #44); the overlay is now shown via a plain conditional check.
> - Moves the open animation into [`ArtifactWorkspaceScreen.kt`](https://github.com/adityavardhansharma/EchoFlow/pull/45/files#diff-22b0a67de891471d5b5fe7ea23412af4b866a6e22218b3e1b8d29ca6e9349a81): on first composition, the screen slides up from the bottom and fades in over 320ms using `animateFloatAsState` with a tween.
> - No exit animation is applied; the overlay is removed immediately when closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97aa5e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->