### PR TITLE
Harden settings storage and simplify chat streaming state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
   implementation(libs.androidx.navigation.compose)
   implementation(libs.androidx.room.ktx)
   implementation(libs.androidx.room.runtime)
+  implementation(libs.androidx.security.crypto)
   implementation(libs.coil.compose)
   implementation(libs.converter.moshi)
   // implementation(libs.firebase.ai)

--- a/app/src/main/java/com/echoflow/data/ChatMode.kt
+++ b/app/src/main/java/com/echoflow/data/ChatMode.kt
@@ -1,0 +1,15 @@
+package com.echoflow.data
+
+/** Mutually exclusive per-message chat capability selected from the input "+" menu. */
+sealed interface ChatMode {
+    data object Normal : ChatMode
+    data object WebSearch : ChatMode
+    data object DeepResearch : ChatMode
+    data object DataAgent : ChatMode
+    data object EchoAdviser : ChatMode
+    data object EchoFusion : ChatMode
+    data object EchoAgent : ChatMode
+    data object BrowserFlow : ChatMode
+    data object Artifact : ChatMode
+}
+

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -1,0 +1,47 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+class ChatRepository(
+    val chatDao: ChatDao,
+    val messageDao: MessageDao,
+    val localModelDao: LocalModelDao,
+    val researchRunDao: ResearchRunDao,
+    val deepResearchModelDao: DeepResearchModelDao,
+    val advisorProfileDao: AdvisorProfileDao,
+    val fusionPanelDao: FusionPanelDao,
+    val agentProfileDao: AgentProfileDao,
+    val browserSessionDao: BrowserSessionDao,
+    val browserStepDao: BrowserStepDao,
+    val artifactDao: ArtifactDao,
+    val artifactVersionDao: ArtifactVersionDao,
+) {
+    fun allThreads(): Flow<List<ChatThread>> = chatDao.getAllThreads()
+    fun messagesForChat(chatId: String): Flow<List<ChatMessage>> = messageDao.getMessagesForChat(chatId)
+    fun searchChatIdsByContent(query: String): Flow<List<String>> = messageDao.searchChatIdsByContent(query)
+
+    suspend fun createThread(title: String = "New Conversation", now: Long = System.currentTimeMillis()): ChatThread {
+        val thread = ChatThread(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            createdAt = now,
+            updatedAt = now,
+        )
+        chatDao.insertThread(thread)
+        return thread
+    }
+
+    suspend fun touchThread(chatId: String, now: Long = System.currentTimeMillis()) {
+        chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = now)) }
+    }
+
+    suspend fun renameThread(chatId: String, title: String) {
+        chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(title = title)) }
+    }
+
+    suspend fun insertMessage(message: ChatMessage) = messageDao.insertMessage(message)
+    suspend fun history(chatId: String): List<ChatMessage> = messageDao.getMessagesForChatSync(chatId)
+    suspend fun thread(chatId: String): ChatThread? = chatDao.getThreadById(chatId)
+}
+

