### PR TITLE
Image generation: create and edit images in chat via OpenRouter

### DIFF
--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -29,6 +29,7 @@ class EchoFlowAppGraph(application: Application) {
             database.advisorProfileDao(),
             database.fusionPanelDao(),
             database.agentProfileDao(),
+            database.imageModelDao(),
         )
     }
 
@@ -48,6 +49,7 @@ class EchoFlowAppGraph(application: Application) {
             database.browserStepDao(),
             database.artifactDao(),
             database.artifactVersionDao(),
+            database.generatedImageDao(),
         )
     }
 }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -12,9 +12,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ChatThread::class, ChatMessage::class, CustomModel::class, LocalModel::class,
         DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
         AgentProfile::class, BrowserSession::class, BrowserStep::class,
-        Artifact::class, ArtifactVersion::class
+        Artifact::class, ArtifactVersion::class,
+        ImageModel::class, GeneratedImage::class
     ],
-    version = 12, // v12: artifacts + artifact_versions (MIGRATION_11_12)
+    version = 13, // v13: image_models + generated_images (MIGRATION_12_13)
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -31,6 +32,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun browserStepDao(): BrowserStepDao
     abstract fun artifactDao(): ArtifactDao
     abstract fun artifactVersionDao(): ArtifactVersionDao
