### PR TITLE
Image gen polish: smooth dot animation, compact placeholder, image-only model picker

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -69,6 +68,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -100,11 +101,11 @@ fun GeneratingImageCard(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxWidth()) {
+        // Deliberately compact while waiting — a full-width square dominates a phone screen.
+        // The finished image (a separate block) is allowed to render larger.
         Box(
             Modifier
-                .widthIn(max = 340.dp)
-                .fillMaxWidth()
-                .aspectRatio(1f)
+                .size(216.dp)
                 .clip(RoundedCornerShape(20.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         ) {
@@ -143,6 +144,10 @@ private fun DotFieldCanvas(pattern: String, modifier: Modifier = Modifier) {
         }
     }
     val dotColor = MaterialTheme.colorScheme.primary
+    // Crest dots shift tone within the same hue — brighter on dark themes, deeper on light —
+    // matching M3 tonal-palette behaviour instead of only changing opacity.
+    val darkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val crestColor = lerp(dotColor, if (darkTheme) Color.White else Color.Black, 0.18f)
     Canvas(modifier) {
         // Reading timeMs inside the draw block redraws every frame without recomposing.
         val t = timeMs
@@ -156,24 +161,23 @@ private fun DotFieldCanvas(pattern: String, modifier: Modifier = Modifier) {
                 } else {
                     ImageDotField.rippleIntensity(ImageDotField.distanceFromCenter(col, row), t)
                 }
+                // Every channel — size, opacity, tone, shape — is a CONTINUOUS function of one
+                // intensity value. No thresholds: a threshold reads as a per-frame pop.
                 val alpha = 0.15f + 0.85f * intensity
                 val radius = restRadius * (1f + 1.35f * intensity)
                 val cx = col * cell + cell / 2f
                 val cy = row * cell + cell / 2f
-                if (intensity > 0.25f) {
-                    // The crest morphs circles toward soft squircles — the Expressive accent.
-                    val side = radius * 3.4f
-                    val corner = side * (0.5f - 0.28f * intensity)
-                    drawRoundRect(
-                        color = dotColor,
-                        alpha = alpha,
-                        topLeft = Offset(cx - side / 2f, cy - side / 2f),
-                        size = Size(side, side),
-                        cornerRadius = CornerRadius(corner, corner),
-                    )
-                } else {
-                    drawCircle(color = dotColor, alpha = alpha, radius = radius, center = Offset(cx, cy))
-                }
+                val side = radius * 2f
+                // Corner radius eases from a perfect circle (side/2) toward a soft squircle as
+                // the crest passes — the Expressive morph, with no discontinuity at any point.
+                val corner = side * (0.5f - 0.24f * intensity * intensity * (3f - 2f * intensity))
+                drawRoundRect(
+                    color = lerp(dotColor, crestColor, intensity),
+                    alpha = alpha,
+                    topLeft = Offset(cx - side / 2f, cy - side / 2f),
+                    size = Size(side, side),
+                    cornerRadius = CornerRadius(corner, corner),
+                )
             }
         }
     }
@@ -252,20 +256,23 @@ fun GeneratedImageBlock(
                         clipRect(bottom = size.height * reveal) { this@drawWithContent.drawContent() }
                         if (reveal < 1f) {
                             val y = size.height * reveal
-                            // Soft glow trail above the line, then the bright 3px scanline.
+                            // Density-aware: raw px here would render a near-invisible hairline
+                            // on a modern phone screen instead of a visible glowing sweep.
+                            val lineHeight = 2.5.dp.toPx()
+                            val glowHeight = 40.dp.toPx()
                             drawRect(
                                 brush = Brush.verticalGradient(
-                                    colors = listOf(Color.Transparent, scanColor.copy(alpha = 0.35f)),
-                                    startY = (y - 48f).coerceAtLeast(0f),
+                                    colors = listOf(Color.Transparent, scanColor.copy(alpha = 0.4f)),
+                                    startY = (y - glowHeight).coerceAtLeast(0f),
                                     endY = y,
                                 ),
-                                topLeft = Offset(0f, (y - 48f).coerceAtLeast(0f)),
-                                size = Size(size.width, 48f.coerceAtMost(y)),
+                                topLeft = Offset(0f, (y - glowHeight).coerceAtLeast(0f)),
+                                size = Size(size.width, glowHeight.coerceAtMost(y)),
                             )
                             drawRect(
                                 color = scanColor,
-                                topLeft = Offset(0f, y - 1.5f),
-                                size = Size(size.width, 3f),
+                                topLeft = Offset(0f, y - lineHeight / 2f),
+                                size = Size(size.width, lineHeight),
                             )
                         }
                     },

--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -102,10 +102,13 @@ fun GeneratingImageCard(
 ) {
     Column(modifier.fillMaxWidth()) {
         // Deliberately compact while waiting — a full-width square dominates a phone screen.
-        // The finished image (a separate block) is allowed to render larger.
+        // Capped, not fixed: in a pane narrower than 216dp (split-screen, folded) the card
+        // shrinks with its parent instead of clipping. The finished image renders larger.
         Box(
             Modifier
-                .size(216.dp)
+                .widthIn(max = 216.dp)
+                .fillMaxWidth()
+                .aspectRatio(1f)
                 .clip(RoundedCornerShape(20.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         ) {

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -169,6 +169,14 @@ fun ChatScreen(
 
     val artifactActive by chatViewModel.artifactActive.collectAsState()
     val imageGenActive by chatViewModel.imageGenActive.collectAsState()
+    val imageGenModelId by settingsViewModel.imageGenModelId.collectAsState()
+    val imageModels by settingsViewModel.imageModels.collectAsState()
+    // "Create image" swaps the model picker to image-output models only.
+    val imageModelEntries = remember(imageModels) {
+        val default = com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
+        listOf(default) + imageModels.filter { it.id != default.first }.map { it.id to it.name }
+    }
+    val imageModelLabel = imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -337,6 +345,7 @@ fun ChatScreen(
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
                 modelName = when {
+                    imageGenActive -> imageModelLabel
                     echoFusionActive -> activePanel?.name ?: "Choose panel"
                     echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
                     echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
@@ -460,7 +469,16 @@ fun ChatScreen(
     }
 
     if (showModelMenu) {
-        if (echoFusionActive) {
+        if (imageGenActive) {
+            ModelPickerSheet(
+                models = imageModelEntries,
+                localModels = emptyList(),
+                selectedId = imageGenModelId,
+                onSelect = { settingsViewModel.saveImageGenModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoFusionActive) {
             FusionPickerSheet(
                 panels = fusionPanels,
                 selectedId = echoFusionPanelId,


### PR DESCRIPTION
## What changed

Two follow-ups to the image generation feature (#60):

**Placeholder animation polish** (`ImageGenComponents.kt`)
- Removed the intensity threshold that made dots pop between a circle and a ~70% larger rounded square in a single frame. Every dot is now a rounded rect whose size, opacity, tone, and corner radius are all continuous functions of one intensity value — the corner radius eases from a perfect circle at rest toward a squircle at the crest via smoothstep, so no frame can jump.
- Crest dots now shift tone within the theme hue (brighter on dark themes, deeper on light) instead of only changing opacity, matching the intended M3 tonal behaviour.
- The reveal scanline and its glow are drawn in dp (2.5dp line, 40dp glow) instead of raw pixels — the old values rendered as a near-invisible hairline on high-density screens.
- The generating placeholder is a compact 216dp card instead of a near-full-width square; the finished image still renders at the larger width after the reveal.

**Model picker respects Create image mode** (`ChatScreen.kt`)
- While the "Create image" chip is active, the top-bar model selector shows the active image model and opens a picker restricted to image-output models (the built-in default plus models added in Settings → Image generation). Selecting one saves the image-gen default; the normal chat picker returns when the chip is off.

## Reviewer notes

- Pure UI changes — no data, schema, or streaming behaviour touched.
- Judge animation smoothness on a real device in Android Studio, not preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image-only model selection while Create Image mode is active.
  * Updated the model picker and top bar to display the selected image model.
  * Improved image-generation visuals with smoother dot rendering and density-aware scanline effects.

* **UI Improvements**
  * Adjusted the image-generation placeholder to a compact square layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes image creation more focused and visually polished. The main changes are:

- A compact, responsive image-generation placeholder.
- Smoother dot and reveal-scanline animation.
- An image-only model picker while Create image is active.

<h3>Confidence Score: 4/5</h3>

This should be fixed before merging.

- The updated placeholder cannot compile until the missing `aspectRatio` import is restored.
- The image-model picker changes otherwise preserve the image-generation model flow.

app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt | Updates the placeholder layout and animation, but the new layout modifier has an unresolved import. |
| app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt | Shows and selects the persisted image-generation model when image mode is active. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt`, line 23-27 ([link](https://github.com/adityavardhansharma/echoflow/blob/092c29ea8d635e0aa9a230558811c35eb446ee1c/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt#L23-L27)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing layout import** The responsive card now calls `aspectRatio(1f)`, but `androidx.compose.foundation.layout.aspectRatio` was removed from this file's imports. Kotlin cannot resolve this extension, so the app module fails to compile. Restore the import.

   **Context Used:** always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: let the generating placeholder shri..."](https://github.com/adityavardhansharma/echoflow/commit/092c29ea8d635e0aa9a230558811c35eb446ee1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43629900)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->