### PR TITLE
Add Labs provider APIs

### DIFF
--- a/app/src/main/java/com/echoflow/data/CustomProviderService.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderService.kt
@@ -1,0 +1,561 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.net.Uri
+import android.util.Base64
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.InputStream
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
+
+data class CustomProviderConfig(
+    val cloudApisEnabled: Boolean,
+    val ollamaEnabled: Boolean,
+    val openAiCompatibleEnabled: Boolean,
+    val openAiApiKey: String,
+    val openAiModel: String,
+    val openAiModels: String,
+    val openAiSelectedModels: String,
+    val claudeApiKey: String,
+    val claudeModel: String,
+    val claudeModels: String,
+    val claudeSelectedModels: String,
+    val geminiApiKey: String,
+    val geminiModel: String,
+    val geminiModels: String,
+    val geminiSelectedModels: String,
+    val ollamaBaseUrl: String,
+    val ollamaModel: String,
+    val ollamaModels: String,
+    val ollamaSelectedModels: String,
+    val ollamaImagesEnabled: Boolean,
+    val ollamaPdfsEnabled: Boolean,
+    val openAiBaseUrl: String,
+    val openAiCompatibleApiKey: String,
+    val openAiCompatibleModel: String,
+    val openAiCompatibleModels: String,
+    val openAiCompatibleSelectedModels: String,
+    val openAiCompatibleImagesEnabled: Boolean,
+    val openAiCompatiblePdfsEnabled: Boolean,
+) {
+    companion object {
+        const val PREFIX_OPENAI = "custom/openai/"
+        const val PREFIX_CLAUDE = "custom/claude/"
+        const val PREFIX_GEMINI = "custom/gemini/"
+        const val PREFIX_OLLAMA = "custom/ollama/"
+        const val PREFIX_OPENAI_COMPATIBLE = "custom/openai-compatible/"
+    }
+}
+
+data class CustomProviderModel(
+    val id: String,
+    val name: String,
+    val group: String,
+    val isLocalLike: Boolean,
+)
+
+enum class CustomModelProvider { OpenAi, Claude, Gemini, Ollama, OpenAiCompatible }
+
+data class ProviderValidationResult(
+    val ok: Boolean,
+    val message: String,
+)
+
+class CustomProviderService(private val context: Context? = null) {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val dynamicAdapter = moshi.adapter(Any::class.java)
+    private val openAiStreamAdapter = moshi.adapter(OpenAiStreamEvent::class.java)
+    private val ollamaStreamAdapter = moshi.adapter(OllamaStreamEvent::class.java)
+    private val geminiStreamAdapter = moshi.adapter(GeminiStreamEvent::class.java)
+
+    @JsonClass(generateAdapter = true)
+    data class OpenAiStreamEvent(val choices: List<OpenAiChoice>? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class OpenAiChoice(val delta: OpenAiDelta? = null, val message: OpenAiMessage? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class OpenAiDelta(
+        val content: String? = null,
+        val reasoning: String? = null,
+        val reasoning_content: String? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OpenAiMessage(val content: String? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class OllamaStreamEvent(
+        val message: OllamaMessage? = null,
+        val response: String? = null,
+        val done: Boolean? = null,
+        val error: String? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class OllamaMessage(val content: String? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class GeminiStreamEvent(val candidates: List<GeminiCandidate>? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class GeminiCandidate(val content: GeminiContent? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class GeminiContent(val parts: List<GeminiPart>? = null)
+
+    @JsonClass(generateAdapter = true)
+    data class GeminiPart(val text: String? = null)
+
+    fun streamOpenAi(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> =
+        streamOpenAiCompatible("https://api.openai.com/v1", apiKey, model, history, systemPrompt, params)
+
+    fun streamClaude(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("Claude API key is missing.")
+        if (model.isBlank()) throw Exception("Enter a Claude model name.")
+        val messages = history.filter { it.role != "system" }.map {
+            mapOf("role" to if (it.role == "assistant") "assistant" else "user", "content" to it.content)
+        }
+        val payload = mutableMapOf<String, Any>(
+            "model" to model.trim(),
+            "messages" to messages,
+            "stream" to true,
+            "max_tokens" to params.maxTokens.coerceAtLeast(256),
+            "temperature" to params.temperature,
+        )
+        if (systemPrompt.isNotBlank()) payload["system"] = systemPrompt
+        val request = Request.Builder()
+            .url("https://api.anthropic.com/v1/messages")
+            .addHeader("x-api-key", apiKey.trim())
+            .addHeader("anthropic-version", "2023-06-01")
+            .addHeader("Content-Type", "application/json")
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception(customError("Claude", response.code, response.body?.string().orEmpty()))
+            val body = response.body ?: throw Exception("Empty stream body received.")
+            body.source().use { source ->
+                while (!source.exhausted()) {
+                    val line = source.readUtf8Line() ?: break
+                    if (!line.startsWith("data:")) continue
+                    val data = line.removePrefix("data:").trim()
+                    if (data.isBlank() || data == "[DONE]") continue
+                    val map = runCatching { dynamicAdapter.fromJson(data) as? Map<*, *> }.getOrNull() ?: continue
+                    val delta = map["delta"] as? Map<*, *>
+                    (delta?.get("text") as? String)?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    fun streamGemini(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("Gemini API key is missing.")
+        if (model.isBlank()) throw Exception("Enter a Gemini model name.")
+        val contents = history.filter { it.role != "system" }.map {
+            mapOf(
+                "role" to if (it.role == "assistant") "model" else "user",
+                "parts" to listOf(mapOf("text" to it.content)),
+            )
+        }
+        val payload = mutableMapOf<String, Any>(
+            "contents" to contents,
+            "generationConfig" to mapOf(
+                "temperature" to params.temperature,
+                "topP" to params.topP,
+                "maxOutputTokens" to params.maxTokens.coerceAtLeast(256),
+            ),
+        )
+        if (systemPrompt.isNotBlank()) {
+            payload["systemInstruction"] = mapOf("parts" to listOf(mapOf("text" to systemPrompt)))
+        }
+        val cleanModel = model.removePrefix("models/")
+        val request = Request.Builder()
+            .url("https://generativelanguage.googleapis.com/v1beta/models/$cleanModel:streamGenerateContent?key=${apiKey.trim()}&alt=sse")
+            .addHeader("Content-Type", "application/json")
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception(customError("Gemini", response.code, response.body?.string().orEmpty()))
+            val body = response.body ?: throw Exception("Empty stream body received.")
+            body.source().use { source ->
+                while (!source.exhausted()) {
+                    val line = source.readUtf8Line() ?: break
+                    if (!line.startsWith("data:")) continue
+                    val data = line.removePrefix("data:").trim()
+                    if (data.isBlank() || data == "[DONE]") continue
+                    val event = runCatching { geminiStreamAdapter.fromJson(data) }.getOrNull() ?: continue
+                    event.candidates?.flatMap { it.content?.parts.orEmpty() }?.forEach { part ->
+                        part.text?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
+                    }
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    fun streamOpenAiCompatible(
+        baseUrl: String,
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> = flow {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        if (model.isBlank()) throw Exception("Enter a model name for the OpenAI-compatible provider.")
+
+        val payload = mutableMapOf<String, Any>(
+            "model" to model.trim(),
+            "messages" to buildOpenAiMessages(history, systemPrompt),
+            "stream" to true,
+            "temperature" to params.temperature,
+            "top_p" to params.topP,
+        )
+        if (params.maxTokens > 0) payload["max_tokens"] = params.maxTokens
+        val request = Request.Builder()
+            .url(joinUrl(baseUrl, "chat/completions"))
+            .addHeader("Content-Type", "application/json")
+            .apply { apiKey.trim().takeIf { it.isNotEmpty() }?.let { addHeader("Authorization", "Bearer $it") } }
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception(customError("OpenAI-compatible provider", response.code, response.body?.string().orEmpty()))
+            val body = response.body ?: throw Exception("Empty stream body received.")
+            body.source().use { source ->
+                while (!source.exhausted()) {
+                    val line = source.readUtf8Line() ?: break
+                    if (!line.startsWith("data:")) continue
+                    val data = line.removePrefix("data:").trim()
+                    if (data.isBlank() || data == "[DONE]") continue
+                    val event = runCatching { openAiStreamAdapter.fromJson(data) }.getOrNull() ?: continue
+                    event.choices?.forEach { choice ->
+                        choice.delta?.reasoning?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Reasoning(it)) }
+                        choice.delta?.reasoning_content?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Reasoning(it)) }
+                        choice.delta?.content?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
+                    }
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    fun streamOllama(
+        baseUrl: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> = flow {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        if (model.isBlank()) throw Exception("Enter an Ollama model name.")
+
+        val payload = mapOf(
+            "model" to model.trim(),
+            "messages" to buildSimpleMessages(history, systemPrompt),
+            "stream" to true,
+            "options" to mapOf(
+                "temperature" to params.temperature,
+                "top_p" to params.topP,
+                "top_k" to params.topK,
+                "num_predict" to params.maxTokens,
+            ),
+        )
+        val request = Request.Builder()
+            .url(joinUrl(baseUrl, "api/chat"))
+            .addHeader("Content-Type", "application/json")
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception(customError("Ollama", response.code, response.body?.string().orEmpty()))
+            val body = response.body ?: throw Exception("Empty stream body received.")
+            body.source().use { source ->
+                while (!source.exhausted()) {
+                    val line = source.readUtf8Line() ?: break
+                    if (line.isBlank()) continue
+                    val event = runCatching { ollamaStreamAdapter.fromJson(line) }.getOrNull() ?: continue
+                    event.error?.takeIf { it.isNotBlank() }?.let { throw Exception(it) }
+                    event.message?.content?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
+                    event.response?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    suspend fun testOpenAiCompatible(baseUrl: String, apiKey: String, model: String): ProviderValidationResult = withContext(Dispatchers.IO) {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { return@withContext it }
+        if (model.isBlank()) return@withContext ProviderValidationResult(false, "Enter a model name first.")
+        runCatching {
+            val payload = mapOf(
+                "model" to model.trim(),
+                "messages" to listOf(mapOf("role" to "user", "content" to "Reply with OK.")),
+                "stream" to false,
+                "max_tokens" to 8,
+            )
+            val request = Request.Builder()
+                .url(joinUrl(baseUrl, "chat/completions"))
+                .addHeader("Content-Type", "application/json")
+                .apply { apiKey.trim().takeIf { it.isNotEmpty() }?.let { addHeader("Authorization", "Bearer $it") } }
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) ProviderValidationResult(false, customError("OpenAI-compatible provider", response.code, response.body?.string().orEmpty()))
+                else ProviderValidationResult(true, "Connection works.")
+            }
+        }.getOrElse { ProviderValidationResult(false, it.message ?: "Connection failed.") }
+    }
+
+    suspend fun fetchModels(provider: CustomModelProvider, baseUrl: String = "", apiKey: String = ""): ProviderValidationResult = withContext(Dispatchers.IO) {
+        runCatching {
+            val models = when (provider) {
+                CustomModelProvider.OpenAi -> fetchOpenAiStyleModels("https://api.openai.com/v1", apiKey)
+                CustomModelProvider.Claude -> fetchClaudeModels(apiKey)
+                CustomModelProvider.Gemini -> fetchGeminiModels(apiKey)
+                CustomModelProvider.Ollama -> fetchOllamaModels(baseUrl)
+                CustomModelProvider.OpenAiCompatible -> fetchOpenAiCompatibleModels(baseUrl, apiKey)
+            }
+            if (models.isEmpty()) ProviderValidationResult(false, "No models were returned. You can still enter one manually.")
+            else ProviderValidationResult(true, models.joinToString("\n"))
+        }.getOrElse { ProviderValidationResult(false, it.message ?: "Could not fetch models.") }
+    }
+
+    suspend fun testOllama(baseUrl: String, model: String): ProviderValidationResult = withContext(Dispatchers.IO) {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { return@withContext it }
+        if (model.isBlank()) return@withContext ProviderValidationResult(false, "Enter an Ollama model name first.")
+        runCatching {
+            val payload = mapOf(
+                "model" to model.trim(),
+                "messages" to listOf(mapOf("role" to "user", "content" to "Reply with OK.")),
+                "stream" to false,
+                "options" to mapOf("num_predict" to 8),
+            )
+            val request = Request.Builder()
+                .url(joinUrl(baseUrl, "api/chat"))
+                .addHeader("Content-Type", "application/json")
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) ProviderValidationResult(false, customError("Ollama", response.code, response.body?.string().orEmpty()))
+                else ProviderValidationResult(true, "Connection works.")
+            }
+        }.getOrElse { ProviderValidationResult(false, it.message ?: "Connection failed.") }
+    }
+
+    private fun buildOpenAiMessages(history: List<ChatMessage>, systemPrompt: String): List<Map<String, Any>> {
+        val out = mutableListOf<Map<String, Any>>()
+        if (systemPrompt.isNotBlank()) out.add(mapOf("role" to "system", "content" to systemPrompt))
+        history.forEach { msg ->
+            val base64 = getBase64FromUri(msg.localAttachmentUri)
+            if (base64 != null && msg.role == "user" && !msg.localAttachmentMimeType.equals("application/pdf", ignoreCase = true)) {
+                val mime = msg.localAttachmentMimeType ?: "image/jpeg"
+                out.add(
+                    mapOf(
+                        "role" to msg.role,
+                        "content" to listOf(
+                            mapOf("type" to "text", "text" to msg.content),
+                            mapOf("type" to "image_url", "image_url" to mapOf("url" to "data:$mime;base64,$base64")),
+                        ),
+                    )
+                )
+            } else {
+                out.add(mapOf("role" to msg.role, "content" to msg.content))
+            }
+        }
+        return out
+    }
+
+    private fun buildSimpleMessages(history: List<ChatMessage>, systemPrompt: String): List<Map<String, String>> =
+        buildList {
+            if (systemPrompt.isNotBlank()) add(mapOf("role" to "system", "content" to systemPrompt))
+            history.forEach { add(mapOf("role" to it.role, "content" to it.content)) }
+        }
+
+    private fun fetchOpenAiCompatibleModels(baseUrl: String, apiKey: String): List<String> {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        val clean = baseUrl.trim().trimEnd('/')
+        val candidates = if (clean.endsWith("/v1")) {
+            listOf("$clean/models")
+        } else {
+            listOf("$clean/v1/models", "$clean/models", "$clean/api/v1/models")
+        }
+        val errors = mutableListOf<String>()
+        for (url in candidates.distinct()) {
+            val models = runCatching { fetchModelsFromUrl(url, apiKey) }
+                .onFailure { errors.add("${url.substringAfter("://").substringAfter("/")}: ${it.message}") }
+                .getOrNull()
+            if (!models.isNullOrEmpty()) return models
+        }
+        throw Exception("Could not fetch models from /v1/models, /models, or /api/v1/models.")
+    }
+
+    private fun fetchOpenAiStyleModels(baseUrl: String, apiKey: String): List<String> {
+        if (apiKey.isBlank()) throw Exception("API key is missing.")
+        return fetchModelsFromUrl("${baseUrl.trimEnd('/')}/models", apiKey)
+    }
+
+    private fun fetchModelsFromUrl(url: String, apiKey: String): List<String> {
+        val request = Request.Builder()
+            .url(url)
+            .apply { apiKey.trim().takeIf { it.isNotEmpty() }?.let { addHeader("Authorization", "Bearer $it") } }
+            .get()
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw Exception("HTTP ${response.code}")
+            return parseModelIds(body)
+        }
+    }
+
+    private fun fetchClaudeModels(apiKey: String): List<String> {
+        if (apiKey.isBlank()) throw Exception("Claude API key is missing.")
+        val request = Request.Builder()
+            .url("https://api.anthropic.com/v1/models")
+            .addHeader("x-api-key", apiKey.trim())
+            .addHeader("anthropic-version", "2023-06-01")
+            .get()
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw Exception(customError("Claude", response.code, body))
+            return parseModelIds(body)
+        }
+    }
+
+    private fun fetchGeminiModels(apiKey: String): List<String> {
+        if (apiKey.isBlank()) throw Exception("Gemini API key is missing.")
+        val request = Request.Builder()
+            .url("https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey.trim()}")
+            .get()
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw Exception(customError("Gemini", response.code, body))
+            val raw = parseModelIds(body)
+            return raw.map { it.removePrefix("models/") }
+        }
+    }
+
+    private fun fetchOllamaModels(baseUrl: String): List<String> {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        val request = Request.Builder()
+            .url("${baseUrl.trim().trimEnd('/')}/api/tags")
+            .get()
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw Exception(customError("Ollama", response.code, body))
+            return parseModelIds(body)
+        }
+    }
+
+    private fun parseModelIds(json: String): List<String> {
+        val map = dynamicAdapter.fromJson(json) as? Map<*, *> ?: return emptyList()
+        val rawList = (map["data"] as? List<*>) ?: (map["models"] as? List<*>) ?: return emptyList()
+        return rawList.mapNotNull { raw ->
+            when (raw) {
+                is String -> raw
+                is Map<*, *> -> (raw["id"] as? String) ?: (raw["name"] as? String) ?: (raw["model"] as? String)
+                else -> null
+            }
+        }.distinct()
+    }
+
+    private fun getBase64FromUri(uriString: String?): String? {
+        if (uriString == null) return null
+        return try {
+            val uri = Uri.parse(uriString)
+            val inputStream: InputStream? = context?.contentResolver?.openInputStream(uri)
+            val bytes = inputStream?.readBytes()
+            inputStream?.close()
+            bytes?.let { Base64.encodeToString(it, Base64.NO_WRAP) }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun joinUrl(baseUrl: String, path: String): String {
+        val cleanBase = baseUrl.trim().trimEnd('/')
+        val normalizedPath = path.trimStart('/')
+        return if (cleanBase.endsWith("/v1") || normalizedPath.startsWith("api/")) "$cleanBase/$normalizedPath"
+        else "$cleanBase/v1/$normalizedPath"
+    }
+
+    private fun validateBaseUrl(raw: String): ProviderValidationResult {
+        val url = raw.trim().toHttpUrlOrNull()
+            ?: return ProviderValidationResult(false, "Enter a valid http:// or https:// base URL.")
+        if (url.scheme != "http" && url.scheme != "https") {
+            return ProviderValidationResult(false, "Base URL must start with http:// or https://.")
+        }
+        if (url.scheme == "http" && !isLocalOrPrivateHost(url.host)) {
+            return ProviderValidationResult(false, "Use HTTPS for internet providers. Plain HTTP is allowed only for localhost or private LAN addresses.")
+        }
+        return ProviderValidationResult(true, "URL looks good.")
+    }
+
+    private fun isLocalOrPrivateHost(host: String): Boolean {
+        val h = host.lowercase()
+        if (h == "localhost" || h == "127.0.0.1" || h == "::1") return true
+        return runCatching {
+            val address = InetAddress.getByName(h)
+            val bytes = address.address.map { it.toInt() and 0xff }
+            address.isSiteLocalAddress ||
+                address.isLoopbackAddress ||
+                (bytes.size == 4 && bytes[0] == 169 && bytes[1] == 254)
+        }.getOrDefault(false)
+    }
+
+    private fun customError(label: String, code: Int, body: String): String {
+        val parsed = runCatching {
+            val map = dynamicAdapter.fromJson(body) as? Map<*, *>
+            val error = map?.get("error")
+            when (error) {
+                is String -> error
+                is Map<*, *> -> error["message"] as? String
+                else -> map?.get("message") as? String
+            }
+        }.getOrNull()
+        return when (code) {
+            401, 403 -> "$label rejected the API key or request."
+            404 -> "$label endpoint or model was not found."
+            else -> parsed ?: "$label returned HTTP $code."
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -156,6 +156,9 @@ class SettingsRepository(context: Context) {
     private val _cloudInferenceParams = MutableStateFlow(getInferenceParamsDirect(local = false))
     val cloudInferenceParams: StateFlow<InferenceParams> = _cloudInferenceParams.asStateFlow()
 
+    private val _customProviderConfig = MutableStateFlow(getCustomProviderConfigDirect())
+    val customProviderConfig: StateFlow<CustomProviderConfig> = _customProviderConfig.asStateFlow()
+
     fun getApiKeyDirect(): String {
         return prefs.getString("openrouter_api_key", "").orEmpty()
     }
@@ -341,6 +344,87 @@ class SettingsRepository(context: Context) {
 
     fun resetInferenceParams(local: Boolean) {
         saveInferenceParams(local, if (local) InferenceLimits.LOCAL_DEFAULTS else InferenceLimits.CLOUD_DEFAULTS)
+    }
+
+    // ── Custom provider (Echo Labs prerelease) ────────────────────────────────────────
+
+    fun getCustomProviderConfigDirect(): CustomProviderConfig =
+        CustomProviderConfig(
+            cloudApisEnabled = prefs.getBoolean("labs_cloud_apis_enabled", false),
+            ollamaEnabled = prefs.getBoolean("labs_ollama_enabled", false),
+            openAiCompatibleEnabled = prefs.getBoolean("labs_openai_compatible_enabled", false),
+            openAiApiKey = prefs.getString("direct_openai_api_key", "").orEmpty(),
+            openAiModel = prefs.getString("direct_openai_model", "").orEmpty(),
+            openAiModels = prefs.getString("direct_openai_models", "").orEmpty(),
+            openAiSelectedModels = prefs.getString("direct_openai_selected_models", "").orEmpty(),
+            claudeApiKey = prefs.getString("direct_claude_api_key", "").orEmpty(),
+            claudeModel = prefs.getString("direct_claude_model", "").orEmpty(),
+            claudeModels = prefs.getString("direct_claude_models", "").orEmpty(),
+            claudeSelectedModels = prefs.getString("direct_claude_selected_models", "").orEmpty(),
+            geminiApiKey = prefs.getString("direct_gemini_api_key", "").orEmpty(),
+            geminiModel = prefs.getString("direct_gemini_model", "").orEmpty(),
+            geminiModels = prefs.getString("direct_gemini_models", "").orEmpty(),
+            geminiSelectedModels = prefs.getString("direct_gemini_selected_models", "").orEmpty(),
+            ollamaBaseUrl = prefs.getString("ollama_base_url", "http://localhost:11434").orEmpty(),
+            ollamaModel = prefs.getString("ollama_model", "").orEmpty(),
+            ollamaModels = prefs.getString("ollama_models", "").orEmpty(),
+            ollamaSelectedModels = prefs.getString("ollama_selected_models", "").orEmpty(),
+            ollamaImagesEnabled = prefs.getBoolean("ollama_images_enabled", false),
+            ollamaPdfsEnabled = prefs.getBoolean("ollama_pdfs_enabled", false),
+            openAiBaseUrl = prefs.getString("openai_compatible_base_url", "http://localhost:1234/v1").orEmpty(),
+            openAiCompatibleApiKey = prefs.getString("openai_compatible_api_key", "").orEmpty(),
+            openAiCompatibleModel = prefs.getString("openai_compatible_model", "").orEmpty(),
+            openAiCompatibleModels = prefs.getString("openai_compatible_models", "").orEmpty(),
+            openAiCompatibleSelectedModels = prefs.getString("openai_compatible_selected_models", "").orEmpty(),
+            openAiCompatibleImagesEnabled = prefs.getBoolean("openai_compatible_images_enabled", false),
+            openAiCompatiblePdfsEnabled = prefs.getBoolean("openai_compatible_pdfs_enabled", false),
+        )
+
+    fun saveCustomProviderConfig(config: CustomProviderConfig) {
+        val clean = config.copy(
+            openAiApiKey = config.openAiApiKey.trim(),
+            openAiModel = config.openAiModel.trim(),
+            claudeApiKey = config.claudeApiKey.trim(),
+            claudeModel = config.claudeModel.trim(),
+            geminiApiKey = config.geminiApiKey.trim(),
+            geminiModel = config.geminiModel.trim(),
+            ollamaBaseUrl = config.ollamaBaseUrl.trim(),
+            ollamaModel = config.ollamaModel.trim(),
+            openAiBaseUrl = config.openAiBaseUrl.trim(),
+            openAiCompatibleApiKey = config.openAiCompatibleApiKey.trim(),
+            openAiCompatibleModel = config.openAiCompatibleModel.trim(),
+        )
+        prefs.edit()
+            .putBoolean("labs_cloud_apis_enabled", clean.cloudApisEnabled)
+            .putBoolean("labs_ollama_enabled", clean.ollamaEnabled)
+            .putBoolean("labs_openai_compatible_enabled", clean.openAiCompatibleEnabled)
+            .putString("direct_openai_api_key", clean.openAiApiKey)
+            .putString("direct_openai_model", clean.openAiModel)
+            .putString("direct_openai_models", clean.openAiModels)
+            .putString("direct_openai_selected_models", clean.openAiSelectedModels)
+            .putString("direct_claude_api_key", clean.claudeApiKey)
+            .putString("direct_claude_model", clean.claudeModel)
+            .putString("direct_claude_models", clean.claudeModels)
+            .putString("direct_claude_selected_models", clean.claudeSelectedModels)
+            .putString("direct_gemini_api_key", clean.geminiApiKey)
+            .putString("direct_gemini_model", clean.geminiModel)
+            .putString("direct_gemini_models", clean.geminiModels)
+            .putString("direct_gemini_selected_models", clean.geminiSelectedModels)
+            .putString("ollama_base_url", clean.ollamaBaseUrl)
+            .putString("ollama_model", clean.ollamaModel)
+            .putString("ollama_models", clean.ollamaModels)
+            .putString("ollama_selected_models", clean.ollamaSelectedModels)
+            .putBoolean("ollama_images_enabled", clean.ollamaImagesEnabled)
+            .putBoolean("ollama_pdfs_enabled", clean.ollamaPdfsEnabled)
+            .putString("openai_compatible_base_url", clean.openAiBaseUrl)
+            .putString("openai_compatible_api_key", clean.openAiCompatibleApiKey)
+            .putString("openai_compatible_model", clean.openAiCompatibleModel)
+            .putString("openai_compatible_models", clean.openAiCompatibleModels)
+            .putString("openai_compatible_selected_models", clean.openAiCompatibleSelectedModels)
+            .putBoolean("openai_compatible_images_enabled", clean.openAiCompatibleImagesEnabled)
+            .putBoolean("openai_compatible_pdfs_enabled", clean.openAiCompatiblePdfsEnabled)
+            .apply()
+        _customProviderConfig.value = clean
     }
 
     // ── Deep Research ────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -110,6 +110,7 @@ class ChatViewModel(
     private val artifactManager = ArtifactManager(artifactDao, artifactVersionDao)
 
     private val openRouterService = OpenRouterService(application)
+    private val customProviderService = CustomProviderService(application)
     private val webSearchService = WebSearchService()
     private val localLlmService = LocalLlmService(application)
     private val chatRepository = ChatRepository(
@@ -769,6 +770,24 @@ class ChatViewModel(
 
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
+            val customProviderConfig = settingsRepository.getCustomProviderConfigDirect()
+            val customProvider = when {
+                selectedModel.startsWith(CustomProviderConfig.PREFIX_OPENAI) -> "openai"
+                selectedModel.startsWith(CustomProviderConfig.PREFIX_CLAUDE) -> "claude"
+                selectedModel.startsWith(CustomProviderConfig.PREFIX_GEMINI) -> "gemini"
+                selectedModel.startsWith(CustomProviderConfig.PREFIX_OLLAMA) -> "ollama"
+                selectedModel.startsWith(CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) -> "openai-compatible"
+                else -> null
+            }
+            val customProviderActive = customProvider != null
+            val requestModel = when (customProvider) {
+                "openai" -> selectedModel.removePrefix(CustomProviderConfig.PREFIX_OPENAI)
+                "claude" -> selectedModel.removePrefix(CustomProviderConfig.PREFIX_CLAUDE)
+                "gemini" -> selectedModel.removePrefix(CustomProviderConfig.PREFIX_GEMINI)
+                "ollama" -> selectedModel.removePrefix(CustomProviderConfig.PREFIX_OLLAMA)
+                "openai-compatible" -> selectedModel.removePrefix(CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE)
+                else -> selectedModel
+            }
             // The "+ → Web Search" chip force-enables search using the last-used provider,
             // so the user never has to open Settings just to search one message.
             val chipProvider = if (_chatMode.value is ChatMode.WebSearch) settingsRepository.resolveChipSearchProvider() else null
@@ -788,8 +807,30 @@ class ChatViewModel(
                 return@launch
             }
 
-            if (!isLocal && apiKey.isBlank()) {
+            if (!isLocal && !customProviderActive && apiKey.isBlank()) {
                 _errorMessage.value = "OpenRouter API Key is missing! Go to Settings to configure it."
+                return@launch
+            }
+
+            val customImageAllowed = when (customProvider) {
+                "openai", "claude", "gemini" -> true
+                "ollama" -> customProviderConfig.ollamaImagesEnabled
+                "openai-compatible" -> customProviderConfig.openAiCompatibleImagesEnabled
+                else -> false
+            }
+            val customPdfAllowed = when (customProvider) {
+                "openai", "claude", "gemini" -> true
+                "ollama" -> customProviderConfig.ollamaPdfsEnabled
+                "openai-compatible" -> customProviderConfig.openAiCompatiblePdfsEnabled
+                else -> false
+            }
+            val pendingIsPdf = attachmentMime.equals("application/pdf", ignoreCase = true)
+            if (customProviderActive && attachmentUri != null && pendingIsPdf && !customPdfAllowed) {
+                _errorMessage.value = "PDF is off for this Labs provider. Turn it on in Settings → Echo Labs → Labs Providers."
+                return@launch
+            }
+            if (customProviderActive && attachmentUri != null && !pendingIsPdf && !customImageAllowed) {
+                _errorMessage.value = "Images are off for this Labs provider. Turn them on in Settings → Echo Labs → Labs Providers."
                 return@launch
             }
 
@@ -815,6 +856,7 @@ class ChatViewModel(
             val effectiveProvider = when {
                 !searchAllowedForModel -> "off"
                 isLocal && provider == "openrouter" -> "off"
+                customProviderActive && provider == "openrouter" -> "off"
                 provider == "openrouter" -> "openrouter"
                 clientSearchReady -> provider
                 else -> "off"
@@ -832,6 +874,10 @@ class ChatViewModel(
                     _errorMessage.value = "Echo Agents needs a cloud main model. Pick one from the model selector."
                     return@launch
                 }
+                if (customProviderActive) {
+                    _errorMessage.value = "Echo Agents uses OpenRouter server tools. Pick an OpenRouter Cloud model first."
+                    return@launch
+                }
                 val profile = agentProfileDao.getById(settingsRepository.getEchoAgentProfileIdDirect())
                 if (profile == null) {
                     _errorMessage.value = "Set up an Echo Agent first in Settings → Echo Agents, then pick it."
@@ -844,6 +890,10 @@ class ChatViewModel(
                     _errorMessage.value = "Echo Adviser needs a cloud model. Pick one from the model selector."
                     return@launch
                 }
+                if (customProviderActive) {
+                    _errorMessage.value = "Echo Adviser uses OpenRouter server tools. Pick an OpenRouter Cloud model first."
+                    return@launch
+                }
                 val profile = advisorProfileDao.getById(settingsRepository.getEchoAdviserProfileIdDirect())
                 if (profile == null) {
                     _errorMessage.value = "Pick an advisor first — set one up in Settings → Echo Adviser."
@@ -852,6 +902,10 @@ class ChatViewModel(
                 advisorReq = OpenRouterService.AdvisorRequest(profile.name, profile.modelId)
                 echoSystemPrompt = SystemPrompts.buildEchoAdviser(profile.name)
             } else if (_chatMode.value is ChatMode.EchoFusion) {
+                if (customProviderActive) {
+                    _errorMessage.value = "Echo Fusion uses OpenRouter server tools. Pick an OpenRouter Cloud model first."
+                    return@launch
+                }
                 val panel = fusionPanelDao.getById(settingsRepository.getEchoFusionPanelIdDirect())
                 if (panel == null || panel.models.isEmpty()) {
                     _errorMessage.value = "Set up a Fusion panel first in Settings → Echo Fusion, then pick it."
@@ -905,7 +959,7 @@ class ChatViewModel(
             // Trigger background Title generation. Local chats use the word fallback:
             // no API key may exist, and the on-device engine is single-flight.
             if (isFirstMsgInChat) {
-                if (isLocal) {
+                if (isLocal || customProviderActive) {
                     val words = prompt.split("\\s+".toRegex())
                     val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
                     chatRepository.renameThread(chatId, fallbackTitle)
@@ -966,6 +1020,8 @@ class ChatViewModel(
                             localModel = localModel,
                         )
                     )
+                artifactMode && customProviderActive ->
+                    customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 artifactMode ->
                     openRouterGateway.stream(
                         LlmStreamRequest(
@@ -1001,6 +1057,20 @@ class ChatViewModel(
                             localModel = localModel,
                         )
                     )
+                customProviderActive && clientSearchReady ->
+                    flow {
+                        val query = prompt
+                        emit(StreamChunk.SearchStarted(query))
+                        val sources = webSearchService.search(provider, searchKey, query)
+                        emit(StreamChunk.SearchSources(query, sources))
+                        val searchContext = sources.joinToString("\n\n") { source ->
+                            "[${source.title}](${source.url})\n${source.snippet.orEmpty()}"
+                        }
+                        val withSearch = systemPrompt + "\n\nUse these web search results when relevant:\n$searchContext"
+                        emitAll(customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, withSearch, inferenceParams))
+                    }
+                customProviderActive ->
+                    customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 provider == "openrouter" ->
                     openRouterGateway.stream(
                         LlmStreamRequest(
@@ -1133,6 +1203,29 @@ class ChatViewModel(
                 setStreamState(chatId, null)
             }
         }
+    }
+
+    private fun customProviderFlow(
+        provider: String?,
+        config: CustomProviderConfig,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+    ): Flow<StreamChunk> = when (provider) {
+        "openai" -> customProviderService.streamOpenAi(config.openAiApiKey, model, history, systemPrompt, params)
+        "claude" -> customProviderService.streamClaude(config.claudeApiKey, model, history, systemPrompt, params)
+        "gemini" -> customProviderService.streamGemini(config.geminiApiKey, model, history, systemPrompt, params)
+        "ollama" -> customProviderService.streamOllama(config.ollamaBaseUrl, model, history, systemPrompt, params)
+        "openai-compatible" -> customProviderService.streamOpenAiCompatible(
+            baseUrl = config.openAiBaseUrl,
+            apiKey = config.openAiCompatibleApiKey,
+            model = model,
+            history = history,
+            systemPrompt = systemPrompt,
+            params = params,
+        )
+        else -> flow { throw Exception("Unknown Labs provider.") }
     }
 
     // -------------------------------------------------------------------------------

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -9,6 +9,10 @@ import com.echoflow.data.AdvisorProfileDao
 import com.echoflow.data.AgentProfile
 import com.echoflow.data.AgentProfileDao
 import com.echoflow.data.CatalogEntry
+import com.echoflow.data.CustomProviderConfig
+import com.echoflow.data.CustomModelProvider
+import com.echoflow.data.CustomProviderModel
+import com.echoflow.data.CustomProviderService
 import com.echoflow.data.CustomModel
 import com.echoflow.data.CustomModelDao
 import com.echoflow.data.DeepResearchModel
@@ -26,6 +30,7 @@ import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.data.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,6 +48,7 @@ class SettingsViewModel(
     private val agentProfileDao: AgentProfileDao
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
+    private val customProviderService = CustomProviderService()
 
     val apiKey: StateFlow<String> = repository.apiKey
     val selectedModel: StateFlow<String> = repository.selectedModel
@@ -65,6 +71,23 @@ class SettingsViewModel(
     // Inference parameters (global, one set per side)
     val localInferenceParams: StateFlow<InferenceParams> = repository.localInferenceParams
     val cloudInferenceParams: StateFlow<InferenceParams> = repository.cloudInferenceParams
+    val customProviderConfig: StateFlow<CustomProviderConfig> = repository.customProviderConfig
+
+    private val _customProviderTestLoading = MutableStateFlow(false)
+    val customProviderTestLoading: StateFlow<Boolean> = _customProviderTestLoading.asStateFlow()
+
+    private val _customProviderTestMessage = MutableStateFlow<String?>(null)
+    val customProviderTestMessage: StateFlow<String?> = _customProviderTestMessage.asStateFlow()
+
+    private val _customProviderFetchLoading = MutableStateFlow<CustomModelProvider?>(null)
+    val customProviderFetchLoading: StateFlow<CustomModelProvider?> = _customProviderFetchLoading.asStateFlow()
+
+    private val _customProviderFetchMessage = MutableStateFlow<String?>(null)
+    val customProviderFetchMessage: StateFlow<String?> = _customProviderFetchMessage.asStateFlow()
+
+    val customProviderModels: StateFlow<List<CustomProviderModel>> = repository.customProviderConfig
+        .map { it.toModelEntries() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // Deep Research
     val deepResearchModelId: StateFlow<String> = repository.deepResearchModel
@@ -217,6 +240,67 @@ class SettingsViewModel(
 
     fun resetInferenceParams(local: Boolean) {
         repository.resetInferenceParams(local)
+    }
+
+    fun saveCustomProviderConfig(config: CustomProviderConfig) {
+        repository.saveCustomProviderConfig(config)
+        _customProviderTestMessage.value = null
+    }
+
+    fun testCustomProvider(config: CustomProviderConfig = customProviderConfig.value) {
+        if (_customProviderTestLoading.value) return
+        viewModelScope.launch {
+            _customProviderTestLoading.value = true
+            _customProviderTestMessage.value = null
+            try {
+                val result = when {
+                    config.ollamaEnabled ->
+                        customProviderService.testOllama(config.ollamaBaseUrl, config.ollamaModel)
+                    config.openAiCompatibleEnabled ->
+                        customProviderService.testOpenAiCompatible(config.openAiBaseUrl, config.openAiCompatibleApiKey, config.openAiCompatibleModel)
+                    else -> null
+                }
+                _customProviderTestMessage.value = result?.message
+            } finally {
+                _customProviderTestLoading.value = false
+            }
+        }
+    }
+
+    fun fetchCustomProviderModels(provider: CustomModelProvider, config: CustomProviderConfig = customProviderConfig.value) {
+        if (_customProviderFetchLoading.value != null) return
+        viewModelScope.launch {
+            _customProviderFetchLoading.value = provider
+            _customProviderFetchMessage.value = null
+            try {
+                val result = when (provider) {
+                    CustomModelProvider.OpenAi -> customProviderService.fetchModels(provider, apiKey = config.openAiApiKey)
+                    CustomModelProvider.Claude -> customProviderService.fetchModels(provider, apiKey = config.claudeApiKey)
+                    CustomModelProvider.Gemini -> customProviderService.fetchModels(provider, apiKey = config.geminiApiKey)
+                    CustomModelProvider.Ollama -> customProviderService.fetchModels(provider, baseUrl = config.ollamaBaseUrl)
+                    CustomModelProvider.OpenAiCompatible -> customProviderService.fetchModels(
+                        provider,
+                        baseUrl = config.openAiBaseUrl,
+                        apiKey = config.openAiCompatibleApiKey,
+                    )
+                }
+                if (result.ok) {
+                    val updated = when (provider) {
+                        CustomModelProvider.OpenAi -> config.copy(openAiModels = result.message)
+                        CustomModelProvider.Claude -> config.copy(claudeModels = result.message)
+                        CustomModelProvider.Gemini -> config.copy(geminiModels = result.message)
+                        CustomModelProvider.Ollama -> config.copy(ollamaModels = result.message)
+                        CustomModelProvider.OpenAiCompatible -> config.copy(openAiCompatibleModels = result.message)
+                    }
+                    saveCustomProviderConfig(updated)
+                    _customProviderFetchMessage.value = "Fetched ${result.message.lineSequence().filter { it.isNotBlank() }.count()} models."
+                } else {
+                    _customProviderFetchMessage.value = result.message
+                }
+            } finally {
+                _customProviderFetchLoading.value = null
+            }
+        }
     }
 
     // ── Deep Research ────────────────────────────────────────────────────────────────
@@ -461,6 +545,36 @@ class SettingsViewModel(
     }
 
     private fun gb(bytes: Long): String = "%.1f GB".format(bytes / (1024.0 * 1024 * 1024))
+
+    private fun CustomProviderConfig.toModelEntries(): List<CustomProviderModel> {
+        fun lines(value: String): List<String> = value.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.distinct().toList()
+        fun withManual(models: String, manual: String): List<String> =
+            (listOf(manual.trim()).filter { it.isNotEmpty() } + lines(models)).distinct()
+
+        val out = mutableListOf<CustomProviderModel>()
+        if (cloudApisEnabled) {
+            withManual(openAiSelectedModels, openAiModel).forEach {
+                out.add(CustomProviderModel(CustomProviderConfig.PREFIX_OPENAI + it, it, "OpenAI", isLocalLike = false))
+            }
+            withManual(claudeSelectedModels, claudeModel).forEach {
+                out.add(CustomProviderModel(CustomProviderConfig.PREFIX_CLAUDE + it, it, "Claude", isLocalLike = false))
+            }
+            withManual(geminiSelectedModels, geminiModel).forEach {
+                out.add(CustomProviderModel(CustomProviderConfig.PREFIX_GEMINI + it, it, "Gemini", isLocalLike = false))
+            }
+        }
+        if (ollamaEnabled) {
+            withManual(ollamaSelectedModels, ollamaModel).forEach {
+                out.add(CustomProviderModel(CustomProviderConfig.PREFIX_OLLAMA + it, it, "Ollama", isLocalLike = true))
+            }
+        }
+        if (openAiCompatibleEnabled) {
+            withManual(openAiCompatibleSelectedModels, openAiCompatibleModel).forEach {
+                out.add(CustomProviderModel(CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE + it, it, "OpenAI-compatible", isLocalLike = true))
+            }
+        }
+        return out
+    }
 
     fun clearImportError() {
         _importError.value = null

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -126,7 +126,9 @@ fun ChatScreen(
     val pendingMime by chatViewModel.pendingAttachmentMimeType.collectAsState()
     val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
     val selectedModelID by settingsViewModel.selectedModel.collectAsState()
+    val customProviderConfig by settingsViewModel.customProviderConfig.collectAsState()
     val customModelsList by settingsViewModel.customModels.collectAsState()
+    val customProviderModels by settingsViewModel.customProviderModels.collectAsState()
     val localModelsList by settingsViewModel.localModels.collectAsState()
     val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
     val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
@@ -192,14 +194,30 @@ fun ChatScreen(
 
     // Image attachments work for cloud models and for on-device .litertlm bundles (which
     // support vision); .task models are text-only, so the Image option is hidden for them.
-    val imageAttachAllowed = remember(selectedModelID, localModelsList) {
-        if (selectedModelID.startsWith("local/")) {
-            localModelsList.firstOrNull { it.id == selectedModelID }
-                ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
-        } else true
+    val imageAttachAllowed = remember(selectedModelID, localModelsList, customProviderConfig) {
+        when {
+            selectedModelID.startsWith("local/") ->
+                localModelsList.firstOrNull { it.id == selectedModelID }
+                    ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) -> customProviderConfig.ollamaImagesEnabled
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) -> customProviderConfig.openAiCompatibleImagesEnabled
+            else -> true
+        }
     }
     val imageAttachAvailable = imageAttachAllowed && !deepResearchActive && !dataAgentActive
-    val selectedModelIsOpenRouter = remember(selectedModelID) { !selectedModelID.startsWith("local/") }
+    val selectedModelIsOpenRouter = remember(selectedModelID) {
+        !selectedModelID.startsWith("local/") && !selectedModelID.startsWith("custom/")
+    }
+    val selectedModelIsCustomCloud = remember(selectedModelID) {
+        selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) ||
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CLAUDE) ||
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_GEMINI)
+    }
+    val selectedModelIsCustomPdfCapable = remember(selectedModelID, customProviderConfig) {
+        selectedModelIsCustomCloud ||
+            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) && customProviderConfig.ollamaPdfsEnabled) ||
+            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) && customProviderConfig.openAiCompatiblePdfsEnabled)
+    }
     val deepResearchUsesOpenRouter = remember(deepResearchActive, drModelId) {
         deepResearchActive && drModelId.isNotBlank() && !DeepResearchCatalog.isProviderEngine(drModelId)
     }
@@ -211,6 +229,7 @@ fun ChatScreen(
         echoAdviserActive,
         echoFusionActive,
         echoAgentActive,
+        selectedModelIsCustomPdfCapable,
     ) {
         when {
             dataAgentActive -> false
@@ -218,7 +237,7 @@ fun ChatScreen(
             echoFusionActive -> true
             echoAdviserActive -> selectedModelIsOpenRouter
             echoAgentActive -> selectedModelIsOpenRouter
-            else -> selectedModelIsOpenRouter
+            else -> selectedModelIsOpenRouter || selectedModelIsCustomPdfCapable
         }
     }
     LaunchedEffect(pendingUri, pendingMime, imageAttachAvailable, pdfAttachAllowed) {
@@ -230,16 +249,30 @@ fun ChatScreen(
         }
     }
 
-    val activeModelList = remember(customModelsList) {
+    val activeModelList = remember(customModelsList, customProviderModels) {
+        val list = mutableListOf(DEFAULT_MODEL)
+        customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
+        customProviderModels.filter { !it.isLocalLike }.forEach { model ->
+            if (list.none { it.first == model.id }) list.add(model.id to "${model.group}: ${model.name}")
+        }
+        list
+    }
+    val openRouterOnlyModelList = remember(customModelsList) {
         val list = mutableListOf(DEFAULT_MODEL)
         customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
         list
     }
-    val localModelEntries = remember(localModelsList, localModelsEnabled) {
-        if (localModelsEnabled) localModelsList.map { it.id to it.name } else emptyList()
+    val localModelEntries = remember(localModelsList, localModelsEnabled, customProviderModels) {
+        val entries = mutableListOf<Pair<String, String>>()
+        if (localModelsEnabled) entries.addAll(localModelsList.map { it.id to it.name })
+        customProviderModels.filter { it.isLocalLike }.forEach { model ->
+            entries.add(model.id to "${model.group}: ${model.name}")
+        }
+        entries
     }
     val modelShortName = activeModelList.firstOrNull { it.first == selectedModelID }?.second
         ?: customModelsList.firstOrNull { it.id == selectedModelID }?.name
+        ?: customProviderModels.firstOrNull { it.id == selectedModelID }?.let { "${it.group}: ${it.name}" }
         ?: localModelsList.firstOrNull { it.id == selectedModelID }?.name
         ?: selectedModelID
     val localSendBlocked = selectedModelID.startsWith("local/") && anyLocalStreamActive && !isStreaming
@@ -426,7 +459,7 @@ fun ChatScreen(
             )
         } else if (echoAdviserActive) {
             AdvisorPickerSheet(
-                models = activeModelList,
+                models = openRouterOnlyModelList,
                 selectedModelId = selectedModelID,
                 profiles = advisorProfiles,
                 selectedProfileId = echoAdviserProfileId,
@@ -437,7 +470,7 @@ fun ChatScreen(
             )
         } else if (echoAgentActive) {
             AgentPickerSheet(
-                models = activeModelList,
+                models = openRouterOnlyModelList,
                 selectedModelId = selectedModelID,
                 profiles = agentProfiles,
                 selectedProfileId = echoAgentProfileId,
@@ -1737,7 +1770,7 @@ private fun ModelPickerSheet(
                 }
                 if (filteredLocal.isNotEmpty()) {
                     item(key = "local-section") {
-                        Box(Modifier.padding(top = Spacing.m)) { SectionLabel("On-device") }
+                        Box(Modifier.padding(top = Spacing.m)) { SectionLabel("Local & network") }
                     }
                     items(filteredLocal, key = { it.first }) { (id, name) ->
                         ModelRow(name, id, id == selectedId, isLocal = true) { onSelect(id) }
@@ -2039,6 +2072,11 @@ private fun DrEngineRow(name: String, description: String, selected: Boolean, on
 private fun ModelRow(name: String, modelId: String, selected: Boolean, isLocal: Boolean = false, onClick: () -> Unit) {
     val displayName = remember(name, isLocal) { modelPickerDisplayName(name, isLocal) }
     val provider = when {
+        modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) -> "Direct OpenAI API"
+        modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CLAUDE) -> "Direct Claude API"
+        modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_GEMINI) -> "Direct Gemini API"
+        modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) -> "Ollama API"
+        modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) -> "OpenAI-compatible API"
         isLocal -> "Runs on this device — private & offline"
         modelId.contains("/") -> modelId.substringBefore("/").replaceFirstChar { it.uppercase() }
         else -> "Custom"

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -88,6 +88,8 @@ import androidx.graphics.shapes.RoundedPolygon
 import com.echoflow.data.AdvisorProfile
 import com.echoflow.data.AgentProfile
 import com.echoflow.data.CatalogEntry
+import com.echoflow.data.CustomModelProvider
+import com.echoflow.data.CustomProviderConfig
 import com.echoflow.data.DataAgentCatalog
 import com.echoflow.data.FusionPanel
 import com.echoflow.data.DeepResearchCatalog
@@ -144,6 +146,7 @@ private const val PageEchoLabs = "echo_labs"
 private const val PageEchoAdviser = "echo_adviser"
 private const val PageEchoFusion = "echo_fusion"
 private const val PageEchoAgent = "echo_agent"
+private const val PageCustomProvider = "custom_provider"
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -200,6 +203,7 @@ fun SettingsScreen(
             PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageEchoLabs })
             PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageEchoLabs })
             PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageEchoLabs })
+            PageCustomProvider -> CustomProviderPage(viewModel, onBack = { page = PageEchoLabs })
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }
@@ -229,6 +233,7 @@ private fun SettingsHomePage(
     val echoAdviserEnabled by viewModel.echoAdviserEnabled.collectAsState()
     val echoFusionEnabled by viewModel.echoFusionEnabled.collectAsState()
     val echoAgentEnabled by viewModel.echoAgentEnabled.collectAsState()
+    val customProviderConfig by viewModel.customProviderConfig.collectAsState()
     val firecrawlKeyHome by viewModel.firecrawlApiKey.collectAsState()
     val advisorProfiles by viewModel.advisorProfiles.collectAsState()
     val fusionPanels by viewModel.fusionPanels.collectAsState()
@@ -278,7 +283,16 @@ private fun SettingsHomePage(
         firecrawlKeyHome.isBlank() -> "On · add a Firecrawl key"
         else -> "Live browser · controlled by chat"
     }
-    val labsOnCount = listOf(dataAgentEnabled, echoAdviserEnabled, echoFusionEnabled, echoAgentEnabled, browserFlowEnabled).count { it }
+    val labsOnCount = listOf(
+        dataAgentEnabled,
+        echoAdviserEnabled,
+        echoFusionEnabled,
+        echoAgentEnabled,
+        browserFlowEnabled,
+        customProviderConfig.cloudApisEnabled,
+        customProviderConfig.ollamaEnabled,
+        customProviderConfig.openAiCompatibleEnabled,
+    ).count { it }
     val echoLabsSubtitle =
         if (labsOnCount == 0) "Experimental modes · all off" else "Experimental modes · $labsOnCount on"
     val echoAdviserSubtitle = when {
@@ -1312,6 +1326,7 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
     val echoFusionEnabled by viewModel.echoFusionEnabled.collectAsState()
     val echoAgentEnabled by viewModel.echoAgentEnabled.collectAsState()
     val browserFlowEnabled by viewModel.browserFlowEnabled.collectAsState()
+    val customProviderConfig by viewModel.customProviderConfig.collectAsState()
     val firecrawlKey by viewModel.firecrawlApiKey.collectAsState()
     val advisorProfiles by viewModel.advisorProfiles.collectAsState()
     val fusionPanels by viewModel.fusionPanels.collectAsState()
@@ -1326,6 +1341,12 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
         firecrawlKey.isBlank() -> "On · add a Firecrawl key"
         else -> "Live browser · chat-controlled"
     }
+    val customProviderCount = listOf(
+        customProviderConfig.cloudApisEnabled,
+        customProviderConfig.ollamaEnabled,
+        customProviderConfig.openAiCompatibleEnabled,
+    ).count { it }
+    val customProviderSubtitle = if (customProviderCount == 0) "Off" else "$customProviderCount provider" + if (customProviderCount == 1) "" else "s"
 
     SettingsPageScaffold(title = "Echo Labs", subtitle = "Experimental modes · turn on what you need", onBack = onBack) {
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
@@ -1336,7 +1357,7 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
                 subtitle = dataAgentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 0, count = 4,
+                index = 0, count = 5,
                 onClick = { onOpen(PageDataAgent) },
             )
             SettingsNavRow(
@@ -1346,7 +1367,7 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
                 subtitle = adviserSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 1, count = 4,
+                index = 1, count = 5,
                 onClick = { onOpen(PageEchoAdviser) },
             )
             SettingsNavRow(
@@ -1356,7 +1377,7 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
                 subtitle = fusionSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 2, count = 4,
+                index = 2, count = 5,
                 onClick = { onOpen(PageEchoFusion) },
             )
             SettingsNavRow(
@@ -1366,8 +1387,18 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
                 subtitle = agentSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 3, count = 4,
+                index = 3, count = 5,
                 onClick = { onOpen(PageEchoAgent) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Hub,
+                polygon = MaterialShapes.Gem,
+                title = "Labs Providers",
+                subtitle = customProviderSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 4, count = 5,
+                onClick = { onOpen(PageCustomProvider) },
             )
         }
 
@@ -1412,6 +1443,317 @@ private fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit,
             }
         }
     }
+}
+
+// ── Custom Provider ──────────────────────────────────────────────────────────────────
+
+@Composable
+private fun CustomProviderPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val savedConfig by viewModel.customProviderConfig.collectAsState()
+    val loading by viewModel.customProviderTestLoading.collectAsState()
+    val fetchLoading by viewModel.customProviderFetchLoading.collectAsState()
+    val fetchMessage by viewModel.customProviderFetchMessage.collectAsState()
+    val testMessage by viewModel.customProviderTestMessage.collectAsState()
+    var draft by remember(savedConfig) { mutableStateOf(savedConfig) }
+
+    SettingsPageScaffold(title = "Labs Providers", subtitle = "Prerelease direct and network APIs", onBack = onBack) {
+        LabProviderToggle(
+            title = "Direct Cloud APIs",
+            subtitle = "OpenAI, Claude and Gemini direct keys",
+            enabled = draft.cloudApisEnabled,
+            onToggle = { draft = draft.copy(cloudApisEnabled = it); viewModel.saveCustomProviderConfig(draft) },
+        )
+        AnimatedVisibility(visible = draft.cloudApisEnabled, enter = sectionEnter(), exit = sectionExit()) {
+            Column {
+                Spacer(Modifier.height(Spacing.m))
+                DirectCloudProviderCard(
+                    draft = draft,
+                    fetchLoading = fetchLoading,
+                    onDraft = { draft = it },
+                    onSave = { viewModel.saveCustomProviderConfig(draft) },
+                    onFetch = { provider ->
+                        viewModel.saveCustomProviderConfig(draft)
+                        viewModel.fetchCustomProviderModels(provider, draft)
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        LabProviderToggle(
+            title = "Ollama API",
+            subtitle = "Local or LAN Ollama server",
+            enabled = draft.ollamaEnabled,
+            onToggle = { draft = draft.copy(ollamaEnabled = it); viewModel.saveCustomProviderConfig(draft) },
+        )
+        AnimatedVisibility(visible = draft.ollamaEnabled, enter = sectionEnter(), exit = sectionExit()) {
+            Column {
+                Spacer(Modifier.height(Spacing.m))
+                NetworkProviderCard(
+                    title = "Ollama",
+                    baseUrl = draft.ollamaBaseUrl,
+                    apiKey = null,
+                    manualModel = draft.ollamaModel,
+                    availableModels = draft.ollamaModels,
+                    selectedModels = draft.ollamaSelectedModels,
+                    images = draft.ollamaImagesEnabled,
+                    pdfs = draft.ollamaPdfsEnabled,
+                    fetchLoading = fetchLoading == CustomModelProvider.Ollama,
+                    testLoading = loading,
+                    testMessage = testMessage,
+                    placeholder = "llama3.1",
+                    onBaseUrl = { draft = draft.copy(ollamaBaseUrl = it) },
+                    onApiKey = {},
+                    onManualModel = { draft = draft.copy(ollamaModel = it) },
+                    onSelectedModels = { draft = draft.copy(ollamaSelectedModels = it) },
+                    onImages = { draft = draft.copy(ollamaImagesEnabled = it) },
+                    onPdfs = { draft = draft.copy(ollamaPdfsEnabled = it) },
+                    onSave = { viewModel.saveCustomProviderConfig(draft) },
+                    onFetch = {
+                        viewModel.saveCustomProviderConfig(draft)
+                        viewModel.fetchCustomProviderModels(CustomModelProvider.Ollama, draft)
+                    },
+                    onTest = {
+                        viewModel.saveCustomProviderConfig(draft)
+                        viewModel.testCustomProvider(draft.copy(openAiCompatibleEnabled = false, ollamaEnabled = true))
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        LabProviderToggle(
+            title = "OpenAI-Compatible API",
+            subtitle = "LM Studio, Jan, vLLM, LocalAI and similar servers",
+            enabled = draft.openAiCompatibleEnabled,
+            onToggle = { draft = draft.copy(openAiCompatibleEnabled = it); viewModel.saveCustomProviderConfig(draft) },
+        )
+        AnimatedVisibility(visible = draft.openAiCompatibleEnabled, enter = sectionEnter(), exit = sectionExit()) {
+            Column {
+                Spacer(Modifier.height(Spacing.m))
+                NetworkProviderCard(
+                    title = "OpenAI-compatible",
+                    baseUrl = draft.openAiBaseUrl,
+                    apiKey = draft.openAiCompatibleApiKey,
+                    manualModel = draft.openAiCompatibleModel,
+                    availableModels = draft.openAiCompatibleModels,
+                    selectedModels = draft.openAiCompatibleSelectedModels,
+                    images = draft.openAiCompatibleImagesEnabled,
+                    pdfs = draft.openAiCompatiblePdfsEnabled,
+                    fetchLoading = fetchLoading == CustomModelProvider.OpenAiCompatible,
+                    testLoading = loading,
+                    testMessage = testMessage,
+                    placeholder = "local-model",
+                    onBaseUrl = { draft = draft.copy(openAiBaseUrl = it) },
+                    onApiKey = { draft = draft.copy(openAiCompatibleApiKey = it) },
+                    onManualModel = { draft = draft.copy(openAiCompatibleModel = it) },
+                    onSelectedModels = { draft = draft.copy(openAiCompatibleSelectedModels = it) },
+                    onImages = { draft = draft.copy(openAiCompatibleImagesEnabled = it) },
+                    onPdfs = { draft = draft.copy(openAiCompatiblePdfsEnabled = it) },
+                    onSave = { viewModel.saveCustomProviderConfig(draft) },
+                    onFetch = {
+                        viewModel.saveCustomProviderConfig(draft)
+                        viewModel.fetchCustomProviderModels(CustomModelProvider.OpenAiCompatible, draft)
+                    },
+                    onTest = {
+                        viewModel.saveCustomProviderConfig(draft)
+                        viewModel.testCustomProvider(draft.copy(openAiCompatibleEnabled = true, ollamaEnabled = false))
+                    },
+                )
+            }
+        }
+
+        ProviderStatusMessage(fetchMessage)
+    }
+}
+
+@Composable
+private fun LabProviderToggle(title: String, subtitle: String, enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Surface(shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainer, modifier = Modifier.fillMaxWidth()) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Spacer(Modifier.width(Spacing.s))
+            Switch(checked = enabled, onCheckedChange = onToggle)
+        }
+    }
+}
+
+@Composable
+private fun DirectCloudProviderCard(
+    draft: CustomProviderConfig,
+    fetchLoading: CustomModelProvider?,
+    onDraft: (CustomProviderConfig) -> Unit,
+    onSave: () -> Unit,
+    onFetch: (CustomModelProvider) -> Unit,
+) {
+    FormCard {
+        DirectProviderBlock("OpenAI", CustomModelProvider.OpenAi, draft.openAiApiKey, draft.openAiModel, draft.openAiModels, draft.openAiSelectedModels, fetchLoading, onKey = { onDraft(draft.copy(openAiApiKey = it)) }, onManual = { onDraft(draft.copy(openAiModel = it)) }, onModels = { onDraft(draft.copy(openAiSelectedModels = it)) }, onFetch = onFetch)
+        Spacer(Modifier.height(Spacing.l))
+        DirectProviderBlock("Claude", CustomModelProvider.Claude, draft.claudeApiKey, draft.claudeModel, draft.claudeModels, draft.claudeSelectedModels, fetchLoading, onKey = { onDraft(draft.copy(claudeApiKey = it)) }, onManual = { onDraft(draft.copy(claudeModel = it)) }, onModels = { onDraft(draft.copy(claudeSelectedModels = it)) }, onFetch = onFetch)
+        Spacer(Modifier.height(Spacing.l))
+        DirectProviderBlock("Gemini", CustomModelProvider.Gemini, draft.geminiApiKey, draft.geminiModel, draft.geminiModels, draft.geminiSelectedModels, fetchLoading, onKey = { onDraft(draft.copy(geminiApiKey = it)) }, onManual = { onDraft(draft.copy(geminiModel = it)) }, onModels = { onDraft(draft.copy(geminiSelectedModels = it)) }, onFetch = onFetch)
+        Spacer(Modifier.height(Spacing.m))
+        Text("Images and PDFs are enabled by default for these direct cloud APIs.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(Spacing.m))
+        Button(onClick = onSave, shape = CircleShape, modifier = Modifier.fillMaxWidth().height(52.dp)) { Text("Save") }
+    }
+}
+
+@Composable
+private fun DirectProviderBlock(
+    title: String,
+    provider: CustomModelProvider,
+    apiKey: String,
+    manualModel: String,
+    availableModels: String,
+    selectedModels: String,
+    fetchLoading: CustomModelProvider?,
+    onKey: (String) -> Unit,
+    onManual: (String) -> Unit,
+    onModels: (String) -> Unit,
+    onFetch: (CustomModelProvider) -> Unit,
+) {
+    var visible by remember { mutableStateOf(false) }
+    Text(title, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+    Spacer(Modifier.height(Spacing.s))
+    OutlinedTextField(
+        value = apiKey,
+        onValueChange = onKey,
+        label = { Text("API key") },
+        singleLine = true,
+        shape = MaterialTheme.shapes.medium,
+        visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+        trailingIcon = { IconButton(onClick = { visible = !visible }) { Icon(if (visible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility, if (visible) "Hide" else "Show") } },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(Spacing.s))
+    OutlinedTextField(value = manualModel, onValueChange = onManual, label = { Text("Manual model") }, singleLine = true, shape = MaterialTheme.shapes.medium, modifier = Modifier.fillMaxWidth())
+    Spacer(Modifier.height(Spacing.s))
+    ProviderModelChips(availableModels, selectedModels, onModels)
+    Spacer(Modifier.height(Spacing.s))
+    FilledTonalButton(onClick = { onFetch(provider) }, enabled = fetchLoading == null, shape = CircleShape, modifier = Modifier.fillMaxWidth().height(48.dp)) {
+        if (fetchLoading == provider) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp) else Text("Fetch models")
+    }
+}
+
+@Composable
+private fun NetworkProviderCard(
+    title: String,
+    baseUrl: String,
+    apiKey: String?,
+    manualModel: String,
+    availableModels: String,
+    selectedModels: String,
+    images: Boolean,
+    pdfs: Boolean,
+    fetchLoading: Boolean,
+    testLoading: Boolean,
+    testMessage: String?,
+    placeholder: String,
+    onBaseUrl: (String) -> Unit,
+    onApiKey: (String) -> Unit,
+    onManualModel: (String) -> Unit,
+    onSelectedModels: (String) -> Unit,
+    onImages: (Boolean) -> Unit,
+    onPdfs: (Boolean) -> Unit,
+    onSave: () -> Unit,
+    onFetch: () -> Unit,
+    onTest: () -> Unit,
+) {
+    var visible by remember { mutableStateOf(false) }
+    FormCard {
+        Text(title, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+        Spacer(Modifier.height(Spacing.s))
+        OutlinedTextField(value = baseUrl, onValueChange = onBaseUrl, label = { Text("Base URL") }, placeholder = { Text("http://192.168.1.50:1234/v1") }, singleLine = true, shape = MaterialTheme.shapes.medium, modifier = Modifier.fillMaxWidth())
+        if (apiKey != null) {
+            Spacer(Modifier.height(Spacing.s))
+            OutlinedTextField(
+                value = apiKey,
+                onValueChange = onApiKey,
+                label = { Text("API key") },
+                placeholder = { Text("Optional for local servers") },
+                singleLine = true,
+                shape = MaterialTheme.shapes.medium,
+                visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = { IconButton(onClick = { visible = !visible }) { Icon(if (visible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility, if (visible) "Hide" else "Show") } },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        Spacer(Modifier.height(Spacing.s))
+        OutlinedTextField(value = manualModel, onValueChange = onManualModel, label = { Text("Manual model") }, placeholder = { Text(placeholder) }, singleLine = true, shape = MaterialTheme.shapes.medium, modifier = Modifier.fillMaxWidth())
+        Spacer(Modifier.height(Spacing.m))
+        ProviderModelChips(availableModels, selectedModels, onSelectedModels)
+        Spacer(Modifier.height(Spacing.m))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Images", Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+            Switch(checked = images, onCheckedChange = onImages)
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("PDFs", Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+            Switch(checked = pdfs, onCheckedChange = onPdfs)
+        }
+        ProviderSafetyText()
+        Spacer(Modifier.height(Spacing.m))
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s), modifier = Modifier.fillMaxWidth()) {
+            FilledTonalButton(onClick = onSave, shape = CircleShape, modifier = Modifier.weight(1f).height(52.dp)) { Text("Save") }
+            FilledTonalButton(onClick = onFetch, enabled = !fetchLoading, shape = CircleShape, modifier = Modifier.weight(1f).height(52.dp)) {
+                if (fetchLoading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp) else Text("Fetch")
+            }
+            Button(onClick = onTest, enabled = !testLoading, shape = CircleShape, modifier = Modifier.weight(1f).height(52.dp)) {
+                if (testLoading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp) else Text("Test")
+            }
+        }
+        ProviderStatusMessage(testMessage)
+    }
+}
+
+@Composable
+private fun ProviderModelChips(availableModels: String, selectedModels: String, onSelectedModels: (String) -> Unit) {
+    val available = remember(availableModels, selectedModels) {
+        (availableModels.lineSequence() + selectedModels.lineSequence()).map { it.trim() }.filter { it.isNotEmpty() }.distinct().toList()
+    }
+    val selected = selectedModels.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+    if (available.isEmpty()) {
+        Text("Fetch models or enter a manual model above.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        return
+    }
+    Text("Show in chat model picker", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Spacer(Modifier.height(Spacing.s))
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+        available.forEach { model ->
+            FilterChip(
+                selected = model in selected,
+                onClick = {
+                    val next = if (model in selected) selected - model else selected + model
+                    onSelectedModels(next.joinToString("\n"))
+                },
+                label = { Text(model, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProviderSafetyText() {
+    Text(
+        "Plain HTTP is allowed for localhost and private LAN addresses only. Use HTTPS for internet-facing servers.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun ProviderStatusMessage(message: String?) {
+    if (message == null) return
+    Spacer(Modifier.height(Spacing.s))
+    Text(
+        message,
+        style = MaterialTheme.typography.bodySmall,
+        color = if (message.contains("works", ignoreCase = true)) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+    )
 }
 
 // ── Data Agent ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add Labs provider configuration for direct OpenAI, Claude, Gemini, Ollama, and OpenAI-compatible APIs.
- Add Echo Labs settings UI with provider toggles, model fetching, and user-selected model visibility.
- Route normal chat through selected Labs providers and keep OpenRouter-only Echo tools constrained to OpenRouter models.

## Validation
- Ran git diff --check HEAD.
- Did not run Gradle build or tests per request.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Labs provider APIs for OpenAI, Claude, Gemini, Ollama, and OpenAI-compatible servers
> - Adds [`CustomProviderService`](https://github.com/adityavardhansharma/EchoFlow/pull/51/files#diff-334eadc34a59a5e579f9c2263e1c959200ed8b027ee94230efa1c8fca7986869) which handles SSE streaming, connectivity testing, and model discovery for OpenAI, Anthropic Claude, Google Gemini, Ollama, and generic OpenAI-compatible endpoints, including base64 image attachment support.
> - Extends [`SettingsRepository`](https://github.com/adityavardhansharma/EchoFlow/pull/51/files#diff-6eb22e86bcb09e14c5881c7ecc8775fa1780d8945e60dda4fc786fd07cd4f381) to persist and expose custom provider configuration (API keys, base URLs, model selections, feature toggles) via a `StateFlow`.
> - Routes chat requests through the appropriate custom provider in [`ChatViewModel`](https://github.com/adityavardhansharma/EchoFlow/pull/51/files#diff-e472e72a7a21812cf8761bce2712390c23a547c3e316b22815fb7dc4cb7d28de), enforcing per-provider attachment rules and blocking Echo Agent/Adviser/Fusion modes when a custom provider is active.
> - Adds a full "Labs Providers" settings page in [`SettingsScreen`](https://github.com/adityavardhansharma/EchoFlow/pull/51/files#diff-56fd121882bb279ab6fe1763d8783dced0e961ae9aa5e245b5d14b6b342cba66) for configuring providers, fetching model lists, and testing connectivity.
> - Updates the chat model picker in [`ChatScreen`](https://github.com/adityavardhansharma/EchoFlow/pull/51/files#diff-63925e52d2910907ae272a548ab47afae1a567a3832ad5f9d4abf74dfa10e4e8) to include custom provider models, label their origin, and restrict Echo Adviser/Agent pickers to OpenRouter-only models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b22e144.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Labs Providers settings page for configuring direct cloud APIs, Ollama, and OpenAI-compatible endpoints.
  * Expanded model selection to show custom provider models and clearer provider labels.
  * Enabled streaming chat responses from additional provider types, including support for attachments where allowed.

* **Bug Fixes**
  * Improved attachment handling so unsupported image/PDF uploads are blocked with clearer feedback.
  * Updated chat and assistant model checks to work correctly with custom provider selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->