### PR TITLE
Update README for current EchoFlow features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,162 @@
 <div align="center">
+  <img src="logo1.png" alt="EchoFlow logo" width="96" />
   <h1>EchoFlow</h1>
-  <p><strong>A privacy-first, bring-your-own-key AI chat app for Android — cloud and on-device models, web search, and multi-step Deep Research, wrapped in expressive Material 3 design.</strong></p>
+  <p><strong>A privacy-first Android AI workspace for chat, local models, custom endpoints, web search, research, agents, browser control, and artifacts.</strong></p>
 
   <p>
-    <img alt="Kotlin" src="https://img.shields.io/badge/Kotlin-2.2.10-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white" />
-    <img alt="Jetpack Compose" src="https://img.shields.io/badge/Jetpack%20Compose-2026.05.00-4285F4?style=for-the-badge&logo=jetpackcompose&logoColor=white" />
-    <img alt="Material 3" src="https://img.shields.io/badge/Material%203-Expressive-6750A4?style=for-the-badge&logo=materialdesign&logoColor=white" />
+    <img alt="Kotlin" src="https://img.shields.io/badge/Kotlin-2.x-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white" />
+    <img alt="Jetpack Compose" src="https://img.shields.io/badge/Jetpack%20Compose-Material%203%20Expressive-4285F4?style=for-the-badge&logo=jetpackcompose&logoColor=white" />
     <img alt="Android" src="https://img.shields.io/badge/Android-API%2024+-3DDC84?style=for-the-badge&logo=android&logoColor=white" />
+    <img alt="Privacy" src="https://img.shields.io/badge/Privacy-No%20backend%20%7C%20BYOK-111827?style=for-the-badge" />
   </p>
 
   <p>
-    <img alt="OpenRouter" src="https://img.shields.io/badge/OpenRouter-Cloud%20Models-111827?style=flat-square" />
+    <img alt="OpenRouter" src="https://img.shields.io/badge/OpenRouter-cloud%20models-111827?style=flat-square" />
+    <img alt="OpenAI" src="https://img.shields.io/badge/OpenAI-direct%20API-10A37F?style=flat-square&logo=openai&logoColor=white" />
+    <img alt="Claude" src="https://img.shields.io/badge/Claude-direct%20API-D97757?style=flat-square" />
+    <img alt="Gemini" src="https://img.shields.io/badge/Gemini-direct%20API-4285F4?style=flat-square&logo=googlegemini&logoColor=white" />
+    <img alt="Cerebras" src="https://img.shields.io/badge/Cerebras-direct%20API-E23B3B?style=flat-square" />
+    <img alt="Ollama" src="https://img.shields.io/badge/Ollama-local%20%2F%20LAN-111827?style=flat-square" />
+    <img alt="OpenAI compatible" src="https://img.shields.io/badge/OpenAI--compatible-LM%20Studio%20%7C%20Jan%20%7C%20vLLM-6366F1?style=flat-square" />
+  </p>
+
+  <p>
     <img alt="On-device" src="https://img.shields.io/badge/On--device-LiteRT%20%2F%20MediaPipe-FF6F00?style=flat-square" />
-    <img alt="Web Search" src="https://img.shields.io/badge/Search-Exa%20%2F%20Parallel%20%2F%20Firecrawl-0F766E?style=flat-square" />
-    <img alt="Room" src="https://img.shields.io/badge/Room-Local%20Storage-2563EB?style=flat-square" />
-    <img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green?style=flat-square" />
+    <img alt="Search" src="https://img.shields.io/badge/Search-OpenRouter%20%7C%20Exa%20%7C%20Parallel%20%7C%20Firecrawl-0F766E?style=flat-square" />
+    <img alt="Research" src="https://img.shields.io/badge/Deep%20Research-Exa%20%7C%20Parallel%20%7C%20Firecrawl-7C3AED?style=flat-square" />
+    <img alt="License" src="https://img.shields.io/badge/License-MIT-green?style=flat-square" />
   </p>
 
   <p>
-    <a href="https://github.com/adityavardhansharma/EchoFlow/releases/latest"><strong>📥 Download the app from GitHub Releases</strong></a>
+    <a href="https://github.com/adityavardhansharma/EchoFlow/releases/latest"><strong>Download from GitHub Releases</strong></a>
   </p>
 </div>
 
 ## Overview
 
