### PR TITLE
Restore animated Stop button + show "Message stopped" notice

### DIFF
--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -165,7 +165,7 @@ data class ArtifactRef(
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact" | "stopped"
     val text: String? = null,
     val query: String? = null,
     val sources: List<SearchSource>? = null,

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1047,7 +1047,7 @@ class ChatViewModel(
                 // User tapped Stop — keep whatever streamed so far and surface no error banner.
                 // The persist runs under NonCancellable so it isn't skipped by the cancellation.
                 withContext(NonCancellable) {
-                    persistAssistantMessage(chatId, segments, interrupted = null)
+                    persistAssistantMessage(chatId, segments, interrupted = null, stopped = true)
                 }
                 throw e
             } catch (e: Exception) {
@@ -1301,7 +1301,8 @@ class ChatViewModel(
     private suspend fun persistAssistantMessage(
         chatId: String,
         segments: List<StreamSegment>,
-        interrupted: String?
+        interrupted: String?,
+        stopped: Boolean = false
     ) {
         val normalizedSegments = normalizeAssistantSegmentsForPersistence(segments)
         val contentText = normalizedSegments.filterIsInstance<StreamSegment.Text>()
@@ -1312,7 +1313,9 @@ class ChatViewModel(
             it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent ||
                 (it is StreamSegment.Artifact && it.artifactId != null)
         }
-        if (contentText.isEmpty() && !hasEchoArtifact) return
+        // A user-stopped turn is always kept (even with no prose yet) so the "Message stopped"
+        // notice is shown; otherwise an empty, content-less turn is dropped.
+        if (contentText.isEmpty() && !hasEchoArtifact && !stopped) return
 
         val reasoningText = normalizedSegments.filterIsInstance<StreamSegment.Reasoning>()
             .joinToString("\n\n") { it.text }.trim()
@@ -1382,8 +1385,11 @@ class ChatViewModel(
                     ?.let { PersistedSegment(type = "text", text = it) }
             }
         }.let { list ->
-            if (interrupted != null) list + PersistedSegment(type = "text", text = "*[Connection lost: $interrupted]*")
-            else list
+            var out = list
+            if (interrupted != null) out = out + PersistedSegment(type = "text", text = "*[Connection lost: $interrupted]*")
+            // A trailing "stopped" segment renders the red "Message stopped" notice under the reply.
+            if (stopped) out = out + PersistedSegment(type = "stopped")
+            out
         }
 
         messageDao.insertMessage(

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -870,6 +870,10 @@ private fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, s
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
                             }
+                            "stopped" -> {
+                                StoppedNotice()
+                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                            }
                             // The plan is rendered as a disclosure inside the report card.
                             "plan" -> Unit
                             "report" -> {
@@ -1045,6 +1049,25 @@ private fun ThinkingRow(modifier: Modifier = Modifier) {
         LoadingIndicator(color = MaterialTheme.colorScheme.primary)
         Spacer(Modifier.width(Spacing.s))
         Text("Thinking…", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+/** Red "Message stopped" line shown under a reply the user cancelled with the Stop button. */
+@Composable
+private fun StoppedNotice(modifier: Modifier = Modifier) {
+    Row(modifier, verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            Icons.Default.Stop,
+            null,
+            Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+        Spacer(Modifier.width(Spacing.xs))
+        Text(
+            "Message stopped",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
     }
 }
 
@@ -1530,20 +1553,27 @@ private fun PlusMenu(
 @Composable
 private fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolean = false, onStop: () -> Unit = {}, onClick: () -> Unit) {
     if (isStreaming) {
-        // Tappable Stop — cancels the in-flight reply (cloud stream or on-device generation).
+        // Tappable Stop that stays in visual sync with the "Thinking…" row: the same expressive
+        // LoadingIndicator keeps spinning so the reply still feels live, with a Stop glyph centered
+        // on top so it reads clearly as "tap to stop". Tapping cancels the in-flight reply (cloud
+        // stream or on-device generation).
         Box(
             Modifier
                 .size(48.dp)
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primary)
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
                 .clickable(onClick = onStop),
             contentAlignment = Alignment.Center,
         ) {
+            LoadingIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(40.dp),
+            )
             Icon(
                 Icons.Default.Stop,
                 "Stop generating",
-                Modifier.size(22.dp),
-                tint = MaterialTheme.colorScheme.onPrimary,
+                Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary,
             )
         }
     } else {


### PR DESCRIPTION
## What & why

The composer **Stop** button works (cancels the in-flight reply), but it had been flattened into a plain static stop icon — losing the fun design that was visually in sync with the "Thinking…" animation. Stopping a reply also left **no indication** it had been cancelled.

This PR keeps the functionality and brings back the fun design, plus surfaces a clear stopped state.

## Changes

**1. Animated, thinking-synced Stop button** — `SendButton` in `ChatScreen.kt`
While streaming, the button now shows the **same expressive `LoadingIndicator`** the "Thinking…" row uses (so the reply still feels alive) with a **Stop glyph centered on top** so it clearly reads as "tap to stop." Tapping still cancels via `stopStreaming()`. Reuses the original `surfaceContainerHighest` circle + primary indicator styling.

**2. Record user-stopped turns** — `ChatViewModel.kt`
- The Stop path (`catch (CancellationException)`) now persists with `stopped = true`.
- `persistAssistantMessage` keeps the turn even if no prose streamed yet (so the notice always shows) and appends a trailing `PersistedSegment(type = "stopped")`.

**3. Red "Message stopped" notice** — `ChatScreen.kt` + `ChatStreamModels.kt`
A new `StoppedNotice` composable renders a Stop icon + **"Message stopped"** in `colorScheme.error` (red) under whatever partial reply streamed before Stop was tapped. The new `"stopped"` segment type round-trips through the existing Moshi JSON — **no DB migration required**.

## Result
Tap the animated Stop mid-stream → generation cancels → the partial reply persists with a red **■ Message stopped** line beneath it.

## Testing
⚠️ Per repo constraints this wasn't built from the CLI — **needs a verify in Android Studio**: send a long prompt, confirm the Stop button shows the spinning indicator with the stop glyph, tap it mid-stream, and confirm the reply stops with the red "Message stopped" line underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore animated Stop button and add 'Message stopped' notice in chat
> - While streaming, the Stop button now shows a spinning `LoadingIndicator` with an overlaid stop icon and updated colors (`surfaceContainerHighest` background, `primary`-tinted icon); tap-to-stop behavior is unchanged.
> - When the user taps Stop, `ChatViewModel.persistAssistantMessage` now appends a trailing `PersistedSegment(type = "stopped")` and persists the turn even if it contains no text or artifacts (previously such empty turns were silently dropped).
> - `MessageBubble` renders a red 'Message stopped' line with a stop icon (`StoppedNotice`) beneath any reply that contains a `stopped` segment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff11e75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Message stopped" indicator that displays between message segments when users stop an in-progress assistant response, providing clear visual feedback about message cancellation status.

* **Style**
  * Refined the stop button's visual design with enhanced styling and appearance updates, including improved visual layering between the stop icon and the loading spinner during active message streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->