### PR TITLE
Fix release build matchParentSize import

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width


### PR DESCRIPTION
## What changed
- removed the invalid top-level `matchParentSize` import from `ImageGenComponents.kt`

## Why
`matchParentSize()` is provided by the surrounding Compose `BoxScope`; importing it as a package-level extension fails release Kotlin compilation with an unresolved reference.

## Impact
Restores release compilation while preserving the existing image layout behavior.

## Validation
- `git diff --cached --check` passed before commit
- Build not run at the user's request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes an invalid Compose import from the image-generation UI.

- Removes the package-level `matchParentSize` import.
- Keeps the existing `BoxScope` layout calls unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt | Removes an invalid top-level Compose import while retaining the existing Box-scoped layout calls. |

<sub>Reviews (1): Last reviewed commit: ["fix: remove invalid matchParentSize impo..."](https://github.com/adityavardhansharma/echoflow/commit/0c82add139443f6569f1e5b10863d7fac881c1c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43635405)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused layout imports without changing visible functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->