-EchoFlow is a native Android AI chat client that puts you in control. It is **bring-your-own-key (BYOK)** and **local-first**: there is **no EchoFlow backend, no account, and no telemetry**. You plug in your own provider key — or run a model fully on-device — and the app talks directly to the provider. Your keys, conversations, and downloaded models stay on your phone.
+EchoFlow is a native Android AI app built around one idea: your device should stay in charge. It is **bring-your-own-key**, **local-first**, and has **no EchoFlow backend, no account system, and no telemetry**. You can use OpenRouter, direct provider APIs, an Ollama server on your network, an OpenAI-compatible local server, or fully on-device models.
 
-Beyond everyday chat, EchoFlow adds two opt-in power-user modes: **Deep Research**, which investigates the web across multiple steps and writes a cited report, and **Data Agent**, which extracts structured data from the web into clean tables. Both run in the background and never route through anyone's servers but the providers you choose.
+It has grown from a chat app into a small AI workspace: normal chat, web search, Deep Research, structured data extraction, Browser Flow, generated artifacts, Echo Adviser, Echo Fusion, and Echo Agents all live in the same Material 3 Expressive interface.
 
-## Privacy
+## Privacy Model
 
-- **No backend, no accounts, no analytics or telemetry.** EchoFlow runs entirely on your device and talks straight to the providers you configure.
-- **Bring your own key.** API keys are stored only on this device.
-- **Local-first storage.** Conversations and history live in a local Room database; nothing is uploaded.
-- **Fully offline option.** On-device models need no internet and no API key at all.
+- **No backend:** EchoFlow talks directly to the providers you configure.
+- **No account or telemetry:** there is no EchoFlow cloud account, analytics pipeline, or hidden sync.
+- **Local storage:** conversations, settings, runs, and downloaded model metadata live on-device.
+- **BYOK:** provider keys are entered at runtime and stored on your device.
+- **Offline path:** on-device models can run without internet or API keys.
+- **Network tools are explicit:** search, browser, data extraction, and provider calls use the services you turn on.
 
-## Highlights
+## Current Features
 
-- **Any cloud model via OpenRouter** — Claude, GPT, Gemini, DeepSeek and more, with a live model directory (pricing + context windows) to build your own picker.
-- **On-device local models** — run models like Gemma, Qwen and DeepSeek distills entirely on your phone: private, offline, and free.
-- **Web search for any model** — Exa, Parallel, Firecrawl, or OpenRouter's server-side search.
-- **Deep Research** — opt-in, multi-step web investigation that produces a cited report; runs in the background and resumes after interruption.
-- **Data Agent** — Firecrawl-powered extraction that returns structured results as cards and tables.
-- **Streaming conversations** with smooth text reveal and **reasoning traces** in a collapsible panel.
-- **Rich markdown rendering** — headings, lists, blockquotes, links, tables, and syntax-highlighted code.
-- **Image attachments** for multimodal conversations.
-- **Material 3 Expressive UI** — Material You dynamic color, accent themes, light/dark, and an adaptive tablet layout.
+- **OpenRouter cloud models:** live model directory, pricing/context metadata, custom model picker, image/PDF-capable cloud workflows.
+- **Custom API Endpoint:** prerelease provider area for direct cloud APIs, Ollama, and OpenAI-compatible endpoints.
+- **Direct cloud APIs:** OpenAI, Claude, Gemini, and Cerebras each get their own setup page, toggle, API key, model fetch, manual model entry, logo badge, and chat-picker model list.
+- **Cerebras support:** streams through the Cerebras OpenAI-compatible endpoint; Gemma-family Cerebras models can use images, while GPT OSS/GLM are treated as text-only and PDFs are disabled.
+- **Ollama:** connect to a local or LAN Ollama server, fetch models, test the connection, and opt into image/PDF support only when your model supports it.
+- **OpenAI-compatible servers:** connect LM Studio, Jan, vLLM, LocalAI, or similar servers over the network, with model fetch fallbacks and test connection.
+- **On-device models:** download curated LiteRT/MediaPipe models, search Hugging Face for `.task` and `.litertlm` bundles, import local model files, and use gated-model tokens.
+- **Web search:** OpenRouter server-side search for OpenRouter models, plus Exa, Parallel, and Firecrawl client-side search that can work across cloud, custom endpoint, and local models.
+- **Deep Research:** Exa, Parallel, Firecrawl, and OpenRouter-model research engines with background execution, notifications, citations, and resume after interruption.
+- **Data Agent:** Firecrawl-powered structured extraction for prices, specs, lists, contacts, and other data-heavy tasks.
+- **Browser Flow:** a live Firecrawl browser session controlled from chat, with domain/send confirmations and visible session controls.
+- **Artifacts:** generate and revise self-contained web/document/report artifacts, with offline artifact handling for local workflows.
+- **Echo Adviser:** let a main model consult a stronger or domain-specific OpenRouter advisor mid-answer.
+- **Echo Fusion:** run a panel of OpenRouter models and a judge model to compare answers and produce a synthesis.
+- **Echo Agents:** give the main model web search/fetch tools and a cheaper worker model it can delegate tasks to.
+- **Rich chat rendering:** streaming markdown, tables, code highlighting, reasoning traces, citations, search progress cards, and result cards.
+- **Material 3 Expressive UI:** dynamic color, accent themes, shaped controls, smooth transitions, and adaptive tablet-friendly layouts.
 
