### PR TITLE
Fix artifact Open doing nothing (cold WhileSubscribed flow + self-close race)

### DIFF
--- a/app/src/main/java/com/echoflow/data/ArtifactManager.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactManager.kt
@@ -15,6 +15,9 @@ class ArtifactManager(
 ) {
     fun observeForChat(chatId: String): Flow<Artifact?> = artifactDao.observeLatestForChat(chatId)
 
+    /** A one-shot read of the chat's latest artifact, for decisions that can't wait on the cold flow. */
+    suspend fun getLatestForChat(chatId: String): Artifact? = artifactDao.getLatestForChat(chatId)
+
     fun observeVersions(artifactId: String): Flow<List<ArtifactVersion>> =
         artifactVersionDao.observeForArtifact(artifactId)
 

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -283,7 +283,17 @@ class ChatViewModel(
     private val _artifactWorkspaceOpen = MutableStateFlow(false)
     val artifactWorkspaceOpen: StateFlow<Boolean> = _artifactWorkspaceOpen.asStateFlow()
 
-    fun openArtifactWorkspace() { if (currentArtifact.value != null) _artifactWorkspaceOpen.value = true }
+    fun openArtifactWorkspace() {
+        // currentArtifact is a WhileSubscribed flow whose only collector is the workspace screen
+        // itself, so outside it the cached .value is a stale null. Resolve existence straight from
+        // the store instead, otherwise the guard is always false and "Open" silently does nothing.
+        viewModelScope.launch {
+            val chatId = _currentChatThreadId.value ?: return@launch
+            if (artifactManager.getLatestForChat(chatId) != null) {
+                _artifactWorkspaceOpen.value = true
+            }
+        }
+    }
     fun closeArtifactWorkspace() { _artifactWorkspaceOpen.value = false }
 
     // Browser Flow igniter chip. Unlike Echo modes it is NOT sticky: it only *starts* a session;

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactWorkspaceScreen.kt
@@ -89,8 +89,14 @@ fun ArtifactWorkspaceScreen(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
 
-    // Leave if the artifact vanishes (e.g. chat deleted).
-    LaunchedEffect(artifact == null) { if (artifact == null) onClose() }
+    // Leave if the artifact vanishes (e.g. chat deleted) — but NOT on the initial null the
+    // WhileSubscribed flow caches before its first emission, which would slam the screen shut the
+    // instant it opens. Only close once we've actually shown an artifact and it later disappears.
+    var hadArtifact by remember { mutableStateOf(false) }
+    LaunchedEffect(artifact) {
+        if (artifact != null) hadArtifact = true
+        else if (hadArtifact) onClose()
+    }
     val a = artifact ?: return
 
     var mode by remember { mutableStateOf(ArtifactViewMode.PREVIEW) }


### PR DESCRIPTION
## What was broken

The artifact **Open** button did nothing — the fullscreen workspace never appeared. The previous attempt (`97aa5e4`) reworked the open animation but didn't clear the actual root cause, so it still didn't open.

## Root cause — two stacked bugs

**1. The open guard read a cold flow.**
`ChatViewModel.openArtifactWorkspace()` gated on `currentArtifact.value`. But `currentArtifact` is a `SharingStarted.WhileSubscribed(5000)` flow whose **only collector is the workspace screen itself** (not composed yet at tap time). With no subscriber, the upstream `flatMapLatest`/Room query never runs, so `.value` is stuck at its initial `null`. The guard `currentArtifact.value != null` was therefore always false → `_artifactWorkspaceOpen` never flipped → nothing opened.

**2. The workspace closed itself on the first frame.**
Even with the guard fixed, opening would snap shut instantly: `currentArtifact` emits its cached `null` before the real row arrives, and `LaunchedEffect(artifact == null) { onClose() }` interpreted that initial `null` as "the artifact vanished."

## The fix

- `openArtifactWorkspace()` now resolves the chat's latest artifact **directly from the store** via a new `ArtifactManager.getLatestForChat(chatId)` suspend read, instead of reading the cold flow's stale `.value`.
- The workspace only auto-closes once it has **actually shown an artifact** and it later disappears (e.g. chat deleted) — the pre-emission `null` no longer triggers a close.

## Files changed
- `data/ArtifactManager.kt` — add `getLatestForChat` one-shot read
- `ui/ChatViewModel.kt` — resolve existence from the store before opening
- `ui/screens/ArtifactWorkspaceScreen.kt` — don't treat the initial `null` as "vanished"

## Testing
⚠️ Per repo constraints this wasn't built from the CLI — **needs a verify in Android Studio**: generate an artifact, close the workspace, wait >5s (so the `WhileSubscribed` window lapses), then tap **Open** on the in-chat card and confirm the workspace opens and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix artifact workspace opening and closing prematurely due to cold Flow race condition
> - `openArtifactWorkspace` in [`ChatViewModel`](https://github.com/adityavardhansharma/EchoFlow/pull/46/files#diff-e472e72a7a21812cf8761bce2712390c23a547c3e316b22815fb7dc4cb7d28de) was reading `currentArtifact.value` from a `WhileSubscribed` Flow, which is null before the Flow warms up. It now performs a one-shot DB lookup via `artifactManager.getLatestForChat(chatId)` to bypass the cold-start null.
> - [`ArtifactWorkspaceScreen`](https://github.com/adityavardhansharma/EchoFlow/pull/46/files#diff-22b0a67de891471d5b5fe7ea23412af4b866a6e22218b3e1b8d29ca6e9349a81) was calling `onClose` immediately on first composition when `artifact` was null. It now tracks a `hadArtifact` flag and only closes after an artifact has been displayed and then disappears.
> - [`ArtifactManager`](https://github.com/adityavardhansharma/EchoFlow/pull/46/files#diff-2c840fbc4c6a32441b2419d21c9ea7923c61fd8d47c0d9a39c34db5dd85282b5) gains a new `getLatestForChat` suspend function that delegates directly to the DAO for a single synchronous read.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e064a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->