### PR TITLE
Native tool calling (web search) for custom API providers

### DIFF
--- a/app/src/main/java/com/echoflow/data/CustomProviderService.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderService.kt
@@ -50,6 +50,7 @@ data class CustomProviderConfig(
     val ollamaSelectedModels: String,
     val ollamaImagesEnabled: Boolean,
     val ollamaPdfsEnabled: Boolean,
+    val ollamaToolCallingEnabled: Boolean,
     val openAiBaseUrl: String,
     val openAiCompatibleApiKey: String,
     val openAiCompatibleModel: String,
@@ -57,6 +58,7 @@ data class CustomProviderConfig(
     val openAiCompatibleSelectedModels: String,
     val openAiCompatibleImagesEnabled: Boolean,
     val openAiCompatiblePdfsEnabled: Boolean,
+    val openAiCompatibleToolCallingEnabled: Boolean,
 ) {
     companion object {
         const val PREFIX_OPENAI = "custom/openai/"
@@ -344,6 +346,449 @@ class CustomProviderService(private val context: Context? = null) {
                     event.response?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Content(it)) }
                 }
             }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    // ── Native tool calling (web search) ──────────────────────────────────────────────
+    //
+    // Separate from the plain stream* methods above: these expose a single `web_search` tool to
+    // the model and run a request → tool_call → search → feed-back loop until the model answers.
+    // Each provider family needs its own wire format (OpenAI tool_calls, Claude tool_use blocks,
+    // Gemini functionCall parts). [search] runs the actual query via the app's client search
+    // provider. Results are fed back with [formatSearchResultsForModel] so the numbered `[n](url)`
+    // citation contract the system prompt describes lines up.
+
+    private val maxToolRounds = 4
+
+    private val webSearchToolOpenAi: Map<String, Any> = mapOf(
+        "type" to "function",
+        "function" to mapOf(
+            "name" to "web_search",
+            "description" to "Search the web for current, recent, niche, or factual information. Returns a numbered list of results.",
+            "parameters" to mapOf(
+                "type" to "object",
+                "properties" to mapOf(
+                    "query" to mapOf("type" to "string", "description" to "A focused, self-contained search query."),
+                ),
+                "required" to listOf("query"),
+            ),
+        ),
+    )
+
+    private val webSearchToolClaude: Map<String, Any> = mapOf(
+        "name" to "web_search",
+        "description" to "Search the web for current, recent, niche, or factual information. Returns a numbered list of results.",
+        "input_schema" to mapOf(
+            "type" to "object",
+            "properties" to mapOf(
+                "query" to mapOf("type" to "string", "description" to "A focused, self-contained search query."),
+            ),
+            "required" to listOf("query"),
+        ),
+    )
+
+    private val webSearchFnGemini: Map<String, Any> = mapOf(
+        "name" to "web_search",
+        "description" to "Search the web for current, recent, niche, or factual information. Returns a numbered list of results.",
+        "parameters" to mapOf(
+            "type" to "object",
+            "properties" to mapOf(
+                "query" to mapOf("type" to "string", "description" to "A focused, self-contained search query."),
+            ),
+            "required" to listOf("query"),
+        ),
+    )
+
+    private class OpenAiPendingCall {
+        var id = ""
+        var name = ""
+        val args = StringBuilder()
+    }
+
+    private class ClaudePendingBlock {
+        var type = ""
+        var id = ""
+        var name = ""
+        val text = StringBuilder()
+        val json = StringBuilder()
+    }
+
+    private fun extractQuery(argsJson: String): String {
+        val q = runCatching { (dynamicAdapter.fromJson(argsJson) as? Map<*, *>)?.get("query") as? String }.getOrNull()
+        return q?.trim().orEmpty().ifBlank { argsJson.trim() }
+    }
+
+    /** OpenAI-style tool loop — used by OpenAI, Cerebras, and any OpenAI-compatible endpoint. */
+    fun streamOpenAiTools(
+        baseUrl: String,
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = flow {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        if (model.isBlank()) throw Exception("Enter a model name.")
+        val messages = ArrayList<Map<String, Any?>>(buildOpenAiMessages(history, systemPrompt))
+        var round = 0
+        while (true) {
+            val payload = mutableMapOf<String, Any?>(
+                "model" to model.trim(),
+                "messages" to messages,
+                "stream" to true,
+                "temperature" to params.temperature,
+                "top_p" to params.topP,
+                "tools" to listOf(webSearchToolOpenAi),
+            )
+            if (params.maxTokens > 0) payload["max_tokens"] = params.maxTokens
+            val request = Request.Builder()
+                .url(joinUrl(baseUrl, "chat/completions"))
+                .addHeader("Content-Type", "application/json")
+                .apply { apiKey.trim().takeIf { it.isNotEmpty() }?.let { addHeader("Authorization", "Bearer $it") } }
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val pending = sortedMapOf<Int, OpenAiPendingCall>()
+            val assistantContent = StringBuilder()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception(customError("provider", response.code, response.body?.string().orEmpty()))
+                val body = response.body ?: throw Exception("Empty stream body received.")
+                body.source().use { source ->
+                    while (!source.exhausted()) {
+                        val line = source.readUtf8Line() ?: break
+                        if (!line.startsWith("data:")) continue
+                        val data = line.removePrefix("data:").trim()
+                        if (data.isBlank() || data == "[DONE]") continue
+                        val map = runCatching { dynamicAdapter.fromJson(data) as? Map<*, *> }.getOrNull() ?: continue
+                        val choice = (map["choices"] as? List<*>)?.firstOrNull() as? Map<*, *> ?: continue
+                        val delta = choice["delta"] as? Map<*, *>
+                        (delta?.get("content") as? String)?.takeIf { it.isNotEmpty() }?.let { assistantContent.append(it); emit(StreamChunk.Content(it)) }
+                        (delta?.get("reasoning") as? String)?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Reasoning(it)) }
+                        (delta?.get("reasoning_content") as? String)?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Reasoning(it)) }
+                        (delta?.get("tool_calls") as? List<*>)?.forEach { tcAny ->
+                            val tc = tcAny as? Map<*, *> ?: return@forEach
+                            val idx = (tc["index"] as? Number)?.toInt() ?: 0
+                            val slot = pending.getOrPut(idx) { OpenAiPendingCall() }
+                            (tc["id"] as? String)?.takeIf { it.isNotEmpty() }?.let { slot.id = it }
+                            val fn = tc["function"] as? Map<*, *>
+                            (fn?.get("name") as? String)?.takeIf { it.isNotEmpty() }?.let { slot.name = it }
+                            (fn?.get("arguments") as? String)?.let { slot.args.append(it) }
+                        }
+                    }
+                }
+            }
+
+            if (pending.values.none { it.name == "web_search" }) break
+            if (round >= maxToolRounds) break
+
+            messages.add(
+                mapOf(
+                    "role" to "assistant",
+                    "content" to assistantContent.toString().takeIf { it.isNotBlank() },
+                    "tool_calls" to pending.values.map { call ->
+                        val callId = call.id.ifBlank { "call_${call.name}" }
+                        mapOf(
+                            "id" to callId,
+                            "type" to "function",
+                            "function" to mapOf("name" to call.name, "arguments" to call.args.toString().ifBlank { "{}" }),
+                        )
+                    },
+                )
+            )
+            for (call in pending.values) {
+                val callId = call.id.ifBlank { "call_${call.name}" }
+                if (call.name != "web_search") {
+                    messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to "Unknown tool."))
+                    continue
+                }
+                val query = extractQuery(call.args.toString())
+                emit(StreamChunk.SearchStarted(query))
+                val sources = runCatching { search(query) }.getOrDefault(emptyList())
+                emit(StreamChunk.SearchSources(query, sources))
+                messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to formatSearchResultsForModel(sources)))
+            }
+            round++
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /** Ollama `/api/chat` tool loop. Ollama returns whole tool calls (not deltas) on the stream. */
+    fun streamOllamaTools(
+        baseUrl: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = flow {
+        validateBaseUrl(baseUrl).takeUnless { it.ok }?.let { throw Exception(it.message) }
+        if (model.isBlank()) throw Exception("Enter an Ollama model name.")
+        val messages = ArrayList<Map<String, Any?>>(buildSimpleMessages(history, systemPrompt))
+        var round = 0
+        while (true) {
+            val payload = mutableMapOf<String, Any?>(
+                "model" to model.trim(),
+                "messages" to messages,
+                "stream" to true,
+                "tools" to listOf(webSearchToolOpenAi),
+                "options" to mapOf(
+                    "temperature" to params.temperature,
+                    "top_p" to params.topP,
+                    "top_k" to params.topK,
+                    "num_predict" to params.maxTokens,
+                ),
+            )
+            val request = Request.Builder()
+                .url(joinUrl(baseUrl, "api/chat"))
+                .addHeader("Content-Type", "application/json")
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val collected = StringBuilder()
+            val toolCalls = mutableListOf<Pair<String, String>>() // name, argsJson
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception(customError("Ollama", response.code, response.body?.string().orEmpty()))
+                val body = response.body ?: throw Exception("Empty stream body received.")
+                body.source().use { source ->
+                    while (!source.exhausted()) {
+                        val line = source.readUtf8Line() ?: break
+                        if (line.isBlank()) continue
+                        val map = runCatching { dynamicAdapter.fromJson(line) as? Map<*, *> }.getOrNull() ?: continue
+                        (map["error"] as? String)?.takeIf { it.isNotBlank() }?.let { throw Exception(it) }
+                        val msg = map["message"] as? Map<*, *>
+                        (msg?.get("content") as? String)?.takeIf { it.isNotEmpty() }?.let { collected.append(it); emit(StreamChunk.Content(it)) }
+                        (msg?.get("tool_calls") as? List<*>)?.forEach { tcAny ->
+                            val fn = (tcAny as? Map<*, *>)?.get("function") as? Map<*, *> ?: return@forEach
+                            val name = fn["name"] as? String ?: return@forEach
+                            val argsJson = when (val a = fn["arguments"]) {
+                                is String -> a
+                                is Map<*, *> -> dynamicAdapter.toJson(a)
+                                else -> "{}"
+                            }
+                            toolCalls.add(name to argsJson)
+                        }
+                    }
+                }
+            }
+
+            if (toolCalls.none { it.first == "web_search" }) break
+            if (round >= maxToolRounds) break
+
+            messages.add(
+                mapOf(
+                    "role" to "assistant",
+                    "content" to collected.toString(),
+                    "tool_calls" to toolCalls.map { (name, args) ->
+                        mapOf("function" to mapOf("name" to name, "arguments" to (runCatching { dynamicAdapter.fromJson(args) }.getOrNull() ?: args)))
+                    },
+                )
+            )
+            for ((name, args) in toolCalls) {
+                if (name != "web_search") {
+                    messages.add(mapOf("role" to "tool", "content" to "Unknown tool."))
+                    continue
+                }
+                val query = extractQuery(args)
+                emit(StreamChunk.SearchStarted(query))
+                val sources = runCatching { search(query) }.getOrDefault(emptyList())
+                emit(StreamChunk.SearchSources(query, sources))
+                messages.add(mapOf("role" to "tool", "content" to formatSearchResultsForModel(sources)))
+            }
+            round++
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /** Anthropic Messages tool loop — accumulates `tool_use` blocks from the SSE stream. */
+    fun streamClaudeTools(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("Claude API key is missing.")
+        if (model.isBlank()) throw Exception("Enter a Claude model name.")
+        val messages = ArrayList<Map<String, Any?>>()
+        history.filter { it.role != "system" }.forEach {
+            messages.add(mapOf("role" to if (it.role == "assistant") "assistant" else "user", "content" to it.content))
+        }
+        var round = 0
+        while (true) {
+            val payload = mutableMapOf<String, Any?>(
+                "model" to model.trim(),
+                "messages" to messages,
+                "stream" to true,
+                "max_tokens" to params.maxTokens.coerceAtLeast(1024),
+                "temperature" to params.temperature,
+                "tools" to listOf(webSearchToolClaude),
+            )
+            if (systemPrompt.isNotBlank()) payload["system"] = systemPrompt
+            val request = Request.Builder()
+                .url("https://api.anthropic.com/v1/messages")
+                .addHeader("x-api-key", apiKey.trim())
+                .addHeader("anthropic-version", "2023-06-01")
+                .addHeader("Content-Type", "application/json")
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val blocks = sortedMapOf<Int, ClaudePendingBlock>()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception(customError("Claude", response.code, response.body?.string().orEmpty()))
+                val body = response.body ?: throw Exception("Empty stream body received.")
+                body.source().use { source ->
+                    while (!source.exhausted()) {
+                        val line = source.readUtf8Line() ?: break
+                        if (!line.startsWith("data:")) continue
+                        val data = line.removePrefix("data:").trim()
+                        if (data.isBlank()) continue
+                        val ev = runCatching { dynamicAdapter.fromJson(data) as? Map<*, *> }.getOrNull() ?: continue
+                        when (ev["type"] as? String) {
+                            "content_block_start" -> {
+                                val idx = (ev["index"] as? Number)?.toInt() ?: 0
+                                val cb = ev["content_block"] as? Map<*, *>
+                                val slot = blocks.getOrPut(idx) { ClaudePendingBlock() }
+                                slot.type = cb?.get("type") as? String ?: ""
+                                if (slot.type == "tool_use") {
+                                    slot.id = cb?.get("id") as? String ?: ""
+                                    slot.name = cb?.get("name") as? String ?: ""
+                                }
+                            }
+                            "content_block_delta" -> {
+                                val idx = (ev["index"] as? Number)?.toInt() ?: 0
+                                val d = ev["delta"] as? Map<*, *>
+                                when (d?.get("type") as? String) {
+                                    "text_delta" -> (d["text"] as? String)?.takeIf { it.isNotEmpty() }?.let {
+                                        blocks.getOrPut(idx) { ClaudePendingBlock() }.text.append(it); emit(StreamChunk.Content(it))
+                                    }
+                                    "input_json_delta" -> (d["partial_json"] as? String)?.let {
+                                        blocks.getOrPut(idx) { ClaudePendingBlock() }.json.append(it)
+                                    }
+                                    "thinking_delta" -> (d["thinking"] as? String)?.takeIf { it.isNotEmpty() }?.let { emit(StreamChunk.Reasoning(it)) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            val toolUses = blocks.values.filter { it.type == "tool_use" }
+            if (toolUses.none { it.name == "web_search" }) break
+            if (round >= maxToolRounds) break
+
+            val assistantBlocks = mutableListOf<Map<String, Any?>>()
+            blocks.values.forEach { b ->
+                when (b.type) {
+                    "text" -> b.text.toString().takeIf { it.isNotBlank() }?.let { assistantBlocks.add(mapOf("type" to "text", "text" to it)) }
+                    "tool_use" -> assistantBlocks.add(
+                        mapOf(
+                            "type" to "tool_use",
+                            "id" to b.id,
+                            "name" to b.name,
+                            "input" to (runCatching { dynamicAdapter.fromJson(b.json.toString().ifBlank { "{}" }) }.getOrNull() ?: emptyMap<String, Any>()),
+                        )
+                    )
+                }
+            }
+            messages.add(mapOf("role" to "assistant", "content" to assistantBlocks))
+
+            val resultBlocks = mutableListOf<Map<String, Any?>>()
+            for (b in toolUses) {
+                if (b.name != "web_search") {
+                    resultBlocks.add(mapOf("type" to "tool_result", "tool_use_id" to b.id, "content" to "Unknown tool."))
+                    continue
+                }
+                val query = extractQuery(b.json.toString())
+                emit(StreamChunk.SearchStarted(query))
+                val sources = runCatching { search(query) }.getOrDefault(emptyList())
+                emit(StreamChunk.SearchSources(query, sources))
+                resultBlocks.add(mapOf("type" to "tool_result", "tool_use_id" to b.id, "content" to formatSearchResultsForModel(sources)))
+            }
+            messages.add(mapOf("role" to "user", "content" to resultBlocks))
+            round++
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /** Gemini generateContent tool loop — collects `functionCall` parts, replies with `functionResponse`. */
+    fun streamGeminiTools(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("Gemini API key is missing.")
+        if (model.isBlank()) throw Exception("Enter a Gemini model name.")
+        val contents = ArrayList<Map<String, Any?>>()
+        history.filter { it.role != "system" }.forEach {
+            contents.add(mapOf("role" to if (it.role == "assistant") "model" else "user", "parts" to listOf(mapOf("text" to it.content))))
+        }
+        val cleanModel = model.removePrefix("models/")
+        var round = 0
+        while (true) {
+            val payload = mutableMapOf<String, Any?>(
+                "contents" to contents,
+                "generationConfig" to mapOf(
+                    "temperature" to params.temperature,
+                    "topP" to params.topP,
+                    "maxOutputTokens" to params.maxTokens.coerceAtLeast(256),
+                ),
+                "tools" to listOf(mapOf("functionDeclarations" to listOf(webSearchFnGemini))),
+            )
+            if (systemPrompt.isNotBlank()) payload["systemInstruction"] = mapOf("parts" to listOf(mapOf("text" to systemPrompt)))
+            val request = Request.Builder()
+                .url("https://generativelanguage.googleapis.com/v1beta/models/$cleanModel:streamGenerateContent?key=${apiKey.trim()}&alt=sse")
+                .addHeader("Content-Type", "application/json")
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val functionCalls = mutableListOf<Pair<String, Map<*, *>>>() // name, args
+            val modelParts = mutableListOf<Map<String, Any?>>()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception(customError("Gemini", response.code, response.body?.string().orEmpty()))
+                val body = response.body ?: throw Exception("Empty stream body received.")
+                body.source().use { source ->
+                    while (!source.exhausted()) {
+                        val line = source.readUtf8Line() ?: break
+                        if (!line.startsWith("data:")) continue
+                        val data = line.removePrefix("data:").trim()
+                        if (data.isBlank()) continue
+                        val ev = runCatching { dynamicAdapter.fromJson(data) as? Map<*, *> }.getOrNull() ?: continue
+                        val cand = (ev["candidates"] as? List<*>)?.firstOrNull() as? Map<*, *>
+                        val parts = (cand?.get("content") as? Map<*, *>)?.get("parts") as? List<*>
+                        parts?.forEach { pAny ->
+                            val p = pAny as? Map<*, *> ?: return@forEach
+                            (p["text"] as? String)?.takeIf { it.isNotEmpty() }?.let { modelParts.add(mapOf("text" to it)); emit(StreamChunk.Content(it)) }
+                            (p["functionCall"] as? Map<*, *>)?.let { fc ->
+                                val name = fc["name"] as? String ?: return@let
+                                val args = fc["args"] as? Map<*, *> ?: emptyMap<String, Any>()
+                                functionCalls.add(name to args)
+                                modelParts.add(mapOf("functionCall" to mapOf("name" to name, "args" to args)))
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (functionCalls.none { it.first == "web_search" }) break
+            if (round >= maxToolRounds) break
+
+            contents.add(mapOf("role" to "model", "parts" to modelParts))
+            val responseParts = mutableListOf<Map<String, Any?>>()
+            for ((name, args) in functionCalls) {
+                if (name != "web_search") {
+                    responseParts.add(mapOf("functionResponse" to mapOf("name" to name, "response" to mapOf("content" to "Unknown tool."))))
+                    continue
+                }
+                val query = (args["query"] as? String)?.trim().orEmpty()
+                emit(StreamChunk.SearchStarted(query))
+                val sources = runCatching { search(query) }.getOrDefault(emptyList())
+                emit(StreamChunk.SearchSources(query, sources))
+                responseParts.add(mapOf("functionResponse" to mapOf("name" to "web_search", "response" to mapOf("results" to formatSearchResultsForModel(sources)))))
+            }
+            contents.add(mapOf("role" to "user", "parts" to responseParts))
+            round++
         }
     }.flowOn(Dispatchers.IO)
 

--- a/app/src/main/java/com/echoflow/data/CustomProviderService.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderService.kt
@@ -358,7 +358,7 @@ class CustomProviderService(private val context: Context? = null) {
     // provider. Results are fed back with [formatSearchResultsForModel] so the numbered `[n](url)`
     // citation contract the system prompt describes lines up.
 
-    private val maxToolRounds = 4
+    private val maxToolSearches = 4
 
     private val webSearchToolOpenAi: Map<String, Any> = mapOf(
         "type" to "function",
@@ -432,6 +432,7 @@ class CustomProviderService(private val context: Context? = null) {
         if (model.isBlank()) throw Exception("Enter a model name.")
         val messages = ArrayList<Map<String, Any?>>(buildOpenAiMessages(history, systemPrompt))
         var round = 0
+        var searchCount = 0
         while (true) {
             val payload = mutableMapOf<String, Any?>(
                 "model" to model.trim(),
@@ -439,8 +440,8 @@ class CustomProviderService(private val context: Context? = null) {
                 "stream" to true,
                 "temperature" to params.temperature,
                 "top_p" to params.topP,
-                "tools" to listOf(webSearchToolOpenAi),
             )
+            if (searchCount < maxToolSearches) payload["tools"] = listOf(webSearchToolOpenAi)
             if (params.maxTokens > 0) payload["max_tokens"] = params.maxTokens
             val request = Request.Builder()
                 .url(joinUrl(baseUrl, "chat/completions"))
@@ -480,7 +481,6 @@ class CustomProviderService(private val context: Context? = null) {
             }
 
             if (pending.values.none { it.name == "web_search" }) break
-            if (round >= maxToolRounds) break
 
             messages.add(
                 mapOf(
@@ -503,10 +503,26 @@ class CustomProviderService(private val context: Context? = null) {
                     continue
                 }
                 val query = extractQuery(call.args.toString())
+                if (searchCount >= maxToolSearches) {
+                    emit(StreamChunk.StatusNote("Search limit reached ($maxToolSearches per answer)"))
+                    messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to "Search limit reached. Answer now using the results already available."))
+                    continue
+                }
+                searchCount++
                 emit(StreamChunk.SearchStarted(query))
-                val sources = runCatching { search(query) }.getOrDefault(emptyList())
-                emit(StreamChunk.SearchSources(query, sources))
-                messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to formatSearchResultsForModel(sources)))
+                val searchResult = runCatching { search(query) }
+                val toolContent = searchResult.fold(
+                    onSuccess = { sources ->
+                        emit(StreamChunk.SearchSources(query, sources))
+                        formatSearchResultsForModel(sources)
+                    },
+                    onFailure = {
+                        emit(StreamChunk.SearchSources(query, emptyList()))
+                        emit(StreamChunk.StatusNote("Search failed: ${it.message}"))
+                        "Search failed: ${it.message ?: "Unknown error"}"
+                    },
+                )
+                messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to toolContent))
             }
             round++
         }
@@ -525,12 +541,12 @@ class CustomProviderService(private val context: Context? = null) {
         if (model.isBlank()) throw Exception("Enter an Ollama model name.")
         val messages = ArrayList<Map<String, Any?>>(buildSimpleMessages(history, systemPrompt))
         var round = 0
+        var searchCount = 0
         while (true) {
             val payload = mutableMapOf<String, Any?>(
                 "model" to model.trim(),
                 "messages" to messages,
                 "stream" to true,
-                "tools" to listOf(webSearchToolOpenAi),
                 "options" to mapOf(
                     "temperature" to params.temperature,
                     "top_p" to params.topP,
@@ -538,6 +554,7 @@ class CustomProviderService(private val context: Context? = null) {
                     "num_predict" to params.maxTokens,
                 ),
             )
+            if (searchCount < maxToolSearches) payload["tools"] = listOf(webSearchToolOpenAi)
             val request = Request.Builder()
                 .url(joinUrl(baseUrl, "api/chat"))
                 .addHeader("Content-Type", "application/json")
@@ -572,27 +589,49 @@ class CustomProviderService(private val context: Context? = null) {
             }
 
             if (toolCalls.none { it.first == "web_search" }) break
-            if (round >= maxToolRounds) break
 
             messages.add(
                 mapOf(
                     "role" to "assistant",
                     "content" to collected.toString(),
-                    "tool_calls" to toolCalls.map { (name, args) ->
-                        mapOf("function" to mapOf("name" to name, "arguments" to (runCatching { dynamicAdapter.fromJson(args) }.getOrNull() ?: args)))
+                    "tool_calls" to toolCalls.mapIndexed { index, (name, args) ->
+                        val callId = "call_${round}_${index}_${name}"
+                        mapOf(
+                            "id" to callId,
+                            "type" to "function",
+                            "function" to mapOf("name" to name, "arguments" to (runCatching { dynamicAdapter.fromJson(args) }.getOrNull() ?: args)),
+                        )
                     },
                 )
             )
-            for ((name, args) in toolCalls) {
+            for ((index, pair) in toolCalls.withIndex()) {
+                val (name, args) = pair
+                val callId = "call_${round}_${index}_${name}"
                 if (name != "web_search") {
-                    messages.add(mapOf("role" to "tool", "content" to "Unknown tool."))
+                    messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to "Unknown tool."))
                     continue
                 }
                 val query = extractQuery(args)
+                if (searchCount >= maxToolSearches) {
+                    emit(StreamChunk.StatusNote("Search limit reached ($maxToolSearches per answer)"))
+                    messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to "Search limit reached. Answer now using the results already available."))
+                    continue
+                }
+                searchCount++
                 emit(StreamChunk.SearchStarted(query))
-                val sources = runCatching { search(query) }.getOrDefault(emptyList())
-                emit(StreamChunk.SearchSources(query, sources))
-                messages.add(mapOf("role" to "tool", "content" to formatSearchResultsForModel(sources)))
+                val searchResult = runCatching { search(query) }
+                val toolContent = searchResult.fold(
+                    onSuccess = { sources ->
+                        emit(StreamChunk.SearchSources(query, sources))
+                        formatSearchResultsForModel(sources)
+                    },
+                    onFailure = {
+                        emit(StreamChunk.SearchSources(query, emptyList()))
+                        emit(StreamChunk.StatusNote("Search failed: ${it.message}"))
+                        "Search failed: ${it.message ?: "Unknown error"}"
+                    },
+                )
+                messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to toolContent))
             }
             round++
         }
@@ -614,6 +653,7 @@ class CustomProviderService(private val context: Context? = null) {
             messages.add(mapOf("role" to if (it.role == "assistant") "assistant" else "user", "content" to it.content))
         }
         var round = 0
+        var searchCount = 0
         while (true) {
             val payload = mutableMapOf<String, Any?>(
                 "model" to model.trim(),
@@ -621,8 +661,8 @@ class CustomProviderService(private val context: Context? = null) {
                 "stream" to true,
                 "max_tokens" to params.maxTokens.coerceAtLeast(1024),
                 "temperature" to params.temperature,
-                "tools" to listOf(webSearchToolClaude),
             )
+            if (searchCount < maxToolSearches) payload["tools"] = listOf(webSearchToolClaude)
             if (systemPrompt.isNotBlank()) payload["system"] = systemPrompt
             val request = Request.Builder()
                 .url("https://api.anthropic.com/v1/messages")
@@ -674,7 +714,6 @@ class CustomProviderService(private val context: Context? = null) {
 
             val toolUses = blocks.values.filter { it.type == "tool_use" }
             if (toolUses.none { it.name == "web_search" }) break
-            if (round >= maxToolRounds) break
 
             val assistantBlocks = mutableListOf<Map<String, Any?>>()
             blocks.values.forEach { b ->
@@ -699,10 +738,26 @@ class CustomProviderService(private val context: Context? = null) {
                     continue
                 }
                 val query = extractQuery(b.json.toString())
+                if (searchCount >= maxToolSearches) {
+                    emit(StreamChunk.StatusNote("Search limit reached ($maxToolSearches per answer)"))
+                    resultBlocks.add(mapOf("type" to "tool_result", "tool_use_id" to b.id, "content" to "Search limit reached. Answer now using the results already available."))
+                    continue
+                }
+                searchCount++
                 emit(StreamChunk.SearchStarted(query))
-                val sources = runCatching { search(query) }.getOrDefault(emptyList())
-                emit(StreamChunk.SearchSources(query, sources))
-                resultBlocks.add(mapOf("type" to "tool_result", "tool_use_id" to b.id, "content" to formatSearchResultsForModel(sources)))
+                val searchResult = runCatching { search(query) }
+                val toolContent = searchResult.fold(
+                    onSuccess = { sources ->
+                        emit(StreamChunk.SearchSources(query, sources))
+                        formatSearchResultsForModel(sources)
+                    },
+                    onFailure = {
+                        emit(StreamChunk.SearchSources(query, emptyList()))
+                        emit(StreamChunk.StatusNote("Search failed: ${it.message}"))
+                        "Search failed: ${it.message ?: "Unknown error"}"
+                    },
+                )
+                resultBlocks.add(mapOf("type" to "tool_result", "tool_use_id" to b.id, "content" to toolContent))
             }
             messages.add(mapOf("role" to "user", "content" to resultBlocks))
             round++
@@ -726,6 +781,7 @@ class CustomProviderService(private val context: Context? = null) {
         }
         val cleanModel = model.removePrefix("models/")
         var round = 0
+        var searchCount = 0
         while (true) {
             val payload = mutableMapOf<String, Any?>(
                 "contents" to contents,
@@ -734,8 +790,8 @@ class CustomProviderService(private val context: Context? = null) {
                     "topP" to params.topP,
                     "maxOutputTokens" to params.maxTokens.coerceAtLeast(256),
                 ),
-                "tools" to listOf(mapOf("functionDeclarations" to listOf(webSearchFnGemini))),
             )
+            if (searchCount < maxToolSearches) payload["tools"] = listOf(mapOf("functionDeclarations" to listOf(webSearchFnGemini)))
             if (systemPrompt.isNotBlank()) payload["systemInstruction"] = mapOf("parts" to listOf(mapOf("text" to systemPrompt)))
             val request = Request.Builder()
                 .url("https://generativelanguage.googleapis.com/v1beta/models/$cleanModel:streamGenerateContent?key=${apiKey.trim()}&alt=sse")
@@ -772,7 +828,6 @@ class CustomProviderService(private val context: Context? = null) {
             }
 
             if (functionCalls.none { it.first == "web_search" }) break
-            if (round >= maxToolRounds) break
 
             contents.add(mapOf("role" to "model", "parts" to modelParts))
             val responseParts = mutableListOf<Map<String, Any?>>()
@@ -781,11 +836,28 @@ class CustomProviderService(private val context: Context? = null) {
                     responseParts.add(mapOf("functionResponse" to mapOf("name" to name, "response" to mapOf("content" to "Unknown tool."))))
                     continue
                 }
-                val query = (args["query"] as? String)?.trim().orEmpty()
+                val query = (args["query"] as? String)?.trim().takeIf { !it.isNullOrBlank() }
+                    ?: args.toString().trim()
+                if (searchCount >= maxToolSearches) {
+                    emit(StreamChunk.StatusNote("Search limit reached ($maxToolSearches per answer)"))
+                    responseParts.add(mapOf("functionResponse" to mapOf("name" to "web_search", "response" to mapOf("content" to "Search limit reached. Answer now using the results already available."))))
+                    continue
+                }
+                searchCount++
                 emit(StreamChunk.SearchStarted(query))
-                val sources = runCatching { search(query) }.getOrDefault(emptyList())
-                emit(StreamChunk.SearchSources(query, sources))
-                responseParts.add(mapOf("functionResponse" to mapOf("name" to "web_search", "response" to mapOf("results" to formatSearchResultsForModel(sources)))))
+                val searchResult = runCatching { search(query) }
+                val toolContent = searchResult.fold(
+                    onSuccess = { sources ->
+                        emit(StreamChunk.SearchSources(query, sources))
+                        formatSearchResultsForModel(sources)
+                    },
+                    onFailure = {
+                        emit(StreamChunk.SearchSources(query, emptyList()))
+                        emit(StreamChunk.StatusNote("Search failed: ${it.message}"))
+                        "Search failed: ${it.message ?: "Unknown error"}"
+                    },
+                )
+                responseParts.add(mapOf("functionResponse" to mapOf("name" to "web_search", "response" to mapOf("results" to toolContent))))
             }
             contents.add(mapOf("role" to "user", "parts" to responseParts))
             round++

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -379,6 +379,7 @@ class SettingsRepository(context: Context) {
             ollamaSelectedModels = prefs.getString("ollama_selected_models", "").orEmpty(),
             ollamaImagesEnabled = prefs.getBoolean("ollama_images_enabled", false),
             ollamaPdfsEnabled = prefs.getBoolean("ollama_pdfs_enabled", false),
+            ollamaToolCallingEnabled = prefs.getBoolean("ollama_tool_calling_enabled", false),
             openAiBaseUrl = prefs.getString("openai_compatible_base_url", "http://localhost:1234/v1").orEmpty(),
             openAiCompatibleApiKey = prefs.getString("openai_compatible_api_key", "").orEmpty(),
             openAiCompatibleModel = prefs.getString("openai_compatible_model", "").orEmpty(),
@@ -386,6 +387,7 @@ class SettingsRepository(context: Context) {
             openAiCompatibleSelectedModels = prefs.getString("openai_compatible_selected_models", "").orEmpty(),
             openAiCompatibleImagesEnabled = prefs.getBoolean("openai_compatible_images_enabled", false),
             openAiCompatiblePdfsEnabled = prefs.getBoolean("openai_compatible_pdfs_enabled", false),
+            openAiCompatibleToolCallingEnabled = prefs.getBoolean("openai_compatible_tool_calling_enabled", false),
         )
 
     fun saveCustomProviderConfig(config: CustomProviderConfig) {
@@ -434,6 +436,7 @@ class SettingsRepository(context: Context) {
             .putString("ollama_selected_models", clean.ollamaSelectedModels)
             .putBoolean("ollama_images_enabled", clean.ollamaImagesEnabled)
             .putBoolean("ollama_pdfs_enabled", clean.ollamaPdfsEnabled)
+            .putBoolean("ollama_tool_calling_enabled", clean.ollamaToolCallingEnabled)
             .putString("openai_compatible_base_url", clean.openAiBaseUrl)
             .putString("openai_compatible_api_key", clean.openAiCompatibleApiKey)
             .putString("openai_compatible_model", clean.openAiCompatibleModel)
@@ -441,6 +444,7 @@ class SettingsRepository(context: Context) {
             .putString("openai_compatible_selected_models", clean.openAiCompatibleSelectedModels)
             .putBoolean("openai_compatible_images_enabled", clean.openAiCompatibleImagesEnabled)
             .putBoolean("openai_compatible_pdfs_enabled", clean.openAiCompatiblePdfsEnabled)
+            .putBoolean("openai_compatible_tool_calling_enabled", clean.openAiCompatibleToolCallingEnabled)
             .apply()
         _customProviderConfig.value = clean
     }

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -38,6 +38,49 @@ object SystemPrompts {
         return sections.joinToString("\n\n")
     }
 
+    /**
+     * System prompt for the custom direct providers (OpenAI / Claude / Gemini / Cerebras / Ollama /
+     * OpenAI-compatible). These run through [CustomProviderService], which has NO native tool /
+     * function calling — so the "you have a web_search tool, call it" framing of [build] is wrong
+     * for them. When search is on, the app runs ONE search on the user's message and pastes the
+     * results in (see ChatViewModel's custom-provider client-search branch); this prompt tells the
+     * model exactly that, so it uses the provided results instead of pretending to call a tool.
+     *
+     * @param provider effective search provider: "off", "exa", "parallel", or "firecrawl".
+     *        ("openrouter" never reaches here — server search can't serve custom providers.)
+     */
+    fun buildCustomProvider(provider: String, currentDate: String = currentDate()): String {
+        val sections = mutableListOf<String>()
+        sections += identity(false)
+        sections += "Current date: $currentDate."
+        sections += when (provider) {
+            "exa", "parallel", "firecrawl" -> injectedSearchGuidance(provider)
+            else -> noSearch(false)
+        }
+        sections += formatting(false)
+        return sections.joinToString("\n\n")
+    }
+
+    private fun injectedSearchGuidance(provider: String): String {
+        val providerNote = when (provider) {
+            "exa" -> "They come from Exa (semantic search): relevant text excerpts, not full pages — quote carefully."
+            "parallel" -> "They come from Parallel: dense excerpts answering the user's question."
+            else -> "They come from Firecrawl: page content as markdown — extract just the facts you need."
+        }
+        return """
+        ## Web search results
+        The app has already run a web search for the user's message and pasted the results below, each
+        as a titled snippet: [Title](URL) followed by an excerpt. You do NOT have a search tool and
+        cannot run more searches this turn — work with what is provided. $providerNote
+
+        - Base any current, time-sensitive, or factual claim on these results rather than memory.
+        - Cite a result-backed claim inline as a markdown link to its URL, e.g. ([Reuters](https://example.com)). Place the citation right after the sentence it supports.
+        - Do NOT announce that you are "searching", offer to search, or emit any tool/function call — the results are already here.
+        - If the results do not answer the question, say what you could not verify instead of guessing.
+        - Never append a separate "Sources" or "References" list — the app shows sources separately.
+        """.trimIndent()
+    }
+
     private fun identity(isLocalModel: Boolean): String = buildString {
         append("You are EchoFlow, a helpful, accurate AI assistant inside an Android chat app.")
         if (isLocalModel) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -866,6 +866,18 @@ class ChatViewModel(
                 else -> "off"
             }
 
+            // Native tool calling for custom providers: the model itself calls web_search in a loop,
+            // instead of the app pre-injecting one search. Needs a client search backend (so an
+            // effective client provider). Cloud brands are always on; Ollama / OpenAI-compatible are
+            // gated by a per-provider toggle since their tool support depends on the chosen model.
+            val customToolCallingActive = customProviderActive &&
+                effectiveProvider in CLIENT_SEARCH_PROVIDERS &&
+                when (customProvider) {
+                    "ollama" -> customProviderConfig.ollamaToolCallingEnabled
+                    "openai-compatible" -> customProviderConfig.openAiCompatibleToolCallingEnabled
+                    else -> true // OpenAI / Claude / Gemini / Cerebras
+                }
+
             // Echo Adviser / Echo Fusion: OpenRouter-only modes. Resolve the active profile/panel
             // here; both override the model, system prompt and response flow. Cloud models only.
             var advisorReq: OpenRouterService.AdvisorRequest? = null
@@ -930,7 +942,15 @@ class ChatViewModel(
                 SystemPrompts.buildArtifact(isLocal, offline, prior)
             } else null
 
-            val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: SystemPrompts.build(isLocal, effectiveProvider)
+            val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: when {
+                // Tool-calling custom providers behave like cloud models: they call web_search
+                // themselves, so they get the standard "you have a web_search tool" prompt.
+                customToolCallingActive -> SystemPrompts.build(false, effectiveProvider)
+                // Other custom providers have no native tool calling; their search results are
+                // pre-injected, so they need the "results are provided" prompt instead.
+                customProviderActive -> SystemPrompts.buildCustomProvider(effectiveProvider)
+                else -> SystemPrompts.build(isLocal, effectiveProvider)
+            }
 
             var isFirstMsgInChat = false
             var chatId = _currentChatThreadId.value
@@ -1061,6 +1081,10 @@ class ChatViewModel(
                             localModel = localModel,
                         )
                     )
+                customToolCallingActive ->
+                    customProviderToolFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams) { query ->
+                        webSearchService.search(provider, searchKey, query)
+                    }
                 customProviderActive && clientSearchReady ->
                     flow {
                         val query = prompt
@@ -1207,6 +1231,29 @@ class ChatViewModel(
                 setStreamState(chatId, null)
             }
         }
+    }
+
+    /**
+     * Custom provider with native tool calling: routes to the per-format tool loop in
+     * [CustomProviderService], passing a [search] executor backed by the active client search
+     * provider. Falls back to the plain (no-tool) flow for any unknown provider.
+     */
+    private fun customProviderToolFlow(
+        provider: String?,
+        config: CustomProviderConfig,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = when (provider) {
+        "openai" -> customProviderService.streamOpenAiTools("https://api.openai.com/v1", config.openAiApiKey, model, history, systemPrompt, params, search)
+        "cerebras" -> customProviderService.streamOpenAiTools("https://api.cerebras.ai/v1", config.cerebrasApiKey, model, history, systemPrompt, params, search)
+        "openai-compatible" -> customProviderService.streamOpenAiTools(config.openAiBaseUrl, config.openAiCompatibleApiKey, model, history, systemPrompt, params, search)
+        "ollama" -> customProviderService.streamOllamaTools(config.ollamaBaseUrl, model, history, systemPrompt, params, search)
+        "claude" -> customProviderService.streamClaudeTools(config.claudeApiKey, model, history, systemPrompt, params, search)
+        "gemini" -> customProviderService.streamGeminiTools(config.geminiApiKey, model, history, systemPrompt, params, search)
+        else -> customProviderFlow(provider, config, model, history, systemPrompt, params)
     }
 
     private fun customProviderFlow(

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -1749,6 +1749,13 @@ private fun OllamaEndpointPage(viewModel: SettingsViewModel, onBack: () -> Unit)
                     onImages = { draft = draft.copy(ollamaImagesEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                     onPdfs = { draft = draft.copy(ollamaPdfsEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                 )
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Tool calling", "Let the model run web searches itself")
+                EndpointToolCallingToggle(
+                    enabled = draft.ollamaToolCallingEnabled,
+                    onToggle = { draft = draft.copy(ollamaToolCallingEnabled = it); viewModel.saveCustomProviderConfig(draft) },
+                )
             }
         }
         AnimatedVisibility(visible = !draft.ollamaEnabled, enter = sectionEnter(), exit = sectionExit()) {
@@ -1836,6 +1843,13 @@ private fun OpenAiCompatibleEndpointPage(viewModel: SettingsViewModel, onBack: (
                     pdfs = draft.openAiCompatiblePdfsEnabled,
                     onImages = { draft = draft.copy(openAiCompatibleImagesEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                     onPdfs = { draft = draft.copy(openAiCompatiblePdfsEnabled = it); viewModel.saveCustomProviderConfig(draft) },
+                )
+
+                Spacer(Modifier.height(Spacing.xl))
+                PageSection("Tool calling", "Let the model run web searches itself")
+                EndpointToolCallingToggle(
+                    enabled = draft.openAiCompatibleToolCallingEnabled,
+                    onToggle = { draft = draft.copy(openAiCompatibleToolCallingEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                 )
             }
         }
@@ -2139,6 +2153,29 @@ private fun EndpointCapabilityToggles(images: Boolean, pdfs: Boolean, onImages: 
     Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
         CapabilityRow("Images", "Allow image attachments for compatible vision models", images, 0, 2, onImages)
         CapabilityRow("PDFs", "Allow PDF attachments only when your endpoint supports them", pdfs, 1, 2, onPdfs)
+    }
+}
+
+/**
+ * Per-endpoint switch for native tool calling (the model runs web_search itself). Off by default
+ * because it only works on models that actually support tool/function calls — when off, the app
+ * falls back to running one search and pasting the results in.
+ */
+@Composable
+private fun EndpointToolCallingToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Surface(shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainer, modifier = Modifier.fillMaxWidth()) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text("Tool calling", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                Text(
+                    "Only turn on if your selected model supports tool/function calls. The model will run web searches itself when it needs to. When off, the app searches once and feeds the results in. Needs a web search provider set up in Settings → Web search.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(Spacing.s))
+            Switch(checked = enabled, onCheckedChange = onToggle)
+        }
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -159,6 +159,7 @@ private const val PageCustomProviderGemini = "custom_provider_gemini"
 private const val PageCustomProviderCerebras = "custom_provider_cerebras"
 private const val PageCustomProviderOllama = "custom_provider_ollama"
 private const val PageCustomProviderCompatible = "custom_provider_compatible"
+private val CustomProviderSectionGap = 28.dp
 
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
@@ -1481,7 +1482,7 @@ private fun CustomApiEndpointPage(viewModel: SettingsViewModel, onOpen: (String)
             )
         }
 
-        Spacer(Modifier.height(Spacing.xl))
+        Spacer(Modifier.height(CustomProviderSectionGap))
         PageSection("Providers", "Each provider has its own setup page")
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
             SettingsNavRow(
@@ -1536,7 +1537,7 @@ private fun DirectCloudApisPage(viewModel: SettingsViewModel, onOpen: (String) -
 
         AnimatedVisibility(visible = draft.cloudApisEnabled, enter = sectionEnter(), exit = sectionExit()) {
             Column {
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Brands", "Open a brand to add its key and choose models")
                 Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
                     brands.forEachIndexed { index, (provider, page) ->
@@ -1551,7 +1552,7 @@ private fun DirectCloudApisPage(viewModel: SettingsViewModel, onOpen: (String) -
                     }
                 }
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 FormCard {
                     Text("Attachments", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
                     Spacer(Modifier.height(Spacing.s))
@@ -1597,7 +1598,7 @@ private fun DirectCloudBrandPage(viewModel: SettingsViewModel, provider: CustomM
 
         AnimatedVisibility(visible = enabled, enter = sectionEnter(), exit = sectionExit()) {
             Column {
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("API key")
                 FormCard {
                     OutlinedTextField(
@@ -1627,7 +1628,7 @@ private fun DirectCloudBrandPage(viewModel: SettingsViewModel, provider: CustomM
                     ) { Text("Save key") }
                 }
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Models", "Choose what appears in the chat model picker")
                 DirectBrandActions(
                     fetchLoading = fetchLoading == provider,
@@ -1651,7 +1652,7 @@ private fun DirectCloudBrandPage(viewModel: SettingsViewModel, provider: CustomM
                 )
                 ProviderStatusMessage(fetchMessage)
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 FormCard {
                     Text("Attachments", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
                     Spacer(Modifier.height(Spacing.s))
@@ -1701,7 +1702,7 @@ private fun OllamaEndpointPage(viewModel: SettingsViewModel, onBack: () -> Unit)
         )
         AnimatedVisibility(visible = draft.ollamaEnabled, enter = sectionEnter(), exit = sectionExit()) {
             Column {
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 EndpointConnectionCard(
                     title = "Server",
                     baseUrl = draft.ollamaBaseUrl,
@@ -1716,7 +1717,7 @@ private fun OllamaEndpointPage(viewModel: SettingsViewModel, onBack: () -> Unit)
                     shape = CircleShape,
                     modifier = Modifier.fillMaxWidth().height(52.dp),
                 ) { Text("Save") }
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Models")
                 EndpointActionsRow(
                     fetchLoading = fetchLoading == CustomModelProvider.Ollama,
@@ -1741,7 +1742,7 @@ private fun OllamaEndpointPage(viewModel: SettingsViewModel, onBack: () -> Unit)
                 ProviderStatusMessage(fetchMessage)
                 ProviderStatusMessage(testMessage)
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Capabilities")
                 EndpointCapabilityToggles(
                     images = draft.ollamaImagesEnabled,
@@ -1750,7 +1751,7 @@ private fun OllamaEndpointPage(viewModel: SettingsViewModel, onBack: () -> Unit)
                     onPdfs = { draft = draft.copy(ollamaPdfsEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                 )
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Tool calling", "Let the model run web searches itself")
                 EndpointToolCallingToggle(
                     enabled = draft.ollamaToolCallingEnabled,
@@ -1796,7 +1797,7 @@ private fun OpenAiCompatibleEndpointPage(viewModel: SettingsViewModel, onBack: (
         )
         AnimatedVisibility(visible = draft.openAiCompatibleEnabled, enter = sectionEnter(), exit = sectionExit()) {
             Column {
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 EndpointConnectionCard(
                     title = "Endpoint",
                     baseUrl = draft.openAiBaseUrl,
@@ -1811,7 +1812,7 @@ private fun OpenAiCompatibleEndpointPage(viewModel: SettingsViewModel, onBack: (
                     shape = CircleShape,
                     modifier = Modifier.fillMaxWidth().height(52.dp),
                 ) { Text("Save") }
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Models")
                 EndpointActionsRow(
                     fetchLoading = fetchLoading == CustomModelProvider.OpenAiCompatible,
@@ -1836,7 +1837,7 @@ private fun OpenAiCompatibleEndpointPage(viewModel: SettingsViewModel, onBack: (
                 ProviderStatusMessage(fetchMessage)
                 ProviderStatusMessage(testMessage)
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Capabilities")
                 EndpointCapabilityToggles(
                     images = draft.openAiCompatibleImagesEnabled,
@@ -1845,7 +1846,7 @@ private fun OpenAiCompatibleEndpointPage(viewModel: SettingsViewModel, onBack: (
                     onPdfs = { draft = draft.copy(openAiCompatiblePdfsEnabled = it); viewModel.saveCustomProviderConfig(draft) },
                 )
 
-                Spacer(Modifier.height(Spacing.xl))
+                Spacer(Modifier.height(CustomProviderSectionGap))
                 PageSection("Tool calling", "Let the model run web searches itself")
                 EndpointToolCallingToggle(
                     enabled = draft.openAiCompatibleToolCallingEnabled,
@@ -2333,7 +2334,6 @@ private fun ManualModelDialog(title: String, initial: String, placeholder: Strin
 
 @Composable
 private fun EndpointOffState(message: String) {
-    Spacer(Modifier.height(Spacing.m))
     Surface(shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainer, modifier = Modifier.fillMaxWidth()) {
         Text(
             message,


### PR DESCRIPTION
## What this adds

Real **native tool calling** (function calling) for the custom API providers, so the model itself calls a `web_search` tool in a loop instead of the app pre-injecting a single search.

Implemented as a **self-contained path** — the OpenRouter, local, Echo, and artifact flows are untouched.

### Per-format tool loops (`CustomProviderService`)
| Method | Providers | Wire format |
|---|---|---|
| `streamOpenAiTools` | OpenAI, Cerebras, OpenAI-compatible | OpenAI `tool_calls` |
| `streamOllamaTools` | Ollama | `/api/chat` tools |
| `streamClaudeTools` | Claude | Anthropic `tool_use` / `tool_result` |
| `streamGeminiTools` | Gemini | `functionCall` / `functionResponse` |

Each loop: caps at 4 tool rounds, **always** exposes the tool (so Claude doesn't error on tool history), emits `SearchStarted`/`SearchSources` so searches render in the timeline, and feeds results back via the existing `formatSearchResultsForModel` (numbered `[n](url)`, matching the citation contract).

### Gating (`ChatViewModel`)
- **Cloud brands** (OpenAI / Claude / Gemini / Cerebras): tool calling whenever a client search provider is active — no toggle.
- **Ollama & OpenAI-compatible**: behind a **per-provider toggle**, off by default (tool support depends on the chosen model).
- Requires a client search provider (Exa / Parallel / Firecrawl) configured + Web Search on — that's the search backend.
- Tool-callers get the real "you have a web_search tool" prompt; everyone else keeps the pre-injection prompt (the earlier `buildCustomProvider` fix is included here).

### Settings
A **Tool calling** toggle on the Ollama and OpenAI-Compatible pages, persisted via two new `CustomProviderConfig` fields.

## Files
`CustomProviderService.kt`, `ChatViewModel.kt`, `SystemPrompts.kt`, `SettingsRepository.kt`, `SettingsScreen.kt` (+577 / -1).

## Reviewer notes / verification
⚠️ Not built or run from CLI (Android SDK build is done in Android Studio). The streaming tool-call accumulation across three formats is the riskiest part — please verify per provider with a tool-capable model and a current-events question, confirming the search chip appears and the answer cites results. Two specific things to check:
- **Gemini** sends `functionResponse` with `role: "user"` (the REST role enum is only user/model).
- **Ollama** needs a recent server + a tool-capable model — exactly why it's behind the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native tool-calling web search support for custom API providers
> - Adds iterative `web_search` tool-calling loops for OpenAI-compatible, Ollama, Claude, and Gemini custom providers in [`CustomProviderService.kt`](https://github.com/adityavardhansharma/EchoFlow/pull/58/files#diff-334eadc34a59a5e579f9c2263e1c959200ed8b027ee94230efa1c8fca7986869), capping at 4 searches per response.
> - Routes chat requests through the new tool-calling flows when enabled, falling back to injected-search with a tailored system prompt for providers where tool calling is off.
> - Adds per-provider toggle settings (Ollama and OpenAI-compatible) in the Settings UI, persisted via `SharedPreferences`.
> - Behavioral Change: custom providers with tool calling enabled now use model-initiated search loops instead of a single pre-injected search result; the system prompt also differs between the two modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7eb3a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tool-calling support for compatible AI providers, allowing models to perform web searches directly during chat.
  * Added new per-provider settings to enable or disable this behavior for supported endpoints.
  * Improved prompt handling so search results are presented more naturally when tool calling is off.

* **Bug Fixes**
  * Updated chat flow to choose the correct search behavior based on each provider’s capabilities and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces native function-calling (web search) for all six custom API provider families — OpenAI, Cerebras, OpenAI-compatible, Ollama, Claude, and Gemini — each with its own wire-format loop in `CustomProviderService`, plus a correct `buildCustomProvider` system prompt for providers that fall back to pre-injected search results.

**What's strong about this direction:** The self-contained path (zero changes to OpenRouter/local/artifact flows), the per-format loops that respect each API's streaming delta contract, and the thoughtful gating (cloud brands always-on, Ollama/OpenAI-compatible behind a toggle that defaults off) are exactly the right shape for this feature. The `buildCustomProvider` prompt that distinguishes "you have a tool" from "results are already pasted in" is a clean separation that will prevent a whole class of hallucinated tool invocations.

**What could be better:** The `streamOpenAiTools` fallback ID (`"call_${call.name}"`) collides when a model requests `web_search` twice in a single round and the provider omits `id` fields — the Ollama loop already solves this with `"call_${round}_${index}_${name}"`, and the same pattern should apply here.

- **Four per-format tool loops** (`streamOpenAiTools`, `streamOllamaTools`, `streamClaudeTools`, `streamGeminiTools`) each handling streaming delta accumulation, result injection, and round management up to a 4-search cap.
- **Gating in `ChatViewModel`** via `customToolCallingActive`: cloud brands activate whenever a client search provider is live; Ollama and OpenAI-compatible require an explicit per-provider toggle.
- **New `buildCustomProvider` system prompt** and a Settings `EndpointToolCallingToggle` composable backed by two new `CustomProviderConfig` booleans, persisted in `SharedPreferences`.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the tool-call ID collision in the OpenAI-compatible loop.

The OpenAI-compatible tool loop generates a fixed fallback ID ("call_web_search") for every call whose provider omits the id field. If the model emits two web_search calls in a single round, both the assistant tool_calls entries and both tool-response messages carry the same ID, leaving the model unable to correlate results — it will either error out or misattribute the second search on the next round. The Ollama loop already avoids this with an index-qualified ID; the OpenAI-compatible loop needs the same treatment. Everything else — the gating logic, the Claude/Gemini/Ollama loops, the system-prompt split, and the settings plumbing — looks solid.

app/src/main/java/com/echoflow/data/CustomProviderService.kt — specifically the streamOpenAiTools fallback ID generation in both the assistant-message builder and the tool-response loop.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/CustomProviderService.kt | Adds four per-format tool-calling loops (OpenAI, Ollama, Claude, Gemini); the OpenAI-compatible loop has a fallback ID collision bug when a provider omits tool-call IDs and the model requests the same function more than once in a round. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Adds customToolCallingActive gating logic and routes eligible requests through customProviderToolFlow; the condition correctly checks for an active client search provider and per-provider toggles before activating tool calling. |
| app/src/main/java/com/echoflow/data/SystemPrompts.kt | Adds buildCustomProvider and injectedSearchGuidance for providers without native tool calling; the prompt correctly explains pre-injected results and matches the existing citation contract. |
| app/src/main/java/com/echoflow/data/SettingsRepository.kt | Adds two new boolean fields (ollamaToolCallingEnabled, openAiCompatibleToolCallingEnabled) to CustomProviderConfig with correct SharedPreferences read/write, default false. |
| app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt | Adds EndpointToolCallingToggle composable and wires it into the Ollama and OpenAI-Compatible pages; spacing constants refactored to a shared CustomProviderSectionGap value. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant VM as ChatViewModel
    participant CPS as CustomProviderService
    participant API as Provider API
    participant WS as WebSearchService

    VM->>VM: Evaluate customToolCallingActive
    VM->>CPS: customProviderToolFlow(provider, ...)
    CPS->>API: POST /chat (with web_search tool declared)
    API-->>CPS: "stream: tool_call{web_search, query}"
    CPS->>CPS: accumulate pending tool calls
    CPS-->>VM: emit SearchStarted(query)
    CPS->>WS: search(query)
    WS-->>CPS: "List<SearchSource>"
    CPS-->>VM: emit SearchSources(query, sources)
    CPS->>API: POST /chat (assistant + tool result injected)
    API-->>CPS: stream: text response
    CPS-->>VM: emit Content(text)
    Note over CPS: Loop up to maxToolSearches=4 rounds
    CPS->>API: POST /chat (no tools when cap reached)
    API-->>CPS: stream: final text answer
    CPS-->>VM: emit Content(finalAnswer)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant VM as ChatViewModel
    participant CPS as CustomProviderService
    participant API as Provider API
    participant WS as WebSearchService

    VM->>VM: Evaluate customToolCallingActive
    VM->>CPS: customProviderToolFlow(provider, ...)
    CPS->>API: POST /chat (with web_search tool declared)
    API-->>CPS: "stream: tool_call{web_search, query}"
    CPS->>CPS: accumulate pending tool calls
    CPS-->>VM: emit SearchStarted(query)
    CPS->>WS: search(query)
    WS-->>CPS: "List<SearchSource>"
    CPS-->>VM: emit SearchSources(query, sources)
    CPS->>API: POST /chat (assistant + tool result injected)
    API-->>CPS: stream: text response
    CPS-->>VM: emit Content(text)
    Note over CPS: Loop up to maxToolSearches=4 rounds
    CPS->>API: POST /chat (no tools when cap reached)
    API-->>CPS: stream: final text answer
    CPS-->>VM: emit Content(finalAnswer)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Fix custom provider settings spacing"](https://github.com/adityavardhansharma/echoflow/commit/a7eb3a65058f0b38c98553cb759301de8223b8ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40862508)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->