### PR TITLE
Fix release build: restore aspectRatio import in ImageGenComponents

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height


### PR DESCRIPTION
## What changed

One-line build fix: restores the `androidx.compose.foundation.layout.aspectRatio` import in `ImageGenComponents.kt`.

## Why

The animation-polish commit in #61 removed the import while it was unused, and the narrow-pane placeholder fix then reintroduced `aspectRatio(1f)` without restoring it, so `assembleRelease` fails on main with `Unresolved reference 'aspectRatio'` at ImageGenComponents.kt:111.

## Reviewer notes

- The KSP `AWT-EventQueue` NullPointerException earlier in the same CI log is cosmetic noise from Room's processor — its task succeeded; the compile error was the only real failure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the Compose layout import needed by the image-generation placeholder.

- Adds the `aspectRatio` extension import.
- Restores compilation for the existing `Modifier.aspectRatio(1f)` call.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt | Adds the missing Compose `aspectRatio` import for the existing placeholder modifier. |

<sub>Reviews (1): Last reviewed commit: ["fix: restore aspectRatio import dropped ..."](https://github.com/adityavardhansharma/echoflow/commit/a0d781aa62c8048640216e98e9909df9320e3647) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43631528)</sub>

<!-- /greptile_comment -->