+    abstract fun imageModelDao(): ImageModelDao
+    abstract fun generatedImageDao(): GeneratedImageDao
 
     companion object {
         @Volatile
@@ -232,6 +235,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS image_models (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "addedAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS generated_images (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "chatId TEXT NOT NULL, " +
+                        "filePath TEXT NOT NULL, " +
+                        "prompt TEXT NOT NULL, " +
+                        "parentId TEXT, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(chatId) REFERENCES chat_threads(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_generated_images_chatId ON generated_images (chatId)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -251,6 +276,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_9_10,
                     MIGRATION_10_11,
                     MIGRATION_11_12,
+                    MIGRATION_12_13,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ChatMode.kt
+++ b/app/src/main/java/com/echoflow/data/ChatMode.kt
@@ -11,5 +11,6 @@ sealed interface ChatMode {
     data object EchoAgent : ChatMode
     data object BrowserFlow : ChatMode
     data object Artifact : ChatMode
+    data object ImageGen : ChatMode
 }
 

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -73,6 +73,29 @@ sealed class StreamChunk {
         val version: Int = 0,
         val truncated: Boolean = false,
     ) : StreamChunk()
+
+    // ── Image generation (OpenRouter multimodal output) ─────────────────────────────
+    /**
+     * An image-mode turn is in flight — the placeholder card shows immediately. [pattern] is
+     * the dot animation chosen for this generation ("ripple" or "rain"); [previousImagePath]
+     * is set on edit turns so the placeholder can show the version being reworked.
+     */
+    data class ImageGenStarted(
+        val pattern: String,
+        val editing: Boolean,
+        val previousImagePath: String? = null,
+    ) : StreamChunk()
+
+    /**
+     * The model returned an image. The transport emits it with only [dataUrl] (base64);
+     * the ViewModel persists the file and re-emits with [filePath]/[imageId] filled in,
+     * which is what resolves the pending placeholder segment.
+     */
+    data class ImageGenerated(
+        val dataUrl: String,
+        val filePath: String? = null,
+        val imageId: String? = null,
+    ) : StreamChunk()
 }
 
 // ── Echo Adviser / Echo Fusion result records ──────────────────────────────────────
@@ -159,20 +182,27 @@ data class ArtifactRef(
     val version: Int,
 )
 
+/** A reference to a persisted [com.echoflow.data.GeneratedImage], embedded in a reply's timeline. */
+data class ImageRef(
+    val imageId: String,
+    val filePath: String,
+)
+
 /**
  * One block of a finished reply, persisted in arrival order so the rendered timeline
  * (reason → search → reason → search → answer) survives exactly as it streamed instead
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact" | "stopped"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact" | "image" | "stopped"
     val text: String? = null,
     val query: String? = null,
     val sources: List<SearchSource>? = null,
     val advisor: AdvisorAdvice? = null, // present when type == "advisor"
     val fusion: FusionAnalysis? = null, // present when type == "fusion"
     val subagent: SubagentResult? = null, // present when type == "subagent"
-    val artifact: ArtifactRef? = null // present when type == "artifact"
+    val artifact: ArtifactRef? = null, // present when type == "artifact"
+    val image: ImageRef? = null // present when type == "image"
 )
 
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -128,6 +128,36 @@ interface AgentProfileDao {
 }
 
 @Dao
+interface ImageModelDao {
+    @Query("SELECT * FROM image_models ORDER BY addedAt ASC")
+    fun getAll(): Flow<List<ImageModel>>
+
+    @Query("SELECT * FROM image_models ORDER BY addedAt ASC")
+    suspend fun getAllSync(): List<ImageModel>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(model: ImageModel)
+
+    @Query("DELETE FROM image_models WHERE id = :modelId")
+    suspend fun delete(modelId: String)
+}
+
+@Dao
+interface GeneratedImageDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(image: GeneratedImage)
+
+    @Query("SELECT * FROM generated_images WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): GeneratedImage?
+
+    @Query("SELECT * FROM generated_images WHERE chatId = :chatId ORDER BY createdAt DESC LIMIT 1")
+    suspend fun getLatestForChat(chatId: String): GeneratedImage?
+
+    @Query("SELECT * FROM generated_images WHERE chatId = :chatId ORDER BY createdAt ASC")
+    suspend fun getForChat(chatId: String): List<GeneratedImage>
+}
+
+@Dao
 interface ResearchRunDao {
     @Query("SELECT * FROM research_runs WHERE chatId = :chatId AND status NOT IN ('completed','failed','cancelled') ORDER BY createdAt DESC LIMIT 1")
     fun observeActiveForChat(chatId: String): Flow<ResearchRun?>

--- a/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
+++ b/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
@@ -52,6 +52,17 @@ class GeneratedImageStore(
         return latest.takeIf { File(it.filePath).exists() }
     }
 
+    /**
+     * Removes this chat's image files from disk. Must run BEFORE the chat thread row is
+     * deleted — the generated_images rows cascade away with it, and after that the PNGs
+     * would be unreachable orphans growing app storage forever.
+     */
+    suspend fun deleteFilesForChat(chatId: String) = withContext(Dispatchers.IO) {
+        dao.getForChat(chatId).forEach { image ->
+            runCatching { File(image.filePath).delete() }
+        }
+    }
+
     /** The stored file re-encoded as a data URL for an edit request, or null if missing. */
     suspend fun asDataUrl(image: GeneratedImage): String? = withContext(Dispatchers.IO) {
         val file = File(image.filePath)

--- a/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
+++ b/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
@@ -1,0 +1,61 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.UUID
+
+/**
+ * Owns generated-image persistence: decodes the model's base64 payload to a PNG file under
+ * filesDir/generated_images/ and records the durable [GeneratedImage] row. The database only
+ * ever stores file paths — image bytes never enter Room or segmentsJson.
+ */
+class GeneratedImageStore(
+    context: Context,
+    private val dao: GeneratedImageDao,
+) {
+    private val imagesDir = File(context.filesDir, "generated_images")
+
+    /**
+     * Decodes [dataUrl] (a `data:image/...;base64,...` URL or bare base64) to disk and inserts
+     * the version row. [parentId] links an edit to the version it revised.
+     */
+    suspend fun save(
+        chatId: String,
+        prompt: String,
+        dataUrl: String,
+        parentId: String?,
+    ): GeneratedImage = withContext(Dispatchers.IO) {
+        val base64 = dataUrl.substringAfter("base64,", dataUrl)
+        val bytes = Base64.decode(base64, Base64.DEFAULT)
+        imagesDir.mkdirs()
+        val id = UUID.randomUUID().toString()
+        val file = File(imagesDir, "$id.png")
+        file.writeBytes(bytes)
+        val image = GeneratedImage(
+            id = id,
+            chatId = chatId,
+            filePath = file.absolutePath,
+            prompt = prompt,
+            parentId = parentId,
+            createdAt = System.currentTimeMillis(),
+        )
+        dao.insert(image)
+        image
+    }
+
+    /** The newest version in this chat — the image a follow-up edit turn revises. */
+    suspend fun latestForChat(chatId: String): GeneratedImage? {
+        val latest = dao.getLatestForChat(chatId) ?: return null
+        return latest.takeIf { File(it.filePath).exists() }
+    }
+
+    /** The stored file re-encoded as a data URL for an edit request, or null if missing. */
+    suspend fun asDataUrl(image: GeneratedImage): String? = withContext(Dispatchers.IO) {
+        val file = File(image.filePath)
+        if (!file.exists()) return@withContext null
+        "data:image/png;base64," + Base64.encodeToString(file.readBytes(), Base64.NO_WRAP)
+    }
+}

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -119,6 +119,44 @@ data class AgentProfile(
 )
 
 /**
+ * A cloud model the user has whitelisted for image generation. Kept separate from
+ * [CustomModel] (chat models) because image output only works on the few directory models
+ * whose `output_modalities` include "image", so it has its own add-model flow and search.
+ */
+@Entity(tableName = "image_models")
+data class ImageModel(
+    @PrimaryKey val id: String, // OpenRouter id, e.g. "google/gemini-2.5-flash-image"
+    val name: String,
+    val addedAt: Long,
+)
+
+/**
+ * One generated image: the decoded PNG lives as a file under filesDir/generated_images/
+ * (never as a DB blob); this row is the durable record. [parentId] links an edit to the
+ * version it was produced from, so walking the chain yields the image's version history.
+ */
+@Entity(
+    tableName = "generated_images",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatThread::class,
+            parentColumns = ["id"],
+            childColumns = ["chatId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("chatId")]
+)
+data class GeneratedImage(
+    @PrimaryKey val id: String, // UUID
+    val chatId: String,
+    val filePath: String, // absolute path of the PNG in app storage
+    val prompt: String, // the user turn that produced this version
+    val parentId: String? = null, // previous version in the edit chain (null = first)
+    val createdAt: Long,
+)
+
+/**
  * The durable record of one Deep Research run. This is the single source of truth: the
  * foreground service writes progress here and the UI observes it, so a run survives the
  * Activity/ViewModel being destroyed and can be resumed after the app is force-killed

--- a/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
@@ -16,6 +16,7 @@ data class OpenRouterModelInfo(
     val contextLength: Int?,
     val promptPricePerM: Double?, // USD per 1M prompt tokens
     val completionPricePerM: Double?, // USD per 1M completion tokens
+    val outputsImage: Boolean = false, // architecture.output_modalities contains "image"
 ) {
     val isFree: Boolean get() = (promptPricePerM ?: 0.0) == 0.0 && (completionPricePerM ?: 0.0) == 0.0
 }
@@ -58,6 +59,7 @@ class OpenRouterModelDirectory {
                     contextLength = raw.contextLength,
                     promptPricePerM = raw.pricing?.prompt?.toDoubleOrNull()?.times(1_000_000),
                     completionPricePerM = raw.pricing?.completion?.toDoubleOrNull()?.times(1_000_000),
+                    outputsImage = raw.architecture?.outputModalities.orEmpty().any { it.equals("image", ignoreCase = true) },
                 )
             }.sortedBy { it.name.lowercase() }
             cache = models
@@ -73,6 +75,11 @@ private data class RawModel(
     val name: String? = null,
     @Json(name = "context_length") val contextLength: Int? = null,
     val pricing: RawPricing? = null,
+    val architecture: RawArchitecture? = null,
+)
+
+private data class RawArchitecture(
+    @Json(name = "output_modalities") val outputModalities: List<String>? = null,
 )
 
 private data class RawPricing(

--- a/app/src/main/java/com/echoflow/data/OpenRouterPayloads.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterPayloads.kt
@@ -44,6 +44,24 @@ internal object OpenRouterPayloads {
         }
     }.toMutableList()
 
+    /**
+     * Image edit turns send the chat's latest generated image with the newest user message so
+     * the model revises it in place. Rewrites the final user message into multi-part content
+     * (its existing parts are preserved — a user photo attachment rides along untouched).
+     */
+    fun attachImageToLastUserMessage(messages: MutableList<Map<String, Any>>, dataUrl: String) {
+        val index = messages.indexOfLast { it["role"] == "user" }
+        if (index < 0) return
+        val message = messages[index]
+        val parts = when (val content = message["content"]) {
+            is List<*> -> content.filterIsInstance<Map<String, Any>>().toMutableList()
+            is String -> mutableListOf<Map<String, Any>>(mapOf("type" to "text", "text" to content))
+            else -> mutableListOf()
+        }
+        parts.add(mapOf("type" to "image_url", "image_url" to mapOf("url" to dataUrl)))
+        messages[index] = mapOf("role" to "user", "content" to parts)
+    }
+
     fun errorMessage(body: String): String? = runCatching {
         val root = json.fromJson(body) as? Map<*, *>
         (root?.get("error") as? Map<*, *>)?.get("message") as? String

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -77,11 +77,32 @@ class OpenRouterService(private val context: Context) {
         val reasoning_content: String? = null,
         val tool_calls: List<OpenRouterToolCallDelta>? = null,
         val annotations: List<OpenRouterAnnotation>? = null,
+        val images: List<OpenRouterImagePayload>? = null,
     )
 
     @JsonClass(generateAdapter = true)
     data class OpenRouterStreamMessage(
         val annotations: List<OpenRouterAnnotation>? = null,
+        val images: List<OpenRouterImagePayload>? = null,
+    )
+
+    /**
+     * One generated image on a delta or final message. The documented shape is
+     * `{type: "image_url", image_url: {url: "data:image/png;base64,..."}}`; [url] covers a
+     * flattened variant seen in beta payloads. (Verify against a live key in Android Studio.)
+     */
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterImagePayload(
+        val type: String? = null,
+        val image_url: OpenRouterImageUrl? = null,
+        val url: String? = null,
+    ) {
+        val dataUrl: String? get() = image_url?.url ?: url
+    }
+
+    @JsonClass(generateAdapter = true)
+    data class OpenRouterImageUrl(
+        val url: String? = null,
     )
 
     @JsonClass(generateAdapter = true)
@@ -354,11 +375,12 @@ class OpenRouterService(private val context: Context) {
         echo: EchoContext? = null,
         agentWorkerModel: String? = null,
         pdfPluginEnabled: Boolean = false,
+        extraBody: Map<String, Any>? = null,
         httpClient: OkHttpClient = client,
         onChunk: suspend (StreamChunk) -> Unit,
     ): TurnResult = streamTransport.streamCompletion(
         apiKey, model, payloadMessages, tools, params, toolChoice, echo,
-        agentWorkerModel, pdfPluginEnabled, httpClient, onChunk,
+        agentWorkerModel, pdfPluginEnabled, extraBody, httpClient, onChunk,
     )
     fun sendChatMessageStream(
         apiKey: String,
@@ -401,6 +423,40 @@ class OpenRouterService(private val context: Context) {
             )
         )
     )
+
+    /**
+     * Image generation / conversational editing via a multimodal-output model (Nano Banana
+     * family). One streaming chat completion with `modalities: ["image","text"]`: history
+     * rides along as text, and on edit turns [editImageDataUrl] (the chat's latest generated
+     * image) is attached to the newest user message so the model revises it in place. Text
+     * deltas stream as usual; the finished image surfaces as [StreamChunk.ImageGenerated].
+     * Uses the long-timeout [echoClient] — generation regularly takes 15–30s.
+     */
+    fun sendImageGeneration(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        editImageDataUrl: String? = null,
+        params: InferenceParams? = null,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) {
+            throw Exception("API key is missing! Please configure it in your Settings.")
+        }
+        val messages = buildMessagesPayload(history, systemPrompt)
+        if (editImageDataUrl != null) {
+            OpenRouterPayloads.attachImageToLastUserMessage(messages, editImageDataUrl)
+        }
+        streamCompletion(
+            apiKey = apiKey,
+            model = model,
+            payloadMessages = messages,
+            tools = null,
+            params = params,
+            extraBody = mapOf("modalities" to listOf("image", "text")),
+            httpClient = echoClient,
+        ) { emit(it) }
+    }.flowOn(Dispatchers.IO)
 
     /** Config for one Echo Agent turn: the worker (subagent) model and its tool-call budget. */
     data class AgentRequest(val workerModel: String, val workerModelName: String, val maxToolCalls: Int)

--- a/app/src/main/java/com/echoflow/data/OpenRouterStreamTransport.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterStreamTransport.kt
@@ -50,6 +50,7 @@ internal class OpenRouterStreamTransport(
         echo: OpenRouterService.EchoContext? = null,
         agentWorkerModel: String? = null,
         pdfPluginEnabled: Boolean = false,
+        extraBody: Map<String, Any>? = null,
         httpClient: OkHttpClient,
         onChunk: suspend (StreamChunk) -> Unit
     ): OpenRouterService.TurnResult {
@@ -62,6 +63,7 @@ internal class OpenRouterStreamTransport(
             "include_reasoning" to true,
             "reasoning" to mapOf("enabled" to true)
         )
+        extraBody?.let { requestMap.putAll(it) }
         addPdfPluginIfNeeded(requestMap, pdfPluginEnabled)
         if (tools != null) {
             requestMap["tools"] = tools
@@ -90,6 +92,9 @@ internal class OpenRouterStreamTransport(
         val seenSourceUrls = mutableSetOf<String>()
         var finishReason: String? = null
         var lastAnnouncedQuery: String? = null
+        // Generated images can appear on a delta and again on the final message object; emit
+        // each distinct payload once (keyed cheaply — data URLs are megabytes long).
+        val seenImageKeys = mutableSetOf<String>()
 
         // Echo Adviser / Fusion: announce the consult/deliberation the moment its tool call
         // appears, then resolve once the (beta, undocumented-shape) result is seen in the stream.
@@ -194,6 +199,17 @@ internal class OpenRouterStreamTransport(
                                 subagentAnnounced[index] = true
                                 onChunk(StreamChunk.SubagentStarted(name, desc, agentWorkerModel))
                             }
+                        }
+                    }
+
+                    // Generated images (modalities: ["image","text"]) arrive base64 on the
+                    // delta or the final message object.
+                    val images = delta?.images ?: choice?.message?.images
+                    images?.forEach { payload ->
+                        val dataUrl = payload.dataUrl ?: return@forEach
+                        val key = "${dataUrl.length}:${dataUrl.takeLast(64)}"
+                        if (seenImageKeys.add(key)) {
+                            onChunk(StreamChunk.ImageGenerated(dataUrl))
                         }
                     }
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterStreamTransport.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterStreamTransport.kt
@@ -202,10 +202,12 @@ internal class OpenRouterStreamTransport(
                         }
                     }
 
-                    // Generated images (modalities: ["image","text"]) arrive base64 on the
-                    // delta or the final message object.
-                    val images = delta?.images ?: choice?.message?.images
-                    images?.forEach { payload ->
+                    // Generated images (modalities: ["image","text"]) can arrive base64 on the
+                    // delta, the final message object, or both — read both sides (an empty
+                    // delta list must not shadow the completed message's image) and let the
+                    // seen-key set drop duplicates.
+                    val images = delta?.images.orEmpty() + choice?.message?.images.orEmpty()
+                    images.forEach { payload ->
                         val dataUrl = payload.dataUrl ?: return@forEach
                         val key = "${dataUrl.length}:${dataUrl.takeLast(64)}"
                         if (seenImageKeys.add(key)) {

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -93,6 +93,10 @@ class SettingsRepository(context: Context) {
     private val _artifactsOffline = MutableStateFlow(getArtifactsOfflineDirect())
     val artifactsOffline: StateFlow<Boolean> = _artifactsOffline.asStateFlow()
 
+    // Image generation: which image-output OpenRouter model the "Create image" mode uses.
+    private val _imageGenModel = MutableStateFlow(getImageGenModelDirect())
+    val imageGenModel: StateFlow<String> = _imageGenModel.asStateFlow()
+
     // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
     private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
     val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
@@ -523,6 +527,16 @@ class SettingsRepository(context: Context) {
         _artifactsOffline.value = enabled
     }
 
+    // ── Image generation ───────────────────────────────────────────────────────────────
+
+    fun getImageGenModelDirect(): String =
+        prefs.getString("image_gen_model", DEFAULT_IMAGE_MODEL_ID).orEmpty()
+
+    fun saveImageGenModel(id: String) {
+        prefs.edit().putString("image_gen_model", id).apply()
+        _imageGenModel.value = id
+    }
+
     /** Minutes of inactivity before Browser Flow auto-stops the session (cost guard). 0 = off. */
     fun getBrowserIdleMinutesDirect(): Int =
         prefs.getInt("browser_idle_minutes", 3)
@@ -537,5 +551,6 @@ class SettingsRepository(context: Context) {
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"
         const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
+        const val DEFAULT_IMAGE_MODEL_ID = "google/gemini-2.5-flash-image"
     }
 }

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -288,6 +288,27 @@ object SystemPrompts {
     // ── Artifacts ────────────────────────────────────────────────────────────────────
 
     /**
+     * Image generation mode: the model natively outputs an image alongside a short line of
+     * text. On edit turns the newest user message carries the previous version, and the model
+     * revises exactly what was asked while keeping everything else consistent.
+     */
+    fun buildImageGen(editing: Boolean, currentDate: String = currentDate()): String {
+        val base = """
+        You are EchoFlow's image generator. Current date: $currentDate.
+
+        The user's message describes an image to create. Generate exactly ONE image per reply.
+        Alongside the image, write one short, friendly sentence about what you made — no
+        markdown headers, no lists, no long explanations.
+        """.trimIndent()
+        val editRules = """
+        The user's newest message includes the current version of their image. This is an EDIT:
+        apply only the requested changes and keep everything else — subject, composition,
+        style, lighting — as consistent with the provided image as possible.
+        """.trimIndent()
+        return if (editing) base + "\n\n" + editRules else base
+    }
+
+    /**
      * Artifact mode: the model produces ONE self-contained, rendered artifact (a web page, a
      * markdown document, or a printable LaTeX report) wrapped in a sentinel block the app extracts
      * from the stream. Works on cloud and on-device models — the on-device variant is trimmed to

--- a/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
+++ b/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
@@ -17,7 +17,8 @@ internal object AssistantMessagePersistence {
         val content = normalized.filterIsInstance<StreamSegment.Text>().joinToString("\n\n") { it.text }.trim()
         val hasDurableCard = normalized.any {
             it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent ||
-                (it is StreamSegment.Artifact && it.artifactId != null)
+                (it is StreamSegment.Artifact && it.artifactId != null) ||
+                (it is StreamSegment.Image && it.filePath != null)
         }
         if (content.isEmpty() && !hasDurableCard && !stopped) return null
         val reasoning = normalized.filterIsInstance<StreamSegment.Reasoning>()
@@ -46,6 +47,9 @@ internal object AssistantMessagePersistence {
         )
         is StreamSegment.Subagent -> PersistedSegment("subagent", subagent = SubagentResult(segment.taskName, segment.taskDescription, segment.workerModel, segment.outcome.orEmpty(), segment.error))
         is StreamSegment.Artifact -> segment.artifactId?.let { PersistedSegment("artifact", artifact = ArtifactRef(it, segment.title, segment.artifactType, segment.version)) }
+        is StreamSegment.Image -> segment.filePath?.let { path ->
+            PersistedSegment("image", image = ImageRef(segment.imageId.orEmpty(), path))
+        }
         is StreamSegment.Text -> segment.text.trim().takeIf(String::isNotEmpty)?.let { PersistedSegment("text", text = it) }
         is StreamSegment.AgentRun -> null
     }

--- a/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
@@ -171,6 +171,41 @@ internal object ChatSegmentReducer {
                     segments[idx] = seg.copy(charCount = chunk.charCount)
                 }
             }
+            is StreamChunk.ImageGenStarted -> {
+                segments.add(
+                    StreamSegment.Image(
+                        imageId = null,
+                        filePath = null,
+                        pattern = chunk.pattern,
+                        editing = chunk.editing,
+                        previousImagePath = chunk.previousImagePath,
+                        generating = true,
+                    )
+                )
+            }
+            is StreamChunk.ImageGenerated -> {
+                // Only chunks the ViewModel already persisted (filePath set) reach the timeline;
+                // a raw base64 chunk that slipped through is ignored rather than rendered.
+                val path = chunk.filePath ?: return null
+                val idx = segments.indexOfLast { it is StreamSegment.Image && it.generating }
+                val done = if (idx >= 0) {
+                    (segments[idx] as StreamSegment.Image).copy(
+                        imageId = chunk.imageId,
+                        filePath = path,
+                        generating = false,
+                    )
+                } else {
+                    StreamSegment.Image(
+                        imageId = chunk.imageId,
+                        filePath = path,
+                        pattern = "ripple",
+                        editing = false,
+                        previousImagePath = null,
+                        generating = false,
+                    )
+                }
+                if (idx >= 0) segments[idx] = done else segments.add(done)
+            }
             is StreamChunk.ArtifactCompleted -> {
                 val idx = segments.indexOfLast { it is StreamSegment.Artifact && it.building }
                 val finished = StreamSegment.Artifact(

--- a/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
@@ -67,4 +67,19 @@ sealed class StreamSegment {
         val building: Boolean,
         val truncated: Boolean,
     ) : StreamSegment()
+
+    /**
+     * A generated image in the assistant stream: the animated placeholder while [generating],
+     * then the revealed image once [filePath] lands. [pattern] picks the dot animation
+     * ("ripple" or "rain") chosen for this generation; [previousImagePath] backs the
+     * edit-turn placeholder (the old version shown dimmed under the dots).
+     */
+    data class Image(
+        val imageId: String?,
+        val filePath: String?,
+        val pattern: String,
+        val editing: Boolean,
+        val previousImagePath: String?,
+        val generating: Boolean,
+    ) : StreamSegment()
 }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -35,11 +35,15 @@ class ChatViewModel(
     private val browserSessionDao: BrowserSessionDao,
     private val browserStepDao: BrowserStepDao,
     private val artifactDao: ArtifactDao,
-    private val artifactVersionDao: ArtifactVersionDao
+    private val artifactVersionDao: ArtifactVersionDao,
+    private val generatedImageDao: GeneratedImageDao
 ) : AndroidViewModel(application) {
 
     // Artifacts: model-built, rendered content (web page / document / report) with version history.
     private val artifactManager = ArtifactManager(artifactDao, artifactVersionDao)
+
+    // Image generation: decoded PNGs on disk, version chain in Room (see GeneratedImageStore).
+    private val generatedImageStore = GeneratedImageStore(application, generatedImageDao)
 
     private val openRouterService = OpenRouterService(application)
     private val customProviderService = CustomProviderService(application)
@@ -212,6 +216,9 @@ class ChatViewModel(
     // follow-ups iterate the chat's current artifact (full version history).
     val artifactActive: StateFlow<Boolean> = modeIs<ChatMode.Artifact>()
 
+    // Image generation mode: sticky, so follow-up turns keep editing the chat's latest image.
+    val imageGenActive: StateFlow<Boolean> = modeIs<ChatMode.ImageGen>()
+
     /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
     @OptIn(ExperimentalCoroutinesApi::class)
     val currentArtifact: StateFlow<Artifact?> = _currentChatThreadId
@@ -313,6 +320,7 @@ class ChatViewModel(
     }
 
     fun toggleArtifact() = toggleMode(ChatMode.Artifact)
+    fun toggleImageGen() = toggleMode(ChatMode.ImageGen)
     fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
     fun toggleWebSearchChip() = toggleMode(ChatMode.WebSearch)
     fun toggleDataAgent() = toggleMode(ChatMode.DataAgent)
@@ -519,6 +527,7 @@ class ChatViewModel(
             clearPendingAttachment()
             clearError()
 
+            val imageGenMode = _chatMode.value is ChatMode.ImageGen
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
             val customProviderConfig = settingsRepository.getCustomProviderConfigDirect()
@@ -547,8 +556,20 @@ class ChatViewModel(
             val provider = chipProvider ?: settingsRepository.getWebSearchProviderDirect()
             val searchScope = if (chipProvider != null) "both" else settingsRepository.getWebSearchScopeDirect()
             // Echo Fusion always runs cloud models (the panel + judge), so it never uses the
-            // on-device engine even if a local model is the global selection.
-            val isLocal = selectedModel.startsWith("local/") && _chatMode.value !is ChatMode.EchoFusion
+            // on-device engine even if a local model is the global selection. Image generation
+            // likewise always runs its own OpenRouter image model, whatever chat model is picked.
+            val isLocal = selectedModel.startsWith("local/") && _chatMode.value !is ChatMode.EchoFusion && !imageGenMode
+
+            if (imageGenMode) {
+                if (apiKey.isBlank()) {
+                    _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                    return@launch
+                }
+                if (attachmentMime.equals("application/pdf", ignoreCase = true)) {
+                    _errorMessage.value = "Image generation works with image attachments only, not PDFs."
+                    return@launch
+                }
+            }
 
             if (isLocal && _activeStreams.value.values.any { it.isLocal }) {
                 _errorMessage.value = "The on-device model is still responding. Wait for it to finish before starting another local reply."
@@ -580,11 +601,11 @@ class ChatViewModel(
                 else -> false
             }
             val pendingIsPdf = attachmentMime.equals("application/pdf", ignoreCase = true)
-            if (customProviderActive && attachmentUri != null && pendingIsPdf && !customPdfAllowed) {
+            if (customProviderActive && !imageGenMode && attachmentUri != null && pendingIsPdf && !customPdfAllowed) {
                 _errorMessage.value = "PDF is off for this custom endpoint. Turn it on in Settings → Echo Labs → Custom API Endpoint."
                 return@launch
             }
-            if (customProviderActive && attachmentUri != null && !pendingIsPdf && !customImageAllowed) {
+            if (customProviderActive && !imageGenMode && attachmentUri != null && !pendingIsPdf && !customImageAllowed) {
                 _errorMessage.value = "Images are off for this custom endpoint. Turn them on in Settings → Echo Labs → Custom API Endpoint."
                 return@launch
             }
@@ -772,7 +793,29 @@ class ChatViewModel(
                 )
             }
 
+            // Image mode: resolve the version being edited (if any) and this generation's dot
+            // animation before building the stream. Ripple and rain alternate at random so the
+            // wait itself has variety across generations.
+            val imageGenModelId = if (imageGenMode) settingsRepository.getImageGenModelDirect() else ""
+            val imagePrev = if (imageGenMode) generatedImageStore.latestForChat(chatId) else null
+            val imageEditUrl = imagePrev?.let { generatedImageStore.asDataUrl(it) }
+            val imagePattern = if (imageGenMode) listOf("ripple", "rain").random() else ""
+
             val baseResponseFlow: Flow<StreamChunk> = when {
+                imageGenMode ->
+                    flow {
+                        emit(StreamChunk.ImageGenStarted(imagePattern, imageEditUrl != null, imagePrev?.filePath))
+                        emitAll(
+                            openRouterService.sendImageGeneration(
+                                apiKey = apiKey,
+                                model = imageGenModelId,
+                                history = fullHistory,
+                                systemPrompt = SystemPrompts.buildImageGen(editing = imageEditUrl != null),
+                                editImageDataUrl = imageEditUrl,
+                                params = inferenceParams,
+                            )
+                        )
+                    }
                 agentReq != null ->
                     openRouterService.sendWithAgentTools(
                         apiKey = apiKey,
@@ -907,6 +950,7 @@ class ChatViewModel(
                 else -> null
             }
             val keepAliveText = when {
+                imageGenMode -> "Creating an image…"
                 agentReq != null -> "Echo Agents — handing tasks to your Echo Agent…"
                 fusionReq != null -> "Echo Fusion — the panel is deliberating…"
                 advisorReq != null -> "Echo Adviser — consulting your advisor…"
@@ -935,16 +979,30 @@ class ChatViewModel(
                 responseFlow.collect { rawChunk ->
                     // Persist a completed artifact version before reducing, so the card/segment
                     // carry a real artifactId/version to deep-link the workspace.
-                    val chunk = if (rawChunk is StreamChunk.ArtifactCompleted && rawChunk.content.isNotBlank()) {
-                        val ref = artifactManager.saveVersion(
-                            chatId = chatId,
-                            title = rawChunk.title,
-                            type = rawChunk.artifactType,
-                            content = rawChunk.content,
-                            sourcePrompt = prompt,
-                        )
-                        rawChunk.copy(artifactId = ref.artifactId, artifactType = ref.type, version = ref.version)
-                    } else rawChunk
+                    val chunk = when {
+                        rawChunk is StreamChunk.ArtifactCompleted && rawChunk.content.isNotBlank() -> {
+                            val ref = artifactManager.saveVersion(
+                                chatId = chatId,
+                                title = rawChunk.title,
+                                type = rawChunk.artifactType,
+                                content = rawChunk.content,
+                                sourcePrompt = prompt,
+                            )
+                            rawChunk.copy(artifactId = ref.artifactId, artifactType = ref.type, version = ref.version)
+                        }
+                        // Persist a generated image to disk/Room before reducing — the timeline
+                        // only ever carries file paths, never multi-MB base64 payloads.
+                        rawChunk is StreamChunk.ImageGenerated && rawChunk.filePath == null -> {
+                            val saved = generatedImageStore.save(
+                                chatId = chatId,
+                                prompt = prompt,
+                                dataUrl = rawChunk.dataUrl,
+                                parentId = imagePrev?.id,
+                            )
+                            StreamChunk.ImageGenerated(dataUrl = "", filePath = saved.filePath, imageId = saved.id)
+                        }
+                        else -> rawChunk
+                    }
                     val note = reduceSegments(segments, chunk)
                     if (note != null) statusNote = note
                     emitStreamUiState()
@@ -1407,14 +1465,16 @@ class ChatViewModel(
             browserSessionDao: BrowserSessionDao,
             browserStepDao: BrowserStepDao,
             artifactDao: ArtifactDao,
-            artifactVersionDao: ArtifactVersionDao
+            artifactVersionDao: ArtifactVersionDao,
+            generatedImageDao: GeneratedImageDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
-                    agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao
+                    agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao,
+                    generatedImageDao
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -450,6 +450,8 @@ class ChatViewModel(
 
     fun deleteThread(thread: ChatThread) {
         viewModelScope.launch {
+            // Image files live outside Room; remove them while their rows (and paths) still exist.
+            generatedImageStore.deleteFilesForChat(thread.id)
             chatDao.deleteThread(thread)
             if (_currentChatThreadId.value == thread.id) {
                 selectThread(allThreads.value.firstOrNull { it.id != thread.id }?.id)

--- a/app/src/main/java/com/echoflow/ui/ImageGenAnimation.kt
+++ b/app/src/main/java/com/echoflow/ui/ImageGenAnimation.kt
@@ -1,0 +1,165 @@
+package com.echoflow.ui
+
+import kotlin.math.exp
+import kotlin.math.pow
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+/**
+ * Pure math behind the image-generation placeholder: a dense dot field that rests near
+ * silence while a single narrow wave band (ripple) or sparse falling streaks (rain) travel
+ * through it. Everything an intensity function returns is 0..1 and drives all visual
+ * channels of a dot (scale, alpha, shape) from one number, so nothing can desync.
+ */
+internal object ImageDotField {
+    /** Grid side. 21×21 keeps dots small enough to read as texture, cheap enough to draw. */
+    const val GRID = 21
+
+    /** One full wave pass; the tail of the cycle is a deliberate rest beat. */
+    const val CYCLE_MS = 3000L
+
+    /** How long the crest actually travels within a cycle. */
+    const val TRAVEL_MS = 2100L
+
+    fun gauss(d: Float, sigma: Float): Float = exp(-(d * d) / (2f * sigma * sigma))
+
+    /** Ease-out: the wavefront launches with energy and lands softly. */
+    fun travelEase(phase: Float): Float = 1f - (1f - phase).pow(2.2f)
+
+    val maxDistance: Float = run {
+        val c = (GRID - 1) / 2f
+        sqrt(2f) * c
+    }
+
+    fun distanceFromCenter(col: Int, row: Int): Float {
+        val c = (GRID - 1) / 2f
+        val dx = col - c
+        val dy = row - c
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    /**
+     * Ripple: a thin ring radiating from the center with a fainter trailing echo, then rest.
+     * [timeMs] is any monotonic clock; [dist] is the dot's distance from center in cells.
+     */
+    fun rippleIntensity(dist: Float, timeMs: Long): Float {
+        val phase = (timeMs % CYCLE_MS).toFloat() / TRAVEL_MS
+        if (phase > 1f) return 0f
+        val pos = travelEase(phase) * (maxDistance + 3f) - 1.5f
+        val crest = gauss(dist - pos, 1.05f)
+        val echo = 0.3f * gauss(dist - pos + 2.4f, 1.3f)
+        return (crest + echo).coerceAtMost(1f)
+    }
+}
+
+/** One falling streak: a bright head with a decaying tail, in its own column at its own speed. */
+internal data class RainDrop(
+    val col: Int,
+    var y: Float, // head position in rows (fractional)
+    val speed: Float, // rows per second
+    val tail: Float, // tail length in rows
+    val bright: Float, // head intensity 0.7..1.0
+)
+
+/**
+ * The rain pattern is deliberately not row-synchronized: drops spawn probabilistically in
+ * random columns with random speeds and tail lengths, so fast streaks overtake slow ones and
+ * the field never repeats. Capped sparse — the gaps are what make it read as rain.
+ */
+internal class RainField(private val random: Random = Random.Default) {
+    val drops = mutableListOf<RainDrop>()
+    private var lastSpawnMs = 0L
+
+    fun step(timeMs: Long, dtMs: Long) {
+        if (timeMs - lastSpawnMs > MIN_SPAWN_GAP_MS && drops.size < MAX_DROPS && random.nextFloat() < SPAWN_CHANCE) {
+            lastSpawnMs = timeMs
+            drops.add(
+                RainDrop(
+                    col = random.nextInt(ImageDotField.GRID),
+                    y = -1f - random.nextFloat() * 4f,
+                    speed = MIN_SPEED + random.nextFloat() * (MAX_SPEED - MIN_SPEED),
+                    tail = MIN_TAIL + random.nextFloat() * (MAX_TAIL - MIN_TAIL),
+                    bright = 0.7f + random.nextFloat() * 0.3f,
+                )
+            )
+        }
+        val dt = dtMs / 1000f
+        val iterator = drops.iterator()
+        while (iterator.hasNext()) {
+            val drop = iterator.next()
+            drop.y += drop.speed * dt
+            if (drop.y - drop.tail > ImageDotField.GRID + 1) iterator.remove()
+        }
+    }
+
+    fun intensityAt(col: Int, row: Int): Float {
+        var total = 0f
+        for (drop in drops) {
+            if (drop.col != col) continue
+            val dy = drop.y - row
+            if (dy < -0.4f || dy > drop.tail) continue
+            val v = if (dy < 0f) ImageDotField.gauss(dy, 0.25f) else (1f - dy / drop.tail).pow(1.6f)
+            total += v * drop.bright
+        }
+        return total.coerceAtMost(1f)
+    }
+
+    companion object {
+        const val MIN_SPAWN_GAP_MS = 80L
+        const val SPAWN_CHANCE = 0.6f
+        const val MAX_DROPS = 18
+        const val MIN_SPEED = 9f
+        const val MAX_SPEED = 20f
+        const val MIN_TAIL = 4f
+        const val MAX_TAIL = 8f
+    }
+}
+
+/**
+ * Deals status phrases from a shuffled deck — no repeats until the whole pool is exhausted,
+ * unlike naive random picks which repeat embarrassingly fast within one generation.
+ */
+internal class PhraseDeck(
+    private val phrases: List<String> = ImageGenPhrases.ALL,
+    private val random: Random = Random.Default,
+) {
+    private var order: MutableList<Int> = mutableListOf()
+
+    fun next(): String {
+        if (order.isEmpty()) {
+            order = phrases.indices.shuffled(random).toMutableList()
+        }
+        return phrases[order.removeAt(0)]
+    }
+}
+
+/** The 100-phrase pool shown under the placeholder while an image generates. */
+internal object ImageGenPhrases {
+    val ALL: List<String> = listOf(
+        "Dreaming it up…", "Mixing the colors…", "Sketching the outline…", "Warming up the canvas…",
+        "Chasing the light…", "Sharpening the details…", "Finding the right shade…", "Letting it take shape…",
+        "Painting outside the lines…", "Softening the edges…", "Balancing the light…", "Adding a little magic…",
+        "Setting the scene…", "Catching the mood…", "Layering the tones…", "Shaping the shadows…",
+        "Polishing the highlights…", "Giving it depth…", "Breathing life into it…", "Arranging the composition…",
+        "Tuning the palette…", "Filling in the sky…", "Drawing the first stroke…", "Studying the brief…",
+        "Getting the angles right…", "Perfecting the texture…", "Blending the horizon…", "Placing the focal point…",
+        "Choosing the brushes…", "Stretching the canvas…", "Waking the muse…", "Following the vision…",
+        "Tracing the silhouette…", "Working on the glow…", "Measuring twice…", "Painting the quiet parts…",
+        "Building the atmosphere…", "Coloring between ideas…", "Finding the harmony…", "Refining the reflections…",
+        "Dusting off the easel…", "Inventing the weather…", "Growing the background…", "Carving out the light…",
+        "Listening to the prompt…", "Adding the finishing dust…", "Weaving the details…", "Composing the frame…",
+        "Testing a bolder hue…", "Steadying the hand…", "Deepening the contrast…", "Smoothing the gradients…",
+        "Curating the chaos…", "Planting the shadows…", "Raising the highlights…", "Sculpting the forms…",
+        "Choosing the hour of day…", "Setting the perspective…", "Warming the tones…", "Cooling the corners…",
+        "Focusing the lens…", "Feathering the clouds…", "Grounding the scene…", "Lighting the subject…",
+        "Framing the moment…", "Checking the proportions…", "Rehearsing the reveal…", "Stirring the pigments…",
+        "Drafting the geometry…", "Aligning the stars…", "Filling the silence…", "Threading the light…",
+        "Casting the reflections…", "Building it pixel by pixel…", "Second-guessing the sky…", "Committing to the palette…",
+        "Detailing the foreground…", "Quieting the background…", "Sharpening the focus…", "Softening the distance…",
+        "Anchoring the horizon…", "Shading the undersides…", "Glazing the surface…", "Balancing the whites…",
+        "Hiding a small surprise…", "Tidying the edges…", "Naming the colors…", "Respecting the shadows…",
+        "Trusting the process…", "Slowing down for quality…", "Taking one more look…", "Adjusting the exposure…",
+        "Enriching the midtones…", "Setting the mood lighting…", "Finessing the last strokes…", "Standing back to check…",
+        "Signing the corner…", "Letting the paint settle…", "Framing it just right…", "Almost there…",
+    )
+}

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -19,6 +19,8 @@ import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DeepResearchModelDao
 import com.echoflow.data.FusionPanel
 import com.echoflow.data.FusionPanelDao
+import com.echoflow.data.ImageModel
+import com.echoflow.data.ImageModelDao
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.InferenceParams
@@ -45,7 +47,8 @@ class SettingsViewModel(
     private val deepResearchModelDao: DeepResearchModelDao,
     private val advisorProfileDao: AdvisorProfileDao,
     private val fusionPanelDao: FusionPanelDao,
-    private val agentProfileDao: AgentProfileDao
+    private val agentProfileDao: AgentProfileDao,
+    private val imageModelDao: ImageModelDao
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
     private val customProviderService = CustomProviderService()
@@ -116,6 +119,11 @@ class SettingsViewModel(
     // Artifacts
     val artifactsOffline: StateFlow<Boolean> = repository.artifactsOffline
 
+    // Image generation
+    val imageGenModelId: StateFlow<String> = repository.imageGenModel
+    val imageModels: StateFlow<List<ImageModel>> = imageModelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     // Echo Adviser / Echo Fusion
     val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
     val echoFusionPanelId: StateFlow<String> = repository.echoFusionPanelId
@@ -171,6 +179,19 @@ class SettingsViewModel(
             val q = query.trim()
             if (q.isEmpty()) all.take(40)
             else all.filter { it.id.contains(q, true) || it.name.contains(q, true) }.take(60)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    /** Same directory, restricted to models whose output modalities include images. */
+    val orImageModelResults: StateFlow<List<OpenRouterModelInfo>> =
+        combine(_orAllModels, _orModelQuery) { all, query ->
+            val imageCapable = all.filter { it.outputsImage }
+            val q = query.trim()
+            if (q.isEmpty()) imageCapable.take(40)
+            else imageCapable.filter { it.id.contains(q, true) || it.name.contains(q, true) }.take(60)
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
@@ -360,6 +381,29 @@ class SettingsViewModel(
         viewModelScope.launch { profileManager.deleteAgent(id) }
     }
 
+    // ── Image generation ─────────────────────────────────────────────────────────────────
+
+    fun saveImageGenModel(id: String) = repository.saveImageGenModel(id)
+
+    fun addImageModel(id: String, name: String) {
+        viewModelScope.launch {
+            val cleanId = id.trim()
+            val cleanName = name.trim().ifEmpty { cleanId.substringAfterLast("/") }
+            if (cleanId.isNotEmpty()) {
+                imageModelDao.insert(ImageModel(cleanId, cleanName, System.currentTimeMillis()))
+            }
+        }
+    }
+
+    fun deleteImageModel(id: String) {
+        viewModelScope.launch {
+            imageModelDao.delete(id)
+            if (repository.getImageGenModelDirect() == id) {
+                repository.saveImageGenModel(SettingsRepository.DEFAULT_IMAGE_MODEL_ID)
+            }
+        }
+    }
+
     fun addDeepResearchModel(id: String, name: String) {
         viewModelScope.launch {
             val cleanId = id.trim()
@@ -526,11 +570,12 @@ class SettingsViewModel(
             deepResearchModelDao: DeepResearchModelDao,
             advisorProfileDao: AdvisorProfileDao,
             fusionPanelDao: FusionPanelDao,
-            agentProfileDao: AgentProfileDao
+            agentProfileDao: AgentProfileDao,
+            imageModelDao: ImageModelDao
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -1,0 +1,365 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.widget.Toast
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
+import com.echoflow.ui.ImageDotField
+import com.echoflow.ui.ImageGenPhrases
+import com.echoflow.ui.PhraseDeck
+import com.echoflow.ui.RainField
+import com.echoflow.ui.theme.Spacing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * The image-generation placeholder: a 21×21 field of tiny theme-colored dots resting near
+ * silence while one narrow wave (ripple) or sparse streaks (rain) travel through them, with
+ * a shuffled-deck status phrase crossfading below. All color comes from the Material scheme,
+ * so it re-skins itself with dynamic color and dark mode. On edit turns the previous version
+ * shows dimmed and blurred beneath the dots — "your image is being reworked".
+ */
+@Composable
+fun GeneratingImageCard(
+    pattern: String,
+    previousImagePath: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.fillMaxWidth()) {
+        Box(
+            Modifier
+                .widthIn(max = 340.dp)
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            previousImagePath?.let { path ->
+                AsyncImage(
+                    model = File(path),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .matchParentSize()
+                        .blur(14.dp) // no-op below API 31; the alpha dim still reads correctly
+                        .alpha(0.35f),
+                )
+            }
+            DotFieldCanvas(pattern = pattern, modifier = Modifier.matchParentSize())
+        }
+        Spacer(Modifier.height(Spacing.s))
+        GeneratingPhraseLine()
+    }
+}
+
+@Composable
+private fun DotFieldCanvas(pattern: String, modifier: Modifier = Modifier) {
+    var timeMs by remember { mutableLongStateOf(0L) }
+    val rain = remember(pattern) { RainField() }
+    LaunchedEffect(pattern) {
+        var last = 0L
+        while (true) {
+            withFrameNanos { nanos ->
+                val now = nanos / 1_000_000
+                val dt = if (last == 0L) 16L else (now - last).coerceIn(1L, 100L)
+                last = now
+                if (pattern == "rain") rain.step(now, dt)
+                timeMs = now
+            }
+        }
+    }
+    val dotColor = MaterialTheme.colorScheme.primary
+    Canvas(modifier) {
+        // Reading timeMs inside the draw block redraws every frame without recomposing.
+        val t = timeMs
+        val n = ImageDotField.GRID
+        val cell = size.minDimension / n
+        val restRadius = cell * 0.16f
+        for (row in 0 until n) {
+            for (col in 0 until n) {
+                val intensity = if (pattern == "rain") {
+                    rain.intensityAt(col, row)
+                } else {
+                    ImageDotField.rippleIntensity(ImageDotField.distanceFromCenter(col, row), t)
+                }
+                val alpha = 0.15f + 0.85f * intensity
+                val radius = restRadius * (1f + 1.35f * intensity)
+                val cx = col * cell + cell / 2f
+                val cy = row * cell + cell / 2f
+                if (intensity > 0.25f) {
+                    // The crest morphs circles toward soft squircles — the Expressive accent.
+                    val side = radius * 3.4f
+                    val corner = side * (0.5f - 0.28f * intensity)
+                    drawRoundRect(
+                        color = dotColor,
+                        alpha = alpha,
+                        topLeft = Offset(cx - side / 2f, cy - side / 2f),
+                        size = Size(side, side),
+                        cornerRadius = CornerRadius(corner, corner),
+                    )
+                } else {
+                    drawCircle(color = dotColor, alpha = alpha, radius = radius, center = Offset(cx, cy))
+                }
+            }
+        }
+    }
+}
+
+/** Shuffled-deck status phrases: no repeats until all 100 have been shown. */
+@Composable
+private fun GeneratingPhraseLine(modifier: Modifier = Modifier) {
+    val deck = remember { PhraseDeck() }
+    var phrase by remember { mutableStateOf(ImageGenPhrases.ALL.first()) }
+    LaunchedEffect(Unit) {
+        phrase = deck.next()
+        while (true) {
+            delay(2800)
+            phrase = deck.next()
+        }
+    }
+    Crossfade(targetState = phrase, label = "image-gen-phrase") { current ->
+        Text(
+            current,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier,
+        )
+    }
+}
+
+/**
+ * A finished generated image, inline in the reply. On first arrival it plays the wipe
+ * reveal (a glowing primary-color line sweeps top→bottom unmasking the image) ending in a
+ * small spring settle; reloading a persisted chat renders instantly. Tap opens fullscreen.
+ */
+@Composable
+fun GeneratedImageBlock(
+    filePath: String,
+    animateReveal: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var viewerOpen by remember { mutableStateOf(false) }
+    var revealed by rememberSaveable(filePath) { mutableStateOf(!animateReveal) }
+    val progress = remember(filePath) { Animatable(if (revealed) 1f else 0f) }
+    LaunchedEffect(filePath) {
+        if (!revealed) {
+            progress.animateTo(1f, tween(durationMillis = 850, easing = FastOutSlowInEasing))
+            revealed = true
+        }
+    }
+    val settle by animateFloatAsState(
+        targetValue = if (progress.value >= 1f) 1f else 0.98f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
+        label = "image-reveal-settle",
+    )
+    val scanColor = MaterialTheme.colorScheme.primary
+
+    Column(modifier.fillMaxWidth()) {
+        Box(
+            Modifier
+                .widthIn(max = 340.dp)
+                .fillMaxWidth()
+                .scale(settle)
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .clickable { viewerOpen = true },
+        ) {
+            AsyncImage(
+                model = File(filePath),
+                contentDescription = "Generated image",
+                contentScale = ContentScale.FillWidth,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 420.dp)
+                    .drawWithContent {
+                        val reveal = progress.value
+                        clipRect(bottom = size.height * reveal) { this@drawWithContent.drawContent() }
+                        if (reveal < 1f) {
+                            val y = size.height * reveal
+                            // Soft glow trail above the line, then the bright 3px scanline.
+                            drawRect(
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(Color.Transparent, scanColor.copy(alpha = 0.35f)),
+                                    startY = (y - 48f).coerceAtLeast(0f),
+                                    endY = y,
+                                ),
+                                topLeft = Offset(0f, (y - 48f).coerceAtLeast(0f)),
+                                size = Size(size.width, 48f.coerceAtMost(y)),
+                            )
+                            drawRect(
+                                color = scanColor,
+                                topLeft = Offset(0f, y - 1.5f),
+                                size = Size(size.width, 3f),
+                            )
+                        }
+                    },
+            )
+        }
+        Spacer(Modifier.height(Spacing.xs))
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+            FilledTonalIconButton(
+                onClick = {
+                    scope.launch {
+                        val ok = withContext(Dispatchers.IO) { saveGeneratedImageToGallery(context, filePath) != null }
+                        Toast.makeText(context, if (ok) "Saved to Pictures/EchoFlow" else "Couldn't save the image", Toast.LENGTH_SHORT).show()
+                    }
+                },
+                modifier = Modifier.size(32.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.Download, "Save to gallery", Modifier.size(16.dp)) }
+            FilledTonalIconButton(
+                onClick = { scope.launch { shareGeneratedImage(context, filePath) } },
+                modifier = Modifier.size(32.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.Share, "Share", Modifier.size(16.dp)) }
+        }
+    }
+
+    if (viewerOpen) {
+        GeneratedImageViewer(filePath = filePath, onDismiss = { viewerOpen = false })
+    }
+}
+
+/** Fullscreen viewer with save/share, matching the workspace overlays' dark treatment. */
+@Composable
+fun GeneratedImageViewer(filePath: String, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.94f))) {
+            AsyncImage(
+                model = File(filePath),
+                contentDescription = "Generated image",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize().padding(Spacing.base),
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd).padding(Spacing.base),
+            ) { Icon(Icons.Default.Close, "Close", tint = Color.White) }
+            Row(
+                Modifier.align(Alignment.BottomCenter).padding(Spacing.xl),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.base),
+            ) {
+                FilledTonalIconButton(onClick = {
+                    scope.launch {
+                        val ok = withContext(Dispatchers.IO) { saveGeneratedImageToGallery(context, filePath) != null }
+                        Toast.makeText(context, if (ok) "Saved to Pictures/EchoFlow" else "Couldn't save the image", Toast.LENGTH_SHORT).show()
+                    }
+                }) { Icon(Icons.Default.Download, "Save to gallery") }
+                FilledTonalIconButton(onClick = { scope.launch { shareGeneratedImage(context, filePath) } }) {
+                    Icon(Icons.Default.Share, "Share")
+                }
+            }
+        }
+    }
+}
+
+/** Copies the PNG into MediaStore (Pictures/EchoFlow); returns the new content Uri or null. */
+private fun saveGeneratedImageToGallery(context: Context, filePath: String): Uri? = runCatching {
+    val file = File(filePath)
+    if (!file.exists()) return null
+    val values = ContentValues().apply {
+        put(MediaStore.Images.Media.DISPLAY_NAME, "EchoFlow_${System.currentTimeMillis()}.png")
+        put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/EchoFlow")
+        }
+    }
+    val uri = context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values) ?: return null
+    context.contentResolver.openOutputStream(uri)?.use { out ->
+        file.inputStream().use { it.copyTo(out) }
+    } ?: return null
+    uri
+}.getOrNull()
+
+/** Shares via a MediaStore copy — no FileProvider needed, works on every API level we ship. */
+private suspend fun shareGeneratedImage(context: Context, filePath: String) {
+    val uri = withContext(Dispatchers.IO) { saveGeneratedImageToGallery(context, filePath) }
+    if (uri == null) {
+        Toast.makeText(context, "Couldn't share the image", Toast.LENGTH_SHORT).show()
+        return
+    }
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "image/png"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(Intent.createChooser(intent, "Share image"))
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -143,6 +143,8 @@ internal fun InputToolbar(
     onToggleBrowserFlow: () -> Unit,
     artifactActive: Boolean,
     onToggleArtifact: () -> Unit,
+    imageGenActive: Boolean,
+    onToggleImageGen: () -> Unit,
     browserSession: com.echoflow.data.BrowserSession?,
     browserSteps: List<com.echoflow.data.BrowserStep>,
     onBrowserOpen: () -> Unit,
@@ -228,7 +230,7 @@ internal fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive || imageGenActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -242,6 +244,9 @@ internal fun InputToolbar(
                 }
                 if (artifactActive) {
                     CapabilityChip(Icons.Default.AutoAwesome, "Artifact", onRemove = onToggleArtifact)
+                }
+                if (imageGenActive) {
+                    CapabilityChip(Icons.Default.Brush, "Create image", onRemove = onToggleImageGen)
                 }
                 if (echoAdviserActive) {
                     CapabilityChip(
@@ -332,6 +337,8 @@ internal fun InputToolbar(
                         browserFlowOn = browserFlowActive,
                         browserFlowAvailable = browserFlowAvailable,
                         artifactOn = artifactActive,
+                        imageGenOn = imageGenActive,
+                        onToggleImageGen = { plusMenuOpen = false; onToggleImageGen() },
                         onImage = { plusMenuOpen = false; onAttach() },
                         onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
@@ -356,6 +363,7 @@ internal fun InputToolbar(
                                 dataAgentActive -> "Describe the data to extract…"
                                 deepResearchActive -> "Research a topic…"
                                 artifactActive -> "Describe an artifact to build…"
+                                imageGenActive -> "Describe an image — or a change…"
                                 else -> "Ask anything…"
                             }
                         )
@@ -408,6 +416,8 @@ internal fun PlusMenu(
     browserFlowOn: Boolean,
     browserFlowAvailable: Boolean,
     artifactOn: Boolean,
+    imageGenOn: Boolean,
+    onToggleImageGen: () -> Unit,
     onImage: () -> Unit,
     onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
@@ -453,6 +463,13 @@ internal fun PlusMenu(
             leadingIcon = { Icon(Icons.Default.AutoAwesome, null) },
             trailingIcon = { if (artifactOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleArtifact,
+        )
+        // Create image — generate and conversationally edit images (OpenRouter image models).
+        DropdownMenuItem(
+            text = { Text("Create image") },
+            leadingIcon = { Icon(Icons.Default.Brush, null) },
+            trailingIcon = { if (imageGenOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleImageGen,
         )
         // Data Agent only appears once it's enabled in Settings and a Firecrawl key exists.
         if (dataAgentAvailable) {

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -287,6 +287,19 @@ internal fun StreamingAssistantBubble(
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }
+                    is StreamSegment.Image -> {
+                        if (segment.generating) {
+                            com.echoflow.ui.components.GeneratingImageCard(
+                                pattern = segment.pattern,
+                                previousImagePath = segment.previousImagePath,
+                            )
+                        } else {
+                            segment.filePath?.let { path ->
+                                com.echoflow.ui.components.GeneratedImageBlock(filePath = path, animateReveal = true)
+                            }
+                        }
+                        Spacer(Modifier.height(Spacing.s))
+                    }
                     is StreamSegment.Text -> {
                         SmoothStreamingText(segment.text, Modifier.fillMaxWidth())
                         if (!isLast) Spacer(Modifier.height(Spacing.s))
@@ -487,6 +500,15 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
                                         charCount = 0,
                                         truncated = false,
                                         onOpen = onArtifactOpen,
+                                    )
+                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                                }
+                            }
+                            "image" -> {
+                                segment.image?.let { ref ->
+                                    com.echoflow.ui.components.GeneratedImageBlock(
+                                        filePath = ref.filePath,
+                                        animateReveal = false,
                                     )
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -168,6 +168,7 @@ fun ChatScreen(
     val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
 
     val artifactActive by chatViewModel.artifactActive.collectAsState()
+    val imageGenActive by chatViewModel.imageGenActive.collectAsState()
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -390,6 +391,8 @@ fun ChatScreen(
                 onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
                 artifactActive = artifactActive,
                 onToggleArtifact = { chatViewModel.toggleArtifact() },
+                imageGenActive = imageGenActive,
+                onToggleImageGen = { chatViewModel.toggleImageGen() },
                 browserSession = browserSession,
                 browserSteps = browserSteps,
                 onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
@@ -1,0 +1,178 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.SettingsRepository
+import com.echoflow.ui.SettingsViewModel
+import com.echoflow.ui.components.GroupedItemGap
+import com.echoflow.ui.components.groupedItemShape
+import com.echoflow.ui.theme.RoundedPolygonShape
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * Image generation settings: pick the default image model and manage the whitelist. The
+ * directory search is restricted to models whose `output_modalities` include "image" —
+ * text-only models can't appear here.
+ */
+@Composable
+internal fun ImageGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val imageModels by viewModel.imageModels.collectAsState()
+    val selectedId by viewModel.imageGenModelId.collectAsState()
+    val orQuery by viewModel.orModelQuery.collectAsState()
+    val orImageResults by viewModel.orImageModelResults.collectAsState()
+    val orLoading by viewModel.orDirectoryLoading.collectAsState()
+    val orError by viewModel.orDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+
+    // The shipped default is always offered, ahead of whatever the user has added.
+    val entries = remember(imageModels) {
+        val default = SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
+        listOf(default) + imageModels
+            .filter { it.id != default.first }
+            .map { it.id to it.name }
+    }
+
+    SettingsPageScaffold(title = "Image generation", subtitle = "Create & edit images in chat", onBack = onBack) {
+        PageSection("How it works", null)
+        Text(
+            "Turn on “Create image” from the + menu in chat, then describe an image. " +
+                "Follow-up messages edit the latest image — “make the sky purple” changes " +
+                "just that. Runs on your OpenRouter key; roughly a few cents per image.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Default model", "The model every image turn uses")
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            entries.forEachIndexed { index, (id, name) ->
+                val selected = id == selectedId
+                Surface(
+                    onClick = { viewModel.saveImageGenModel(id) },
+                    shape = groupedItemShape(index, entries.size),
+                    color = if (selected) MaterialTheme.colorScheme.primaryContainer
+                    else MaterialTheme.colorScheme.surfaceContainer,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Box(
+                            Modifier
+                                .size(40.dp)
+                                .clip(RoundedPolygonShape(MaterialShapes.Flower))
+                                .background(
+                                    if (selected) MaterialTheme.colorScheme.primary
+                                    else MaterialTheme.colorScheme.tertiaryContainer
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Default.Brush, null, Modifier.size(20.dp),
+                                tint = if (selected) MaterialTheme.colorScheme.onPrimary
+                                else MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        }
+                        Spacer(Modifier.width(Spacing.base))
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                name,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+                                else MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                id,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        if (selected) {
+                            Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
+                        } else if (id != SettingsRepository.DEFAULT_IMAGE_MODEL_ID) {
+                            IconButton(onClick = { viewModel.deleteImageModel(id) }) {
+                                Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.l))
+        Button(
+            onClick = {
+                showDirectory = true
+                viewModel.loadOpenRouterDirectory()
+            },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Search, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Browse image models")
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            "Only models that can output images appear in this search.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (showDirectory) {
+        OpenRouterDirectorySheet(
+            query = orQuery,
+            results = orImageResults,
+            loading = orLoading,
+            error = orError,
+            addedIds = imageModels.map { it.id }.toSet() + SettingsRepository.DEFAULT_IMAGE_MODEL_ID,
+            onQueryChange = viewModel::updateOrModelQuery,
+            onRetry = viewModel::loadOpenRouterDirectory,
+            onAdd = { info -> viewModel.addImageModel(info.id, info.name.substringAfter(": ")) },
+            onRemove = viewModel::deleteImageModel,
+            onDismiss = { showDirectory = false },
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.BrightnessAuto
+import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
@@ -145,6 +146,7 @@ internal const val PageCloudModels = "cloud_models"
 internal const val PageWebSearch = "web_search"
 internal const val PageLocalModels = "local_models"
 internal const val PageDeepResearch = "deep_research"
+internal const val PageImageGen = "image_gen"
 internal const val PageDataAgent = "data_agent"
 internal const val PageBrowserFlow = "browser_flow"
 internal const val PageEchoLabs = "echo_labs"
@@ -210,6 +212,7 @@ fun SettingsScreen(
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
+            PageImageGen -> ImageGenPage(viewModel, onBack = { page = PageHome })
             PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = { page = PageHome })
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageEchoLabs })
             PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageEchoLabs })
@@ -288,6 +291,11 @@ internal fun SettingsHomePage(
         localModels.isEmpty() -> "On · No models installed yet"
         else -> "On · ${localModels.size} installed"
     }
+    val imageGenModelId by viewModel.imageGenModelId.collectAsState()
+    val imageModelsHome by viewModel.imageModels.collectAsState()
+    val imageGenSubtitle = imageModelsHome.firstOrNull { it.id == imageGenModelId }?.name
+        ?: if (imageGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID) "Gemini 2.5 Flash Image"
+        else imageGenModelId
     val deepResearchSubtitle = when {
         deepResearchModelId.isBlank() -> "No engine selected"
         else -> DeepResearchCatalog.providerEngineById(deepResearchModelId)?.name
@@ -337,7 +345,7 @@ internal fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 6,
+                index = 0, count = 7,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -347,7 +355,7 @@ internal fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 6,
+                index = 1, count = 7,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -357,7 +365,7 @@ internal fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 2, count = 6,
+                index = 2, count = 7,
                 onClick = { onOpen(PageLocalModels) },
             )
             SettingsNavRow(
@@ -367,7 +375,7 @@ internal fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 3, count = 6,
+                index = 3, count = 7,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -377,8 +385,18 @@ internal fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 4, count = 6,
+                index = 4, count = 7,
                 onClick = { onOpen(PageDeepResearch) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Brush,
+                polygon = MaterialShapes.Flower,
+                title = "Image generation",
+                subtitle = imageGenSubtitle,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 5, count = 7,
+                onClick = { onOpen(PageImageGen) },
             )
             SettingsNavRow(
                 icon = Icons.Default.AutoAwesome,
@@ -387,7 +405,7 @@ internal fun SettingsHomePage(
                 subtitle = echoLabsSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 5, count = 6,
+                index = 6, count = 7,
                 onClick = { onOpen(PageEchoLabs) },
             )
         }

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,8 +56,12 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version twelve without data loss`() {
+    fun `production database upgrades version one through version thirteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
+
+        // v13 tables exist and are queryable after the chained migration.
+        database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM image_models").use { it.moveToFirst() }
+        database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM generated_images").use { it.moveToFirst() }
 
         database.openHelper.readableDatabase.query(
             "SELECT content, reasoning, localAttachmentUri, localAttachmentName " +

--- a/app/src/test/java/com/echoflow/data/OpenRouterPayloadsTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterPayloadsTest.kt
@@ -31,6 +31,32 @@ class OpenRouterPayloadsTest {
         assertFalse(OpenRouterPayloads.historyHasPdf(history))
     }
 
+    @Test fun `attaches edit image to the newest user message preserving existing parts`() {
+        val history = listOf(
+            message(role = "user", content = "draw a cat"),
+            message(role = "assistant", content = "here it is"),
+            message(role = "user", content = "make it night", uri = "content://photo"),
+        )
+        val messages = OpenRouterPayloads.messages(history) { if (it == null) null else "cGhvdG8=" }
+        OpenRouterPayloads.attachImageToLastUserMessage(messages, "data:image/png;base64,QUJD")
+
+        val parts = messages.last()["content"] as List<*>
+        assertEquals(3, parts.size) // text + user photo + previous generated version
+        val attached = parts.last() as Map<*, *>
+        assertEquals("image_url", attached["type"])
+        assertEquals("data:image/png;base64,QUJD", (attached["image_url"] as Map<*, *>)["url"])
+        // The assistant message stays scalar text.
+        assertEquals("here it is", messages[1]["content"])
+    }
+
+    @Test fun `attach image rewrites scalar user content into parts`() {
+        val messages = OpenRouterPayloads.messages(listOf(message(role = "user", content = "redo it"))) { null }
+        OpenRouterPayloads.attachImageToLastUserMessage(messages, "data:image/png;base64,QUJD")
+        val parts = messages.single()["content"] as List<*>
+        assertEquals("text", (parts[0] as Map<*, *>)["type"])
+        assertEquals("image_url", (parts[1] as Map<*, *>)["type"])
+    }
+
     @Test fun `extracts only structured OpenRouter error message`() {
         assertEquals("quota", OpenRouterPayloads.errorMessage("""{"error":{"message":"quota"}}"""))
         assertNull(OpenRouterPayloads.errorMessage("broken"))

--- a/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
+++ b/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
@@ -15,6 +15,35 @@ class AssistantMessagePersistenceTest {
         assertEquals("stopped", draft.segments.single().type)
     }
 
+    @Test fun `a finished image is durable even without answer text`() {
+        val draft = AssistantMessagePersistence.draft(
+            listOf(
+                StreamSegment.Image(
+                    imageId = "img-1", filePath = "/data/img.png", pattern = "ripple",
+                    editing = false, previousImagePath = null, generating = false,
+                )
+            ),
+            null, stopped = false,
+        )!!
+        val segment = draft.segments.single()
+        assertEquals("image", segment.type)
+        assertEquals("/data/img.png", segment.image?.filePath)
+        assertEquals("img-1", segment.image?.imageId)
+    }
+
+    @Test fun `a still-generating image placeholder is not persisted`() {
+        val draft = AssistantMessagePersistence.draft(
+            listOf(
+                StreamSegment.Image(
+                    imageId = null, filePath = null, pattern = "rain",
+                    editing = false, previousImagePath = null, generating = true,
+                )
+            ),
+            null, stopped = false,
+        )
+        assertNull(draft)
+    }
+
     @Test fun `normalizes reasoning only answer and appends interruption`() {
         val draft = AssistantMessagePersistence.draft(
             listOf(StreamSegment.Reasoning("work\nAnswer: result")), "timeout", stopped = false,

--- a/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
+++ b/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
@@ -25,6 +25,29 @@ class ChatSegmentReducerTest {
         assertEquals("working", ChatSegmentReducer.reduce(segments, StreamChunk.StatusNote("working")))
     }
 
+    @Test fun `image generation seeds a pending placeholder and resolves on the saved file`() {
+        val segments = mutableListOf<StreamSegment>()
+        ChatSegmentReducer.reduce(segments, StreamChunk.ImageGenStarted("rain", editing = true, previousImagePath = "/old.png"))
+        val pending = segments.single() as StreamSegment.Image
+        assertEquals("rain", pending.pattern)
+        assertEquals("/old.png", pending.previousImagePath)
+        ChatSegmentReducer.reduce(segments, StreamChunk.Content("Here you go"))
+        ChatSegmentReducer.reduce(segments, StreamChunk.ImageGenerated(dataUrl = "", filePath = "/new.png", imageId = "img-1"))
+        val resolved = segments.filterIsInstance<StreamSegment.Image>().single()
+        assertFalse(resolved.generating)
+        assertEquals("/new.png", resolved.filePath)
+        assertEquals("img-1", resolved.imageId)
+    }
+
+    @Test fun `an unsaved base64 image chunk never reaches the timeline`() {
+        val segments = mutableListOf<StreamSegment>()
+        ChatSegmentReducer.reduce(segments, StreamChunk.ImageGenStarted("ripple", editing = false))
+        ChatSegmentReducer.reduce(segments, StreamChunk.ImageGenerated(dataUrl = "data:image/png;base64,AAAA"))
+        val image = segments.single() as StreamSegment.Image
+        assertNull(image.filePath)
+        assertEquals(true, image.generating)
+    }
+
     @Test fun `real output removes transient agent banner`() {
         val segments = mutableListOf<StreamSegment>()
         assertNull(ChatSegmentReducer.reduce(segments, StreamChunk.AgentRunStarted))

--- a/app/src/test/java/com/echoflow/ui/ImageGenAnimationTest.kt
+++ b/app/src/test/java/com/echoflow/ui/ImageGenAnimationTest.kt
@@ -1,0 +1,56 @@
+package com.echoflow.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class ImageGenAnimationTest {
+    @Test fun `ripple has a crest during travel and full silence in the rest beat`() {
+        // Mid-travel the crest sits somewhere in the field at near-full intensity.
+        val midTravel = ImageDotField.TRAVEL_MS / 2
+        val peak = (0..40).maxOf { step ->
+            ImageDotField.rippleIntensity(ImageDotField.maxDistance * step / 40f, midTravel)
+        }
+        assertTrue("crest should light up, was $peak", peak > 0.8f)
+        // Between TRAVEL_MS and CYCLE_MS every dot rests at zero — the deliberate breath.
+        val resting = ImageDotField.rippleIntensity(3f, ImageDotField.TRAVEL_MS + 400)
+        assertEquals(0f, resting, 1e-6f)
+    }
+
+    @Test fun `ripple crest travels outward over time`() {
+        fun crestPosition(t: Long): Float = (0..200)
+            .map { it * ImageDotField.maxDistance / 200f }
+            .maxBy { ImageDotField.rippleIntensity(it, t) }
+        assertTrue(crestPosition(1500) > crestPosition(400))
+    }
+
+    @Test fun `rain drops fall independently and stay column-bound`() {
+        val field = RainField(Random(7))
+        var time = 0L
+        repeat(200) { time += 16; field.step(time, 16) }
+        assertTrue("drops should have spawned", field.drops.isNotEmpty())
+        assertTrue(field.drops.size <= RainField.MAX_DROPS)
+        assertTrue(field.drops.all { it.col in 0 until ImageDotField.GRID })
+        // Not row-synchronized: heads sit at different fractional rows.
+        if (field.drops.size > 2) {
+            assertTrue(field.drops.map { it.y }.distinct().size > 1)
+        }
+        // A dot in a drop's column near its head is lit; other columns stay dark.
+        val drop = field.drops.first { it.y in 1f..(ImageDotField.GRID - 1f) }
+        val row = drop.y.toInt()
+        assertTrue(field.intensityAt(drop.col, row) > 0.2f)
+        val emptyCol = (0 until ImageDotField.GRID).first { col -> field.drops.none { it.col == col } }
+        assertEquals(0f, field.intensityAt(emptyCol, row), 1e-6f)
+    }
+
+    @Test fun `phrase deck deals all 100 without repeats then reshuffles`() {
+        assertEquals(100, ImageGenPhrases.ALL.size)
+        assertEquals(100, ImageGenPhrases.ALL.distinct().size)
+        val deck = PhraseDeck(random = Random(3))
+        val firstPass = List(100) { deck.next() }
+        assertEquals(100, firstPass.distinct().size)
+        // The deck keeps dealing after exhaustion.
+        assertTrue(deck.next() in ImageGenPhrases.ALL)
+    }
+}


### PR DESCRIPTION
## What changedAdds a full image-generation feature behind a new **"Create image"** entry in the chat "+" menu (`ChatMode.ImageGen`, sticky like the other modes):- **OpenRouter wiring** — image turns run a normal streaming chat completion with `modalities: ["image","text"]` against an image-output model (default `google/gemini-2.5-flash-image`). `OpenRouterStreamTransport` now decodes base64 image deltas (deduped across delta/final-message repeats) into a new `StreamChunk.ImageGenerated`.- **Conversational editing** — follow-up turns re-attach the chat's latest generated image to the newest user message (`OpenRouterPayloads.attachImageToLastUserMessage`), so "make the sky purple" revises the image in place. History goes as text; only the newest image ships, keeping per-turn cost flat. User photo attachments compose with this ("edit my photo").- **Storage (Room v13)** — `GeneratedImageStore` writes PNGs under `filesDir/generated_images/` and records rows in a new `generated_images` table with a `parentId` version chain; `image_models` holds the user's whitelist. Explicit `MIGRATION_12_13`; base64 never enters Room or `segmentsJson` — the ViewModel intercepts raw image chunks, saves to disk, and re-emits path-only chunks (the reducer ignores unsaved ones).- **Placeholder animation** — a 21×21 theme-colored dot field (M3 dynamic-color + dark-mode adaptive): dots rest near-silent while a narrow ripple wave or probabilistic rain streaks travel through, crest dots morphing toward squircles. **Ripple or rain is chosen at random per generation.** A shuffled deck of 100 status phrases crossfades below; edit turns show the previous version blurred under the dots. Pure math lives in `ui/ImageGenAnimation.kt` (unit-tested).- **Reveal + inline rendering** — finished images unmask with a top-down glowing scanline wipe and spring settle, render inline in the reply (height-capped), with save-to-gallery, share (via MediaStore, no FileProvider needed), and a fullscreen viewer. Persisted chats re-render images from disk.- **Settings** — new "Image generation" hub page: pick the default model, manage the whitelist, and browse the OpenRouter directory **filtered to models whose `output_modalities` include "image"** (directory parsing extended to read `architecture.output_modalities`).## TestsNew/extended units: `ImageGenAnimationTest` (ripple crest/rest beat, rain independence and column-binding, phrase-deck no-repeat), `ChatSegmentReducerTest` (placeholder seed/resolve, unsaved-chunk guard), `AssistantMessagePersistenceTest` (image durable without text; pending placeholder never persists), `OpenRouterPayloadsTest` (edit-image attachment shapes), `DatabaseUpgradeTest` (v1 → v13 chain, new tables queryable).## Reviewer notes- **Not built from CLI** (project convention): please build in Android Studio, run the unit tests, and commit the newly exported Room schema `app/schemas/13.json` if it isn't picked up automatically.- **Verify the SSE image shape with a real key** — `OpenRouterImagePayload` models both the documented `delta.images[].image_url.url` and a flattened `url` variant, but this API surface is young (same caveat class as the Echo modes).- `SettingsViewModel`/`ChatViewModel` factories and `EchoFlowAppGraph` gained the new DAOs; settings hub rows renumbered 6 → 7.<!-- This is an auto-generated comment: release notes by coderabbit.ai -->## Summary by CodeRabbit* **New Features**  * Added image generation mode for creating and editing images in chat.  * Added animated generation previews and polished image result displays.  * Added fullscreen viewing, saving, and sharing for generated images.  * Added image-generation model selection and model directory browsing in Settings.  * Generated images now persist in chat history for later viewing and editing.* **Bug Fixes**  * Improved handling of image attachments and persisted generated-image results.* **Tests**  * Added coverage for image generation, persistence, payload handling, animations, and database upgrades.<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- greptile_comment --><h3>Greptile Summary</h3>This PR adds OpenRouter-backed image generation and image editing in chat. The main changes are:- Adds image-generation mode, streaming image handling, and inline rendering.- Stores generated images on disk with Room metadata and version links.- Adds image-model settings, directory filtering, and generation UI states.- Extends chat persistence and database migration support for generated images.<h3>Confidence Score: 4/5</h3>The active image-generation deletion path should be fixed before merging.- Final-message image handling now covers empty delta image lists.- Deleting a chat during image generation can still leave an unreachable PNG on disk.app/src/main/java/com/echoflow/ui/ChatViewModel.kt; app/src/main/java/com/echoflow/data/GeneratedImageStore.kt<h3>Important Files Changed</h3>| Filename | Overview ||----------|----------|| app/src/main/java/com/echoflow/data/OpenRouterStreamTransport.kt | Combines delta and final-message image payloads so empty delta image lists no longer hide completed images. || app/src/main/java/com/echoflow/data/GeneratedImageStore.kt | Adds disk-backed image storage and per-chat file cleanup, but cleanup is not synchronized with active image writes. || app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Connects image generation, persistence, and thread deletion; active streams can write images after deletion cleanup begins. |<h3>Sequence Diagram</h3><a href="#gh-light-mode-only">```mermaid%%{init: {'theme': 'neutral'}}%%sequenceDiagram    participant User    participant Chat as ChatViewModel    participant API as OpenRouter    participant Store as GeneratedImageStore    participant DB as Room    User->>Chat: Create or edit image    Chat->>API: Streaming request with image modalities    API-->>Chat: ImageGenerated data URL    Chat->>Store: Save decoded image    Store->>DB: Insert generated-image record    Store-->>Chat: File path and image ID    Chat-->>User: Render persisted image```</a><a href="#gh-dark-mode-only">```mermaid%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%sequenceDiagram    participant User    participant Chat as ChatViewModel    participant API as OpenRouter    participant Store as GeneratedImageStore    participant DB as Room    User->>Chat: Create or edit image    Chat->>API: Streaming request with image modalities    API-->>Chat: ImageGenerated data URL    Chat->>Store: Save decoded image    Store->>DB: Insert generated-image record    Store-->>Chat: File path and image ID    Chat-->>User: Render persisted image```</a><sub>Reviews (2): Last reviewed commit: ["fix: read final-message images and clean..."](https://github.com/adityavardhansharma/echoflow/commit/d5724b7a22b6982b27a6a383ff13c4cab107ffcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43511977)</sub>> Greptile also left **1 inline comment** on this PR.**Context used:**- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))<!-- /greptile_comment -->