### PR TITLE
Fix invisible status bar icons under in-app theme

### DIFF
--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -18,7 +18,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.material.icons.Icons
@@ -130,6 +132,17 @@ class MainActivity : ComponentActivity() {
                 "light" -> false
                 "dark" -> true
                 else -> isSystemDark
+            }
+
+            // Status/navigation bar icons must contrast with the page, which follows the in-app
+            // theme — not the system uiMode that enableEdgeToEdge() keys off by default. Without
+            // this, a "Light" theme under a dark OS leaves white icons invisible on white.
+            val view = LocalView.current
+            LaunchedEffect(themeActiveDark) {
+                WindowCompat.getInsetsController(this@MainActivity.window, view).apply {
+                    isAppearanceLightStatusBars = !themeActiveDark
+                    isAppearanceLightNavigationBars = !themeActiveDark
+                }
             }
 
             EchoFlowTheme(


### PR DESCRIPTION
## What changed

The system **status bar / navigation bar icons** (clock, battery, signal) could become invisible — e.g. white icons on a white page.

## Why
`enableEdgeToEdge()` decides the bar icon contrast from the **system** dark-mode setting, and nothing overrode it afterwards. The app has its own Light/Dark/System theme switch (`themeActiveDark`), so the two disagree whenever the in-app theme differs from the OS (pick "Light" while the phone is in Dark mode → light icons on a light background → invisible).

## Fix
Drive the bar icon appearance from the app's own theme, reacting to changes:

```kotlin
val view = LocalView.current
LaunchedEffect(themeActiveDark) {
    WindowCompat.getInsetsController(this@MainActivity.window, view).apply {
        isAppearanceLightStatusBars = !themeActiveDark
        isAppearanceLightNavigationBars = !themeActiveDark
    }
}
```

- Light theme → dark icons (visible on white)
- Dark theme → light icons (visible on dark)
- Keyed on `themeActiveDark`, so toggling the theme in Settings updates the bar immediately; also covers the 3-button nav bar.

Placed in the Activity rather than `EchoFlowTheme` on purpose — the theme is a pure, reusable composable used by Roborazzi screenshot tests, so it should stay window-agnostic.

## Reviewer notes
- One file changed (`MainActivity.kt`), 13 lines added.
- ⚠️ Not built/run from CLI (Android SDK build happens in Android Studio). Please verify by toggling **Settings → Appearance** between Light/Dark with the OS in the opposite mode, and confirm the status-bar icons stay visible on both the white settings pages and the chat screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invisible status bar icons under in-app theme by syncing icon appearance with active theme
> In [MainActivity.kt](https://github.com/adityavardhansharma/EchoFlow/pull/57/files#diff-2373d90fe70694f1d7243401821f08e46d0a4fec0af0bef4a9ff4cd196400166), a `LaunchedEffect` keyed on `themeActiveDark` now calls `WindowCompat.getInsetsController` and sets `isAppearanceLightStatusBars` and `isAppearanceLightNavigationBars` to the inverse of `themeActiveDark`. This ensures status and navigation bar icons use dark icons on a light theme and light icons on a dark theme, regardless of the OS `uiMode`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b2745.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX bug where status bar and navigation bar icons became invisible when the app's in-app theme (Light/Dark/System) disagreed with the OS dark-mode setting. `enableEdgeToEdge()` previously determined icon contrast solely from the system `uiMode`, causing white-on-white situations.

- A `LaunchedEffect(themeActiveDark)` block is added inside `MainActivity.setContent` to drive `WindowCompat.getInsetsController` icon appearance directly from the app's resolved theme state, covering both the status bar and the 3-button navigation bar.
- The fix is correctly placed in the Activity rather than `EchoFlowTheme`, keeping the composable theme window-agnostic and Roborazzi-compatible.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is minimal, isolated to MainActivity, and the logic mapping light/dark theme to icon contrast is straightforward and correct.

The fix is functionally correct and well-placed. The only note is that LaunchedEffect wraps purely synchronous work, where SideEffect is the more idiomatic Compose primitive; this doesn't affect correctness or user-visible behavior.

No files require special attention beyond confirming manual device testing as noted in the PR description.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/MainActivity.kt | Adds a LaunchedEffect keyed on themeActiveDark to sync status/navigation bar icon contrast with the app's own theme. Logic is correct; SideEffect would be more idiomatic for this synchronous window-state push. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OS as OS Dark Mode
    participant App as SettingsViewModel
    participant Main as MainActivity (setContent)
    participant WC as WindowCompat.getInsetsController

    OS->>Main: isSystemInDarkTheme()
    App->>Main: userDarkModeId ("light" / "dark" / "system")
    Main->>Main: "themeActiveDark = when(userDarkModeId) { ... }"
    Main->>WC: LaunchedEffect(themeActiveDark)
    WC->>WC: "isAppearanceLightStatusBars = !themeActiveDark"
    WC->>WC: "isAppearanceLightNavigationBars = !themeActiveDark"
    Main->>Main: "EchoFlowTheme(darkTheme = themeActiveDark)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OS as OS Dark Mode
    participant App as SettingsViewModel
    participant Main as MainActivity (setContent)
    participant WC as WindowCompat.getInsetsController

    OS->>Main: isSystemInDarkTheme()
    App->>Main: userDarkModeId ("light" / "dark" / "system")
    Main->>Main: "themeActiveDark = when(userDarkModeId) { ... }"
    Main->>WC: LaunchedEffect(themeActiveDark)
    WC->>WC: "isAppearanceLightStatusBars = !themeActiveDark"
    WC->>WC: "isAppearanceLightNavigationBars = !themeActiveDark"
    Main->>Main: "EchoFlowTheme(darkTheme = themeActiveDark)"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix invisible status bar icons under in-..."](https://github.com/adityavardhansharma/echoflow/commit/e8b27454d736342be92b4c1a7aa52eade5414841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40800368)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->