--- a/app/src/main/java/com/echoflow/data/LlmGateway.kt
+++ b/app/src/main/java/com/echoflow/data/LlmGateway.kt
@@ -1,0 +1,48 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+
+interface LlmGateway {
+    fun stream(request: LlmStreamRequest): Flow<StreamChunk>
+}
+
+data class LlmStreamRequest(
+    val apiKey: String = "",
+    val model: String,
+    val chatId: String,
+    val history: List<ChatMessage>,
+    val systemPrompt: String,
+    val params: InferenceParams,
+    val localModel: LocalModel? = null,
+    val serverWebSearch: Boolean = false,
+)
+
+class OpenRouterGateway(
+    private val service: OpenRouterService,
+) : LlmGateway {
+    override fun stream(request: LlmStreamRequest): Flow<StreamChunk> =
+        service.sendChatMessageStream(
+            apiKey = request.apiKey,
+            model = request.model,
+            history = request.history,
+            systemPrompt = request.systemPrompt,
+            serverWebSearch = request.serverWebSearch,
+            params = request.params,
+        )
+}
+
+class LocalLlmGateway(
+    private val service: LocalLlmService,
+) : LlmGateway {
+    override fun stream(request: LlmStreamRequest): Flow<StreamChunk> {
+        val model = request.localModel ?: error("Local model is required for local gateway requests.")
+        return service.generate(
+            model = model,
+            chatId = request.chatId,
+            history = request.history,
+            systemPrompt = request.systemPrompt,
+            params = request.params,
+        )
+    }
+}
+

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -40,11 +41,65 @@ class OpenRouterService(private val context: Context) {
         .build()
 
     private val dynamicAdapter = moshi.adapter(Any::class.java)
+    private val streamChunkAdapter = moshi.adapter(OpenRouterStreamEvent::class.java)
 
     data class LocalAttachment(
         val uri: String,
         val mimeType: String?,
         val name: String?,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterStreamEvent(
+        val choices: List<OpenRouterStreamChoice>? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterStreamChoice(
+        val delta: OpenRouterStreamDelta? = null,
+        val message: OpenRouterStreamMessage? = null,
+        val finish_reason: String? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterStreamDelta(
+        val content: String? = null,
+        val reasoning: String? = null,
+        val reasoning_content: String? = null,
+        val tool_calls: List<OpenRouterToolCallDelta>? = null,
+        val annotations: List<OpenRouterAnnotation>? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterStreamMessage(
+        val annotations: List<OpenRouterAnnotation>? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterToolCallDelta(
+        val index: Int? = null,
+        val id: String? = null,
+        val type: String? = null,
+        val function: OpenRouterFunctionDelta? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterFunctionDelta(
+        val name: String? = null,
+        val arguments: String? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterAnnotation(
+        val type: String? = null,
+        val url_citation: OpenRouterUrlCitation? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterUrlCitation(
+        val title: String? = null,
+        val url: String? = null,
+        val content: String? = null,
     )
 
     /**
@@ -555,20 +610,18 @@ class OpenRouterService(private val context: Context) {
                 if (dataPart == "[DONE]" || dataPart.startsWith("[DONE]")) break
 
                 try {
-                    val map = dynamicAdapter.fromJson(dataPart) as? Map<*, *>
-                    val choices = map?.get("choices") as? List<*>
-                    val choice = choices?.firstOrNull() as? Map<*, *>
-                    val delta = choice?.get("delta") as? Map<*, *>
+                    val event = streamChunkAdapter.fromJson(dataPart)
+                    val choice = event?.choices?.firstOrNull()
+                    val delta = choice?.delta
 
                     // Reasoning tokens (different providers name the field differently).
-                    val reasoning = (delta?.get("reasoning") as? String)
-                        ?: (delta?.get("reasoning_content") as? String)
+                    val reasoning = delta?.reasoning ?: delta?.reasoning_content
                     if (!reasoning.isNullOrEmpty()) {
                         reasoningBuf.append(reasoning)
                         onChunk(StreamChunk.Reasoning(reasoning))
                     }
 
-                    val content = delta?.get("content") as? String
+                    val content = delta?.content
                     if (!content.isNullOrEmpty()) {
                         contentBuf.append(content)
                         onChunk(StreamChunk.Content(content))
@@ -577,16 +630,14 @@ class OpenRouterService(private val context: Context) {
                     // Tool call deltas: fragments accumulate per index. Used both by the
                     // OpenRouter server tool (search runs server-side mid-stream) and by
                     // client function calling (we run the search between requests).
-                    val toolCallDeltas = delta?.get("tool_calls") as? List<*>
-                    toolCallDeltas?.forEach { rawCall ->
-                        val call = rawCall as? Map<*, *> ?: return@forEach
-                        val index = (call["index"] as? Double)?.toInt() ?: 0
+                    val toolCallDeltas = delta?.tool_calls
+                    toolCallDeltas?.forEach { call ->
+                        val index = call.index ?: 0
                         val builder = toolCallBuilders.getOrPut(index) { ToolCallBuilder() }
-                        (call["id"] as? String)?.let { builder.id = it }
-                        (call["type"] as? String)?.let { builder.type = it }
-                        val function = call["function"] as? Map<*, *>
-                        (function?.get("name") as? String)?.let { builder.name = it }
-                        (function?.get("arguments") as? String)?.let { builder.args.append(it) }
+                        call.id?.let { builder.id = it }
+                        call.type?.let { builder.type = it }
+                        call.function?.name?.let { builder.name = it }
+                        call.function?.arguments?.let { builder.args.append(it) }
 
                         if (!builder.announced && builder.looksLikeWebSearch()) {
                             val query = parseQueryArgument(builder.args.toString())
@@ -629,20 +680,18 @@ class OpenRouterService(private val context: Context) {
                     }
 
                     // url_citation annotations may arrive on the delta or on a message object.
-                    val annotations = (delta?.get("annotations") as? List<*>)
-                        ?: ((choice?.get("message") as? Map<*, *>)?.get("annotations") as? List<*>)
+                    val annotations = delta?.annotations ?: choice?.message?.annotations
                     if (annotations != null) {
                         val fresh = mutableListOf<SearchSource>()
-                        annotations.forEach { rawAnn ->
-                            val ann = rawAnn as? Map<*, *> ?: return@forEach
-                            if ((ann["type"] as? String) != "url_citation") return@forEach
-                            val cite = ann["url_citation"] as? Map<*, *> ?: return@forEach
-                            val url = cite["url"] as? String ?: return@forEach
+                        annotations.forEach { ann ->
+                            if (ann.type != "url_citation") return@forEach
+                            val cite = ann.url_citation ?: return@forEach
+                            val url = cite.url ?: return@forEach
                             if (!seenSourceUrls.add(url)) return@forEach
                             val source = SearchSource(
-                                title = (cite["title"] as? String).orEmpty().ifBlank { url },
+                                title = cite.title.orEmpty().ifBlank { url },
                                 url = url,
-                                snippet = cite["content"] as? String
+                                snippet = cite.content
                             )
                             collectedSources.add(source)
                             fresh.add(source)
@@ -656,6 +705,8 @@ class OpenRouterService(private val context: Context) {
                     // tree. The exact shape is beta/undocumented, so we walk the whole chunk
                     // defensively for the signature keys and degrade to "consulted, no body" if
                     // nothing parses — never a crash. (Verify shapes against a live key.)
+                    val needsDynamicScan = echo != null || agentWorkerModel != null
+                    val map = if (needsDynamicScan) dynamicAdapter.fromJson(dataPart) as? Map<*, *> else null
                     if (echo != null && map != null) {
                         if (echo.advisorName != null && !advisorResolved) {
                             scanForAdvisorResult(map)?.let { (advisorModel, advice) ->
@@ -699,7 +750,7 @@ class OpenRouterService(private val context: Context) {
                         }
                     }
 
-                    (choice?.get("finish_reason") as? String)?.let { finishReason = it }
+                    choice?.finish_reason?.let { finishReason = it }
                 } catch (e: Exception) {
                     // Resilient inline SSE fail ignores
                 }

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -2,18 +2,55 @@ package com.echoflow.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class SettingsRepository(context: Context) {
-    private val prefs: SharedPreferences = context.getSharedPreferences("settings_prefs", Context.MODE_PRIVATE)
+    private val legacyPrefs: SharedPreferences = context.getSharedPreferences(LEGACY_PREFS, Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = createSecurePrefs(context) ?: legacyPrefs
 
     init {
+        migrateLegacyPrefsIfNeeded()
         // One-time migration from the legacy boolean toggle to the provider-based setting.
         if (!prefs.contains(KEY_SEARCH_PROVIDER) && prefs.getBoolean("web_search_enabled", false)) {
             prefs.edit().putString(KEY_SEARCH_PROVIDER, "openrouter").apply()
         }
+    }
+
+    private fun createSecurePrefs(context: Context): SharedPreferences? = runCatching {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            SECURE_PREFS,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }.getOrNull()
+
+    private fun migrateLegacyPrefsIfNeeded() {
+        if (prefs === legacyPrefs || prefs.getBoolean(KEY_SECURE_PREFS_MIGRATED, false)) return
+        val edit = prefs.edit()
+        legacyPrefs.all.forEach { (key, value) ->
+            if (prefs.contains(key)) return@forEach
+            when (value) {
+                is String -> edit.putString(key, value)
+                is Boolean -> edit.putBoolean(key, value)
+                is Int -> edit.putInt(key, value)
+                is Long -> edit.putLong(key, value)
+                is Float -> edit.putFloat(key, value)
+                is Set<*> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    edit.putStringSet(key, value as Set<String>)
+                }
+            }
+        }
+        edit.putBoolean(KEY_SECURE_PREFS_MIGRATED, true).apply()
     }
 
     private val _apiKey = MutableStateFlow(getApiKeyDirect())
@@ -425,6 +462,9 @@ class SettingsRepository(context: Context) {
     }
 
     companion object {
+        private const val LEGACY_PREFS = "settings_prefs"
+        private const val SECURE_PREFS = "secure_settings_prefs"
+        private const val KEY_SECURE_PREFS_MIGRATED = "secure_prefs_migrated_v1"
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -110,6 +110,22 @@ class ChatViewModel(
     private val openRouterService = OpenRouterService(application)
     private val webSearchService = WebSearchService()
     private val localLlmService = LocalLlmService(application)
+    private val chatRepository = ChatRepository(
+        chatDao = chatDao,
+        messageDao = messageDao,
+        localModelDao = localModelDao,
+        researchRunDao = researchRunDao,
+        deepResearchModelDao = deepResearchModelDao,
+        advisorProfileDao = advisorProfileDao,
+        fusionPanelDao = fusionPanelDao,
+        agentProfileDao = agentProfileDao,
+        browserSessionDao = browserSessionDao,
+        browserStepDao = browserStepDao,
+        artifactDao = artifactDao,
+        artifactVersionDao = artifactVersionDao,
+    )
+    private val openRouterGateway = OpenRouterGateway(openRouterService)
+    private val localGateway = LocalLlmGateway(localLlmService)
 
     // Browser Flow: stateful Firecrawl browser controlled through chat. The manager owns all
     // orchestration and writes session/step rows; the UI observes them.
@@ -117,7 +133,7 @@ class ChatViewModel(
         chatDao, messageDao, browserSessionDao, browserStepDao, settingsRepository, webSearchService, viewModelScope
     )
 
-    val allThreads: StateFlow<List<ChatThread>> = chatDao.getAllThreads()
+    val allThreads: StateFlow<List<ChatThread>> = chatRepository.allThreads()
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
@@ -137,7 +153,7 @@ class ChatViewModel(
         allThreads,
         _drawerSearchQuery,
         _drawerSearchQuery.flatMapLatest { query ->
-            if (query.isBlank()) flowOf(emptyList()) else messageDao.searchChatIdsByContent(query.trim())
+            if (query.isBlank()) flowOf(emptyList()) else chatRepository.searchChatIdsByContent(query.trim())
         },
     ) { threads, query, contentMatchIds ->
         val q = query.trim()
@@ -158,7 +174,7 @@ class ChatViewModel(
             if (chatId == null) {
                 flowOf(emptyList())
             } else {
-                messageDao.getMessagesForChat(chatId)
+                chatRepository.messagesForChat(chatId)
             }
         }
         .stateIn(
@@ -241,31 +257,24 @@ class ChatViewModel(
     private val _pendingAttachmentName = MutableStateFlow<String?>(null)
     val pendingAttachmentName: StateFlow<String?> = _pendingAttachmentName.asStateFlow()
 
-    // Per-message capability toggles surfaced by the "+" menu as chips above the input.
-    private val _deepResearchActive = MutableStateFlow(false)
-    val deepResearchActive: StateFlow<Boolean> = _deepResearchActive.asStateFlow()
+    // Per-message capability selected by the "+" menu. Exposed as legacy boolean flows so
+    // existing UI components can stay simple while illegal combinations remain unrepresentable.
+    private val _chatMode = MutableStateFlow<ChatMode>(ChatMode.Normal)
+    val chatMode: StateFlow<ChatMode> = _chatMode.asStateFlow()
 
-    private val _webSearchChipOn = MutableStateFlow(false)
-    val webSearchChipOn: StateFlow<Boolean> = _webSearchChipOn.asStateFlow()
-
-    private val _dataAgentActive = MutableStateFlow(false)
-    val dataAgentActive: StateFlow<Boolean> = _dataAgentActive.asStateFlow()
+    val deepResearchActive: StateFlow<Boolean> = modeIs<ChatMode.DeepResearch>()
+    val webSearchChipOn: StateFlow<Boolean> = modeIs<ChatMode.WebSearch>()
+    val dataAgentActive: StateFlow<Boolean> = modeIs<ChatMode.DataAgent>()
 
     // Echo Adviser / Echo Fusion: OpenRouter-only modes chosen from the "+" menu. Persist
     // across messages (a deliberate, cost-heavy choice) until the user turns them off.
-    private val _echoAdviserActive = MutableStateFlow(false)
-    val echoAdviserActive: StateFlow<Boolean> = _echoAdviserActive.asStateFlow()
-
-    private val _echoFusionActive = MutableStateFlow(false)
-    val echoFusionActive: StateFlow<Boolean> = _echoFusionActive.asStateFlow()
-
-    private val _echoAgentActive = MutableStateFlow(false)
-    val echoAgentActive: StateFlow<Boolean> = _echoAgentActive.asStateFlow()
+    val echoAdviserActive: StateFlow<Boolean> = modeIs<ChatMode.EchoAdviser>()
+    val echoFusionActive: StateFlow<Boolean> = modeIs<ChatMode.EchoFusion>()
+    val echoAgentActive: StateFlow<Boolean> = modeIs<ChatMode.EchoAgent>()
 
     // Artifact mode: sticky like the Echo modes. While on, every turn builds/updates an artifact;
     // follow-ups iterate the chat's current artifact (full version history).
-    private val _artifactActive = MutableStateFlow(false)
-    val artifactActive: StateFlow<Boolean> = _artifactActive.asStateFlow()
+    val artifactActive: StateFlow<Boolean> = modeIs<ChatMode.Artifact>()
 
     /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -298,8 +307,7 @@ class ChatViewModel(
 
     // Browser Flow igniter chip. Unlike Echo modes it is NOT sticky: it only *starts* a session;
     // once a session exists, the session row (not this flag) captures the owning chat's routing.
-    private val _browserFlowActive = MutableStateFlow(false)
-    val browserFlowActive: StateFlow<Boolean> = _browserFlowActive.asStateFlow()
+    val browserFlowActive: StateFlow<Boolean> = modeIs<ChatMode.BrowserFlow>()
 
     /** The single app-wide live browser session (start-lock + global pill). */
     val activeBrowserSession: StateFlow<BrowserSession?> = browserAgent.activeSession
@@ -355,61 +363,27 @@ class ChatViewModel(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    // Web Search, Deep Research, Data Agent, Echo Adviser and Echo Fusion are mutually
-    // exclusive capabilities — turning one on clears the rest.
-    private fun clearCapabilitiesExcept(keep: MutableStateFlow<Boolean>) {
-        listOf(_webSearchChipOn, _deepResearchActive, _dataAgentActive, _echoAdviserActive, _echoFusionActive, _echoAgentActive, _browserFlowActive, _artifactActive)
-            .filter { it !== keep }
-            .forEach { it.value = false }
+    private inline fun <reified T : ChatMode> modeIs(): StateFlow<Boolean> =
+        _chatMode
+            .map { it is T }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), _chatMode.value is T)
+
+    private fun setMode(mode: ChatMode) {
+        _chatMode.value = mode
     }
 
-    fun toggleArtifact() {
-        val next = !_artifactActive.value
-        _artifactActive.value = next
-        if (next) clearCapabilitiesExcept(_artifactActive)
+    private fun toggleMode(mode: ChatMode) {
+        _chatMode.value = if (_chatMode.value == mode) ChatMode.Normal else mode
     }
 
-    fun toggleDeepResearch() {
-        val next = !_deepResearchActive.value
-        _deepResearchActive.value = next
-        if (next) clearCapabilitiesExcept(_deepResearchActive)
-    }
-
-    fun toggleWebSearchChip() {
-        val next = !_webSearchChipOn.value
-        _webSearchChipOn.value = next
-        if (next) clearCapabilitiesExcept(_webSearchChipOn)
-    }
-
-    fun toggleDataAgent() {
-        val next = !_dataAgentActive.value
-        _dataAgentActive.value = next
-        if (next) clearCapabilitiesExcept(_dataAgentActive)
-    }
-
-    fun toggleEchoAdviser() {
-        val next = !_echoAdviserActive.value
-        _echoAdviserActive.value = next
-        if (next) clearCapabilitiesExcept(_echoAdviserActive)
-    }
-
-    fun toggleEchoFusion() {
-        val next = !_echoFusionActive.value
-        _echoFusionActive.value = next
-        if (next) clearCapabilitiesExcept(_echoFusionActive)
-    }
-
-    fun toggleEchoAgent() {
-        val next = !_echoAgentActive.value
-        _echoAgentActive.value = next
-        if (next) clearCapabilitiesExcept(_echoAgentActive)
-    }
-
-    fun toggleBrowserFlow() {
-        val next = !_browserFlowActive.value
-        _browserFlowActive.value = next
-        if (next) clearCapabilitiesExcept(_browserFlowActive)
-    }
+    fun toggleArtifact() = toggleMode(ChatMode.Artifact)
+    fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
+    fun toggleWebSearchChip() = toggleMode(ChatMode.WebSearch)
+    fun toggleDataAgent() = toggleMode(ChatMode.DataAgent)
+    fun toggleEchoAdviser() = toggleMode(ChatMode.EchoAdviser)
+    fun toggleEchoFusion() = toggleMode(ChatMode.EchoFusion)
+    fun toggleEchoAgent() = toggleMode(ChatMode.EchoAgent)
+    fun toggleBrowserFlow() = toggleMode(ChatMode.BrowserFlow)
 
     // ── Browser Flow actions (delegate to the manager; the card/workspace observe its rows) ──
 
@@ -725,11 +699,11 @@ class ChatViewModel(
 
         // Deep Research and Data Agent are different pipelines (foreground service +
         // provider/agent orchestration), so they short-circuit the normal streaming send.
-        if (_deepResearchActive.value && prompt.isNotEmpty()) {
+        if (_chatMode.value is ChatMode.DeepResearch && prompt.isNotEmpty()) {
             startDeepResearch(prompt, attachmentUri, attachmentMime, attachmentName)
             return
         }
-        if (_dataAgentActive.value && prompt.isNotEmpty()) {
+        if (_chatMode.value is ChatMode.DataAgent && prompt.isNotEmpty()) {
             startDataAgent(prompt)
             return
         }
@@ -741,7 +715,7 @@ class ChatViewModel(
             return
         }
         // Igniter: the "+ → Browser Flow" chip starts a new session, then turns itself off.
-        if (_browserFlowActive.value && prompt.isNotEmpty()) {
+        if (_chatMode.value is ChatMode.BrowserFlow && prompt.isNotEmpty()) {
             startBrowserSession(prompt)
             return
         }
@@ -758,12 +732,12 @@ class ChatViewModel(
             val selectedModel = settingsRepository.getSelectedModelDirect()
             // The "+ → Web Search" chip force-enables search using the last-used provider,
             // so the user never has to open Settings just to search one message.
-            val chipProvider = if (_webSearchChipOn.value) settingsRepository.resolveChipSearchProvider() else null
+            val chipProvider = if (_chatMode.value is ChatMode.WebSearch) settingsRepository.resolveChipSearchProvider() else null
             val provider = chipProvider ?: settingsRepository.getWebSearchProviderDirect()
             val searchScope = if (chipProvider != null) "both" else settingsRepository.getWebSearchScopeDirect()
             // Echo Fusion always runs cloud models (the panel + judge), so it never uses the
             // on-device engine even if a local model is the global selection.
-            val isLocal = selectedModel.startsWith("local/") && !_echoFusionActive.value
+            val isLocal = selectedModel.startsWith("local/") && _chatMode.value !is ChatMode.EchoFusion
 
             if (isLocal && _activeStreams.value.values.any { it.isLocal }) {
                 _errorMessage.value = "The on-device model is still responding. Wait for it to finish before starting another local reply."
@@ -814,7 +788,7 @@ class ChatViewModel(
             var agentReq: OpenRouterService.AgentRequest? = null
             var echoModel = selectedModel
             var echoSystemPrompt: String? = null
-            if (_echoAgentActive.value) {
+            if (_chatMode.value is ChatMode.EchoAgent) {
                 if (isLocal) {
                     _errorMessage.value = "Echo Agents needs a cloud main model. Pick one from the model selector."
                     return@launch
@@ -826,7 +800,7 @@ class ChatViewModel(
                 }
                 agentReq = OpenRouterService.AgentRequest(profile.workerModelId, profile.workerModelName, profile.maxToolCalls)
                 echoSystemPrompt = SystemPrompts.buildEchoAgent(profile.name)
-            } else if (_echoAdviserActive.value) {
+            } else if (_chatMode.value is ChatMode.EchoAdviser) {
                 if (isLocal) {
                     _errorMessage.value = "Echo Adviser needs a cloud model. Pick one from the model selector."
                     return@launch
@@ -838,7 +812,7 @@ class ChatViewModel(
                 }
                 advisorReq = OpenRouterService.AdvisorRequest(profile.name, profile.modelId)
                 echoSystemPrompt = SystemPrompts.buildEchoAdviser(profile.name)
-            } else if (_echoFusionActive.value) {
+            } else if (_chatMode.value is ChatMode.EchoFusion) {
                 val panel = fusionPanelDao.getById(settingsRepository.getEchoFusionPanelIdDirect())
                 if (panel == null || panel.models.isEmpty()) {
                     _errorMessage.value = "Set up a Fusion panel first in Settings → Echo Fusion, then pick it."
@@ -852,7 +826,7 @@ class ChatViewModel(
 
             // Artifact mode: override the system prompt with the artifact builder. Feed the chat's
             // current artifact back so a follow-up revises it. On-device implies offline (no CDN).
-            val artifactMode = _artifactActive.value
+            val artifactMode = _chatMode.value is ChatMode.Artifact
             val artifactSystemPrompt = if (artifactMode) {
                 val prior = _currentChatThreadId.value?.let { artifactManager.getLatestVersionContent(it) }
                 val offline = settingsRepository.getArtifactsOfflineDirect() || isLocal
@@ -866,14 +840,7 @@ class ChatViewModel(
 
             if (chatId == null) {
                 isFirstMsgInChat = true
-                chatId = UUID.randomUUID().toString()
-                val newThread = ChatThread(
-                    id = chatId,
-                    title = "New Conversation",
-                    createdAt = System.currentTimeMillis(),
-                    updatedAt = System.currentTimeMillis()
-                )
-                chatDao.insertThread(newThread)
+                chatId = chatRepository.createThread().id
                 _currentChatThreadId.value = chatId
             }
 
@@ -891,13 +858,10 @@ class ChatViewModel(
                 localAttachmentMimeType = attachmentMime,
                 localAttachmentName = attachmentName
             )
-            messageDao.insertMessage(userMsg)
+            chatRepository.insertMessage(userMsg)
 
             // Update Thread Timestamp
-            val tempThread = chatDao.getThreadById(chatId)
-            if (tempThread != null) {
-                chatDao.updateThread(tempThread.copy(updatedAt = System.currentTimeMillis()))
-            }
+            chatRepository.touchThread(chatId)
 
             // Trigger background Title generation. Local chats use the word fallback:
             // no API key may exist, and the on-device engine is single-flight.
@@ -905,22 +869,17 @@ class ChatViewModel(
                 if (isLocal) {
                     val words = prompt.split("\\s+".toRegex())
                     val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
-                    chatDao.getThreadById(chatId)?.let { thread ->
-                        chatDao.updateThread(thread.copy(title = fallbackTitle))
-                    }
+                    chatRepository.renameThread(chatId, fallbackTitle)
                 } else {
                     launch {
                         val generatedTitle = openRouterService.generateTitle(apiKey, selectedModel, prompt)
-                        val activeThread = chatDao.getThreadById(chatId!!)
-                        if (activeThread != null) {
-                            chatDao.updateThread(activeThread.copy(title = generatedTitle))
-                        }
+                        chatRepository.renameThread(chatId!!, generatedTitle)
                     }
                 }
             }
 
             // Load updated dialog history
-            val fullHistory = messageDao.getMessagesForChatSync(chatId)
+            val fullHistory = chatRepository.history(chatId)
 
             // Resolve the user's global sampler settings for whichever model is about to run,
             // clamped to that model's limits (so a budget set for a big model can't break a
@@ -958,9 +917,28 @@ class ChatViewModel(
                 // Artifact mode runs the plain streaming path (no search); the parser extracts the
                 // <echo:artifact> block from the content stream.
                 artifactMode && isLocal ->
-                    localLlmService.generate(localModel!!, chatId, fullHistory, systemPrompt, inferenceParams)
+                    localGateway.stream(
+                        LlmStreamRequest(
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            localModel = localModel,
+                        )
+                    )
                 artifactMode ->
-                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false, params = inferenceParams)
+                    openRouterGateway.stream(
+                        LlmStreamRequest(
+                            apiKey = apiKey,
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            serverWebSearch = false,
+                        )
+                    )
                 advisorReq != null || fusionReq != null ->
                     openRouterService.sendWithEchoTools(
                         apiKey = apiKey,
@@ -974,15 +952,44 @@ class ChatViewModel(
                 isLocal && clientSearchReady ->
                     localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey, inferenceParams)
                 isLocal ->
-                    localLlmService.generate(localModel!!, chatId, fullHistory, systemPrompt, inferenceParams)
+                    localGateway.stream(
+                        LlmStreamRequest(
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            localModel = localModel,
+                        )
+                    )
                 provider == "openrouter" ->
-                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = true, params = inferenceParams)
+                    openRouterGateway.stream(
+                        LlmStreamRequest(
+                            apiKey = apiKey,
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            serverWebSearch = true,
+                        )
+                    )
                 clientSearchReady ->
                     openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
                         webSearchService.search(provider, searchKey, query)
                     }
                 else ->
-                    openRouterService.sendChatMessageStream(apiKey, selectedModel, fullHistory, systemPrompt, serverWebSearch = false, params = inferenceParams)
+                    openRouterGateway.stream(
+                        LlmStreamRequest(
+                            apiKey = apiKey,
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            serverWebSearch = false,
+                        )
+                    )
             }
 
             // In artifact mode, route the <echo:artifact> block out of the chat bubble into
@@ -1020,6 +1027,23 @@ class ChatViewModel(
             // Keep the process unfrozen so the reply keeps streaming while minimized.
             KeepAliveService.acquire(getApplication(), keepAliveText)
             try {
+                var lastStreamUiEmit = 0L
+                var pendingStreamUiState: ActiveStreamState? = null
+                fun emitStreamUiState(force: Boolean = false) {
+                    val state = ActiveStreamState(
+                        segments = segments.toList(),
+                        statusNote = statusNote,
+                        progressLoading = false,
+                        isLocal = isLocal
+                    )
+                    pendingStreamUiState = state
+                    val now = System.currentTimeMillis()
+                    if (force || now - lastStreamUiEmit >= STREAM_UI_EMIT_MS) {
+                        setStreamState(chatId, state)
+                        pendingStreamUiState = null
+                        lastStreamUiEmit = now
+                    }
+                }
                 responseFlow.collect { rawChunk ->
                     // Persist a completed artifact version before reducing, so the card/segment
                     // carry a real artifactId/version to deep-link the workspace.
@@ -1035,16 +1059,9 @@ class ChatViewModel(
                     } else rawChunk
                     val note = reduceSegments(segments, chunk)
                     if (note != null) statusNote = note
-                    setStreamState(
-                        chatId,
-                        ActiveStreamState(
-                            segments = segments.toList(),
-                            statusNote = statusNote,
-                            progressLoading = false,
-                            isLocal = isLocal
-                        )
-                    )
+                    emitStreamUiState()
                 }
+                pendingStreamUiState?.let { emitStreamUiState(force = true) }
                 persistAssistantMessage(chatId, segments, interrupted = null)
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
@@ -1149,15 +1166,14 @@ class ChatViewModel(
             val now = System.currentTimeMillis()
             var chatId = _currentChatThreadId.value
             if (chatId == null) {
-                chatId = UUID.randomUUID().toString()
-                chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
+                chatId = chatRepository.createThread(now = now).id
                 _currentChatThreadId.value = chatId
                 val words = topic.split("\\s+".toRegex())
                 val fallbackTitle = words.take(5).joinToString(" ") + if (words.size > 5) "…" else ""
-                chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(title = fallbackTitle)) }
+                chatRepository.renameThread(chatId, fallbackTitle)
             }
 
-            messageDao.insertMessage(
+            chatRepository.insertMessage(
                 ChatMessage(
                     id = UUID.randomUUID().toString(),
                     chatId = chatId,
@@ -1169,7 +1185,7 @@ class ChatViewModel(
                     localAttachmentName = attachmentName,
                 )
             )
-            chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = now)) }
+            chatRepository.touchThread(chatId, now)
 
             val runId = UUID.randomUUID().toString()
             researchRunDao.upsert(
@@ -1194,7 +1210,7 @@ class ChatViewModel(
             )
             DeepResearchForegroundService.start(getApplication(), runId)
             clearPendingAttachment()
-            _deepResearchActive.value = false // deliberate, per-question opt-in
+            setMode(ChatMode.Normal) // deliberate, per-question opt-in
         }
     }
 
@@ -1239,7 +1255,7 @@ class ChatViewModel(
                     chatDao.updateThread(thread.copy(title = title.ifBlank { "Browser session" }))
                 }
             }
-            _browserFlowActive.value = false // igniter consumed
+            setMode(ChatMode.Normal) // igniter consumed
             browserAgent.startSession(chatId, prompt)
         }
     }
@@ -1299,7 +1315,7 @@ class ChatViewModel(
                 )
             )
             DeepResearchForegroundService.start(getApplication(), runId)
-            _dataAgentActive.value = false
+            setMode(ChatMode.Normal)
         }
     }
 
@@ -1610,6 +1626,7 @@ class ChatViewModel(
     companion object {
         private val CLIENT_SEARCH_PROVIDERS = setOf("exa", "parallel", "firecrawl")
         private const val MAX_LOCAL_SEARCH_ROUNDS = 3
+        private const val STREAM_UI_EMIT_MS = 33L
 
         fun provideFactory(
             application: Application,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ llamacppKotlin = "0.4.0"
 moshiKotlin = "1.15.2"
 moshiKotlinCodegen = "1.15.2"
 datastorePreferences = "1.1.7"
+securityCrypto = "1.1.0-alpha06"
 robolectric = "4.16.1"
 roborazzi = "1.59.0"
 firebaseBom = "34.12.0"
@@ -104,6 +105,7 @@ llamacpp-kotlin = { group = "io.github.ljcamargo", name = "llamacpp-kotlin", ver
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
 roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }


### PR DESCRIPTION
## Summary
- Move settings storage to encrypted shared preferences with legacy migration fallback
- Parse OpenRouter SSE chunks with typed Moshi models instead of ad hoc maps
- Consolidate chat capability toggles into a single mode state and route persistence through a shared repository
- Throttle active stream UI updates to reduce churn during generation

## Testing
- Not run (not requested)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Encrypt settings storage and consolidate chat streaming state into a single `ChatMode`
> - Switches `SettingsRepository` to use `EncryptedSharedPreferences` (AES256) with a one-time migration from legacy unencrypted prefs, falling back to unencrypted if secure creation fails.
> - Replaces multiple per-message boolean flags in `ChatViewModel` with a single `MutableStateFlow<ChatMode>` sealed interface; derived boolean `StateFlow`s preserve UI compatibility.
> - Throttles streaming UI updates to ~30 FPS (every 33 ms) instead of emitting on every chunk.
> - Introduces `ChatRepository`, `LlmGateway`, `OpenRouterGateway`, and `LocalLlmGateway` to centralize thread/message CRUD and route local vs. cloud model streaming.
> - Risk: settings migration is one-way; if `EncryptedSharedPreferences` creation fails silently, the app falls back to plaintext prefs without user notification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a5b939.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->