-## Download & Setup
+## Provider Matrix
 
-1. Grab the latest APK from [GitHub Releases](https://github.com/adityavardhansharma/EchoFlow/releases/latest) and install it (you may need to allow installs from unknown sources).
-2. Open **Settings → Cloud models** and paste an [OpenRouter](https://openrouter.ai) API key to use cloud models — or open **Settings → Local models** to download an on-device model and run with no key at all.
-3. (Optional) Add an Exa, Parallel, or Firecrawl key under **Settings → Web search** to enable web search, Deep Research, and the Data Agent.
+| Provider path | Setup location | Model source | Search support | Attachments |
+| --- | --- | --- | --- | --- |
+| OpenRouter | Settings -> Cloud models | OpenRouter directory + manual picks | OpenRouter server search, Exa, Parallel, Firecrawl | Images/PDFs where provider model supports them |
+| OpenAI direct | Echo Labs -> Custom API Endpoint -> Direct Cloud APIs -> OpenAI | `/v1/models` + manual | Exa, Parallel, Firecrawl | Images/PDFs enabled |
+| Claude direct | Echo Labs -> Custom API Endpoint -> Direct Cloud APIs -> Claude | Anthropic models endpoint + manual | Exa, Parallel, Firecrawl | Images/PDFs enabled |
+| Gemini direct | Echo Labs -> Custom API Endpoint -> Direct Cloud APIs -> Gemini | Gemini models endpoint + manual | Exa, Parallel, Firecrawl | Images/PDFs enabled |
+| Cerebras direct | Echo Labs -> Custom API Endpoint -> Direct Cloud APIs -> Cerebras | Cerebras `/v1/models` + manual | Exa, Parallel, Firecrawl | Images for Gemma-family models; PDFs off |
+| Ollama | Echo Labs -> Custom API Endpoint -> Ollama API | `/api/tags` + manual | Exa, Parallel, Firecrawl | User-controlled image/PDF toggles |
+| OpenAI-compatible | Echo Labs -> Custom API Endpoint -> OpenAI-Compatible API | `/v1/models`, `/models`, `/api/v1/models` + manual | Exa, Parallel, Firecrawl | User-controlled image/PDF toggles |
+| On-device | Settings -> Local models | Curated catalog, Hugging Face search, file import | Exa, Parallel, Firecrawl | Images for `.litertlm`; PDFs off |
 
-## Modes
+## Getting Started
+
+1. Install the latest APK from [GitHub Releases](https://github.com/adityavardhansharma/EchoFlow/releases/latest).
+2. Choose how you want to run models:
+   - **OpenRouter:** Settings -> Cloud models.
+   - **On-device:** Settings -> Local models.
+   - **Direct/custom providers:** Settings -> Echo Labs -> Custom API Endpoint.
+3. Add optional search keys in Settings -> Web search for Exa, Parallel, or Firecrawl.
+4. Turn on optional Echo Labs features such as Browser Flow, Data Agent, Echo Adviser, Echo Fusion, Echo Agents, Artifacts, and Custom API Endpoint.
+
+## Chat Modes
 
 ### Chat
 
-Streaming answers with independent per-conversation scroll state, reasoning traces for supported models, image attachments, and first-class markdown. Pick any configured cloud or local model from the in-chat model picker.
+The default mode for normal conversations. It supports streaming output, markdown, reasoning traces, citations, image attachments where available, PDF attachments where available, and model switching from the in-chat picker.
 
 ### Web Search
 
-Give any model live answers. Choose a provider in Settings (OpenRouter server-side search, or **Exa / Parallel / Firecrawl** with your own key), or flip the per-message **Web search** toggle from the **+** menu to search a single message using your last-used provider — no Settings trip required. Citations are shown under the answer.
+Use the per-message Web search chip from the `+` menu or set a default in Settings. OpenRouter server-side search is only used with OpenRouter models. Exa, Parallel, and Firecrawl are client-side tools and can work with OpenRouter, direct cloud APIs, Ollama, OpenAI-compatible endpoints, and local models.
 
 ### Deep Research
 
-An opt-in mode for questions that need real investigation, producing a cited, well-structured report. Choose how it runs from the engine picker:
+A background research mode for questions that need investigation. It supports:
 
-- **Exa** — Deep Lite, Deep, Deep Reasoning, and **Exa Agent** (with a Low/Medium/High/X-High effort dial)
-- **Parallel** — Pro and Ultra
-- **Firecrawl** — autonomous deep research
-- **Your own chat models** — any OpenRouter model that plans searches and writes the report
+- Exa Deep Lite, Deep, Deep Reasoning, and Exa Agent with effort controls.
+- Parallel Pro and Ultra.
+- Firecrawl Research.
+- User-added OpenRouter research models.
 
-Runs happen in a foreground service with a **status-bar notification** (live progress + Cancel) and **resume after the app is closed**. Reports lead with a TL;DR, use sections and comparison tables, and cite sources inline.
+Runs use a foreground notification with progress and cancel controls, persist through interruption, and return cited reports with sections, tables, and source cards.
 
 ### Data Agent
 
-When you need *data* instead of an explanation — pricing, specs, lists, contacts — point the **Firecrawl** agent at a task and get structured results back, rendered automatically as cards and label→value sections. Includes a **live credit meter** and a configurable **spending limit**. Off by default; enable it in **Settings → Data Agent**.
+For extracting structured data instead of prose. It uses Firecrawl, shows a live credit budget, and renders structured results as cards and tables.
+
+### Browser Flow
+
+Starts a live Firecrawl browser that chat can control over multiple turns. EchoFlow shows session state, steps, domain confirmations, send confirmations, stop/finish controls, and a browser workspace.
+
+### Artifacts
+
+Builds or revises self-contained generated artifacts such as small web pages, reports, and documents. Artifacts are versioned and can run in an offline-safe mode for local workflows.
+
+### Echo Adviser
+
+Lets the active OpenRouter chat model consult a configured advisor model before finishing difficult work. Useful for coding, math, research, and review-style checks.
+
+### Echo Fusion
+
+Runs multiple OpenRouter models as a panel, then asks a judge model to compare, synthesize, and call out disagreement or missing pieces.
+
+### Echo Agents
+
+Gives the main OpenRouter model a tool-using workflow with web search, web fetch, and a separate worker model for delegated tasks. Each agent has a configurable tool-call budget.
 
 ## On-device Models
 
-EchoFlow runs local LLMs through LiteRT-LM / MediaPipe, fully on the device:
+EchoFlow supports local model workflows through LiteRT-LM / MediaPipe:
 
-- **Curated catalog** of mobile-ready models, plus **search across Hugging Face** for `.task` / `.litertlm` bundles.
-- **Import your own** model file from storage.
-- **Hugging Face token** support for gated models (e.g. Gemma).
-- Local models are private, work offline, and need no API key. Web search can still be offered to them as a tool.
+- Curated mobile-ready catalog.
+- Hugging Face search for `.task` and `.litertlm` bundles.
+- Import from storage.
+- Hugging Face token support for gated models.
+- Local inference parameters separate from cloud parameters.
+- Offline operation with no provider key.
 
 ## Design System
 
-EchoFlow follows a Material 3 Expressive direction: tactile, shaped, and responsive, but calm enough for long sessions.
+EchoFlow uses Material 3 Expressive throughout:
 
-- **Chat surface** — a floating transparent top bar and floating input toolbar let the message list span the full screen. Assistant replies are full-width readable content; user messages keep a distinct authored shape.
-- **Motion & shape** — expressive shape morphs, springy press feedback, and Material shape primitives from `androidx.graphics.shapes`.
-- **Color** — Material You wallpaper-derived dynamic color by default, with curated accent palettes; color roles flow across containers, drawers, controls, and surfaces.
-- **Markdown** — finished and streaming messages share one parsing path (no restyle jumps); code is selectable, scrollable, and highlighted; tables wrap instead of clipping. Deep Research reports and Data Agent results have purpose-built layouts.
+- Dynamic Material You color plus manual accent palettes.
+- Light/dark/system theme controls.
+- Morphing shapes and responsive motion.
+- Full-height model/search sheets.
+- Grouped settings rows and per-feature pages.
+- Dense but readable operational UI for settings, agents, research, and local models.
+- Custom markdown renderer with code highlighting, tables, selectable code, and stable streaming layout.
 
 ## Tech Stack
 
@@ -102,42 +164,42 @@ EchoFlow follows a Material 3 Expressive direction: tactile, shaped, and respons
 | --- | --- |
 | Language | Kotlin |
 | UI | Jetpack Compose, Material 3 Expressive |
+| Android | compileSdk 37, targetSdk 36, minSdk 24 |
 | Architecture | ViewModel, StateFlow, Compose state |
-| Cloud AI | OpenRouter chat completions |
-| On-device AI | LiteRT-LM / MediaPipe GenAI |
-| Search & Research | Exa, Parallel, Firecrawl, OpenRouter |
-| Background work | Foreground service + Room-backed run store |
+| Cloud AI | OpenRouter, OpenAI, Anthropic Claude, Google Gemini, Cerebras |
+| Custom/local endpoints | Ollama, OpenAI-compatible APIs |
+| On-device AI | LiteRT-LM, MediaPipe GenAI |
+| Search & research | OpenRouter search, Exa, Parallel, Firecrawl |
+| Browser automation | Firecrawl browser sessions |
+| Background work | Foreground services, notifications, Room-backed state |
 | Networking | OkHttp, Retrofit |
 | JSON | Moshi |
-| Persistence | Room |
-| Preferences | Shared settings repository |
+| Persistence | Room, shared settings repository |
 | Images | Coil |
-| Markdown | Custom Compose renderer + Mike Penz markdown modules |
-| Code Highlighting | `dev.snipme:highlights` |
-| Design Utilities | `androidx.graphics:graphics-shapes` |
-| Testing | JUnit, AndroidX test, Robolectric, Roborazzi |
+| Markdown/code | Custom Compose renderer, Mike Penz markdown modules, `dev.snipme:highlights` |
+| Design utilities | `androidx.graphics:graphics-shapes` |
+| Testing stack | JUnit, AndroidX test, Robolectric, Roborazzi |
 
 ## Project Structure
 
 ```text
 app/src/main/java/com/echoflow
-├── data        # Room entities/DAOs, settings, OpenRouter + web search services,
-│               # local-model engine/downloader, Deep Research engine + foreground service
-├── ui          # ViewModels and app state
-├── ui/components  # reusable expressive UI, markdown + research/result rendering
-├── ui/screens  # Chat and settings screens
-└── ui/theme    # Material Expressive theme, color, shape, motion helpers
+├── data           # Room entities/DAOs, provider services, settings, research, agents, browser, artifacts, local models
+├── ui             # ViewModels and app state
+├── ui/components  # expressive UI, markdown, cards, reports, browser/data/research result components
+├── ui/screens     # Chat and settings screens
+└── ui/theme       # Material theme, color, shape, motion helpers
 ```
 
-## Building from Source
+## Build From Source
 
-EchoFlow is a standard Gradle Android project — open it in Android Studio and run the `app` configuration, or build a debug APK:
+Open the project in Android Studio and run the `app` configuration, or build a debug APK:
 
 ```bash
 ./gradlew assembleDebug
 ```
 
-No keys are required to build. Provider keys are entered at runtime in the app's Settings.
+No provider keys are required to build. API keys and endpoint URLs are configured at runtime in Settings.
 
 ## License
 


### PR DESCRIPTION
## Summary
- refreshes README to match the current EchoFlow feature set
- adds current provider badges for OpenRouter, direct APIs, Cerebras, Ollama, OpenAI-compatible endpoints, search, research, and local models
- documents Custom API Endpoint, Echo Labs modes, provider matrix, attachment behavior, and updated tech stack

## Validation
- Ran `git diff --check`
- README-only change; no build or tests run

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to document current EchoFlow features and architecture
> Rewrites [README.md](https://github.com/adityavardhansharma/EchoFlow/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect the current state of the app, covering new and existing functionality across chat modes, on-device models, and the tech stack.
>
> - Adds sections for Chat Modes (Web Search, Deep Research, Data Agent, Browser Flow, Artifacts, Echo Adviser, Echo Fusion, Echo Agents) and a Provider Matrix table
> - Expands On-device Models with catalog, search, and import details, plus local inference parameters
> - Updates Tech Stack to include SDK targets, additional cloud providers, custom/local endpoints, browser automation, and the testing stack
> - Updates Project Structure to reflect new data domains: providers, research, agents, browser, and artifacts
> - Renames the build section to "Build From Source" and clarifies instructions
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a07709c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the README to reflect EchoFlow's expanded feature set, moving well beyond the earlier single-provider chat description to document the full workspace: direct provider APIs (OpenAI, Claude, Gemini, Cerebras), Ollama, OpenAI-compatible endpoints, Browser Flow, Echo Adviser/Fusion/Agents, Artifacts, and a Provider Matrix table that maps each provider to its setup path, model source, search support, and attachment capabilities.

**What's great about this direction:** the Privacy Model section, Provider Matrix, and Getting Started rewrite are exactly the kind of structured reference material that makes a power-user app approachable. The decision to expose each provider's attachment and search capabilities in a single table is a strong UX signal about how seriously the project takes transparency.

**What could land even better:**
- A short screen recording or annotated screenshots in the README would dramatically improve first impressions — the feature surface is large and hard to picture from prose alone.
- The Kotlin badge was loosened from the pinned version (`2.2.10`) to `2.x`; since `gradle/libs.versions.toml` still pins the exact version, restoring that specificity helps contributors immediately.

<h3>Confidence Score: 4/5</h3>

README-only change; no runtime code is affected. Safe to merge after the Getting Started step-ordering fix.

The Getting Started section directs users to Settings -> Echo Labs -> Custom API Endpoint in Step 2 before Step 4 tells them to enable it, creating a dead end for new users who follow the steps in order. All other changes are accurate and well-structured.

README.md — specifically the Getting Started numbered list (steps 2 and 4) needs reordering so the Echo Labs enable step precedes the direct-provider navigation step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Comprehensive README refresh adding provider matrix, Echo Labs modes, Privacy Model section, and expanded tech stack; one step-ordering issue in Getting Started could confuse new users trying direct providers before enabling the Echo Labs toggle. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install APK from GitHub Releases] --> B{Choose model provider}
    B --> C[OpenRouter\nSettings → Cloud models]
    B --> D[On-device\nSettings → Local models]
    B --> E[Direct / Custom\nEcho Labs → Custom API Endpoint]
    E --> E1[OpenAI / Claude / Gemini / Cerebras]
    E --> E2[Ollama LAN server]
    E --> E3[OpenAI-compatible\nLM Studio / Jan / vLLM]
    C & D & E1 & E2 & E3 --> F[Optional: add search keys\nSettings → Web search\nExa / Parallel / Firecrawl]
    F --> G[Enable Echo Labs features\nBrowser Flow · Data Agent\nEcho Adviser · Echo Fusion\nEcho Agents · Artifacts]
    G --> H[Start chatting]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Install APK from GitHub Releases] --> B{Choose model provider}
    B --> C[OpenRouter\nSettings → Cloud models]
    B --> D[On-device\nSettings → Local models]
    B --> E[Direct / Custom\nEcho Labs → Custom API Endpoint]
    E --> E1[OpenAI / Claude / Gemini / Cerebras]
    E --> E2[Ollama LAN server]
    E --> E3[OpenAI-compatible\nLM Studio / Jan / vLLM]
    C & D & E1 & E2 & E3 --> F[Optional: add search keys\nSettings → Web search\nExa / Parallel / Firecrawl]
    F --> G[Enable Echo Labs features\nBrowser Flow · Data Agent\nEcho Adviser · Echo Fusion\nEcho Agents · Artifacts]
    G --> H[Start chatting]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Update README for current provider featu..."](https://github.com/adityavardhansharma/echoflow/commit/a07709cb982b0e1bf136efd586eb0439239d371e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40783971)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->