### PR TITLE
Add on-device image generation with persistent model downloads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
   buildFeatures {
+    aidl = true
     compose = true
     buildConfig = true
   }
@@ -107,6 +108,7 @@ dependencies {
   implementation(libs.androidx.navigation.compose)
   implementation(libs.androidx.room.ktx)
   implementation(libs.androidx.room.runtime)
+  implementation(libs.androidx.work.runtime.ktx)
   implementation(libs.androidx.security.crypto)
   implementation(libs.coil.compose)
   implementation(libs.converter.moshi)
@@ -116,7 +118,9 @@ dependencies {
   implementation(libs.logging.interceptor)
   implementation(libs.litertlm.android)
   implementation(libs.llamacpp.kotlin)
+  implementation(libs.llamatik)
   implementation(libs.mediapipe.tasks.genai)
+  implementation(libs.mediapipe.tasks.vision.image.generator)
   implementation(libs.moshi.kotlin)
   implementation(libs.okhttp)
   // implementation(libs.play.services.location)
@@ -124,6 +128,7 @@ dependencies {
   testImplementation(libs.androidx.compose.ui.test.junit4)
   testImplementation(libs.androidx.core)
   testImplementation(libs.androidx.junit)
+  testImplementation(libs.androidx.work.testing)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.robolectric)

--- a/app/schemas/com.echoflow.data.AppDatabase/14.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/14.json
@@ -1,0 +1,1121 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "c0045c8ba9f5e6dfedbff136c245cbf9",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `directoryName` TEXT NOT NULL, `installedBytes` INTEGER NOT NULL, `sourceRevision` TEXT NOT NULL, `sourceCheckpointSha256` TEXT NOT NULL, `bundleSha256` TEXT NOT NULL, `licenseId` TEXT NOT NULL, `activationPhrase` TEXT, `defaultNegativePrompt` TEXT, `bundleFormatVersion` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryName",
+            "columnName": "directoryName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedBytes",
+            "columnName": "installedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRevision",
+            "columnName": "sourceRevision",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceCheckpointSha256",
+            "columnName": "sourceCheckpointSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleSha256",
+            "columnName": "bundleSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseId",
+            "columnName": "licenseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activationPhrase",
+            "columnName": "activationPhrase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultNegativePrompt",
+            "columnName": "defaultNegativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bundleFormatVersion",
+            "columnName": "bundleFormatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c0045c8ba9f5e6dfedbff136c245cbf9')"
+    ]
+  }
+}

--- a/app/schemas/com.echoflow.data.AppDatabase/15.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/15.json
@@ -1,0 +1,1133 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "3043ed308e289fd7e1b054462e3a63ae",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `directoryName` TEXT NOT NULL, `installedBytes` INTEGER NOT NULL, `sourceRevision` TEXT NOT NULL, `sourceCheckpointSha256` TEXT NOT NULL, `bundleSha256` TEXT NOT NULL, `licenseId` TEXT NOT NULL, `activationPhrase` TEXT, `defaultNegativePrompt` TEXT, `bundleFormatVersion` INTEGER NOT NULL, `runtime` TEXT NOT NULL DEFAULT 'mediapipe', `modelFileName` TEXT, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryName",
+            "columnName": "directoryName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedBytes",
+            "columnName": "installedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRevision",
+            "columnName": "sourceRevision",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceCheckpointSha256",
+            "columnName": "sourceCheckpointSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleSha256",
+            "columnName": "bundleSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseId",
+            "columnName": "licenseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activationPhrase",
+            "columnName": "activationPhrase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultNegativePrompt",
+            "columnName": "defaultNegativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bundleFormatVersion",
+            "columnName": "bundleFormatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'mediapipe'"
+          },
+          {
+            "fieldPath": "modelFileName",
+            "columnName": "modelFileName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3043ed308e289fd7e1b054462e3a63ae')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <!-- LiteRT-LM may declare a higher library minSdk than ours; local models only run
          on modern arm64 devices in practice, so merging it in is safe. -->
-    <uses-sdk tools:overrideLibrary="com.google.ai.edge.litertlm" />
+    <uses-sdk tools:overrideLibrary="com.google.ai.edge.litertlm,com.llamatik" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -21,6 +21,19 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.EchoFlow">
+
+        <!-- MediaPipe Image Generator runs diffusion on the GPU where a vendor OpenCL
+             driver exists; all are optional so devices without them still install. -->
+        <uses-native-library
+            android:name="libOpenCL.so"
+            android:required="false" />
+        <uses-native-library
+            android:name="libOpenCL-car.so"
+            android:required="false" />
+        <uses-native-library
+            android:name="libOpenCL-pixel.so"
+            android:required="false" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -39,10 +52,26 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- Long-running model downloads are owned by WorkManager so they can resume after
+             process death. Android 14+ requires the foreground-service type on its merged
+             service as well as on the ForegroundInfo supplied by the worker. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+
         <service
             android:name=".data.DeepResearchForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Experimental checkpoints run out-of-process so an unsupported model or native
+             memory failure cannot terminate the app or damage its persisted data. -->
+        <service
+            android:name=".data.StableDiffusionGenerationService"
+            android:exported="false"
+            android:process=":image_generation"
+            android:stopWithTask="false" />
     </application>
 
 </manifest>

--- a/app/src/main/aidl/com/echoflow/data/IStableDiffusionGenerationCallback.aidl
+++ b/app/src/main/aidl/com/echoflow/data/IStableDiffusionGenerationCallback.aidl
@@ -1,0 +1,7 @@
+package com.echoflow.data;
+
+/** Result channel for the isolated stable-diffusion.cpp process. */
+oneway interface IStableDiffusionGenerationCallback {
+    void onSuccess(String pngPath);
+    void onError(String message);
+}

--- a/app/src/main/aidl/com/echoflow/data/IStableDiffusionGenerationService.aidl
+++ b/app/src/main/aidl/com/echoflow/data/IStableDiffusionGenerationService.aidl
@@ -1,0 +1,24 @@
+package com.echoflow.data;
+
+import com.echoflow.data.IStableDiffusionGenerationCallback;
+
+/**
+ * Small cross-process API around stable-diffusion.cpp. Image bytes are written to an
+ * app-private temporary PNG instead of crossing Binder's transaction-size limit.
+ */
+interface IStableDiffusionGenerationService {
+    void generate(
+        String modelPath,
+        String prompt,
+        String negativePrompt,
+        int width,
+        int height,
+        int steps,
+        float cfgScale,
+        long seed,
+        IStableDiffusionGenerationCallback callback
+    );
+
+    void cancel();
+    void release();
+}

--- a/app/src/main/assets/third_party_notices/on_device_image_runtime.txt
+++ b/app/src/main/assets/third_party_notices/on_device_image_runtime.txt
@@ -1,0 +1,47 @@
+ON-DEVICE IMAGE RUNTIME NOTICES
+
+The experimental on-device image runtime includes the following software:
+
+Llamatik 1.9.0
+Copyright (c) 2025 Ferran Pons
+Source: https://github.com/ferranpons/llamatik/tree/v1.9.0
+Repository licence: MIT. (The Maven POM labels the artifact Apache-2.0; the
+repository's LICENSE file is the source used for this notice.)
+
+stable-diffusion.cpp
+Copyright (c) 2023 leejet
+Source revision: 90e87bc846f17059771efb8aaa31e9ef0cab6f78
+Licence: MIT
+
+llama.cpp, ggml and whisper.cpp
+Copyright (c) 2023-2026 The ggml authors
+Licence: MIT
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+LLVM OpenMP runtime (libomp)
+Copyright (c) 1997-2019 Intel Corporation and LLVM contributors
+Licence: Apache License 2.0 with LLVM Exceptions
+Full upstream licence text:
+https://github.com/llvm/llvm-project/blob/main/openmp/LICENSE.TXT
+
+Model weights are not bundled in the application. Their licence/terms and
+source links are shown in each model's details before or after download.

--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -2,6 +2,8 @@ package com.echoflow
 
 import android.app.Application
 import com.echoflow.data.AppDatabase
+import com.echoflow.data.LocalImageModelManager
+import com.echoflow.data.LocalInferenceGate
 import com.echoflow.data.ModelDownloadManager
 import com.echoflow.data.SettingsRepository
 import com.echoflow.ui.ChatViewModel
@@ -18,6 +20,11 @@ class EchoFlowAppGraph(application: Application) {
     val settingsRepository = SettingsRepository(application.applicationContext)
     private val modelDownloadManager =
         ModelDownloadManager(application.applicationContext, database.localModelDao())
+    private val localImageModelManager =
+        LocalImageModelManager(application.applicationContext, database.localImageModelDao())
+
+    // One gate app-wide: local LLM inference and local image generation never overlap.
+    private val localInferenceGate = LocalInferenceGate()
 
     val settingsViewModelFactory by lazy {
         SettingsViewModel.provideFactory(
@@ -30,6 +37,9 @@ class EchoFlowAppGraph(application: Application) {
             database.fusionPanelDao(),
             database.agentProfileDao(),
             database.imageModelDao(),
+            database.localImageModelDao(),
+            localImageModelManager,
+            localInferenceGate,
         )
     }
 
@@ -50,6 +60,9 @@ class EchoFlowAppGraph(application: Application) {
             database.artifactDao(),
             database.artifactVersionDao(),
             database.generatedImageDao(),
+            database.localImageModelDao(),
+            localImageModelManager,
+            localInferenceGate,
         )
     }
 }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -13,9 +13,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
         AgentProfile::class, BrowserSession::class, BrowserStep::class,
         Artifact::class, ArtifactVersion::class,
-        ImageModel::class, GeneratedImage::class
+        ImageModel::class, GeneratedImage::class, LocalImageModel::class
     ],
-    version = 13, // v13: image_models + generated_images (MIGRATION_12_13)
+    version = 15, // v15: runtime metadata for mixed local image engines
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,6 +34,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun artifactVersionDao(): ArtifactVersionDao
     abstract fun imageModelDao(): ImageModelDao
     abstract fun generatedImageDao(): GeneratedImageDao
+    abstract fun localImageModelDao(): LocalImageModelDao
 
     companion object {
         @Volatile
@@ -257,6 +258,39 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS local_image_models (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "directoryName TEXT NOT NULL, " +
+                        "installedBytes INTEGER NOT NULL, " +
+                        "sourceRevision TEXT NOT NULL, " +
+                        "sourceCheckpointSha256 TEXT NOT NULL, " +
+                        "bundleSha256 TEXT NOT NULL, " +
+                        "licenseId TEXT NOT NULL, " +
+                        "activationPhrase TEXT, " +
+                        "defaultNegativePrompt TEXT, " +
+                        "bundleFormatVersion INTEGER NOT NULL, " +
+                        "addedAt INTEGER NOT NULL)"
+                )
+            }
+        }
+
+        /** Existing v14 installs were all MediaPipe directory bundles. */
+        internal val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE local_image_models ADD COLUMN runtime TEXT NOT NULL " +
+                        "DEFAULT 'mediapipe'"
+                )
+                db.execSQL(
+                    "ALTER TABLE local_image_models ADD COLUMN modelFileName TEXT"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -277,6 +311,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_10_11,
                     MIGRATION_11_12,
                     MIGRATION_12_13,
+                    MIGRATION_13_14,
+                    MIGRATION_14_15,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -143,6 +143,24 @@ interface ImageModelDao {
 }
 
 @Dao
+interface LocalImageModelDao {
+    @Query("SELECT * FROM local_image_models ORDER BY addedAt ASC")
+    fun getAll(): Flow<List<LocalImageModel>>
+
+    @Query("SELECT * FROM local_image_models ORDER BY addedAt ASC")
+    suspend fun getAllSync(): List<LocalImageModel>
+
+    @Query("SELECT * FROM local_image_models WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): LocalImageModel?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(model: LocalImageModel)
+
+    @Query("DELETE FROM local_image_models WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
 interface GeneratedImageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(image: GeneratedImage)

--- a/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
+++ b/app/src/main/java/com/echoflow/data/GeneratedImageStore.kt
@@ -46,6 +46,92 @@ class GeneratedImageStore(
         image
     }
 
+    /**
+     * Persists an on-device generation result. The PNG is compressed to a temporary file
+     * and atomically renamed, and the Room row is only inserted once the final file exists —
+     * a failed compression leaves neither a file nor a row behind.
+     */
+    suspend fun saveBitmap(
+        chatId: String,
+        prompt: String,
+        bitmap: android.graphics.Bitmap,
+        parentId: String?,
+    ): GeneratedImage = withContext(Dispatchers.IO) {
+        imagesDir.mkdirs()
+        val id = UUID.randomUUID().toString()
+        val finalFile = File(imagesDir, "$id.png")
+        val tempFile = File(imagesDir, "$id.png.tmp")
+        try {
+            tempFile.outputStream().use { out ->
+                if (!bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)) {
+                    throw Exception("Could not encode the generated image.")
+                }
+            }
+            if (!tempFile.renameTo(finalFile)) {
+                tempFile.copyTo(finalFile, overwrite = true)
+                tempFile.delete()
+            }
+        } catch (e: Exception) {
+            tempFile.delete()
+            finalFile.delete()
+            throw e
+        }
+        val image = GeneratedImage(
+            id = id,
+            chatId = chatId,
+            filePath = finalFile.absolutePath,
+            prompt = prompt,
+            parentId = parentId,
+            createdAt = System.currentTimeMillis(),
+        )
+        dao.insert(image)
+        image
+    }
+
+    /**
+     * Adopts a PNG produced by the isolated native image process. Moving a file path keeps
+     * the full-resolution bitmap out of Binder and avoids decoding/re-encoding it in the
+     * main process. The source must be an app-private pending file.
+     */
+    suspend fun savePngFile(
+        chatId: String,
+        prompt: String,
+        pendingFile: File,
+        parentId: String?,
+    ): GeneratedImage = withContext(Dispatchers.IO) {
+        val canonicalPending = pendingFile.canonicalFile
+        val allowedRoot = File(imagesDir, ".native_pending").canonicalFile
+        require(
+            canonicalPending.parentFile == allowedRoot &&
+                canonicalPending.isFile &&
+                canonicalPending.extension.equals("png", ignoreCase = true)
+        ) { "The native image result was invalid." }
+
+        imagesDir.mkdirs()
+        val id = UUID.randomUUID().toString()
+        val finalFile = File(imagesDir, "$id.png")
+        try {
+            if (!canonicalPending.renameTo(finalFile)) {
+                canonicalPending.copyTo(finalFile, overwrite = false)
+                canonicalPending.delete()
+            }
+            val image = GeneratedImage(
+                id = id,
+                chatId = chatId,
+                filePath = finalFile.absolutePath,
+                prompt = prompt,
+                parentId = parentId,
+                createdAt = System.currentTimeMillis(),
+            )
+            dao.insert(image)
+            image
+        } catch (e: Exception) {
+            canonicalPending.delete()
+            finalFile.delete()
+            throw e
+        }
+    }
+
     /** The newest version in this chat — the image a follow-up edit turn revises. */
     suspend fun latestForChat(chatId: String): GeneratedImage? {
         val latest = dao.getLatestForChat(chatId) ?: return null

--- a/app/src/main/java/com/echoflow/data/ImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/ImageGenerationEngine.kt
@@ -1,0 +1,55 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * One image-generation turn, engine-agnostic. Cloud-only fields ([apiKey], [history],
+ * [systemPrompt], [editImageDataUrl]) are ignored by the on-device engine; local-only
+ * fields ([localModel], [iterations], [seed]) are ignored by the cloud engine.
+ */
+data class ImageGenerationRequest(
+    val chatId: String,
+    val prompt: String,
+    val negativePrompt: String? = null,
+    val modelId: String,
+    val iterations: Int = SettingsRepository.LOCAL_IMAGE_ITERATIONS_DEFAULT,
+    val seed: Int? = null, // null = random per generation
+    val previousImage: GeneratedImage? = null,
+    // Cloud (OpenRouter) context:
+    val apiKey: String = "",
+    val history: List<ChatMessage> = emptyList(),
+    val systemPrompt: String = "",
+    val editImageDataUrl: String? = null,
+    val params: InferenceParams? = null,
+    // On-device context. The selected model carries its own runtime discriminator.
+    val localModel: LocalImageModel? = null,
+    val localModelInstallDir: String? = null,
+)
+
+/** What an engine emits while a generation runs. Failures surface as flow exceptions. */
+sealed interface ImageGenerationEvent {
+    /** Streamed assistant text accompanying the image (cloud engines only). */
+    data class Text(val delta: String) : ImageGenerationEvent
+
+    /** The finished image, already persisted to disk + Room by the engine. */
+    data class ImageFile(val image: GeneratedImage) : ImageGenerationEvent
+}
+
+/** Typed domain errors so routing/UI can react without string-matching messages. */
+sealed class ImageGenerationException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+    class ModelNotInstalled(message: String) : ImageGenerationException(message)
+    class InitializationFailed(message: String, cause: Throwable? = null) : ImageGenerationException(message, cause)
+    class GenerationFailed(message: String, cause: Throwable? = null) : ImageGenerationException(message, cause)
+    class DeviceUnsupported(message: String) : ImageGenerationException(message)
+}
+
+/**
+ * A source of generated images. [generate] runs one turn; [cancel] aborts the active turn
+ * where the backend allows it; [close] releases every held resource (loaded models, native
+ * memory). Implementations include OpenRouter and the model-routed on-device engines.
+ */
+interface ImageGenerationEngine {
+    fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent>
+    fun cancel()
+    fun close()
+}

--- a/app/src/main/java/com/echoflow/data/LocalImageGenerationEngineRouter.kt
+++ b/app/src/main/java/com/echoflow/data/LocalImageGenerationEngineRouter.kt
@@ -1,0 +1,57 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Routes an installed model to its persisted runtime. The settings screen exposes models,
+ * not implementation details, so this is the only place the app chooses an on-device engine.
+ */
+class LocalImageGenerationEngineRouter(
+    private val mediaPipe: ImageGenerationEngine,
+    private val stableDiffusionCpp: ImageGenerationEngine,
+) : ImageGenerationEngine {
+    @Volatile
+    private var active: ImageGenerationEngine? = null
+
+    override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> {
+        val model = request.localModel
+            ?: return failedFlow(
+                ImageGenerationException.ModelNotInstalled(
+                    "Pick an on-device image model in Settings → Image generation first."
+                )
+            )
+        val engine = when (model.runtime) {
+            LocalImageRuntime.MEDIAPIPE.id -> mediaPipe
+            LocalImageRuntime.STABLE_DIFFUSION_CPP.id -> stableDiffusionCpp
+            else -> return failedFlow(
+                ImageGenerationException.InitializationFailed(
+                    "${model.name} uses an image runtime this version of EchoFlow doesn't support."
+                )
+            )
+        }
+        return flow {
+            active = engine
+            try {
+                emitAll(engine.generate(request))
+            } finally {
+                if (active === engine) active = null
+            }
+        }
+    }
+
+    override fun cancel() {
+        active?.cancel()
+    }
+
+    override fun close() {
+        active = null
+        mediaPipe.close()
+        stableDiffusionCpp.close()
+    }
+
+    private fun failedFlow(error: ImageGenerationException): Flow<ImageGenerationEvent> = flow {
+        throw error
+    }
+}

--- a/app/src/main/java/com/echoflow/data/LocalImageModelCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/LocalImageModelCatalog.kt
@@ -1,0 +1,184 @@
+package com.echoflow.data
+
+/** Runtime used by an installed on-device image model. Values are persisted in Room. */
+enum class LocalImageRuntime(val id: String) {
+    MEDIAPIPE("mediapipe"),
+    STABLE_DIFFUSION_CPP("stable-diffusion-cpp");
+
+    companion object {
+        fun fromId(id: String): LocalImageRuntime =
+            entries.firstOrNull { it.id == id } ?: MEDIAPIPE
+    }
+}
+
+/** Shape of the pinned artifact downloaded by [LocalImageModelDownloadWorker]. */
+enum class LocalImageArtifactFormat {
+    /** ZIP entries are the MediaPipe model directory and are extracted under install/bins/. */
+    MEDIAPIPE_ROOT_ZIP,
+    /** A single stable-diffusion.cpp safetensors checkpoint. */
+    SAFETENSORS,
+    /** A single stable-diffusion.cpp PyTorch checkpoint. */
+    CHECKPOINT,
+}
+
+/**
+ * One immutable curated artifact. URLs always pin a model revision (or a Civitai model-version
+ * endpoint), and every artifact has an exact byte count and SHA-256 before it can be offered.
+ */
+data class LocalImageCatalogEntry(
+    val id: String,
+    val name: String,
+    val category: String,
+    val description: String,
+    val runtime: LocalImageRuntime,
+    val artifactFormat: LocalImageArtifactFormat,
+    val artifactUrl: String?,
+    val downloadBytes: Long?,
+    val installedBytes: Long?,
+    val artifactRevision: String?,
+    val artifactSha256: String?,
+    val modelFileName: String?,
+    val experimental: Boolean,
+    val licenseId: String,
+    val licenseUrl: String,
+    val sourceUrl: String,
+    val activationPhrase: String?,
+    val defaultNegativePrompt: String,
+    val minRamBytes: Long,
+    val bundleFormatVersion: Int = LocalImageModelCatalog.BUNDLE_FORMAT_VERSION,
+) {
+    val artifactAvailable: Boolean
+        get() = !artifactUrl.isNullOrBlank() &&
+            SHA256_REGEX.matches(artifactSha256.orEmpty()) &&
+            !artifactRevision.isNullOrBlank() &&
+            (downloadBytes ?: 0L) > 0L &&
+            (installedBytes ?: 0L) > 0L &&
+            when (artifactFormat) {
+                LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP -> modelFileName == null
+                LocalImageArtifactFormat.SAFETENSORS ->
+                    modelFileName?.endsWith(".safetensors", ignoreCase = true) == true
+                LocalImageArtifactFormat.CHECKPOINT ->
+                    modelFileName?.endsWith(".ckpt", ignoreCase = true) == true
+            }
+
+    fun canDownload(experimentalEnabled: Boolean): Boolean =
+        artifactAvailable && (!experimental || experimentalEnabled)
+
+    /** Compatibility for the existing settings row: experimental artifacts stay disabled. */
+    val available: Boolean get() = canDownload(experimentalEnabled = false)
+
+    // Compatibility aliases for the original MediaPipe-only installer/tests.
+    val bundleUrl: String? get() = artifactUrl
+    val sourceRevision: String? get() = artifactRevision
+    val sourceCheckpointSha256: String? get() = artifactSha256
+    val bundleSha256: String? get() = artifactSha256
+
+    companion object {
+        val SHA256_REGEX = Regex("^[0-9a-f]{64}$")
+    }
+}
+
+object LocalImageModelCatalog {
+    const val LICENSE_OPENRAIL_M = "creativeml-openrail-m"
+    const val LICENSE_OPENRAIL_M_URL =
+        "https://huggingface.co/spaces/CompVis/stable-diffusion-license"
+    const val LICENSE_CIVITAI_MODEL_TERMS = "civitai-model-terms"
+    const val DREAMSHAPER_TERMS_URL = "https://civitai.com/models/4384/dreamshaper"
+    const val BUNDLE_FORMAT_VERSION = 1
+
+    private const val MIN_RAM_BYTES = 4L * 1024 * 1024 * 1024
+
+    val entries: List<LocalImageCatalogEntry> = listOf(
+        LocalImageCatalogEntry(
+            id = "local-image/stable-diffusion-1.5",
+            name = "Stable Diffusion 1.5",
+            category = "Balanced",
+            description = "Reliable general-purpose image generation",
+            runtime = LocalImageRuntime.MEDIAPIPE,
+            artifactFormat = LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP,
+            artifactUrl = "https://huggingface.co/na5h13/stable-diffusion-v1-5-mediapipe/resolve/" +
+                "645265e20ab21ec6d4b93b030d87178017c04c7e/sd15-mediapipe.zip",
+            downloadBytes = 1_906_219_565L,
+            installedBytes = 2_067_362_572L,
+            artifactRevision = "645265e20ab21ec6d4b93b030d87178017c04c7e",
+            artifactSha256 = "0e17f95821b6a247d01807b20920206052fc32483af2af42f03ff61954397758",
+            modelFileName = null,
+            experimental = false,
+            licenseId = LICENSE_OPENRAIL_M,
+            licenseUrl = LICENSE_OPENRAIL_M_URL,
+            sourceUrl = "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
+            activationPhrase = null,
+            defaultNegativePrompt = "low quality, distorted, deformed",
+            minRamBytes = MIN_RAM_BYTES,
+        ),
+        LocalImageCatalogEntry(
+            id = "local-image/dreamshaper-8",
+            name = "DreamShaper 8",
+            category = "Creative",
+            description = "Illustration, fantasy and expressive artwork",
+            runtime = LocalImageRuntime.STABLE_DIFFUSION_CPP,
+            artifactFormat = LocalImageArtifactFormat.SAFETENSORS,
+            artifactUrl = "https://civitai.com/api/download/models/128713",
+            downloadBytes = 2_132_625_894L,
+            installedBytes = 2_132_625_894L,
+            artifactRevision = "civitai-model-version-128713",
+            artifactSha256 = "879db523c30d3b9017143d56705015e15a2cb5628762c11d086fed9538abd7fd",
+            modelFileName = "dreamshaper_8.safetensors",
+            experimental = true,
+            licenseId = LICENSE_CIVITAI_MODEL_TERMS,
+            licenseUrl = DREAMSHAPER_TERMS_URL,
+            sourceUrl = "https://civitai.com/models/4384/dreamshaper",
+            activationPhrase = null,
+            defaultNegativePrompt = "low quality, distorted, deformed",
+            minRamBytes = MIN_RAM_BYTES,
+        ),
+        LocalImageCatalogEntry(
+            id = "local-image/analog-diffusion",
+            name = "Analog Diffusion",
+            category = "Photography",
+            description = "Portraits and analogue film photography",
+            runtime = LocalImageRuntime.STABLE_DIFFUSION_CPP,
+            artifactFormat = LocalImageArtifactFormat.SAFETENSORS,
+            artifactUrl = "https://huggingface.co/wavymulder/Analog-Diffusion/resolve/" +
+                "211449c273875dedc683fdb5a95d8a0ff9d76484/analog-diffusion-1.0.safetensors",
+            downloadBytes = 2_132_625_462L,
+            installedBytes = 2_132_625_462L,
+            artifactRevision = "211449c273875dedc683fdb5a95d8a0ff9d76484",
+            artifactSha256 = "51f6fff5088a9c5f5aa7cefa0a5a859d0424fc68fdc440e0ee5608a2b82e5ff9",
+            modelFileName = "analog-diffusion-1.0.safetensors",
+            experimental = true,
+            licenseId = LICENSE_OPENRAIL_M,
+            licenseUrl = LICENSE_OPENRAIL_M_URL,
+            sourceUrl = "https://huggingface.co/wavymulder/Analog-Diffusion",
+            activationPhrase = "analog style",
+            defaultNegativePrompt = "blur, haze, distorted, low quality",
+            minRamBytes = MIN_RAM_BYTES,
+        ),
+        LocalImageCatalogEntry(
+            id = "local-image/openjourney-v4",
+            name = "OpenJourney v4",
+            category = "Concept art",
+            description = "Detailed concept art and illustration",
+            runtime = LocalImageRuntime.STABLE_DIFFUSION_CPP,
+            artifactFormat = LocalImageArtifactFormat.CHECKPOINT,
+            artifactUrl = "https://huggingface.co/prompthero/openjourney-v4/resolve/" +
+                "b195ed2d503f3eb29637050a886d77bd81d35f0e/openjourney-v4.ckpt",
+            downloadBytes = 2_132_910_209L,
+            installedBytes = 2_132_910_209L,
+            artifactRevision = "b195ed2d503f3eb29637050a886d77bd81d35f0e",
+            artifactSha256 = "02e37aad9f74f574808ad456043b89e8c6b24e22828743fcf002168f76493d9b",
+            modelFileName = "openjourney-v4.ckpt",
+            experimental = true,
+            licenseId = LICENSE_OPENRAIL_M,
+            licenseUrl = LICENSE_OPENRAIL_M_URL,
+            sourceUrl = "https://huggingface.co/prompthero/openjourney-v4",
+            activationPhrase = null,
+            defaultNegativePrompt = "low quality, distorted, deformed",
+            minRamBytes = MIN_RAM_BYTES,
+        ),
+    )
+
+    fun entryById(id: String): LocalImageCatalogEntry? = entries.firstOrNull { it.id == id }
+
+    fun directoryNameFor(id: String): String = id.substringAfterLast('/')
+}

--- a/app/src/main/java/com/echoflow/data/LocalImageModelDownloadWorker.kt
+++ b/app/src/main/java/com/echoflow/data/LocalImageModelDownloadWorker.kt
@@ -1,0 +1,395 @@
+package com.echoflow.data
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.StatFs
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.echoflow.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+internal class RetryableModelDownloadException(message: String, cause: Throwable? = null) :
+    IOException(message, cause)
+
+internal class PermanentModelDownloadException(message: String) : IOException(message)
+
+/** HTTP downloader with strict Content-Range validation and resumable `.part` files. */
+internal class ResumableArtifactDownloader(
+    private val client: OkHttpClient,
+) {
+    suspend fun download(
+        entry: LocalImageCatalogEntry,
+        partFile: File,
+        onProgress: suspend (downloaded: Long, total: Long) -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        val url = entry.artifactUrl ?: throw PermanentModelDownloadException("The model URL is missing.")
+        val expectedBytes = entry.downloadBytes
+            ?: throw PermanentModelDownloadException("The model size is unknown.")
+        partFile.parentFile?.mkdirs()
+        if (partFile.length() > expectedBytes) partFile.delete()
+
+        var existingBytes = partFile.length()
+        onProgress(existingBytes, expectedBytes)
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept-Encoding", "identity")
+            .header("User-Agent", "EchoFlow-Android")
+            .apply { if (existingBytes > 0L) header("Range", "bytes=$existingBytes-") }
+            .build()
+
+        val response = try {
+            client.newCall(request).execute()
+        } catch (error: IOException) {
+            throw RetryableModelDownloadException("Connection lost. The download will resume.", error)
+        }
+
+        response.use {
+            when {
+                it.code == 416 && existingBytes == expectedBytes -> return@withContext
+                it.code == 416 -> {
+                    partFile.delete()
+                    throw RetryableModelDownloadException("The server rejected the saved download position; retrying from the start.")
+                }
+                it.code == 408 || it.code == 429 || it.code >= 500 ->
+                    throw RetryableModelDownloadException("The model host is temporarily unavailable (HTTP ${it.code}).")
+                it.code == 401 || it.code == 403 ->
+                    throw PermanentModelDownloadException("The model host denied this download (HTTP ${it.code}).")
+                it.code == 404 ->
+                    throw PermanentModelDownloadException("The model file is no longer available.")
+                !it.isSuccessful ->
+                    throw PermanentModelDownloadException("Download failed (HTTP ${it.code}).")
+            }
+
+            val append = if (existingBytes > 0L && it.code == 206) {
+                val contentRange = parseContentRange(it.header("Content-Range"))
+                    ?: run {
+                        partFile.delete()
+                        throw RetryableModelDownloadException("The server returned an invalid resume response.")
+                    }
+                if (contentRange.first != existingBytes || contentRange.third != expectedBytes) {
+                    partFile.delete()
+                    throw RetryableModelDownloadException("The model changed while it was downloading; retrying from the start.")
+                }
+                true
+            } else {
+                // A server may ignore Range and return the full file. Truncate instead of
+                // appending, otherwise the final hash could never match.
+                existingBytes = 0L
+                false
+            }
+
+            val body = it.body ?: throw RetryableModelDownloadException("The model host returned an empty response.")
+            var copied = existingBytes
+            var lastReportedBytes = copied
+            var lastReportedAt = System.nanoTime()
+            try {
+                body.byteStream().use { input ->
+                    FileOutputStream(partFile, append).use { output ->
+                        val buffer = ByteArray(256 * 1024)
+                        while (true) {
+                            currentCoroutineContext().ensureActive()
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            copied += read
+                            if (copied > expectedBytes) {
+                                partFile.delete()
+                                throw PermanentModelDownloadException("The downloaded file is larger than expected.")
+                            }
+                            val now = System.nanoTime()
+                            if (copied - lastReportedBytes >= PROGRESS_BYTES ||
+                                now - lastReportedAt >= PROGRESS_NANOS
+                            ) {
+                                lastReportedBytes = copied
+                                lastReportedAt = now
+                                onProgress(copied, expectedBytes)
+                            }
+                        }
+                        output.flush()
+                    }
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: PermanentModelDownloadException) {
+                throw error
+            } catch (error: IOException) {
+                throw RetryableModelDownloadException("Connection lost. The download will resume.", error)
+            }
+
+            onProgress(copied, expectedBytes)
+            if (copied != expectedBytes) {
+                throw RetryableModelDownloadException("The download was interrupted and will resume.")
+            }
+        }
+    }
+
+    /** Returns start, end and total. */
+    private fun parseContentRange(value: String?): Triple<Long, Long, Long>? {
+        val match = CONTENT_RANGE.matchEntire(value.orEmpty()) ?: return null
+        val start = match.groupValues[1].toLongOrNull() ?: return null
+        val end = match.groupValues[2].toLongOrNull() ?: return null
+        val total = match.groupValues[3].toLongOrNull() ?: return null
+        if (start < 0 || end < start || total <= end) return null
+        return Triple(start, end, total)
+    }
+
+    companion object {
+        private const val PROGRESS_BYTES = 8L * 1024 * 1024
+        private const val PROGRESS_NANOS = 750L * 1_000_000
+        private val CONTENT_RANGE = Regex("bytes (\\d+)-(\\d+)/(\\d+)")
+    }
+}
+
+/**
+ * Persistent owner of model download, verification and installation. WorkManager recreates this
+ * worker after process death/reboot; the revision-named `.part` file lets HTTP continue by Range.
+ */
+class LocalImageModelDownloadWorker(
+    context: Context,
+    parameters: WorkerParameters,
+) : CoroutineWorker(context, parameters) {
+    private val database by lazy { AppDatabase.getDatabase(applicationContext) }
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val modelId = inputData.getString(KEY_MODEL_ID)
+            ?: return@withContext failure("The scheduled model id is missing.")
+        val entry = LocalImageModelCatalog.entryById(modelId)
+            ?: return@withContext failure("This model is no longer in the catalog.")
+        if (!entry.artifactAvailable) return@withContext failure("This model isn't ready to download yet.")
+        if (entry.runtime == LocalImageRuntime.STABLE_DIFFUSION_CPP &&
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+        ) {
+            return@withContext failure("Experimental image models require Android 8 or newer.")
+        }
+        if (LocalImageDownloadFiles.cancellationMarker(applicationContext, entry.id).exists()) {
+            return@withContext failure("The model download was cancelled.")
+        }
+
+        val partFile = LocalImageDownloadFiles.partialFile(applicationContext, entry)
+        val installingDir = LocalImageDownloadFiles.installingDirectory(
+            applicationContext,
+            entry,
+            id.toString(),
+        )
+        val expectedBytes = entry.downloadBytes ?: return@withContext failure("The model size is unknown.")
+
+        try {
+            recoverCompletedInstall(entry)?.let {
+                LocalImageDownloadFiles.partialFile(applicationContext, entry).delete()
+                selectFirstInstall(entry)
+                LocalImageDownloadFiles.cancellationMarker(applicationContext, entry.id).delete()
+                return@withContext Result.success(workDataOf(KEY_MODEL_ID to entry.id))
+            }
+            currentCoroutineContext().ensureActive()
+            if (LocalImageDownloadFiles.cancellationMarker(applicationContext, entry.id).exists()) {
+                throw CancellationException("Model download was cancelled.")
+            }
+            ensureFreeSpace(entry, partFile)
+            publish(PHASE_DOWNLOADING, partFile.length(), expectedBytes, entry.name)
+            ResumableArtifactDownloader(client).download(entry, partFile) { downloaded, total ->
+                publish(PHASE_DOWNLOADING, downloaded, total, entry.name)
+            }
+
+            publish(PHASE_VERIFYING, partFile.length(), expectedBytes, entry.name)
+            val coroutineContext = currentCoroutineContext()
+            val actualHash = LocalImageBundleValidator.sha256Of(partFile) {
+                coroutineContext.ensureActive()
+            }
+            if (!actualHash.equals(entry.artifactSha256, ignoreCase = true)) {
+                partFile.delete()
+                return@withContext failure("The downloaded file failed verification. Retry the download.")
+            }
+
+            val installer = LocalImageModelInstaller(
+                applicationContext,
+                database.localImageModelDao(),
+                LocalImageModelManager.mediaPipeSmokeTest(applicationContext),
+            )
+            installer.install(
+                entry = entry,
+                artifact = partFile,
+                ownerId = id.toString(),
+                installingDirectory = installingDir,
+                onState = {
+                    publish(PHASE_INSTALLING, expectedBytes, expectedBytes, entry.name)
+                },
+                cancellationCheck = { coroutineContext.ensureActive() },
+            )
+            partFile.delete()
+
+            // Do this in the worker rather than the UI so the first install is selected even
+            // when it finishes after the activity has been closed or the process was recreated.
+            selectFirstInstall(entry)
+            LocalImageDownloadFiles.cancellationMarker(applicationContext, entry.id).delete()
+            Result.success(workDataOf(KEY_MODEL_ID to entry.id))
+        } catch (error: CancellationException) {
+            installingDir.deleteRecursively()
+            throw error
+        } catch (error: RetryableModelDownloadException) {
+            installingDir.deleteRecursively()
+            Result.retry()
+        } catch (error: Exception) {
+            installingDir.deleteRecursively()
+            failure(error.message ?: "Download failed.")
+        }
+    }
+
+    private suspend fun recoverCompletedInstall(entry: LocalImageCatalogEntry): LocalImageModel? =
+        LocalImageInstallLocks.withModelLock(entry.id) {
+            val dao = database.localImageModelDao()
+            val finalDir = LocalImageDownloadFiles.finalDirectory(applicationContext, entry)
+            var row = dao.getById(entry.id)
+
+            // Marker is written only after hash/format validation (and MediaPipe smoke test),
+            // so a killed first install can safely finish its Room commit without redownloading.
+            if (row == null &&
+                LocalImageInstallMarker.matches(finalDir, entry) &&
+                LocalImageInstalledModelFiles.isInstalled(finalDir, entry.runtime.id, entry.modelFileName)
+            ) {
+                row = LocalImageModelRecords.fromInstalledDirectory(entry, finalDir)
+                dao.upsert(row)
+            } else {
+                LocalImageInstallRecovery.reconcileEntryLocked(applicationContext, entry, row)
+            }
+
+            row?.takeIf {
+                it.bundleSha256.equals(entry.artifactSha256, ignoreCase = true) &&
+                    it.runtime == entry.runtime.id &&
+                    it.modelFileName == entry.modelFileName &&
+                    LocalImageInstalledModelFiles.isInstalled(finalDir, it.runtime, it.modelFileName) &&
+                    (!LocalImageInstallMarker.exists(finalDir) || LocalImageInstallMarker.matches(finalDir, it))
+            }
+        }
+
+    private fun selectFirstInstall(entry: LocalImageCatalogEntry) {
+        SettingsRepository(applicationContext).let { settings ->
+            if (settings.getLocalImageModelDirect().isBlank()) {
+                settings.saveLocalImageModel(entry.id)
+            }
+        }
+    }
+
+    private fun ensureFreeSpace(entry: LocalImageCatalogEntry, partFile: File) {
+        val total = entry.downloadBytes ?: 0L
+        val remainingDownload = (total - partFile.length()).coerceAtLeast(0L)
+        val installOverhead = when (entry.artifactFormat) {
+            LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP -> entry.installedBytes ?: total
+            LocalImageArtifactFormat.SAFETENSORS,
+            LocalImageArtifactFormat.CHECKPOINT -> 64L * 1024 * 1024
+        }
+        val safetyMargin = 128L * 1024 * 1024
+        val required = remainingDownload + installOverhead + safetyMargin
+        val available = StatFs(LocalImageDownloadFiles.root(applicationContext).absolutePath).availableBytes
+        if (available < required) {
+            throw PermanentModelDownloadException("Not enough free storage to download and install this model.")
+        }
+    }
+
+    private suspend fun publish(phase: String, downloaded: Long, total: Long, name: String) {
+        setProgress(
+            workDataOf(
+                KEY_PHASE to phase,
+                KEY_DOWNLOADED_BYTES to downloaded,
+                KEY_TOTAL_BYTES to total,
+            )
+        )
+        setForeground(createForegroundInfo(phase, downloaded, total, name))
+    }
+
+    private fun createForegroundInfo(
+        phase: String,
+        downloaded: Long,
+        total: Long,
+        name: String,
+    ): ForegroundInfo {
+        createNotificationChannel()
+        val cancelIntent = WorkManager.getInstance(applicationContext).createCancelPendingIntent(id)
+        val phaseText = when (phase) {
+            PHASE_VERIFYING -> "Verifying $name"
+            PHASE_INSTALLING -> "Installing $name"
+            else -> "Downloading $name"
+        }
+        val progress = if (total > 0L) ((downloaded.coerceIn(0L, total) * 100L) / total).toInt() else 0
+        val notification = NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo)
+            .setContentTitle("On-device image model")
+            .setContentText(phaseText)
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setProgress(100, progress, total <= 0L || phase != PHASE_DOWNLOADING)
+            .addAction(android.R.drawable.ic_delete, "Cancel", cancelIntent)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build()
+        val notificationId = NOTIFICATION_ID_BASE + (id.hashCode() and 0x0fff)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(notificationId, notification)
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = applicationContext.getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                "Model downloads",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply { description = "On-device model download and installation progress" }
+        )
+    }
+
+    private fun failure(message: String): Result =
+        Result.failure(workDataOf(KEY_ERROR to message))
+
+    companion object {
+        const val WORK_TAG = "local-image-model-download"
+        const val KEY_MODEL_ID = "model_id"
+        const val KEY_ENQUEUED_AT = "enqueued_at"
+        const val KEY_PHASE = "phase"
+        const val KEY_DOWNLOADED_BYTES = "downloaded_bytes"
+        const val KEY_TOTAL_BYTES = "total_bytes"
+        const val KEY_ERROR = "error"
+        const val PHASE_DOWNLOADING = "downloading"
+        const val PHASE_VERIFYING = "verifying"
+        const val PHASE_INSTALLING = "installing"
+
+        private const val NOTIFICATION_CHANNEL_ID = "model_downloads"
+        private const val NOTIFICATION_ID_BASE = 4_200
+        private const val MODEL_TAG_PREFIX = "local-image-model:"
+        private const val ENQUEUED_TAG_PREFIX = "local-image-enqueued:"
+
+        fun uniqueWorkName(modelId: String): String = "local-image-download:$modelId"
+        fun modelTag(modelId: String): String = MODEL_TAG_PREFIX + modelId
+        fun enqueuedAtTag(timestamp: Long): String = ENQUEUED_TAG_PREFIX + timestamp
+        fun modelIdFromTags(tags: Set<String>): String? =
+            tags.firstOrNull { it.startsWith(MODEL_TAG_PREFIX) }?.removePrefix(MODEL_TAG_PREFIX)
+        fun enqueuedAtFromTags(tags: Set<String>): Long =
+            tags.firstOrNull { it.startsWith(ENQUEUED_TAG_PREFIX) }
+                ?.removePrefix(ENQUEUED_TAG_PREFIX)
+                ?.toLongOrNull() ?: 0L
+    }
+}

--- a/app/src/main/java/com/echoflow/data/LocalImageModelManager.kt
+++ b/app/src/main/java/com/echoflow/data/LocalImageModelManager.kt
@@ -1,0 +1,852 @@
+package com.echoflow.data
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.Observer
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.google.mediapipe.tasks.vision.imagegenerator.ImageGenerator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.ConcurrentHashMap
+import java.util.zip.ZipFile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+sealed interface LocalImageDownloadState {
+    data class Downloading(val downloadedBytes: Long, val totalBytes: Long) : LocalImageDownloadState {
+        val fraction: Float get() = if (totalBytes > 0) downloadedBytes.toFloat() / totalBytes else 0f
+    }
+    data object Verifying : LocalImageDownloadState
+    data object Installing : LocalImageDownloadState
+    data object Done : LocalImageDownloadState
+    data class Failed(val message: String) : LocalImageDownloadState
+}
+
+/** Stable on-disk paths shared by the scheduler, worker and startup reconciliation. */
+internal object LocalImageDownloadFiles {
+    fun root(context: Context): File = File(context.filesDir, "image_models").apply { mkdirs() }
+
+    fun downloads(context: Context): File = File(root(context), ".downloads").apply { mkdirs() }
+
+    fun finalDirectory(context: Context, entry: LocalImageCatalogEntry): File =
+        File(root(context), LocalImageModelCatalog.directoryNameFor(entry.id))
+
+    fun previousDirectory(context: Context, entry: LocalImageCatalogEntry): File =
+        File(root(context), "${LocalImageModelCatalog.directoryNameFor(entry.id)}.previous")
+
+    fun installingDirectory(context: Context, entry: LocalImageCatalogEntry, ownerId: String): File =
+        File(root(context), "${LocalImageModelCatalog.directoryNameFor(entry.id)}.installing.$ownerId")
+
+    fun partialFile(context: Context, entry: LocalImageCatalogEntry): File {
+        val extension = when (entry.artifactFormat) {
+            LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP -> "zip"
+            LocalImageArtifactFormat.SAFETENSORS -> "safetensors"
+            LocalImageArtifactFormat.CHECKPOINT -> "ckpt"
+        }
+        val revision = entry.artifactSha256.orEmpty().take(12)
+        val slug = LocalImageModelCatalog.directoryNameFor(entry.id)
+        return File(downloads(context), "$slug-$revision.$extension.part")
+    }
+
+    fun partialFilesFor(context: Context, modelId: String): List<File> {
+        val prefix = LocalImageModelCatalog.directoryNameFor(modelId) + "-"
+        return downloads(context).listFiles().orEmpty().filter {
+            it.isFile && it.name.startsWith(prefix) && it.name.endsWith(".part")
+        }
+    }
+
+    fun cancellationMarker(context: Context, modelId: String): File =
+        File(downloads(context), "${LocalImageModelCatalog.directoryNameFor(modelId)}.cancelled")
+
+    fun revisionPartialFile(
+        context: Context,
+        modelId: String,
+        artifactSha256: String,
+        modelFileName: String,
+    ): File {
+        val extension = modelFileName.substringAfterLast('.', "model")
+        val slug = LocalImageModelCatalog.directoryNameFor(modelId)
+        return File(downloads(context), "$slug-${artifactSha256.take(12)}.$extension.part")
+    }
+}
+
+/** Serializes final-directory swaps, recovery and deletion across activity graph instances. */
+internal object LocalImageInstallLocks {
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
+    suspend fun <T> withModelLock(modelId: String, block: suspend () -> T): T =
+        locks.getOrPut(modelId) { Mutex() }.withLock { block() }
+}
+
+/**
+ * Fingerprint moved atomically with an installing directory. Room matching this marker is the
+ * durable commit record; a mismatch means the process died after the rename but before upsert.
+ */
+internal object LocalImageInstallMarker {
+    private const val FILE_NAME = ".echoflow-install"
+
+    data class Fingerprint(
+        val modelId: String,
+        val artifactSha256: String,
+        val runtime: String,
+        val modelFileName: String?,
+    )
+
+    fun write(directory: File, entry: LocalImageCatalogEntry) {
+        File(directory, FILE_NAME).writeText(
+            listOf(
+                entry.id,
+                entry.artifactSha256.orEmpty(),
+                entry.runtime.id,
+                entry.modelFileName.orEmpty(),
+            ).joinToString("\n")
+        )
+    }
+
+    fun exists(directory: File): Boolean = File(directory, FILE_NAME).isFile
+
+    fun read(directory: File): Fingerprint? {
+        val lines = runCatching { File(directory, FILE_NAME).readLines() }.getOrNull() ?: return null
+        return Fingerprint(
+            modelId = lines.getOrNull(0) ?: return null,
+            artifactSha256 = lines.getOrNull(1) ?: return null,
+            runtime = lines.getOrNull(2) ?: return null,
+            modelFileName = lines.getOrNull(3)?.ifBlank { null },
+        )
+    }
+
+    fun matches(directory: File, model: LocalImageModel?): Boolean {
+        if (model == null) return false
+        val fingerprint = read(directory) ?: return false
+        return fingerprint.modelId == model.id &&
+            fingerprint.artifactSha256 == model.bundleSha256 &&
+            fingerprint.runtime == model.runtime &&
+            fingerprint.modelFileName == model.modelFileName
+    }
+
+    fun matches(directory: File, entry: LocalImageCatalogEntry): Boolean {
+        val fingerprint = read(directory) ?: return false
+        return fingerprint.modelId == entry.id &&
+            fingerprint.artifactSha256 == entry.artifactSha256 &&
+            fingerprint.runtime == entry.runtime.id &&
+            fingerprint.modelFileName == entry.modelFileName
+    }
+}
+
+internal object LocalImageInstalledModelFiles {
+    fun isInstalled(directory: File, runtime: String, modelFileName: String?): Boolean =
+        when (LocalImageRuntime.fromId(runtime)) {
+            LocalImageRuntime.MEDIAPIPE -> File(directory, "bins").let { bins ->
+                bins.isDirectory && bins.walkTopDown().any { it.isFile && it.length() > 0L }
+            }
+            LocalImageRuntime.STABLE_DIFFUSION_CPP ->
+                modelFileName?.let { File(directory, it) }?.let { it.isFile && it.length() > 0L } == true
+        }
+}
+
+internal object LocalImageModelRecords {
+    fun fromInstalledDirectory(entry: LocalImageCatalogEntry, directory: File): LocalImageModel =
+        LocalImageModel(
+            id = entry.id,
+            name = entry.name,
+            directoryName = LocalImageModelCatalog.directoryNameFor(entry.id),
+            installedBytes = directory.walkTopDown().filter { it.isFile }.sumOf { it.length() },
+            sourceRevision = entry.artifactRevision.orEmpty(),
+            sourceCheckpointSha256 = entry.artifactSha256.orEmpty(),
+            bundleSha256 = entry.artifactSha256.orEmpty(),
+            licenseId = entry.licenseId,
+            activationPhrase = entry.activationPhrase,
+            defaultNegativePrompt = entry.defaultNegativePrompt,
+            bundleFormatVersion = entry.bundleFormatVersion,
+            runtime = entry.runtime.id,
+            modelFileName = entry.modelFileName,
+            addedAt = System.currentTimeMillis(),
+        )
+}
+
+internal object LocalImageSelectionRecovery {
+    fun reconcile(context: Context, actuallyInstalled: List<LocalImageModel>) {
+        val settings = SettingsRepository(context)
+        val selectedId = settings.getLocalImageModelDirect()
+        if (selectedId.isNotBlank() && actuallyInstalled.none { it.id == selectedId }) {
+            settings.saveLocalImageModel(actuallyInstalled.firstOrNull()?.id.orEmpty())
+        }
+    }
+}
+
+/** Pure validation helpers; cancellation is injected so ZIP and hash loops remain testable. */
+internal object LocalImageBundleValidator {
+    private const val DEFAULT_MAX_ENTRIES = 10_000
+    private const val MAX_SAFETENSORS_HEADER_BYTES = 64L * 1024 * 1024
+
+    fun sha256Of(file: File, cancellationCheck: () -> Unit = {}): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(256 * 1024)
+            while (true) {
+                cancellationCheck()
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    fun extractZipSafely(
+        zip: File,
+        targetDir: File,
+        maxExtractedBytes: Long,
+        maxEntries: Int = DEFAULT_MAX_ENTRIES,
+        cancellationCheck: () -> Unit = {},
+    ) {
+        require(maxExtractedBytes > 0) { "maxExtractedBytes must be positive" }
+        targetDir.mkdirs()
+        val targetRoot = targetDir.canonicalFile
+        var extractedBytes = 0L
+        var entryCount = 0
+
+        ZipFile(zip).use { archive ->
+            val entries = archive.entries()
+            while (entries.hasMoreElements()) {
+                cancellationCheck()
+                if (++entryCount > maxEntries) {
+                    throw IOException("The model archive contains too many files.")
+                }
+                val entry = entries.nextElement()
+                val normalized = entry.name.replace('\\', '/')
+                val pathParts = normalized.split('/')
+                if (normalized.startsWith('/') || normalized.contains(':') || pathParts.any { it == ".." }) {
+                    throw IOException("The model archive contains an unsafe path.")
+                }
+                if (entry.size > maxExtractedBytes ||
+                    (entry.size >= 0 && entry.size > maxExtractedBytes - extractedBytes)
+                ) {
+                    throw IOException("The model archive expands beyond its expected size.")
+                }
+
+                val output = File(targetDir, normalized)
+                val canonical = output.canonicalFile
+                if (canonical != targetRoot && !canonical.path.startsWith(targetRoot.path + File.separator)) {
+                    throw IOException("The model archive contains an unsafe path.")
+                }
+                if (entry.isDirectory) {
+                    output.mkdirs()
+                    continue
+                }
+
+                output.parentFile?.mkdirs()
+                archive.getInputStream(entry).use { input ->
+                    output.outputStream().use { sink ->
+                        val buffer = ByteArray(256 * 1024)
+                        while (true) {
+                            cancellationCheck()
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            if (read.toLong() > maxExtractedBytes - extractedBytes) {
+                                throw IOException("The model archive expands beyond its expected size.")
+                            }
+                            sink.write(buffer, 0, read)
+                            extractedBytes += read
+                        }
+                    }
+                }
+            }
+        }
+
+        targetDir.walkTopDown().filter { it != targetDir }.forEach { file ->
+            cancellationCheck()
+            val expected = File(file.parentFile?.canonicalFile, file.name)
+            if (file.canonicalFile.path != expected.path) {
+                throw IOException("The model archive contains a symbolic link.")
+            }
+        }
+    }
+
+    fun validateMediaPipeDirectory(binsDir: File) {
+        if (!binsDir.isDirectory || binsDir.walkTopDown().none { it.isFile && it.length() > 0L }) {
+            throw IOException("The model archive contains no model files.")
+        }
+    }
+
+    fun validateSingleModelFile(file: File, format: LocalImageArtifactFormat) {
+        if (!file.isFile || file.length() < 16L) throw IOException("The downloaded model file is empty.")
+        RandomAccessFile(file, "r").use { source ->
+            when (format) {
+                LocalImageArtifactFormat.SAFETENSORS -> {
+                    val lengthBytes = ByteArray(8)
+                    source.readFully(lengthBytes)
+                    var headerLength = 0L
+                    for (index in 0 until 8) {
+                        headerLength = headerLength or
+                            ((lengthBytes[index].toLong() and 0xffL) shl (index * 8))
+                    }
+                    if (headerLength !in 2..MAX_SAFETENSORS_HEADER_BYTES ||
+                        headerLength > file.length() - 8
+                    ) {
+                        throw IOException("The downloaded safetensors header is invalid.")
+                    }
+                    if (source.readByte().toInt().toChar() != '{') {
+                        throw IOException("The downloaded file is not a safetensors model.")
+                    }
+                }
+                LocalImageArtifactFormat.CHECKPOINT -> {
+                    val prefix = ByteArray(4)
+                    source.readFully(prefix)
+                    val zipCheckpoint = prefix.contentEquals(byteArrayOf(0x50, 0x4b, 0x03, 0x04))
+                    val pickleCheckpoint = prefix[0] == 0x80.toByte() &&
+                        (prefix[1].toInt() and 0xff) in 2..5
+                    if (!zipCheckpoint && !pickleCheckpoint) {
+                        throw IOException("The downloaded file is not a supported checkpoint.")
+                    }
+                }
+                LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP ->
+                    throw IOException("A ZIP archive cannot be installed as a single model file.")
+            }
+        }
+    }
+}
+
+/**
+ * Validates and commits already-downloaded artifacts. The final directory is changed only inside
+ * a non-cancellable rename/Room transaction-like section, with a rollback directory preserving
+ * the previously working install until the new row is durable.
+ */
+internal class LocalImageModelInstaller(
+    private val context: Context,
+    private val dao: LocalImageModelDao,
+    private val smokeTest: suspend (binsDir: File) -> Unit,
+) {
+    suspend fun install(
+        entry: LocalImageCatalogEntry,
+        artifact: File,
+        ownerId: String,
+        onState: suspend (LocalImageDownloadState) -> Unit = {},
+        cancellationCheck: () -> Unit = {},
+        installingDirectory: File = LocalImageDownloadFiles.installingDirectory(context, entry, ownerId),
+    ): LocalImageModel {
+        return when (entry.artifactFormat) {
+            LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP ->
+                installMediaPipe(entry, artifact, installingDirectory, onState, cancellationCheck)
+            LocalImageArtifactFormat.SAFETENSORS,
+            LocalImageArtifactFormat.CHECKPOINT ->
+                installSingleFile(entry, artifact, installingDirectory, onState, cancellationCheck)
+        }
+    }
+
+    private suspend fun installMediaPipe(
+        entry: LocalImageCatalogEntry,
+        artifact: File,
+        installingDir: File,
+        onState: suspend (LocalImageDownloadState) -> Unit,
+        cancellationCheck: () -> Unit,
+    ): LocalImageModel {
+        onState(LocalImageDownloadState.Installing)
+        installingDir.deleteRecursively()
+        val bins = File(installingDir, "bins")
+        val expected = entry.installedBytes ?: throw IOException("The model's installed size is unknown.")
+        val extractionLimit = expected + expected / 4 + 64L * 1024 * 1024
+        try {
+            LocalImageBundleValidator.extractZipSafely(
+                artifact,
+                bins,
+                maxExtractedBytes = extractionLimit,
+                cancellationCheck = cancellationCheck,
+            )
+            LocalImageBundleValidator.validateMediaPipeDirectory(bins)
+            smokeTest(bins)
+            cancellationCheck()
+            return commitDirectory(entry, installingDir)
+        } catch (error: Throwable) {
+            installingDir.deleteRecursively()
+            throw error
+        }
+    }
+
+    private suspend fun installSingleFile(
+        entry: LocalImageCatalogEntry,
+        artifact: File,
+        installingDir: File,
+        onState: suspend (LocalImageDownloadState) -> Unit,
+        cancellationCheck: () -> Unit,
+    ): LocalImageModel {
+        onState(LocalImageDownloadState.Installing)
+        LocalImageBundleValidator.validateSingleModelFile(artifact, entry.artifactFormat)
+        cancellationCheck()
+        val fileName = entry.modelFileName ?: throw IOException("The model filename is missing.")
+        installingDir.deleteRecursively()
+        installingDir.mkdirs()
+        val preparedFile = File(installingDir, fileName)
+        if (!artifact.renameTo(preparedFile)) {
+            throw IOException("Couldn't prepare the downloaded model for installation.")
+        }
+
+        try {
+            return commitDirectory(entry, installingDir) { newDirectory ->
+                val installedFile = File(newDirectory, fileName)
+                artifact.parentFile?.mkdirs()
+                if (installedFile.exists() && !installedFile.renameTo(artifact)) {
+                    throw IOException("Couldn't preserve the downloaded model during rollback.")
+                }
+            }
+        } catch (error: Throwable) {
+            if (preparedFile.exists() && !preparedFile.renameTo(artifact)) {
+                error.addSuppressed(IOException("The verified model remains in ${installingDir.name}."))
+            } else {
+                installingDir.deleteRecursively()
+            }
+            throw error
+        }
+    }
+
+    private suspend fun commitDirectory(
+        entry: LocalImageCatalogEntry,
+        installingDir: File,
+        preserveNewOnRollback: (File) -> Unit = {},
+    ): LocalImageModel = LocalImageInstallLocks.withModelLock(entry.id) {
+        // Waiting for the per-model lock remains cancellable. Only the tiny filesystem/Room
+        // commit below is non-cancellable, so a queued cancelled worker can never resurrect data.
+        currentCoroutineContext().ensureActive()
+        withContext(NonCancellable + Dispatchers.IO) {
+            val finalDir = LocalImageDownloadFiles.finalDirectory(context, entry)
+            val previousDir = LocalImageDownloadFiles.previousDirectory(context, entry)
+            LocalImageInstallMarker.write(installingDir, entry)
+
+            // A retry may enter with both final and previous left by a killed Worker. Reconcile
+            // against Room + marker before touching either directory.
+            LocalImageInstallRecovery.reconcileEntryLocked(context, entry, dao.getById(entry.id))
+            if (LocalImageDownloadFiles.cancellationMarker(context, entry.id).exists()) {
+                throw CancellationException("Model installation was cancelled.")
+            }
+
+            var movedPrevious = false
+            try {
+                if (finalDir.exists()) {
+                    if (!finalDir.renameTo(previousDir)) {
+                        throw IOException("Couldn't prepare the existing model for an update.")
+                    }
+                    movedPrevious = true
+                }
+                if (!installingDir.renameTo(finalDir)) {
+                    throw IOException("Couldn't finalize the model installation.")
+                }
+
+                val row = LocalImageModelRecords.fromInstalledDirectory(entry, finalDir)
+                dao.upsert(row)
+                // Failure to delete is safe: marker+Room prove final is committed and startup
+                // reconciliation will retry removing the rollback copy.
+                if (previousDir.exists()) previousDir.deleteRecursively()
+                row
+            } catch (error: Throwable) {
+                val newDirectory = when {
+                    finalDir.exists() -> finalDir
+                    installingDir.exists() -> installingDir
+                    else -> null
+                }
+                val preserveError = newDirectory?.let {
+                    runCatching { preserveNewOnRollback(it) }.exceptionOrNull()
+                }
+                preserveError?.let(error::addSuppressed)
+                if (newDirectory != null && preserveError == null &&
+                    newDirectory.exists() && !newDirectory.deleteRecursively()
+                ) {
+                    error.addSuppressed(IOException("The incomplete installation could not be removed."))
+                }
+                if (movedPrevious && previousDir.exists()) {
+                    if (finalDir.exists()) {
+                        error.addSuppressed(IOException("The previous model is safe in ${previousDir.name}, but final is still occupied."))
+                    } else if (!previousDir.renameTo(finalDir)) {
+                        error.addSuppressed(IOException("The previous model could not be restored."))
+                    }
+                }
+                throw error
+            }
+        }
+    }
+}
+
+/** Crash recovery for the rename-to-previous → rename-new → Room-upsert commit sequence. */
+internal object LocalImageInstallRecovery {
+    suspend fun reconcile(
+        context: Context,
+        dao: LocalImageModelDao,
+        activeModelIds: Set<String> = emptySet(),
+    ) = withContext(Dispatchers.IO) {
+        val rows = dao.getAllSync().associateBy { it.id }
+        val catalogEntries = LocalImageModelCatalog.entries.associateBy { it.id }
+        catalogEntries.values.filterNot { it.id in activeModelIds }.forEach { entry ->
+            LocalImageInstallLocks.withModelLock(entry.id) {
+                val finalDir = LocalImageDownloadFiles.finalDirectory(context, entry)
+                var row = rows[entry.id]
+                if (row == null &&
+                    LocalImageInstallMarker.matches(finalDir, entry) &&
+                    LocalImageInstalledModelFiles.isInstalled(finalDir, entry.runtime.id, entry.modelFileName)
+                ) {
+                    row = LocalImageModelRecords.fromInstalledDirectory(entry, finalDir)
+                    dao.upsert(row)
+                }
+                reconcileEntryLocked(context, entry, row)
+            }
+        }
+        // Installed rows deliberately outlive the curated catalog. If a later app update removes
+        // an entry while its install swap is interrupted, recover it from the persisted directory
+        // name instead of dropping the row and stranding the known-good `.previous` directory.
+        rows.values
+            .filter { it.id !in catalogEntries && it.id !in activeModelIds }
+            .forEach { row ->
+                LocalImageInstallLocks.withModelLock(row.id) {
+                    reconcilePathsLocked(context, row.name, row.directoryName, row)
+                }
+            }
+    }
+
+    internal fun reconcileEntryLocked(
+        context: Context,
+        entry: LocalImageCatalogEntry,
+        row: LocalImageModel?,
+    ) = reconcilePathsLocked(
+        context = context,
+        displayName = entry.name,
+        directoryName = LocalImageModelCatalog.directoryNameFor(entry.id),
+        row = row,
+    )
+
+    private fun reconcilePathsLocked(
+        context: Context,
+        displayName: String,
+        directoryName: String,
+        row: LocalImageModel?,
+    ) {
+        val finalDir = File(LocalImageDownloadFiles.root(context), directoryName)
+        val previousDir = File(LocalImageDownloadFiles.root(context), "$directoryName.previous")
+
+        when {
+            previousDir.exists() && !finalDir.exists() -> {
+                if (!previousDir.renameTo(finalDir)) {
+                    throw IOException("Couldn't restore the previous $displayName installation.")
+                }
+            }
+            previousDir.exists() && finalDir.exists() &&
+                LocalImageInstallMarker.matches(finalDir, row) -> {
+                // Room committed the new fingerprint; the rollback copy is obsolete.
+                if (!previousDir.deleteRecursively()) {
+                    throw IOException("Couldn't remove the old $displayName rollback copy.")
+                }
+            }
+            previousDir.exists() && finalDir.exists() &&
+                LocalImageInstallMarker.exists(finalDir) -> {
+                preserveSingleFileArtifact(context, finalDir)
+                if (!finalDir.deleteRecursively()) {
+                    throw IOException("Couldn't remove the uncommitted $displayName installation.")
+                }
+                if (!previousDir.renameTo(finalDir)) {
+                    throw IOException("Couldn't restore the previous $displayName installation.")
+                }
+            }
+            previousDir.exists() && finalDir.exists() -> {
+                // A pre-marker (v14) final is the only provably installed directory.
+                if (!previousDir.deleteRecursively()) {
+                    throw IOException("Couldn't remove a stale $displayName rollback copy.")
+                }
+            }
+            finalDir.exists() && LocalImageInstallMarker.exists(finalDir) &&
+                !LocalImageInstallMarker.matches(finalDir, row) -> {
+                preserveSingleFileArtifact(context, finalDir)
+                if (!finalDir.deleteRecursively()) {
+                    throw IOException("Couldn't remove the uncommitted $displayName installation.")
+                }
+            }
+        }
+    }
+
+    private fun preserveSingleFileArtifact(context: Context, directory: File) {
+        val fingerprint = LocalImageInstallMarker.read(directory) ?: return
+        if (fingerprint.runtime != LocalImageRuntime.STABLE_DIFFUSION_CPP.id) return
+        val fileName = fingerprint.modelFileName ?: return
+        val modelFile = File(directory, fileName)
+        if (!modelFile.isFile) return
+        val partial = LocalImageDownloadFiles.revisionPartialFile(
+            context,
+            fingerprint.modelId,
+            fingerprint.artifactSha256,
+            fileName,
+        )
+        partial.parentFile?.mkdirs()
+        if (partial.exists() && !partial.delete()) {
+            throw IOException("Couldn't replace the saved partial model during recovery.")
+        }
+        if (!modelFile.renameTo(partial)) {
+            throw IOException("Couldn't preserve the verified model during recovery.")
+        }
+    }
+}
+
+/**
+ * App-facing facade. WorkManager owns downloads; this class only enqueues unique work, translates
+ * durable WorkInfo into the existing settings state, and provides installed-file paths.
+ */
+class LocalImageModelManager(
+    private val context: Context,
+    private val dao: LocalImageModelDao,
+    private val smokeTest: suspend (binsDir: File) -> Unit = mediaPipeSmokeTest(context),
+    private val workManager: WorkManager = WorkManager.getInstance(context),
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val immediateFailures = MutableStateFlow<Map<String, LocalImageDownloadState.Failed>>(emptyMap())
+
+    val states: StateFlow<Map<String, LocalImageDownloadState>> = combine(
+        workInfosFlow(),
+        immediateFailures.asStateFlow(),
+    ) { workInfos, failures ->
+        val latestByModel = workInfos
+            .mapNotNull { info ->
+                val modelId = LocalImageModelDownloadWorker.modelIdFromTags(info.tags)
+                    ?: return@mapNotNull null
+                Triple(modelId, LocalImageModelDownloadWorker.enqueuedAtFromTags(info.tags), info)
+            }
+            .groupBy { it.first }
+            .mapValues { (_, candidates) -> candidates.maxBy { it.second }.third }
+
+        buildMap {
+            latestByModel.forEach { (id, info) ->
+                workInfoState(info)?.let { put(id, it) }
+            }
+            // Local validation happens after any older WorkInfo was recorded. Keep that
+            // actionable failure visible instead of letting a stale completed job replace it.
+            failures.forEach { (id, state) -> put(id, state) }
+        }
+    }.stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    init {
+        // Reconcile at graph construction, not only when the user later opens Settings.
+        scope.launch(Dispatchers.IO) { pruneOrphans() }
+    }
+
+    val imageModelsDir: File get() = LocalImageDownloadFiles.root(context)
+
+    fun directoryFor(model: LocalImageModel): File = File(imageModelsDir, model.directoryName)
+
+    fun binsDirFor(model: LocalImageModel): File = File(directoryFor(model), "bins")
+
+    fun modelFileFor(model: LocalImageModel): File? =
+        model.modelFileName?.let { File(directoryFor(model), it) }
+
+    fun isInstalled(model: LocalImageModel): Boolean =
+        LocalImageInstalledModelFiles.isInstalled(directoryFor(model), model.runtime, model.modelFileName)
+
+    fun deviceMeetsRam(entry: LocalImageCatalogEntry): Boolean {
+        val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val info = ActivityManager.MemoryInfo().also { manager.getMemoryInfo(it) }
+        return info.totalMem <= 0 || info.totalMem >= entry.minRamBytes
+    }
+
+    fun deviceSupportsRuntime(entry: LocalImageCatalogEntry): Boolean =
+        entry.runtime != LocalImageRuntime.STABLE_DIFFUSION_CPP ||
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+
+    fun download(entry: LocalImageCatalogEntry) {
+        if (!entry.artifactAvailable) {
+            immediateFailures.value = immediateFailures.value +
+                (entry.id to LocalImageDownloadState.Failed("This model isn't ready to download yet."))
+            return
+        }
+        if (!deviceSupportsRuntime(entry)) {
+            immediateFailures.value = immediateFailures.value +
+                (entry.id to LocalImageDownloadState.Failed("Experimental image models require Android 8 or newer."))
+            return
+        }
+        immediateFailures.value = immediateFailures.value - entry.id
+        LocalImageDownloadFiles.cancellationMarker(context, entry.id).delete()
+        val enqueuedAt = System.currentTimeMillis()
+        val request = OneTimeWorkRequestBuilder<LocalImageModelDownloadWorker>()
+            .setInputData(
+                workDataOf(
+                    LocalImageModelDownloadWorker.KEY_MODEL_ID to entry.id,
+                    LocalImageModelDownloadWorker.KEY_ENQUEUED_AT to enqueuedAt,
+                    LocalImageModelDownloadWorker.KEY_TOTAL_BYTES to (entry.downloadBytes ?: 0L),
+                )
+            )
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresStorageNotLow(true)
+                    .build()
+            )
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .addTag(LocalImageModelDownloadWorker.WORK_TAG)
+            .addTag(LocalImageModelDownloadWorker.modelTag(entry.id))
+            .addTag(LocalImageModelDownloadWorker.enqueuedAtTag(enqueuedAt))
+            .build()
+        workManager.enqueueUniqueWork(
+            LocalImageModelDownloadWorker.uniqueWorkName(entry.id),
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+    }
+
+    fun cancel(entryId: String) {
+        immediateFailures.value = immediateFailures.value - entryId
+        LocalImageDownloadFiles.cancellationMarker(context, entryId).apply {
+            parentFile?.mkdirs()
+            writeText("cancelled")
+        }
+        workManager.cancelUniqueWork(LocalImageModelDownloadWorker.uniqueWorkName(entryId))
+    }
+
+    fun clearFailed(entryId: String) {
+        immediateFailures.value = immediateFailures.value - entryId
+    }
+
+    suspend fun delete(model: LocalImageModel) = withContext(Dispatchers.IO) {
+        LocalImageDownloadFiles.cancellationMarker(context, model.id).apply {
+            parentFile?.mkdirs()
+            writeText("cancelled")
+        }
+        workManager.cancelUniqueWork(LocalImageModelDownloadWorker.uniqueWorkName(model.id))
+        LocalImageInstallLocks.withModelLock(model.id) {
+            val directory = directoryFor(model)
+            if (directory.exists() && !directory.deleteRecursively()) {
+                throw IOException("Couldn't delete ${model.name} from device storage.")
+            }
+            val previous = File(imageModelsDir, "${model.directoryName}.previous")
+            if (previous.exists() && !previous.deleteRecursively()) {
+                throw IOException("Couldn't delete ${model.name}'s rollback copy.")
+            }
+            dao.delete(model.id)
+        }
+        LocalImageDownloadFiles.partialFilesFor(context, model.id).forEach(File::delete)
+        immediateFailures.value = immediateFailures.value - model.id
+    }
+
+    /** Compatibility/test seam for the MediaPipe archive installer. */
+    internal suspend fun installDownloadedZip(
+        entry: LocalImageCatalogEntry,
+        zipFile: File,
+        installingDir: File,
+    ): LocalImageModel {
+        require(entry.artifactFormat == LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP)
+        val expectedSha = entry.artifactSha256 ?: throw IOException("This model isn't ready to download yet.")
+        if (!LocalImageBundleValidator.sha256Of(zipFile).equals(expectedSha, ignoreCase = true)) {
+            throw IOException("The downloaded file failed verification. Retry the download.")
+        }
+        return LocalImageModelInstaller(context, dao, smokeTest).install(
+            entry = entry,
+            artifact = zipFile,
+            ownerId = "direct",
+            installingDirectory = installingDir,
+        )
+    }
+
+    /**
+     * Reconcile completed installs without deleting resumable partials. Only abandoned
+     * `.installing.<work-id>` directories whose WorkInfo is no longer active are removed.
+     */
+    suspend fun pruneOrphans() = withContext(Dispatchers.IO) {
+        val activeWork = runCatching {
+            workManager.getWorkInfosByTag(LocalImageModelDownloadWorker.WORK_TAG)
+                .get(10, TimeUnit.SECONDS)
+                .filter { !it.state.isFinished }
+        }.getOrNull() ?: return@withContext
+        val activeWorkIds = activeWork.map { it.id.toString() }.toSet()
+        val activeModelIds = activeWork.mapNotNull {
+            LocalImageModelDownloadWorker.modelIdFromTags(it.tags)
+        }.toSet()
+
+        imageModelsDir.listFiles().orEmpty().forEach { file ->
+            if (file.isDirectory && ".installing." in file.name) {
+                val ownerId = file.name.substringAfterLast(".installing.")
+                if (ownerId !in activeWorkIds) file.deleteRecursively()
+            }
+        }
+        LocalImageInstallRecovery.reconcile(context, dao, activeModelIds)
+        dao.getAllSync().filterNot { it.id in activeModelIds }.forEach { model ->
+            LocalImageInstallLocks.withModelLock(model.id) {
+                if (!isInstalled(model)) dao.delete(model.id)
+            }
+        }
+
+        val installedRows = dao.getAllSync().filter(::isInstalled)
+        LocalImageSelectionRecovery.reconcile(context, installedRows)
+    }
+
+    private fun workInfoState(info: WorkInfo): LocalImageDownloadState? {
+        val phase = info.progress.getString(LocalImageModelDownloadWorker.KEY_PHASE)
+        val downloaded = info.progress.getLong(LocalImageModelDownloadWorker.KEY_DOWNLOADED_BYTES, 0L)
+        val total = info.progress.getLong(
+            LocalImageModelDownloadWorker.KEY_TOTAL_BYTES,
+            LocalImageModelDownloadWorker.modelIdFromTags(info.tags)
+                ?.let(LocalImageModelCatalog::entryById)
+                ?.downloadBytes ?: 0L,
+        )
+        return when (info.state) {
+            WorkInfo.State.ENQUEUED,
+            WorkInfo.State.BLOCKED -> LocalImageDownloadState.Downloading(downloaded, total)
+            WorkInfo.State.RUNNING -> when (phase) {
+                LocalImageModelDownloadWorker.PHASE_VERIFYING -> LocalImageDownloadState.Verifying
+                LocalImageModelDownloadWorker.PHASE_INSTALLING -> LocalImageDownloadState.Installing
+                else -> LocalImageDownloadState.Downloading(downloaded, total)
+            }
+            WorkInfo.State.SUCCEEDED -> LocalImageDownloadState.Done
+            WorkInfo.State.FAILED -> LocalImageDownloadState.Failed(
+                info.outputData.getString(LocalImageModelDownloadWorker.KEY_ERROR)
+                    ?: "Download failed."
+            )
+            WorkInfo.State.CANCELLED -> null
+        }
+    }
+
+    private fun workInfosFlow() = callbackFlow<List<WorkInfo>> {
+        val liveData = workManager.getWorkInfosByTagLiveData(LocalImageModelDownloadWorker.WORK_TAG)
+        val observer = Observer<List<WorkInfo>> { infos -> trySend(infos.orEmpty()) }
+        withContext(Dispatchers.Main.immediate) { liveData.observeForever(observer) }
+        awaitClose {
+            val mainLooper = Looper.getMainLooper()
+            if (Looper.myLooper() == mainLooper) {
+                liveData.removeObserver(observer)
+            } else {
+                Handler(mainLooper).post { liveData.removeObserver(observer) }
+            }
+        }
+    }
+
+    companion object {
+        fun mediaPipeSmokeTest(context: Context): suspend (File) -> Unit = { binsDir ->
+            withContext(Dispatchers.Default) {
+                val options = ImageGenerator.ImageGeneratorOptions.builder()
+                    .setImageGeneratorModelDirectory(binsDir.absolutePath)
+                    .build()
+                ImageGenerator.createFromOptions(context, options).close()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/LocalInferenceGate.kt
+++ b/app/src/main/java/com/echoflow/data/LocalInferenceGate.kt
@@ -1,0 +1,45 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Coordinates on-device inference: exactly one local LLM generation OR one local image
+ * generation may run at a time (both compete for the same RAM and accelerators), while
+ * cloud requests remain unlimited. A single gate object replaces scattered "is something
+ * local running?" flag checks.
+ *
+ * Non-queuing by design: a second local request fails fast with [LocalInferenceBusy]
+ * (matching the app's existing "the on-device model is still responding" behaviour)
+ * instead of silently waiting behind a minutes-long generation.
+ */
+class LocalInferenceGate {
+    private val mutex = Mutex()
+
+    @Volatile
+    var currentHolder: String? = null
+        private set
+
+    /**
+     * Runs [block] holding the gate. Throws [LocalInferenceBusy] immediately when another
+     * local task holds it. The gate is released on success, failure and cancellation alike.
+     */
+    suspend fun <T> withExclusive(label: String, block: suspend () -> T): T {
+        // No owner token: Mutex.tryLock(owner) THROWS on a repeat acquisition by the same
+        // owner instead of returning false, which would turn "busy" into a crash.
+        if (!mutex.tryLock()) {
+            throw LocalInferenceBusy(currentHolder ?: "another on-device task")
+        }
+        currentHolder = label
+        try {
+            return block()
+        } finally {
+            currentHolder = null
+            mutex.unlock()
+        }
+    }
+
+    val isBusy: Boolean get() = mutex.isLocked
+}
+
+class LocalInferenceBusy(holder: String) :
+    Exception("On-device compute is busy with $holder. Wait for it to finish and try again.")

--- a/app/src/main/java/com/echoflow/data/MediaPipeImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/MediaPipeImageGenerationEngine.kt
@@ -1,0 +1,171 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import com.google.mediapipe.framework.image.BitmapExtractor
+import com.google.mediapipe.tasks.vision.imagegenerator.ImageGenerator
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import kotlin.random.Random
+
+/**
+ * Pure prompt/parameter composition for the on-device engine — separated so the rules are
+ * unit-testable without the MediaPipe SDK.
+ */
+internal object LocalImagePromptComposer {
+    /** The model's activation phrase (when present) silently prefixes every prompt. */
+    fun composePrompt(activationPhrase: String?, userPrompt: String): String {
+        val phrase = activationPhrase?.trim().orEmpty()
+        val prompt = userPrompt.trim()
+        return when {
+            phrase.isEmpty() -> prompt
+            prompt.startsWith(phrase, ignoreCase = true) -> prompt
+            else -> "$phrase, $prompt"
+        }
+    }
+
+    /** Catalog negative prompt and the user's optional one combine, deduplicated blanks. */
+    fun composeNegativePrompt(catalogNegative: String?, userNegative: String?): String =
+        listOfNotNull(catalogNegative?.trim(), userNegative?.trim())
+            .filter { it.isNotEmpty() }
+            .joinToString(", ")
+
+    fun clampIterations(value: Int): Int = value.coerceIn(
+        SettingsRepository.LOCAL_IMAGE_ITERATIONS_MIN,
+        SettingsRepository.LOCAL_IMAGE_ITERATIONS_MAX,
+    )
+
+    /** Fixed seed passes through; random mode draws a fresh non-negative seed per turn. */
+    fun resolveSeed(fixedSeed: Int?, random: Random = Random.Default): Int =
+        fixedSeed ?: random.nextInt(0, Int.MAX_VALUE)
+}
+
+/**
+ * On-device diffusion through MediaPipe Image Generator. The generator initializes lazily
+ * from an installed bundle's bins directory and is reused across generations with the same
+ * model; switching models closes the old instance first. All SDK work runs off the main
+ * thread and one generation runs at a time (callers additionally hold [LocalInferenceGate]
+ * so local LLM inference can't overlap either).
+ *
+ * Intermediate diffusion previews are intentionally not enabled: publishing every
+ * iteration slows generation and grows memory, and EchoFlow's own placeholder animation
+ * already carries the wait.
+ *
+ * Note: the MediaPipe Android API takes only (prompt, iterations, seed) — the composed
+ * negative prompt is kept in the request pipeline (and tested) so it can be forwarded the
+ * moment the SDK exposes it, but it is not sent today.
+ */
+class MediaPipeImageGenerationEngine(
+    private val context: Context,
+    private val store: GeneratedImageStore,
+) : ImageGenerationEngine {
+
+    private val generatorLock = Mutex()
+    private var generator: ImageGenerator? = null
+    private var loadedBinsDir: String? = null
+    @Volatile private var closed = false
+
+    override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> = flow {
+        if (closed) throw CancellationException("The on-device image engine was closed.")
+        val model = request.localModel
+            ?: throw ImageGenerationException.ModelNotInstalled(
+                "Pick an on-device image model in Settings → Image generation first."
+            )
+        val installDir = request.localModelInstallDir
+            ?: throw ImageGenerationException.ModelNotInstalled(
+                "${model.name} isn't installed. Download it in Settings → Image generation."
+            )
+        val binsDir = File(installDir, "bins").absolutePath
+        if (!File(binsDir).isDirectory || File(binsDir).listFiles().isNullOrEmpty()) {
+            throw ImageGenerationException.ModelNotInstalled(
+                "${model.name}'s files are missing. Re-download it in Settings → Image generation."
+            )
+        }
+
+        val prompt = LocalImagePromptComposer.composePrompt(model.activationPhrase, request.prompt)
+        // Composed and validated even though today's SDK can't accept it (see class KDoc).
+        LocalImagePromptComposer.composeNegativePrompt(model.defaultNegativePrompt, request.negativePrompt)
+        val iterations = LocalImagePromptComposer.clampIterations(request.iterations)
+        val seed = LocalImagePromptComposer.resolveSeed(request.seed)
+
+        val bitmap: Bitmap = generatorLock.withLock {
+            if (closed) throw CancellationException("The on-device image engine was closed.")
+            try {
+                val gen = obtainGenerator(binsDir, model.name)
+                val result = gen.generate(prompt, iterations, seed)
+                val mpImage = result.generatedImage()
+                    ?: throw ImageGenerationException.GenerationFailed(
+                        "${model.name} finished without producing an image. Try again."
+                    )
+                BitmapExtractor.extract(mpImage)
+            } catch (e: ImageGenerationException) {
+                throw e
+            } catch (e: Exception) {
+                throw ImageGenerationException.GenerationFailed(
+                    "On-device generation failed: ${e.message ?: "unknown error"}", e
+                )
+            } finally {
+                if (closed) releaseGeneratorLocked()
+            }
+        }
+
+        val saved = store.saveBitmap(
+            chatId = request.chatId,
+            prompt = request.prompt,
+            bitmap = bitmap,
+            parentId = request.previousImage?.id,
+        )
+        emit(ImageGenerationEvent.ImageFile(saved))
+    }.flowOn(Dispatchers.Default)
+
+    private fun obtainGenerator(binsDir: String, modelName: String): ImageGenerator {
+        val current = generator
+        if (current != null && loadedBinsDir == binsDir) return current
+        // Model switch: release the old native instance before loading the new one.
+        current?.let { runCatching { it.close() } }
+        generator = null
+        loadedBinsDir = null
+        return try {
+            val options = ImageGenerator.ImageGeneratorOptions.builder()
+                .setImageGeneratorModelDirectory(binsDir)
+                .build()
+            ImageGenerator.createFromOptions(context, options).also {
+                generator = it
+                loadedBinsDir = binsDir
+            }
+        } catch (e: Exception) {
+            throw ImageGenerationException.InitializationFailed(
+                "Couldn't load $modelName. Try re-downloading it in Settings → Image generation.", e
+            )
+        }
+    }
+
+    /**
+     * The one-shot MediaPipe generate call has no mid-run abort; cancelling the collecting
+     * coroutine drops the result. Partial output is never surfaced as a completed image.
+     */
+    override fun cancel() = Unit
+
+    override fun close() {
+        closed = true
+        if (!generatorLock.tryLock()) return
+        try {
+            releaseGeneratorLocked()
+        } finally {
+            generatorLock.unlock()
+        }
+    }
+
+    private fun releaseGeneratorLocked() {
+        val current = generator
+        generator = null
+        loadedBinsDir = null
+        current?.let { runCatching { it.close() } }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.ForeignKey
 import androidx.room.Index
+import androidx.room.ColumnInfo
 
 @Entity(tableName = "chat_threads")
 data class ChatThread(
@@ -127,6 +128,31 @@ data class AgentProfile(
 data class ImageModel(
     @PrimaryKey val id: String, // OpenRouter id, e.g. "google/gemini-2.5-flash-image"
     val name: String,
+    val addedAt: Long,
+)
+
+/**
+ * One installed on-device image model (a preconverted MediaPipe Image Generator bundle
+ * extracted under filesDir/image_models/[directoryName]). A row exists only after the
+ * bundle downloaded, verified, validated, passed its smoke test and atomically installed.
+ */
+@Entity(tableName = "local_image_models")
+data class LocalImageModel(
+    @PrimaryKey val id: String, // catalog id, "local-image/<slug>"
+    val name: String,
+    val directoryName: String, // directory under filesDir/image_models/
+    val installedBytes: Long,
+    val sourceRevision: String,
+    val sourceCheckpointSha256: String,
+    val bundleSha256: String,
+    val licenseId: String,
+    val activationPhrase: String?,
+    val defaultNegativePrompt: String?,
+    val bundleFormatVersion: Int,
+    /** Runtime id persisted with the install so catalog changes cannot reroute it. */
+    @ColumnInfo(defaultValue = "'mediapipe'") val runtime: String,
+    /** File inside [directoryName] for single-file stable-diffusion.cpp installs. */
+    val modelFileName: String?,
     val addedAt: Long,
 )
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterImageGenerationEngine.kt
@@ -1,0 +1,47 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Cloud image generation, unchanged in behaviour: one streaming chat completion with
+ * `modalities: ["image","text"]` through [OpenRouterService.sendImageGeneration]
+ * (conversational editing included via [ImageGenerationRequest.editImageDataUrl]). The
+ * base64 payload is persisted through [GeneratedImageStore] here so raw multi-MB data
+ * URLs never travel further up than this class.
+ */
+class OpenRouterImageGenerationEngine(
+    private val service: OpenRouterService,
+    private val store: GeneratedImageStore,
+) : ImageGenerationEngine {
+
+    override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> = flow {
+        service.sendImageGeneration(
+            apiKey = request.apiKey,
+            model = request.modelId,
+            history = request.history,
+            systemPrompt = request.systemPrompt,
+            editImageDataUrl = request.editImageDataUrl,
+            params = request.params,
+        ).collect { chunk ->
+            when (chunk) {
+                is StreamChunk.Content -> emit(ImageGenerationEvent.Text(chunk.text))
+                is StreamChunk.ImageGenerated -> {
+                    val saved = store.save(
+                        chatId = request.chatId,
+                        prompt = request.prompt,
+                        dataUrl = chunk.dataUrl,
+                        parentId = request.previousImage?.id,
+                    )
+                    emit(ImageGenerationEvent.ImageFile(saved))
+                }
+                else -> Unit // reasoning/search chunks don't occur on the image path
+            }
+        }
+    }
+
+    /** The one-shot HTTP call is cancelled by cancelling the collecting coroutine. */
+    override fun cancel() = Unit
+
+    override fun close() = Unit
+}

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -97,6 +97,27 @@ class SettingsRepository(context: Context) {
     private val _imageGenModel = MutableStateFlow(getImageGenModelDirect())
     val imageGenModel: StateFlow<String> = _imageGenModel.asStateFlow()
 
+    // Image generation engine ("openrouter" | "local") and the on-device knobs.
+    private val _imageGenEngine = MutableStateFlow(getImageGenEngineDirect())
+    val imageGenEngine: StateFlow<String> = _imageGenEngine.asStateFlow()
+
+    private val _localImageModel = MutableStateFlow(getLocalImageModelDirect())
+    val localImageModel: StateFlow<String> = _localImageModel.asStateFlow()
+
+    private val _localImageIterations = MutableStateFlow(getLocalImageIterationsDirect())
+    val localImageIterations: StateFlow<Int> = _localImageIterations.asStateFlow()
+
+    private val _localImageSeedMode = MutableStateFlow(getLocalImageSeedModeDirect())
+    val localImageSeedMode: StateFlow<String> = _localImageSeedMode.asStateFlow() // "random" | "fixed"
+
+    private val _localImageFixedSeed = MutableStateFlow(getLocalImageFixedSeedDirect())
+    val localImageFixedSeed: StateFlow<Int> = _localImageFixedSeed.asStateFlow()
+
+    // The broader experimental catalog is intentionally opt-in. This preference only gates
+    // discovery/download; already-installed models remain selectable and runnable.
+    private val _experimentalImageModelsEnabled = MutableStateFlow(getExperimentalImageModelsEnabledDirect())
+    val experimentalImageModelsEnabled: StateFlow<Boolean> = _experimentalImageModelsEnabled.asStateFlow()
+
     // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
     private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
     val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
@@ -537,6 +558,61 @@ class SettingsRepository(context: Context) {
         _imageGenModel.value = id
     }
 
+    /** Existing users never stored this key, so they default to the cloud engine. */
+    fun getImageGenEngineDirect(): String =
+        prefs.getString("image_generation_engine", IMAGE_ENGINE_OPENROUTER).orEmpty()
+            .takeIf { it == IMAGE_ENGINE_LOCAL } ?: IMAGE_ENGINE_OPENROUTER
+
+    fun saveImageGenEngine(engine: String) {
+        val clean = if (engine == IMAGE_ENGINE_LOCAL) IMAGE_ENGINE_LOCAL else IMAGE_ENGINE_OPENROUTER
+        prefs.edit().putString("image_generation_engine", clean).apply()
+        _imageGenEngine.value = clean
+    }
+
+    fun getLocalImageModelDirect(): String =
+        prefs.getString("local_image_model_id", "").orEmpty()
+
+    fun saveLocalImageModel(id: String) {
+        prefs.edit().putString("local_image_model_id", id).apply()
+        _localImageModel.value = id
+    }
+
+    fun getLocalImageIterationsDirect(): Int =
+        prefs.getInt("local_image_iterations", LOCAL_IMAGE_ITERATIONS_DEFAULT)
+            .coerceIn(LOCAL_IMAGE_ITERATIONS_MIN, LOCAL_IMAGE_ITERATIONS_MAX)
+
+    fun saveLocalImageIterations(value: Int) {
+        val clamped = value.coerceIn(LOCAL_IMAGE_ITERATIONS_MIN, LOCAL_IMAGE_ITERATIONS_MAX)
+        prefs.edit().putInt("local_image_iterations", clamped).apply()
+        _localImageIterations.value = clamped
+    }
+
+    fun getLocalImageSeedModeDirect(): String =
+        prefs.getString("local_image_seed_mode", "random").orEmpty()
+            .takeIf { it == "fixed" } ?: "random"
+
+    fun saveLocalImageSeedMode(mode: String) {
+        val clean = if (mode == "fixed") "fixed" else "random"
+        prefs.edit().putString("local_image_seed_mode", clean).apply()
+        _localImageSeedMode.value = clean
+    }
+
+    fun getLocalImageFixedSeedDirect(): Int =
+        prefs.getInt("local_image_fixed_seed", 1)
+
+    fun saveLocalImageFixedSeed(seed: Int) {
+        prefs.edit().putInt("local_image_fixed_seed", seed).apply()
+        _localImageFixedSeed.value = seed
+    }
+
+    fun getExperimentalImageModelsEnabledDirect(): Boolean =
+        prefs.getBoolean(KEY_EXPERIMENTAL_IMAGE_MODELS_ENABLED, false)
+
+    fun saveExperimentalImageModelsEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_EXPERIMENTAL_IMAGE_MODELS_ENABLED, enabled).apply()
+        _experimentalImageModelsEnabled.value = enabled
+    }
+
     /** Minutes of inactivity before Browser Flow auto-stops the session (cost guard). 0 = off. */
     fun getBrowserIdleMinutesDirect(): Int =
         prefs.getInt("browser_idle_minutes", 3)
@@ -550,7 +626,13 @@ class SettingsRepository(context: Context) {
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"
+        private const val KEY_EXPERIMENTAL_IMAGE_MODELS_ENABLED = "experimental_image_models_enabled"
         const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
         const val DEFAULT_IMAGE_MODEL_ID = "google/gemini-2.5-flash-image"
+        const val IMAGE_ENGINE_OPENROUTER = "openrouter"
+        const val IMAGE_ENGINE_LOCAL = "local"
+        const val LOCAL_IMAGE_ITERATIONS_DEFAULT = 20
+        const val LOCAL_IMAGE_ITERATIONS_MIN = 10
+        const val LOCAL_IMAGE_ITERATIONS_MAX = 30
     }
 }

--- a/app/src/main/java/com/echoflow/data/StableDiffusionCppImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/StableDiffusionCppImageGenerationEngine.kt
@@ -1,0 +1,360 @@
+package com.echoflow.data
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Build
+import android.os.IBinder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+
+/**
+ * Experimental on-device image engine backed by stable-diffusion.cpp. Native execution is
+ * delegated to [StableDiffusionGenerationService], which lives in a private process so an
+ * unsupported checkpoint or device driver cannot terminate EchoFlow's main process.
+ */
+class StableDiffusionCppImageGenerationEngine(
+    context: Context,
+    private val store: GeneratedImageStore,
+) : ImageGenerationEngine {
+    private val client = StableDiffusionGenerationClient(context.applicationContext)
+
+    override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> = flow {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            throw ImageGenerationException.DeviceUnsupported(
+                "Experimental image models need Android 8.0 or newer."
+            )
+        }
+        val model = request.localModel
+            ?: throw ImageGenerationException.ModelNotInstalled(
+                "Pick an on-device image model in Settings → Image generation first."
+            )
+        val installDir = request.localModelInstallDir?.let(::File)
+            ?: throw ImageGenerationException.ModelNotInstalled(
+                "${model.name} isn't installed. Download it in Settings → Image generation."
+            )
+        val fileName = model.modelFileName
+            ?: throw ImageGenerationException.InitializationFailed(
+                "${model.name} has no runnable model file. Re-download it after updating EchoFlow."
+            )
+        val modelFile = File(installDir, fileName)
+        if (!modelFile.isFile) {
+            throw ImageGenerationException.ModelNotInstalled(
+                "${model.name}'s files are missing. Re-download it in Settings → Image generation."
+            )
+        }
+
+        val prompt = LocalImagePromptComposer.composePrompt(model.activationPhrase, request.prompt)
+        val negativePrompt = LocalImagePromptComposer.composeNegativePrompt(
+            model.defaultNegativePrompt,
+            request.negativePrompt,
+        )
+        val iterations = LocalImagePromptComposer.clampIterations(request.iterations)
+        val seed = LocalImagePromptComposer.resolveSeed(request.seed).toLong()
+
+        val pendingPath = try {
+            client.generate(
+                modelPath = modelFile.absolutePath,
+                prompt = prompt,
+                negativePrompt = negativePrompt,
+                width = IMAGE_SIZE,
+                height = IMAGE_SIZE,
+                steps = iterations,
+                cfgScale = CFG_SCALE,
+                seed = seed,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw ImageGenerationException.GenerationFailed(
+                e.message ?: "The experimental image runtime stopped unexpectedly.",
+                e,
+            )
+        }
+
+        val saved = store.savePngFile(
+            chatId = request.chatId,
+            prompt = request.prompt,
+            pendingFile = File(pendingPath),
+            parentId = request.previousImage?.id,
+        )
+        emit(ImageGenerationEvent.ImageFile(saved))
+    }.flowOn(Dispatchers.Default)
+
+    override fun cancel() = client.cancel()
+
+    override fun close() = client.close()
+
+    private companion object {
+        const val IMAGE_SIZE = 512
+        const val CFG_SCALE = 7.0f
+    }
+}
+
+/** One reusable binding to the private native process. */
+private class StableDiffusionGenerationClient(private val context: Context) {
+    private val connectionMutex = Mutex()
+    private val stateLock = Any()
+
+    @Volatile
+    private var remote: IStableDiffusionGenerationService? = null
+
+    private var connection: ServiceConnection? = null
+    private var pendingConnection: CompletableDeferred<IStableDiffusionGenerationService>? = null
+    private var pendingGeneration: CompletableDeferred<String>? = null
+
+    suspend fun generate(
+        modelPath: String,
+        prompt: String,
+        negativePrompt: String,
+        width: Int,
+        height: Int,
+        steps: Int,
+        cfgScale: Float,
+        seed: Long,
+    ): String {
+        val service = service()
+        val result = CompletableDeferred<String>()
+        synchronized(stateLock) {
+            if (remote !== service || connection == null || !service.asBinder().isBinderAlive) {
+                throw nativeStopped()
+            }
+            check(pendingGeneration == null) { "Another on-device image is still being generated." }
+            pendingGeneration = result
+        }
+        val callback = object : IStableDiffusionGenerationCallback.Stub() {
+            override fun onSuccess(pngPath: String) {
+                result.complete(pngPath)
+            }
+
+            override fun onError(message: String) {
+                result.completeExceptionally(
+                    IllegalStateException(message.ifBlank { "On-device image generation failed." })
+                )
+            }
+        }
+        try {
+            try {
+                service.generate(
+                    modelPath,
+                    prompt,
+                    negativePrompt,
+                    width,
+                    height,
+                    steps,
+                    cfgScale,
+                    seed,
+                    callback,
+                )
+            } catch (error: Exception) {
+                throw nativeStopped(error)
+            }
+            return try {
+                result.await()
+            } catch (error: CancellationException) {
+                cancel()
+                throw error
+            }
+        } finally {
+            synchronized(stateLock) {
+                if (pendingGeneration === result) pendingGeneration = null
+            }
+        }
+    }
+
+    private suspend fun service(): IStableDiffusionGenerationService {
+        remote?.takeIf { it.asBinder().isBinderAlive }?.let { return it }
+        return connectionMutex.withLock {
+            remote?.takeIf { it.asBinder().isBinderAlive }?.let { return@withLock it }
+            connect()
+        }
+    }
+
+    private suspend fun connect(): IStableDiffusionGenerationService {
+        val result = CompletableDeferred<IStableDiffusionGenerationService>()
+        lateinit var candidate: ServiceConnection
+        candidate = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val service = IStableDiffusionGenerationService.Stub.asInterface(binder)
+                if (service == null) {
+                    bindingFailed(this, result, "The experimental image runtime did not start.")
+                    return
+                }
+                val accepted = synchronized(stateLock) {
+                    if (connection === this && pendingConnection === result) {
+                        remote = service
+                        pendingConnection = null
+                        true
+                    } else {
+                        false
+                    }
+                }
+                if (accepted) {
+                    if (!result.complete(service)) detachConnected(this)
+                } else {
+                    unbind(this)
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) = disconnected(this)
+
+            override fun onBindingDied(name: ComponentName?) = disconnected(this)
+
+            override fun onNullBinding(name: ComponentName?) {
+                bindingFailed(this, result, "The experimental image runtime is unavailable.")
+            }
+        }
+
+        val staleConnection = synchronized(stateLock) {
+            val stale = connection
+            remote = null
+            connection = candidate
+            pendingConnection?.cancel()
+            pendingConnection = result
+            stale
+        }
+        staleConnection?.let(::unbind)
+
+        val bound = runCatching {
+            context.bindService(
+                Intent(context, StableDiffusionGenerationService::class.java),
+                candidate,
+                Context.BIND_AUTO_CREATE,
+            )
+        }.getOrDefault(false)
+        if (!bound) {
+            bindingFailed(
+                candidate,
+                result,
+                "The experimental image runtime could not be started.",
+            )
+        }
+
+        return try {
+            result.await()
+        } catch (error: CancellationException) {
+            detachPendingBinding(candidate, result)
+            throw error
+        }
+    }
+
+    private fun bindingFailed(
+        candidate: ServiceConnection,
+        result: CompletableDeferred<IStableDiffusionGenerationService>,
+        message: String,
+    ) {
+        val wasCurrent = synchronized(stateLock) {
+            if (connection === candidate && pendingConnection === result) {
+                remote = null
+                connection = null
+                pendingConnection = null
+                true
+            } else {
+                false
+            }
+        }
+        if (wasCurrent) result.completeExceptionally(IllegalStateException(message))
+        unbind(candidate)
+    }
+
+    private fun disconnected(candidate: ServiceConnection) {
+        val pending = synchronized(stateLock) {
+            if (connection !== candidate) return
+            remote = null
+            connection = null
+            val connecting = pendingConnection
+            val generating = pendingGeneration
+            pendingConnection = null
+            pendingGeneration = null
+            connecting to generating
+        }
+        unbind(candidate)
+        val error = nativeStopped()
+        pending.first?.completeExceptionally(error)
+        pending.second?.completeExceptionally(error)
+    }
+
+    private fun detachPendingBinding(
+        candidate: ServiceConnection,
+        result: CompletableDeferred<IStableDiffusionGenerationService>,
+    ) {
+        val wasCurrent = synchronized(stateLock) {
+            if (connection === candidate && pendingConnection === result) {
+                remote = null
+                connection = null
+                pendingConnection = null
+                true
+            } else {
+                false
+            }
+        }
+        if (wasCurrent) unbind(candidate)
+    }
+
+    private fun detachConnected(candidate: ServiceConnection) {
+        val wasCurrent = synchronized(stateLock) {
+            if (connection === candidate) {
+                remote = null
+                connection = null
+                true
+            } else {
+                false
+            }
+        }
+        if (wasCurrent) unbind(candidate)
+    }
+
+    fun cancel() {
+        val state = clearState()
+        val cancellation = CancellationException("On-device image generation was stopped.")
+        state.connecting?.cancel(cancellation)
+        state.generating?.cancel(cancellation)
+        val current = state.remote
+        runCatching { current?.cancel() }
+        state.connection?.let(::unbind)
+    }
+
+    fun close() {
+        val state = clearState()
+        val cancellation = CancellationException("The on-device image runtime was closed.")
+        state.connecting?.cancel(cancellation)
+        state.generating?.cancel(cancellation)
+        val current = state.remote
+        runCatching { current?.release() }
+        state.connection?.let(::unbind)
+    }
+
+    private fun clearState(): ClientState = synchronized(stateLock) {
+        ClientState(remote, connection, pendingConnection, pendingGeneration).also {
+            remote = null
+            connection = null
+            pendingConnection = null
+            pendingGeneration = null
+        }
+    }
+
+    private fun unbind(candidate: ServiceConnection) {
+        runCatching { context.unbindService(candidate) }
+    }
+
+    private fun nativeStopped(cause: Throwable? = null): IllegalStateException =
+        IllegalStateException(
+            "The experimental model stopped. It may need more memory than this phone has.",
+            cause,
+        )
+
+    private data class ClientState(
+        val remote: IStableDiffusionGenerationService?,
+        val connection: ServiceConnection?,
+        val connecting: CompletableDeferred<IStableDiffusionGenerationService>?,
+        val generating: CompletableDeferred<String>?,
+    )
+}

--- a/app/src/main/java/com/echoflow/data/StableDiffusionGenerationService.kt
+++ b/app/src/main/java/com/echoflow/data/StableDiffusionGenerationService.kt
@@ -1,0 +1,276 @@
+package com.echoflow.data
+
+import android.app.Service
+import android.content.ComponentCallbacks2
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Build
+import android.os.IBinder
+import android.os.Process
+import com.llamatik.library.platform.StableDiffusionBridge
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.io.File
+import java.util.UUID
+
+/** Validation kept outside JNI so malformed Binder calls cannot reach the native runtime. */
+internal object StableDiffusionRequestValidator {
+    private const val MAX_PROMPT_CHARS = 8_192
+    private const val MAX_STEPS = 50
+    private const val MAX_CFG_SCALE = 30f
+
+    fun validate(
+        prompt: String,
+        negativePrompt: String,
+        width: Int,
+        height: Int,
+        steps: Int,
+        cfgScale: Float,
+    ) {
+        require(width in 256..1024 && width % 64 == 0) { "Unsupported image width." }
+        require(height in 256..1024 && height % 64 == 0) { "Unsupported image height." }
+        require(steps in 1..MAX_STEPS) { "Unsupported generation step count." }
+        require(cfgScale.isFinite() && cfgScale in 0f..MAX_CFG_SCALE) {
+            "Unsupported guidance scale."
+        }
+        require(prompt.isNotBlank() && prompt.length <= MAX_PROMPT_CHARS) {
+            "The image prompt is empty or too long."
+        }
+        require(negativePrompt.length <= MAX_PROMPT_CHARS) {
+            "The negative prompt is too long."
+        }
+    }
+}
+
+/**
+ * Hosts the experimental native image runtime in a private process. A malformed model,
+ * driver failure, or native out-of-memory crash can therefore take down this service
+ * without closing the main EchoFlow process or losing chat data.
+ *
+ * The bound service keeps its model loaded for follow-up generations until
+ * [StableDiffusionGenerationClient.close] releases it with the owning chat ViewModel. Calls are
+ * serialized because the upstream bridge owns one native context per process.
+ */
+class StableDiffusionGenerationService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val generationLock = Any()
+
+    @Volatile
+    private var activeJob: Job? = null
+
+    private var idleReleaseJob: Job? = null
+    private var closing = false
+    private var loadedModelPath: String? = null
+
+    private val binder = object : IStableDiffusionGenerationService.Stub() {
+        override fun generate(
+            modelPath: String,
+            prompt: String,
+            negativePrompt: String,
+            width: Int,
+            height: Int,
+            steps: Int,
+            cfgScale: Float,
+            seed: Long,
+            callback: IStableDiffusionGenerationCallback,
+        ) {
+            val job = synchronized(generationLock) {
+                idleReleaseJob?.cancel()
+                idleReleaseJob = null
+                if (closing) {
+                    runCatching { callback.onError("The on-device image runtime is closing.") }
+                    return
+                }
+                if (activeJob?.isCompleted == false) {
+                    runCatching { callback.onError("Another on-device image is still being generated.") }
+                    return
+                }
+                scope.launch(start = CoroutineStart.LAZY) {
+                    try {
+                        require(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            "Experimental image models need Android 8.0 or newer."
+                        }
+                        require(File(modelPath).isFile) { "The downloaded model file is missing." }
+                        StableDiffusionRequestValidator.validate(
+                            prompt,
+                            negativePrompt,
+                            width,
+                            height,
+                            steps,
+                            cfgScale,
+                        )
+
+                        if (loadedModelPath != modelPath) {
+                            if (loadedModelPath != null) StableDiffusionBridge.release()
+                            loadedModelPath = null
+                            val threads = Runtime.getRuntime().availableProcessors().coerceIn(1, 6)
+                            if (!StableDiffusionBridge.initModel(modelPath, threads)) {
+                                error("This model could not be loaded on this phone.")
+                            }
+                            loadedModelPath = modelPath
+                        }
+
+                        val rgba = StableDiffusionBridge.txt2img(
+                            prompt = prompt,
+                            negativePrompt = negativePrompt.ifBlank { null },
+                            width = width,
+                            height = height,
+                            steps = steps,
+                            cfgScale = cfgScale,
+                            seed = seed,
+                        )
+                        val expectedBytes = width.toLong() * height.toLong() * 4L
+                        if (rgba.size.toLong() != expectedBytes) {
+                            error("The native image runtime returned an incomplete image.")
+                        }
+                        val png = writePendingPng(rgba, width, height)
+                        runCatching { callback.onSuccess(png.absolutePath) }
+                            .onFailure { png.delete() }
+                    } catch (_: Error) {
+                        // OOM, linkage errors and other fatal VM/native failures can leave the
+                        // process-global context unsafe. Sacrifice only this private process.
+                        synchronized(generationLock) { closing = true }
+                        Process.killProcess(Process.myPid())
+                    } catch (e: Exception) {
+                        runCatching {
+                            callback.onError(e.message?.takeIf { it.isNotBlank() }
+                                ?: "On-device image generation failed.")
+                        }
+                    } finally {
+                        synchronized(generationLock) {
+                            activeJob = null
+                            scheduleIdleReleaseLocked()
+                        }
+                    }
+                }.also { activeJob = it }
+            }
+            job.start()
+        }
+
+        override fun cancel() {
+            // The bridge version shipped for the prerelease does not expose native
+            // cancellation. Ending only this private process is the one reliable way to
+            // stop a long diffusion pass without risking the main application process.
+            Process.killProcess(Process.myPid())
+        }
+
+        override fun release() {
+            val releaseState = synchronized(generationLock) {
+                closing = true
+                idleReleaseJob?.cancel()
+                idleReleaseJob = null
+                (activeJob?.isCompleted == false) to (loadedModelPath != null)
+            }
+            if (releaseState.first) {
+                Process.killProcess(Process.myPid())
+                return
+            }
+            if (releaseState.second) runCatching { StableDiffusionBridge.release() }
+            loadedModelPath = null
+            stopSelf()
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        pendingDir().listFiles()?.forEach { file ->
+            if (System.currentTimeMillis() - file.lastModified() > PENDING_MAX_AGE_MS) file.delete()
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+            scope.launch { releaseLoadedModelIfIdle() }
+        }
+    }
+
+    private fun scheduleIdleReleaseLocked() {
+        if (closing || loadedModelPath == null) return
+        idleReleaseJob?.cancel()
+        idleReleaseJob = scope.launch {
+            delay(MODEL_IDLE_TIMEOUT_MS)
+            releaseLoadedModelIfIdle()
+        }
+    }
+
+    private fun releaseLoadedModelIfIdle() {
+        synchronized(generationLock) {
+            if (closing || activeJob?.isCompleted == false || loadedModelPath == null) return
+            runCatching { StableDiffusionBridge.release() }
+            loadedModelPath = null
+            idleReleaseJob = null
+        }
+    }
+
+    private fun pendingDir(): File =
+        File(filesDir, "generated_images/.native_pending").apply { mkdirs() }
+
+    private fun writePendingPng(rgba: ByteArray, width: Int, height: Int): File {
+        val pixels = IntArray(width * height)
+        var source = 0
+        for (index in pixels.indices) {
+            val red = rgba[source++].toInt() and 0xff
+            val green = rgba[source++].toInt() and 0xff
+            val blue = rgba[source++].toInt() and 0xff
+            val alpha = rgba[source++].toInt() and 0xff
+            pixels[index] = Color.argb(alpha, red, green, blue)
+        }
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+        val directory = pendingDir()
+        val finalFile = File(directory, "${UUID.randomUUID()}.png")
+        val tempFile = File(directory, "${finalFile.name}.tmp")
+        try {
+            tempFile.outputStream().use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not encode the generated image."
+                }
+            }
+            if (!tempFile.renameTo(finalFile)) {
+                tempFile.copyTo(finalFile, overwrite = true)
+                tempFile.delete()
+            }
+            return finalFile
+        } finally {
+            bitmap.recycle()
+            tempFile.delete()
+        }
+    }
+
+    override fun onDestroy() {
+        val nativeCallMayBeActive = synchronized(generationLock) {
+            closing = true
+            idleReleaseJob?.cancel()
+            idleReleaseJob = null
+            activeJob?.isCompleted == false
+        }
+        activeJob?.cancel()
+        // Coroutine cancellation cannot interrupt txt2img. Releasing its process-global context
+        // while JNI is still using it is unsafe, so let process teardown reclaim it instead.
+        if (!nativeCallMayBeActive && loadedModelPath != null) {
+            runCatching { StableDiffusionBridge.release() }
+        }
+        loadedModelPath = null
+        scope.cancel()
+        super.onDestroy()
+        if (nativeCallMayBeActive) Process.killProcess(Process.myPid())
+    }
+
+    private companion object {
+        const val PENDING_MAX_AGE_MS = 24L * 60L * 60L * 1_000L
+        const val MODEL_IDLE_TIMEOUT_MS = 2L * 60L * 1_000L
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -37,7 +37,10 @@ class ChatViewModel(
     private val browserStepDao: BrowserStepDao,
     private val artifactDao: ArtifactDao,
     private val artifactVersionDao: ArtifactVersionDao,
-    private val generatedImageDao: GeneratedImageDao
+    private val generatedImageDao: GeneratedImageDao,
+    private val localImageModelDao: LocalImageModelDao,
+    private val localImageModelManager: LocalImageModelManager,
+    private val localInferenceGate: LocalInferenceGate
 ) : AndroidViewModel(application) {
 
     // Artifacts: model-built, rendered content (web page / document / report) with version history.
@@ -45,6 +48,15 @@ class ChatViewModel(
 
     // Image generation: decoded PNGs on disk, version chain in Room (see GeneratedImageStore).
     private val generatedImageStore = GeneratedImageStore(application, generatedImageDao)
+
+    // Cloud and model-routed local image engines; the ViewModel never exposes pipeline choices.
+    private val openRouterImageEngine by lazy { OpenRouterImageGenerationEngine(openRouterService, generatedImageStore) }
+    private val localImageEngine by lazy {
+        LocalImageGenerationEngineRouter(
+            mediaPipe = MediaPipeImageGenerationEngine(application, generatedImageStore),
+            stableDiffusionCpp = StableDiffusionCppImageGenerationEngine(application, generatedImageStore),
+        )
+    }
 
     private val openRouterService = OpenRouterService(application)
     private val customProviderService = CustomProviderService(application)
@@ -481,6 +493,20 @@ class ChatViewModel(
 
     private fun reduceSegments(segments: MutableList<StreamSegment>, chunk: StreamChunk): String? =
         ChatSegmentReducer.reduce(segments, chunk)
+
+    /**
+     * Routes a local (on-device) generation flow through the shared inference gate so a
+     * local LLM reply and a local image generation can never run at the same time. The
+     * gate is released on completion, failure and cancellation alike.
+     */
+    private fun Flow<StreamChunk>.withLocalInferenceGate(label: String): Flow<StreamChunk> {
+        val upstream = this
+        return flow {
+            localInferenceGate.withExclusive(label) {
+                upstream.collect { emit(it) }
+            }
+        }
+    }
     // -------------------------------------------------------------------------------
     // Send + routing
     // -------------------------------------------------------------------------------
@@ -563,13 +589,33 @@ class ChatViewModel(
             // likewise always runs its own OpenRouter image model, whatever chat model is picked.
             val isLocal = selectedModel.startsWith("local/") && _chatMode.value !is ChatMode.EchoFusion && !imageGenMode
 
+            val imageEngineLocal = imageGenMode &&
+                settingsRepository.getImageGenEngineDirect() == SettingsRepository.IMAGE_ENGINE_LOCAL
+            var localImageModel: LocalImageModel? = null
             if (imageGenMode) {
-                if (apiKey.isBlank()) {
-                    _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Cloud models."
-                    return@launch
-                }
                 if (attachmentMime.equals("application/pdf", ignoreCase = true)) {
                     _errorMessage.value = "Image generation works with image attachments only, not PDFs."
+                    return@launch
+                }
+                if (imageEngineLocal) {
+                    // On-device engine: no API key needed — but the model must be installed.
+                    val selectedId = settingsRepository.getLocalImageModelDirect()
+                    localImageModel = selectedId.takeIf { it.isNotBlank() }?.let { localImageModelDao.getById(it) }
+                    if (localImageModel == null || !localImageModelManager.isInstalled(localImageModel)) {
+                        _errorMessage.value = "Download an on-device image model in Settings → Image generation first."
+                        return@launch
+                    }
+                    val catalogEntry = LocalImageModelCatalog.entryById(localImageModel.id)
+                    if (catalogEntry != null && !localImageModelManager.deviceSupportsRuntime(catalogEntry)) {
+                        _errorMessage.value = "${localImageModel.name} needs Android 8.0 or newer."
+                        return@launch
+                    }
+                    if (catalogEntry != null && !localImageModelManager.deviceMeetsRam(catalogEntry)) {
+                        _errorMessage.value = "${localImageModel.name} needs more memory than this device has. Try the OpenRouter engine instead."
+                        return@launch
+                    }
+                } else if (apiKey.isBlank()) {
+                    _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Cloud models."
                     return@launch
                 }
             }
@@ -801,23 +847,59 @@ class ChatViewModel(
             // wait itself has variety across generations.
             val imageGenModelId = if (imageGenMode) settingsRepository.getImageGenModelDirect() else ""
             val imagePrev = if (imageGenMode) generatedImageStore.latestForChat(chatId) else null
-            val imageEditUrl = imagePrev?.let { generatedImageStore.asDataUrl(it) }
+            // The base64 re-encode is cloud-only: OpenRouter gets true conversational editing.
+            val imageEditUrl = if (imageGenMode && !imageEngineLocal) imagePrev?.let { generatedImageStore.asDataUrl(it) } else null
             val imagePattern = if (imageGenMode) listOf("ripple", "rain").random() else ""
 
             val baseResponseFlow: Flow<StreamChunk> = when {
                 imageGenMode ->
                     flow {
-                        emit(StreamChunk.ImageGenStarted(imagePattern, imageEditUrl != null, imagePrev?.filePath))
-                        emitAll(
-                            openRouterService.sendImageGeneration(
-                                apiKey = apiKey,
-                                model = imageGenModelId,
-                                history = fullHistory,
-                                systemPrompt = SystemPrompts.buildImageGen(editing = imageEditUrl != null),
-                                editImageDataUrl = imageEditUrl,
-                                params = inferenceParams,
-                            )
+                        emit(StreamChunk.ImageGenStarted(imagePattern, imagePrev != null, imagePrev?.filePath))
+                        // On-device runtimes do not support instruction-based editing: a local
+                        // follow-up regenerates from the prior prompt plus the requested change,
+                        // linked into the same version chain via parentId.
+                        val localPrompt = if (imageEngineLocal && imagePrev != null) {
+                            "${imagePrev.prompt}, $prompt"
+                        } else prompt
+                        val request = ImageGenerationRequest(
+                            chatId = chatId,
+                            prompt = localPrompt,
+                            modelId = if (imageEngineLocal) localImageModel!!.id else imageGenModelId,
+                            iterations = settingsRepository.getLocalImageIterationsDirect(),
+                            seed = if (settingsRepository.getLocalImageSeedModeDirect() == "fixed") {
+                                settingsRepository.getLocalImageFixedSeedDirect()
+                            } else null,
+                            previousImage = imagePrev,
+                            apiKey = apiKey,
+                            history = fullHistory,
+                            systemPrompt = SystemPrompts.buildImageGen(editing = imageEditUrl != null),
+                            editImageDataUrl = imageEditUrl,
+                            params = inferenceParams,
+                            localModel = localImageModel,
+                            localModelInstallDir = localImageModel?.let {
+                                localImageModelManager.directoryFor(it).absolutePath
+                            },
                         )
+                        val relay: suspend (ImageGenerationEvent) -> Unit = { event ->
+                            when (event) {
+                                is ImageGenerationEvent.Text -> emit(StreamChunk.Content(event.delta))
+                                is ImageGenerationEvent.ImageFile -> emit(
+                                    StreamChunk.ImageGenerated(
+                                        dataUrl = "",
+                                        filePath = event.image.filePath,
+                                        imageId = event.image.id,
+                                    )
+                                )
+                            }
+                        }
+                        if (imageEngineLocal) {
+                            // Local diffusion and local LLM inference never overlap.
+                            localInferenceGate.withExclusive("image generation") {
+                                localImageEngine.generate(request).collect(relay)
+                            }
+                        } else {
+                            openRouterImageEngine.generate(request).collect(relay)
+                        }
                     }
                 agentReq != null ->
                     openRouterService.sendWithAgentTools(
@@ -840,7 +922,7 @@ class ChatViewModel(
                             params = inferenceParams,
                             localModel = localModel,
                         )
-                    )
+                    ).withLocalInferenceGate("a chat reply")
                 artifactMode && customProviderActive ->
                     customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 artifactMode ->
@@ -867,6 +949,7 @@ class ChatViewModel(
                     )
                 isLocal && clientSearchReady ->
                     localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey, inferenceParams)
+                        .withLocalInferenceGate("a chat reply")
                 isLocal ->
                     localGateway.stream(
                         LlmStreamRequest(
@@ -877,7 +960,7 @@ class ChatViewModel(
                             params = inferenceParams,
                             localModel = localModel,
                         )
-                    )
+                    ).withLocalInferenceGate("a chat reply")
                 customToolCallingActive ->
                     customProviderToolFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams) { query ->
                         webSearchService.search(provider, searchKey, query)
@@ -1454,6 +1537,7 @@ class ChatViewModel(
 
     override fun onCleared() {
         localLlmService.releaseAll()
+        localImageEngine.close()
         super.onCleared()
     }
 
@@ -1477,7 +1561,10 @@ class ChatViewModel(
             browserStepDao: BrowserStepDao,
             artifactDao: ArtifactDao,
             artifactVersionDao: ArtifactVersionDao,
-            generatedImageDao: GeneratedImageDao
+            generatedImageDao: GeneratedImageDao,
+            localImageModelDao: LocalImageModelDao,
+            localImageModelManager: LocalImageModelManager,
+            localInferenceGate: LocalInferenceGate
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -1485,7 +1572,7 @@ class ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
                     agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao,
-                    generatedImageDao
+                    generatedImageDao, localImageModelDao, localImageModelManager, localInferenceGate
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -21,6 +21,12 @@ import com.echoflow.data.FusionPanel
 import com.echoflow.data.FusionPanelDao
 import com.echoflow.data.ImageModel
 import com.echoflow.data.ImageModelDao
+import com.echoflow.data.LocalImageCatalogEntry
+import com.echoflow.data.LocalImageDownloadState
+import com.echoflow.data.LocalImageModel
+import com.echoflow.data.LocalImageModelDao
+import com.echoflow.data.LocalImageModelManager
+import com.echoflow.data.LocalInferenceGate
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.InferenceParams
@@ -32,6 +38,7 @@ import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.data.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -48,7 +55,10 @@ class SettingsViewModel(
     private val advisorProfileDao: AdvisorProfileDao,
     private val fusionPanelDao: FusionPanelDao,
     private val agentProfileDao: AgentProfileDao,
-    private val imageModelDao: ImageModelDao
+    private val imageModelDao: ImageModelDao,
+    private val localImageModelDao: LocalImageModelDao,
+    private val localImageModelManager: LocalImageModelManager,
+    private val localInferenceGate: LocalInferenceGate
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
     private val customProviderService = CustomProviderService()
@@ -123,6 +133,20 @@ class SettingsViewModel(
     val imageGenModelId: StateFlow<String> = repository.imageGenModel
     val imageModels: StateFlow<List<ImageModel>> = imageModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // On-device image generation
+    val imageGenEngine: StateFlow<String> = repository.imageGenEngine
+    val localImageModelId: StateFlow<String> = repository.localImageModel
+    val localImageIterations: StateFlow<Int> = repository.localImageIterations
+    val localImageSeedMode: StateFlow<String> = repository.localImageSeedMode
+    val localImageFixedSeed: StateFlow<Int> = repository.localImageFixedSeed
+    val experimentalImageModelsEnabled: StateFlow<Boolean> = repository.experimentalImageModelsEnabled
+    val localImageModels: StateFlow<List<LocalImageModel>> = localImageModelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val localImageDownloadStates: StateFlow<Map<String, LocalImageDownloadState>> = localImageModelManager.states
+
+    private val _localImageMessage = MutableStateFlow<String?>(null)
+    val localImageMessage: StateFlow<String?> = _localImageMessage.asStateFlow()
 
     // Echo Adviser / Echo Fusion
     val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
@@ -214,6 +238,20 @@ class SettingsViewModel(
 
     init {
         viewModelScope.launch { downloadManager.pruneOrphans() }
+        viewModelScope.launch {
+            // The background Worker can finish in a recreated process with its own repository
+            // instance. Reconcile this ViewModel's hot flow with the durable preference and the
+            // files that are actually runnable whenever Room changes.
+            localImageModelDao.getAll().collect { models ->
+                val installed = models.filter(localImageModelManager::isInstalled)
+                val persisted = repository.getLocalImageModelDirect()
+                val desired = persisted.takeIf { selected -> installed.any { it.id == selected } }
+                    ?: installed.firstOrNull()?.id.orEmpty()
+                if (persisted != desired || repository.localImageModel.value != desired) {
+                    repository.saveLocalImageModel(desired)
+                }
+            }
+        }
     }
 
     fun saveApiKey(key: String) {
@@ -384,6 +422,80 @@ class SettingsViewModel(
     // ── Image generation ─────────────────────────────────────────────────────────────────
 
     fun saveImageGenModel(id: String) = repository.saveImageGenModel(id)
+
+    fun saveImageGenEngine(engine: String) = repository.saveImageGenEngine(engine)
+    fun saveLocalImageModel(id: String) = repository.saveLocalImageModel(id)
+    fun saveLocalImageIterations(value: Int) = repository.saveLocalImageIterations(value)
+    fun saveLocalImageSeedMode(mode: String) = repository.saveLocalImageSeedMode(mode)
+    fun saveLocalImageFixedSeed(seed: Int) = repository.saveLocalImageFixedSeed(seed)
+    fun saveExperimentalImageModelsEnabled(enabled: Boolean) {
+        repository.saveExperimentalImageModelsEnabled(enabled)
+        if (enabled) _localImageMessage.value = null
+    }
+
+    fun localImageRuntimeSupported(entry: LocalImageCatalogEntry): Boolean =
+        localImageModelManager.deviceSupportsRuntime(entry)
+
+    /** Picker path: choosing an on-device model also switches the engine to local. */
+    fun selectLocalImageModel(id: String) {
+        repository.saveLocalImageModel(id)
+        repository.saveImageGenEngine(com.echoflow.data.SettingsRepository.IMAGE_ENGINE_LOCAL)
+    }
+
+    /** Picker path: choosing a cloud image model also switches the engine to OpenRouter. */
+    fun selectCloudImageModel(id: String) {
+        repository.saveImageGenModel(id)
+        repository.saveImageGenEngine(com.echoflow.data.SettingsRepository.IMAGE_ENGINE_OPENROUTER)
+    }
+
+    fun downloadLocalImageModel(entry: LocalImageCatalogEntry) {
+        val experimentalEnabled = repository.getExperimentalImageModelsEnabledDirect()
+        if (!localImageModelManager.deviceSupportsRuntime(entry)) {
+            _localImageMessage.value = "${entry.name} needs Android 8.0 or newer."
+            return
+        }
+        if (!entry.canDownload(experimentalEnabled)) {
+            _localImageMessage.value = if (entry.experimental && !experimentalEnabled) {
+                "Turn on Show experimental models to download ${entry.name}."
+            } else {
+                "${entry.name} isn't ready to download yet."
+            }
+            return
+        }
+        _localImageMessage.value = null
+        localImageModelManager.download(entry)
+    }
+
+    fun cancelLocalImageDownload(entryId: String) = localImageModelManager.cancel(entryId)
+
+    fun retryLocalImageDownload(entry: LocalImageCatalogEntry) {
+        localImageModelManager.clearFailed(entry.id)
+        downloadLocalImageModel(entry)
+    }
+
+    fun clearLocalImageMessage() {
+        _localImageMessage.value = null
+    }
+
+    fun deleteLocalImageModel(model: LocalImageModel) {
+        viewModelScope.launch {
+            if (localInferenceGate.isBusy) {
+                _localImageMessage.value = "Wait for the current on-device task to finish before deleting a model."
+                return@launch
+            }
+            try {
+                localImageModelManager.delete(model)
+                if (repository.getLocalImageModelDirect() == model.id) {
+                    // Fall over to another installed model, or clear the selection entirely.
+                    val remaining = localImageModelDao.getAllSync()
+                        .firstOrNull { it.id != model.id && localImageModelManager.isInstalled(it) }
+                    repository.saveLocalImageModel(remaining?.id.orEmpty())
+                }
+            } catch (error: Exception) {
+                _localImageMessage.value = error.message ?: "Couldn't delete ${model.name}."
+            }
+        }
+    }
 
     fun addImageModel(id: String, name: String) {
         viewModelScope.launch {
@@ -571,11 +683,14 @@ class SettingsViewModel(
             advisorProfileDao: AdvisorProfileDao,
             fusionPanelDao: FusionPanelDao,
             agentProfileDao: AgentProfileDao,
-            imageModelDao: ImageModelDao
+            imageModelDao: ImageModelDao,
+            localImageModelDao: LocalImageModelDao,
+            localImageModelManager: LocalImageModelManager,
+            localInferenceGate: LocalInferenceGate
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao, localImageModelDao, localImageModelManager, localInferenceGate) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -171,12 +171,23 @@ fun ChatScreen(
     val imageGenActive by chatViewModel.imageGenActive.collectAsState()
     val imageGenModelId by settingsViewModel.imageGenModelId.collectAsState()
     val imageModels by settingsViewModel.imageModels.collectAsState()
-    // "Create image" swaps the model picker to image-output models only.
+    val imageGenEngine by settingsViewModel.imageGenEngine.collectAsState()
+    val localImageModels by settingsViewModel.localImageModels.collectAsState()
+    val localImageModelId by settingsViewModel.localImageModelId.collectAsState()
+    // "Create image" swaps the model picker to image models only: OpenRouter entries plus
+    // the installed on-device ones. Picking a row also selects the matching engine.
     val imageModelEntries = remember(imageModels) {
         val default = com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
         listOf(default) + imageModels.filter { it.id != default.first }.map { it.id to it.name }
     }
-    val imageModelLabel = imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
+    val localImageEntries = remember(localImageModels) { localImageModels.map { it.id to it.name } }
+    val imageEngineIsLocal = imageGenEngine == com.echoflow.data.SettingsRepository.IMAGE_ENGINE_LOCAL
+    val selectedImageModelId = if (imageEngineIsLocal) localImageModelId else imageGenModelId
+    val imageModelLabel = if (imageEngineIsLocal) {
+        localImageModels.firstOrNull { it.id == localImageModelId }?.name ?: "Pick an image model"
+    } else {
+        imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
+    }
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -472,9 +483,15 @@ fun ChatScreen(
         if (imageGenActive) {
             ModelPickerSheet(
                 models = imageModelEntries,
-                localModels = emptyList(),
-                selectedId = imageGenModelId,
-                onSelect = { settingsViewModel.saveImageGenModel(it); showModelMenu = false },
+                localModels = localImageEntries,
+                selectedId = selectedImageModelId,
+                onSelect = { id ->
+                    // Selecting a model also selects its engine; the normal chat LLM
+                    // selection is untouched either way.
+                    if (id.startsWith("local-image/")) settingsViewModel.selectLocalImageModel(id)
+                    else settingsViewModel.selectCloudImageModel(id)
+                    showModelMenu = false
+                },
                 onManage = { showModelMenu = false; onSettingsClicked() },
                 onDismiss = { showModelMenu = false },
             )

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
@@ -2,6 +2,11 @@
 
 package com.echoflow.ui.screens
 
+import android.text.format.Formatter
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,17 +22,28 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.CloudQueue
 import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -36,9 +52,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.echoflow.data.LocalImageCatalogEntry
+import com.echoflow.data.LocalImageDownloadState
+import com.echoflow.data.LocalImageModel
+import com.echoflow.data.LocalImageModelCatalog
 import com.echoflow.data.SettingsRepository
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.components.GroupedItemGap
@@ -47,12 +70,45 @@ import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
 
 /**
- * Image generation settings: pick the default image model and manage the whitelist. The
- * directory search is restricted to models whose `output_modalities` include "image" —
- * text-only models can't appear here.
+ * Image generation settings. A top engine selector splits the page: OpenRouter keeps the
+ * existing cloud model list + directory search; On device offers four curated models with the
+ * same download experience as local LLMs — no search, no import, no tokens.
  */
 @Composable
 internal fun ImageGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val engine by viewModel.imageGenEngine.collectAsState()
+
+    SettingsPageScaffold(title = "Image generation", subtitle = "Create & edit images in chat", onBack = onBack) {
+        ConnectedToggleRow(
+            options = listOf(
+                SettingsRepository.IMAGE_ENGINE_OPENROUTER to "OpenRouter",
+                SettingsRepository.IMAGE_ENGINE_LOCAL to "On device",
+            ),
+            selected = engine,
+            onSelect = viewModel::saveImageGenEngine,
+            icons = listOf(Icons.Default.CloudQueue, Icons.Default.PhoneAndroid),
+        )
+        Spacer(Modifier.height(Spacing.xl))
+
+        val effects = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
+        AnimatedContent(
+            targetState = engine,
+            transitionSpec = { fadeIn(effects) togetherWith fadeOut(effects) },
+            label = "imageEngineSections",
+        ) { current ->
+            if (current == SettingsRepository.IMAGE_ENGINE_LOCAL) {
+                LocalImageEngineSection(viewModel)
+            } else {
+                OpenRouterImageEngineSection(viewModel)
+            }
+        }
+    }
+}
+
+// ── OpenRouter engine (unchanged behaviour) ─────────────────────────────────────────────
+
+@Composable
+private fun OpenRouterImageEngineSection(viewModel: SettingsViewModel) {
     val imageModels by viewModel.imageModels.collectAsState()
     val selectedId by viewModel.imageGenModelId.collectAsState()
     val orQuery by viewModel.orModelQuery.collectAsState()
@@ -70,7 +126,7 @@ internal fun ImageGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             .map { it.id to it.name }
     }
 
-    SettingsPageScaffold(title = "Image generation", subtitle = "Create & edit images in chat", onBack = onBack) {
+    Column {
         PageSection("How it works", null)
         Text(
             "Turn on “Create image” from the + menu in chat, then describe an image. " +
@@ -175,4 +231,370 @@ internal fun ImageGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             onDismiss = { showDirectory = false },
         )
     }
+}
+
+// ── On-device models ────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun LocalImageEngineSection(viewModel: SettingsViewModel) {
+    val installed by viewModel.localImageModels.collectAsState()
+    val selectedId by viewModel.localImageModelId.collectAsState()
+    val states by viewModel.localImageDownloadStates.collectAsState()
+    val message by viewModel.localImageMessage.collectAsState()
+    val experimentalEnabled by viewModel.experimentalImageModelsEnabled.collectAsState()
+
+    var detailsFor by remember { mutableStateOf<LocalImageCatalogEntry?>(null) }
+
+    Column {
+        Text("Private, offline and free", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            "Runs entirely on this phone",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        message?.let {
+            Spacer(Modifier.height(Spacing.s))
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+
+        if (installed.isNotEmpty()) {
+            Spacer(Modifier.height(Spacing.xl))
+            PageSection("Installed")
+            Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+                installed.forEachIndexed { index, model ->
+                    InstalledLocalImageRow(
+                        model = model,
+                        index = index,
+                        count = installed.size,
+                        selected = model.id == selectedId,
+                        onSelect = { viewModel.saveLocalImageModel(model.id) },
+                        onDelete = { viewModel.deleteLocalImageModel(model) },
+                        onDetails = { detailsFor = LocalImageModelCatalog.entryById(model.id) },
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier
+                        .size(40.dp)
+                        .clip(RoundedPolygonShape(MaterialShapes.Gem))
+                        .background(MaterialTheme.colorScheme.tertiaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Default.Brush,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.base))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Show experimental models",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        "Experimental models may be slower or unavailable on some phones.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(
+                    checked = experimentalEnabled,
+                    onCheckedChange = viewModel::saveExperimentalImageModelsEnabled,
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Get models", "Four curated styles, tuned for phones")
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            LocalImageModelCatalog.entries.forEachIndexed { index, entry ->
+                LocalImageCatalogRow(
+                    entry = entry,
+                    index = index,
+                    count = LocalImageModelCatalog.entries.size,
+                    installed = installed.any { it.id == entry.id },
+                    state = states[entry.id],
+                    experimentalEnabled = experimentalEnabled,
+                    runtimeSupported = viewModel.localImageRuntimeSupported(entry),
+                    onDownload = { viewModel.downloadLocalImageModel(entry) },
+                    onCancel = { viewModel.cancelLocalImageDownload(entry.id) },
+                    onRetry = { viewModel.retryLocalImageDownload(entry) },
+                    onDetails = { detailsFor = entry },
+                )
+            }
+        }
+    }
+
+    detailsFor?.let { entry ->
+        LocalImageModelDetailsDialog(
+            entry = entry,
+            installedModel = installed.firstOrNull { it.id == entry.id },
+            onDismiss = { detailsFor = null },
+        )
+    }
+}
+
+@Composable
+private fun InstalledLocalImageRow(
+    model: LocalImageModel,
+    index: Int,
+    count: Int,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    onDelete: () -> Unit,
+    onDetails: () -> Unit,
+) {
+    val context = LocalContext.current
+    Surface(
+        onClick = onSelect,
+        shape = groupedItemShape(index, count),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .clip(RoundedPolygonShape(MaterialShapes.Flower))
+                    .background(
+                        if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.tertiaryContainer
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Brush, null, Modifier.size(20.dp),
+                    tint = if (selected) MaterialTheme.colorScheme.onPrimary
+                    else MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Spacer(Modifier.width(Spacing.base))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    model.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    "Installed · " + Formatter.formatShortFileSize(context, model.installedBytes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = onDetails) {
+                Icon(Icons.Default.Info, "Model details", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (selected) {
+                Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.DeleteOutline, "Delete", tint = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalImageCatalogRow(
+    entry: LocalImageCatalogEntry,
+    index: Int,
+    count: Int,
+    installed: Boolean,
+    state: LocalImageDownloadState?,
+    experimentalEnabled: Boolean,
+    runtimeSupported: Boolean,
+    onDownload: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+    onDetails: () -> Unit,
+) {
+    val context = LocalContext.current
+    val experimentalLocked = entry.experimental && !experimentalEnabled
+    val downloadLocked = experimentalLocked || !runtimeSupported
+    Surface(
+        onClick = onDetails,
+        shape = groupedItemShape(index, count),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth().alpha(if (experimentalLocked) 0.58f else 1f),
+    ) {
+        Column(Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            entry.name,
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Spacer(Modifier.width(Spacing.s))
+                        val badge = if (entry.experimental) "Experimental" else "Recommended"
+                        Surface(
+                            shape = CircleShape,
+                            color = MaterialTheme.colorScheme.tertiaryContainer,
+                        ) {
+                            Text(
+                                badge,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier.padding(horizontal = Spacing.s, vertical = 2.dp),
+                            )
+                        }
+                    }
+                    Text(
+                        "${entry.category} · ${entry.description}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    entry.downloadBytes?.let {
+                        Text(
+                            Formatter.formatShortFileSize(context, it),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    if (!runtimeSupported) {
+                        Text(
+                            "Needs Android 8.0 or newer",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Spacer(Modifier.width(Spacing.s))
+                when {
+                    installed -> Icon(
+                        Icons.Default.CheckCircle, "Installed",
+                        Modifier.padding(Spacing.m), tint = MaterialTheme.colorScheme.primary,
+                    )
+                    state is LocalImageDownloadState.Downloading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularWavyProgressIndicator(
+                            progress = { state.fraction },
+                            modifier = Modifier.size(32.dp),
+                        )
+                        IconButton(onClick = onCancel) {
+                            Icon(Icons.Default.Close, "Cancel download", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                    state is LocalImageDownloadState.Verifying || state is LocalImageDownloadState.Installing ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularWavyProgressIndicator(modifier = Modifier.size(32.dp))
+                            Spacer(Modifier.width(Spacing.s))
+                            Text(
+                                if (state is LocalImageDownloadState.Verifying) "Verifying…" else "Installing…",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    state is LocalImageDownloadState.Failed &&
+                        entry.canDownload(experimentalEnabled) && runtimeSupported -> IconButton(onClick = onRetry) {
+                        Icon(Icons.Default.Refresh, "Retry download", tint = MaterialTheme.colorScheme.error)
+                    }
+                    !entry.artifactAvailable -> Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    ) {
+                        Text(
+                            "Coming soon",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = Spacing.m, vertical = Spacing.xs),
+                        )
+                    }
+                    downloadLocked -> FilledTonalIconButton(onClick = {}, enabled = false) {
+                        Icon(
+                            Icons.Default.Download,
+                            if (!runtimeSupported) "Android 8.0 is required to download ${entry.name}"
+                            else "Enable experimental models to download ${entry.name}",
+                        )
+                    }
+                    else -> FilledTonalIconButton(onClick = onDownload, enabled = entry.canDownload(experimentalEnabled)) {
+                        Icon(Icons.Default.Download, "Download ${entry.name}")
+                    }
+                }
+            }
+            if (state is LocalImageDownloadState.Downloading) {
+                Text(
+                    "${Formatter.formatShortFileSize(context, state.downloadedBytes)} of " +
+                        Formatter.formatShortFileSize(context, state.totalBytes),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (state is LocalImageDownloadState.Failed) {
+                Spacer(Modifier.height(Spacing.xs))
+                Text(
+                    state.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+/** Subtle details view: name, category, source link, licence, installed size. */
+@Composable
+private fun LocalImageModelDetailsDialog(
+    entry: LocalImageCatalogEntry,
+    installedModel: LocalImageModel?,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Brush, null) },
+        title = { Text(entry.name) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+                Text("Category: ${entry.category}", style = MaterialTheme.typography.bodyMedium)
+                Text(entry.description, style = MaterialTheme.typography.bodyMedium)
+                installedModel?.let {
+                    Text(
+                        "Installed size: " + Formatter.formatShortFileSize(context, it.installedBytes),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                val licenceName = when (entry.licenseId) {
+                    LocalImageModelCatalog.LICENSE_OPENRAIL_M -> "CreativeML OpenRAIL-M"
+                    LocalImageModelCatalog.LICENSE_CIVITAI_MODEL_TERMS -> "CivitAI model terms"
+                    else -> entry.licenseId
+                }
+                Text("Licence: $licenceName", style = MaterialTheme.typography.bodyMedium)
+                Row {
+                    TextButton(onClick = { uriHandler.openUri(entry.sourceUrl) }) {
+                        Text("View source")
+                    }
+                    TextButton(onClick = { uriHandler.openUri(entry.licenseUrl) }) {
+                        Text("View licence")
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
+    )
 }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -293,9 +293,16 @@ internal fun SettingsHomePage(
     }
     val imageGenModelId by viewModel.imageGenModelId.collectAsState()
     val imageModelsHome by viewModel.imageModels.collectAsState()
-    val imageGenSubtitle = imageModelsHome.firstOrNull { it.id == imageGenModelId }?.name
-        ?: if (imageGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID) "Gemini 2.5 Flash Image"
-        else imageGenModelId
+    val imageGenEngineHome by viewModel.imageGenEngine.collectAsState()
+    val localImageModelsHome by viewModel.localImageModels.collectAsState()
+    val localImageModelIdHome by viewModel.localImageModelId.collectAsState()
+    val imageGenSubtitle = if (imageGenEngineHome == com.echoflow.data.SettingsRepository.IMAGE_ENGINE_LOCAL) {
+        "On device · " + (localImageModelsHome.firstOrNull { it.id == localImageModelIdHome }?.name ?: "pick a model")
+    } else {
+        imageModelsHome.firstOrNull { it.id == imageGenModelId }?.name
+            ?: if (imageGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID) "Gemini 2.5 Flash Image"
+            else imageGenModelId
+    }
     val deepResearchSubtitle = when {
         deepResearchModelId.isBlank() -> "No engine selected"
         else -> DeepResearchCatalog.providerEngineById(deepResearchModelId)?.name

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -12,4 +12,5 @@
     <exclude domain="sharedpref" path="settings_prefs.xml" />
     <!-- Downloaded models are reproducible and can exceed Android's backup quota. -->
     <exclude domain="file" path="models/" />
+    <exclude domain="file" path="image_models/" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -8,10 +8,12 @@
         <exclude domain="sharedpref" path="secure_settings_prefs.xml" />
         <exclude domain="sharedpref" path="settings_prefs.xml" />
         <exclude domain="file" path="models/" />
+        <exclude domain="file" path="image_models/" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="sharedpref" path="secure_settings_prefs.xml" />
         <exclude domain="sharedpref" path="settings_prefs.xml" />
         <exclude domain="file" path="models/" />
+        <exclude domain="file" path="image_models/" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,12 +56,20 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version thirteen without data loss`() {
+    fun `production database upgrades version one through version fifteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
 
         // v13 tables exist and are queryable after the chained migration.
         database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM image_models").use { it.moveToFirst() }
         database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM generated_images").use { it.moveToFirst() }
+        // v14: local_image_models is created and starts empty.
+        database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM local_image_models").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        database.openHelper.readableDatabase.query(
+            "SELECT runtime, modelFileName FROM local_image_models LIMIT 0"
+        ).use { /* v15 columns are queryable */ }
 
         database.openHelper.readableDatabase.query(
             "SELECT content, reasoning, localAttachmentUri, localAttachmentName " +

--- a/app/src/test/java/com/echoflow/data/GeneratedImageStoreTest.kt
+++ b/app/src/test/java/com/echoflow/data/GeneratedImageStoreTest.kt
@@ -1,0 +1,86 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class GeneratedImageStoreTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var database: AppDatabase
+    private lateinit var store: GeneratedImageStore
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        store = GeneratedImageStore(context, database.generatedImageDao())
+        runBlocking {
+            database.chatDao().insertThread(ChatThread("chat-1", "Chat", 1L, 1L))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        File(context.filesDir, "generated_images").deleteRecursively()
+    }
+
+    @Test fun `saveBitmap writes a PNG, cleans temp files and links the version chain`() = runBlocking {
+        val bitmap = Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
+        val first = store.saveBitmap("chat-1", "a castle", bitmap, parentId = null)
+        val file = File(first.filePath)
+        assertTrue(file.isFile)
+        assertTrue(file.length() > 0)
+        assertTrue(file.name.endsWith(".png"))
+        // No .tmp residue anywhere in the images directory.
+        assertFalse(file.parentFile!!.listFiles()!!.any { it.name.endsWith(".tmp") })
+        // Row exists and is the chat's latest.
+        assertEquals(first.id, store.latestForChat("chat-1")?.id)
+
+        val second = store.saveBitmap("chat-1", "a castle, at night", bitmap, parentId = first.id)
+        assertEquals(first.id, second.parentId)
+        assertEquals(second.id, store.latestForChat("chat-1")?.id)
+        assertNotNull(database.generatedImageDao().getById(second.id))
+    }
+
+    @Test fun `savePngFile atomically adopts only a native pending result`() = runBlocking {
+        val pendingDir = File(context.filesDir, "generated_images/.native_pending").apply { mkdirs() }
+        val pending = File(pendingDir, "native-result.png").apply {
+            writeBytes(byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47))
+        }
+
+        val saved = store.savePngFile(
+            chatId = "chat-1",
+            prompt = "a lighthouse",
+            pendingFile = pending,
+            parentId = null,
+        )
+
+        assertFalse(pending.exists())
+        assertTrue(File(saved.filePath).isFile)
+        assertEquals(saved.id, database.generatedImageDao().getById(saved.id)?.id)
+
+        val outside = File(context.cacheDir, "outside.png").apply { writeBytes(byteArrayOf(1)) }
+        try {
+            store.savePngFile("chat-1", "invalid", outside, null)
+            throw AssertionError("Expected an app-private pending path to be required")
+        } catch (_: IllegalArgumentException) {
+            // Expected: an arbitrary same-UID path must never be adopted as a generated image.
+        } finally {
+            outside.delete()
+        }
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ImageGenSettingsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ImageGenSettingsTest.kt
@@ -1,0 +1,64 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ImageGenSettingsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetPreferences() {
+        SettingsPreferenceStorage.legacy(context).edit().clear().commit()
+        SettingsPreferenceStorage.secureOrNull(context)?.edit()?.clear()?.commit()
+    }
+
+    @Test fun `existing users default to the OpenRouter engine and sane local defaults`() {
+        val repository = SettingsRepository(context)
+        assertEquals(SettingsRepository.IMAGE_ENGINE_OPENROUTER, repository.getImageGenEngineDirect())
+        assertEquals("", repository.getLocalImageModelDirect())
+        assertEquals(20, repository.getLocalImageIterationsDirect())
+        assertEquals("random", repository.getLocalImageSeedModeDirect())
+        assertEquals(1, repository.getLocalImageFixedSeedDirect())
+        assertEquals(false, repository.getExperimentalImageModelsEnabledDirect())
+        // The existing cloud image model preference is untouched by the engine split.
+        assertEquals(SettingsRepository.DEFAULT_IMAGE_MODEL_ID, repository.getImageGenModelDirect())
+    }
+
+    @Test fun `engine, model, seed settings persist and unknown values normalize`() {
+        val repository = SettingsRepository(context)
+        repository.saveImageGenEngine(SettingsRepository.IMAGE_ENGINE_LOCAL)
+        repository.saveLocalImageModel("local-image/dreamshaper-8")
+        repository.saveLocalImageSeedMode("fixed")
+        repository.saveLocalImageFixedSeed(1234)
+        repository.saveExperimentalImageModelsEnabled(true)
+
+        val reloaded = SettingsRepository(context)
+        assertEquals(SettingsRepository.IMAGE_ENGINE_LOCAL, reloaded.getImageGenEngineDirect())
+        assertEquals("local-image/dreamshaper-8", reloaded.getLocalImageModelDirect())
+        assertEquals("fixed", reloaded.getLocalImageSeedModeDirect())
+        assertEquals(1234, reloaded.getLocalImageFixedSeedDirect())
+        assertEquals(true, reloaded.getExperimentalImageModelsEnabledDirect())
+        assertEquals(true, reloaded.experimentalImageModelsEnabled.value)
+
+        reloaded.saveImageGenEngine("nonsense")
+        assertEquals(SettingsRepository.IMAGE_ENGINE_OPENROUTER, reloaded.getImageGenEngineDirect())
+        reloaded.saveLocalImageSeedMode("nonsense")
+        assertEquals("random", reloaded.getLocalImageSeedModeDirect())
+    }
+
+    @Test fun `local iterations clamp to 10-30 on save and on read`() {
+        val repository = SettingsRepository(context)
+        repository.saveLocalImageIterations(1)
+        assertEquals(10, repository.getLocalImageIterationsDirect())
+        repository.saveLocalImageIterations(500)
+        assertEquals(30, repository.getLocalImageIterationsDirect())
+        repository.saveLocalImageIterations(25)
+        assertEquals(25, repository.getLocalImageIterationsDirect())
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalImageGenerationEngineRouterTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalImageGenerationEngineRouterTest.kt
@@ -1,0 +1,97 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalImageGenerationEngineRouterTest {
+    @Test
+    fun `routes each persisted runtime without exposing pipeline choice`() = runTest {
+        val mediaPipe = RecordingEngine()
+        val cpp = RecordingEngine()
+        val router = LocalImageGenerationEngineRouter(mediaPipe, cpp)
+
+        router.generate(request(runtime = LocalImageRuntime.MEDIAPIPE.id)).toList()
+        router.generate(request(runtime = LocalImageRuntime.STABLE_DIFFUSION_CPP.id)).toList()
+
+        assertEquals(1, mediaPipe.generations)
+        assertEquals(1, cpp.generations)
+    }
+
+    @Test
+    fun `rejects an unknown persisted runtime instead of silently rerouting`() = runTest {
+        val mediaPipe = RecordingEngine()
+        val cpp = RecordingEngine()
+        val router = LocalImageGenerationEngineRouter(mediaPipe, cpp)
+
+        val error = try {
+            router.generate(request(runtime = "future-runtime")).toList()
+            null
+        } catch (failure: Throwable) {
+            failure
+        }
+        assertTrue(error is ImageGenerationException.InitializationFailed)
+        assertEquals(0, mediaPipe.generations)
+        assertEquals(0, cpp.generations)
+    }
+
+    @Test
+    fun `close releases both runtimes`() {
+        val mediaPipe = RecordingEngine()
+        val cpp = RecordingEngine()
+        val router = LocalImageGenerationEngineRouter(mediaPipe, cpp)
+
+        router.close()
+
+        assertTrue(mediaPipe.closed)
+        assertTrue(cpp.closed)
+        assertFalse(mediaPipe.cancelled)
+        assertFalse(cpp.cancelled)
+    }
+
+    private fun request(runtime: String) = ImageGenerationRequest(
+        chatId = "chat",
+        prompt = "a lighthouse",
+        modelId = "local-image/test",
+        localModel = LocalImageModel(
+            id = "local-image/test",
+            name = "Test model",
+            directoryName = "test",
+            installedBytes = 1,
+            sourceRevision = "revision",
+            sourceCheckpointSha256 = "a".repeat(64),
+            bundleSha256 = "b".repeat(64),
+            licenseId = "license",
+            activationPhrase = null,
+            defaultNegativePrompt = null,
+            bundleFormatVersion = 1,
+            runtime = runtime,
+            modelFileName = null,
+            addedAt = 1,
+        ),
+    )
+
+    private class RecordingEngine : ImageGenerationEngine {
+        var generations = 0
+        var cancelled = false
+        var closed = false
+
+        override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> {
+            generations++
+            return emptyFlow()
+        }
+
+        override fun cancel() {
+            cancelled = true
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalImageModelCatalogTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalImageModelCatalogTest.kt
@@ -1,0 +1,76 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalImageModelCatalogTest {
+    @Test
+    fun `catalog exposes exactly four pinned artifacts`() {
+        val entries = LocalImageModelCatalog.entries
+        assertEquals(4, entries.size)
+        assertEquals(4, entries.map { it.id }.distinct().size)
+        assertTrue(entries.all { it.id.startsWith("local-image/") })
+        assertTrue(entries.all { it.artifactAvailable })
+        assertEquals(4, entries.mapNotNull { it.artifactUrl }.distinct().size)
+        entries.forEach {
+            assertTrue(LocalImageCatalogEntry.SHA256_REGEX.matches(it.artifactSha256.orEmpty()))
+            assertTrue((it.downloadBytes ?: 0L) > 2_000_000_000L || !it.experimental)
+        }
+    }
+
+    @Test
+    fun `only recommended MediaPipe model downloads before experimental opt in`() {
+        val defaultEntries = LocalImageModelCatalog.entries.filter { it.canDownload(false) }
+        assertEquals(listOf("local-image/stable-diffusion-1.5"), defaultEntries.map { it.id })
+        assertTrue(LocalImageModelCatalog.entries.all { it.canDownload(true) })
+
+        val recommended = defaultEntries.single()
+        assertEquals(LocalImageRuntime.MEDIAPIPE, recommended.runtime)
+        assertEquals(LocalImageArtifactFormat.MEDIAPIPE_ROOT_ZIP, recommended.artifactFormat)
+        assertNull(recommended.modelFileName)
+        assertEquals(1_906_219_565L, recommended.downloadBytes)
+        assertEquals(
+            "0e17f95821b6a247d01807b20920206052fc32483af2af42f03ff61954397758",
+            recommended.artifactSha256,
+        )
+    }
+
+    @Test
+    fun `three experimental models route to stable diffusion cpp with correct files`() {
+        val experimental = LocalImageModelCatalog.entries.filter { it.experimental }
+        assertEquals(3, experimental.size)
+        assertTrue(experimental.all { it.runtime == LocalImageRuntime.STABLE_DIFFUSION_CPP })
+        assertEquals(
+            setOf(
+                "dreamshaper_8.safetensors",
+                "analog-diffusion-1.0.safetensors",
+                "openjourney-v4.ckpt",
+            ),
+            experimental.mapNotNull { it.modelFileName }.toSet(),
+        )
+        assertEquals(LocalImageArtifactFormat.CHECKPOINT, experimental.single { it.id.endsWith("openjourney-v4") }.artifactFormat)
+    }
+
+    @Test
+    fun `DreamShaper carries Civitai terms while Hugging Face artifacts carry OpenRAIL`() {
+        val dreamShaper = LocalImageModelCatalog.entryById("local-image/dreamshaper-8")!!
+        assertEquals(LocalImageModelCatalog.LICENSE_CIVITAI_MODEL_TERMS, dreamShaper.licenseId)
+        assertEquals(LocalImageModelCatalog.DREAMSHAPER_TERMS_URL, dreamShaper.licenseUrl)
+        LocalImageModelCatalog.entries.filter { it !== dreamShaper }.forEach {
+            assertEquals(LocalImageModelCatalog.LICENSE_OPENRAIL_M, it.licenseId)
+        }
+    }
+
+    @Test
+    fun `analog diffusion activation phrase remains catalog metadata`() {
+        assertEquals(
+            "analog style",
+            LocalImageModelCatalog.entryById("local-image/analog-diffusion")?.activationPhrase,
+        )
+        assertFalse(LocalImageModelCatalog.entries.filterNot { it.id.endsWith("analog-diffusion") }
+            .any { it.activationPhrase != null })
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalImageModelInstallTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalImageModelInstallTest.kt
@@ -1,0 +1,299 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+class LocalImageModelInstallTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var database: AppDatabase
+    private lateinit var dao: LocalImageModelDao
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.localImageModelDao()
+        LocalImageDownloadFiles.root(context).deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        LocalImageDownloadFiles.root(context).deleteRecursively()
+        SettingsRepository(context).saveLocalImageModel("")
+    }
+
+    private fun mediaEntry(zip: File): LocalImageCatalogEntry =
+        LocalImageModelCatalog.entries.first().copy(
+            artifactUrl = "https://example.invalid/model.zip",
+            downloadBytes = zip.length(),
+            installedBytes = 64,
+            artifactRevision = "test-revision",
+            artifactSha256 = LocalImageBundleValidator.sha256Of(zip),
+        )
+
+    private fun buildZip(
+        entryName: String = "weights.bin",
+        content: ByteArray = ByteArray(16) { it.toByte() },
+    ): File {
+        val zip = File.createTempFile("image-model", ".zip", context.cacheDir)
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(entryName))
+            output.write(content)
+            output.closeEntry()
+        }
+        return zip
+    }
+
+    private fun installer(
+        targetDao: LocalImageModelDao = dao,
+        smokeTest: suspend (File) -> Unit = {},
+    ) = LocalImageModelInstaller(context, targetDao, smokeTest)
+
+    @Test
+    fun `MediaPipe root archive installs under bins and persists runtime`() = runBlocking {
+        val zip = buildZip()
+        val entry = mediaEntry(zip)
+        val model = installer().install(entry, zip, "test")
+
+        val finalDir = LocalImageDownloadFiles.finalDirectory(context, entry)
+        assertTrue(File(finalDir, "bins/weights.bin").isFile)
+        assertEquals(LocalImageRuntime.MEDIAPIPE.id, model.runtime)
+        assertNull(model.modelFileName)
+        assertNotNull(dao.getById(entry.id))
+    }
+
+    @Test
+    fun `unsafe path and excessive expanded size are rejected`() {
+        val traversal = buildZip("../outside.bin")
+        try {
+            LocalImageBundleValidator.extractZipSafely(traversal, File(context.cacheDir, "unsafe"), 1024)
+            fail("expected unsafe-path rejection")
+        } catch (error: IOException) {
+            assertTrue(error.message!!.contains("unsafe"))
+        }
+
+        val oversized = buildZip(content = ByteArray(128))
+        try {
+            LocalImageBundleValidator.extractZipSafely(oversized, File(context.cacheDir, "oversized"), 32)
+            fail("expected expansion-limit rejection")
+        } catch (error: IOException) {
+            assertTrue(error.message!!.contains("expected size"))
+        }
+    }
+
+    @Test
+    fun `cancellation during extraction removes the installing directory`() = runBlocking {
+        val zip = buildZip(content = ByteArray(512 * 1024))
+        val entry = mediaEntry(zip).copy(installedBytes = 512 * 1024)
+        var checks = 0
+        try {
+            installer().install(
+                entry = entry,
+                artifact = zip,
+                ownerId = "cancelled",
+                cancellationCheck = {
+                    checks++
+                    if (checks > 3) throw CancellationException("cancel")
+                },
+            )
+            fail("expected cancellation")
+        } catch (_: CancellationException) {
+            // expected
+        }
+        assertFalse(LocalImageDownloadFiles.installingDirectory(context, entry, "cancelled").exists())
+        assertNull(dao.getById(entry.id))
+    }
+
+    @Test
+    fun `failed smoke test never replaces an existing working install`() = runBlocking {
+        val firstZip = buildZip(content = "old".toByteArray())
+        val entry = mediaEntry(firstZip)
+        installer().install(entry, firstZip, "first")
+        val existingFile = File(LocalImageDownloadFiles.finalDirectory(context, entry), "bins/weights.bin")
+        assertEquals("old", existingFile.readText())
+
+        val replacement = buildZip(content = "new".toByteArray())
+        try {
+            installer(smokeTest = { throw IOException("smoke failed") })
+                .install(mediaEntry(replacement), replacement, "replacement")
+            fail("expected smoke failure")
+        } catch (_: IOException) {
+            // expected
+        }
+        assertEquals("old", existingFile.readText())
+        assertNotNull(dao.getById(entry.id))
+    }
+
+    @Test
+    fun `Room failure rolls directory swap back to previous install`() = runBlocking {
+        val zip = buildZip(content = "new".toByteArray())
+        val entry = mediaEntry(zip)
+        val finalDir = LocalImageDownloadFiles.finalDirectory(context, entry)
+        File(finalDir, "bins").mkdirs()
+        File(finalDir, "bins/weights.bin").writeText("old")
+
+        val failingDao = object : LocalImageModelDao {
+            override fun getAll(): Flow<List<LocalImageModel>> = flowOf(emptyList())
+            override suspend fun getAllSync(): List<LocalImageModel> = emptyList()
+            override suspend fun getById(id: String): LocalImageModel? = null
+            override suspend fun upsert(model: LocalImageModel) = throw IOException("db failed")
+            override suspend fun delete(id: String) = Unit
+        }
+        try {
+            installer(failingDao).install(entry, zip, "rollback")
+            fail("expected database failure")
+        } catch (_: IOException) {
+            // expected
+        }
+        assertEquals("old", File(finalDir, "bins/weights.bin").readText())
+        assertFalse(LocalImageDownloadFiles.previousDirectory(context, entry).exists())
+    }
+
+    @Test
+    fun `startup recovery restores previous directory after crash before Room commit`() = runBlocking {
+        val oldZip = buildZip(content = "old".toByteArray())
+        val oldEntry = mediaEntry(oldZip)
+        installer().install(oldEntry, oldZip, "old")
+        val finalDir = LocalImageDownloadFiles.finalDirectory(context, oldEntry)
+        val previousDir = LocalImageDownloadFiles.previousDirectory(context, oldEntry)
+        assertTrue(finalDir.renameTo(previousDir))
+
+        val newZip = buildZip(content = "new".toByteArray())
+        val newEntry = mediaEntry(newZip)
+        File(finalDir, "bins").mkdirs()
+        File(finalDir, "bins/weights.bin").writeText("new")
+        LocalImageInstallMarker.write(finalDir, newEntry)
+        // Deliberately do not upsert newEntry: this is the exact process-death window.
+
+        LocalImageInstallRecovery.reconcile(context, dao)
+
+        assertEquals("old", File(finalDir, "bins/weights.bin").readText())
+        assertFalse(previousDir.exists())
+        assertEquals(oldEntry.artifactSha256, dao.getById(oldEntry.id)?.bundleSha256)
+    }
+
+    @Test
+    fun `startup recovery adopts validated first install marker without redownload`() = runBlocking {
+        val header = "{\"weights\":{}}".toByteArray()
+        // Recovery deliberately adopts only the artifact fingerprint pinned by the current
+        // catalog. The marker proves the real Worker already verified the full artifact before
+        // its atomic rename; this tiny file only stands in for the installed payload.
+        val entry = LocalImageModelCatalog.entryById("local-image/dreamshaper-8")!!
+        val finalDir = LocalImageDownloadFiles.finalDirectory(context, entry)
+        val modelFile = File(finalDir, entry.modelFileName!!).apply {
+            parentFile?.mkdirs()
+            outputStream().use { output ->
+                output.write(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(header.size.toLong()).array())
+                output.write(header)
+                output.write(ByteArray(32))
+            }
+        }
+        LocalImageInstallMarker.write(finalDir, entry)
+
+        LocalImageInstallRecovery.reconcile(context, dao)
+
+        val adopted = dao.getById(entry.id)
+        assertNotNull(adopted)
+        assertEquals(entry.artifactSha256, adopted!!.bundleSha256)
+        assertTrue(modelFile.isFile)
+        assertFalse(LocalImageDownloadFiles.partialFile(context, entry).exists())
+    }
+
+    @Test
+    fun `startup recovery keeps an installed model removed from a later catalog`() = runBlocking {
+        val model = LocalImageModel(
+            id = "local-image/retired-model",
+            name = "Retired model",
+            directoryName = "retired-model",
+            installedBytes = 3,
+            sourceRevision = "old-revision",
+            sourceCheckpointSha256 = "a".repeat(64),
+            bundleSha256 = "b".repeat(64),
+            licenseId = "test-license",
+            activationPhrase = null,
+            defaultNegativePrompt = null,
+            bundleFormatVersion = 1,
+            runtime = LocalImageRuntime.MEDIAPIPE.id,
+            modelFileName = null,
+            addedAt = 1L,
+        )
+        dao.upsert(model)
+        val previous = File(LocalImageDownloadFiles.root(context), "retired-model.previous")
+        File(previous, "bins/weights.bin").apply {
+            parentFile?.mkdirs()
+            writeText("old")
+        }
+
+        LocalImageInstallRecovery.reconcile(context, dao)
+
+        assertEquals("old", File(LocalImageDownloadFiles.root(context), "retired-model/bins/weights.bin").readText())
+        assertFalse(previous.exists())
+        assertNotNull(dao.getById(model.id))
+    }
+
+    @Test
+    fun `selection recovery falls back only to an actually installed row`() = runBlocking {
+        val zip = buildZip()
+        val entry = mediaEntry(zip)
+        val installed = installer().install(entry, zip, "selected")
+        val settings = SettingsRepository(context)
+        settings.saveLocalImageModel("local-image/missing")
+
+        LocalImageSelectionRecovery.reconcile(context, listOf(installed))
+        assertEquals(installed.id, SettingsRepository(context).getLocalImageModelDirect())
+
+        LocalImageSelectionRecovery.reconcile(context, emptyList())
+        assertEquals("", SettingsRepository(context).getLocalImageModelDirect())
+    }
+
+    @Test
+    fun `safetensors artifact installs as one cpp model file without native smoke test`() = runBlocking {
+        val header = "{\"weights\":{}}".toByteArray()
+        val modelFile = File.createTempFile("model", ".part", context.cacheDir)
+        modelFile.outputStream().use { output ->
+            output.write(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(header.size.toLong()).array())
+            output.write(header)
+            output.write(ByteArray(32))
+        }
+        val base = LocalImageModelCatalog.entryById("local-image/dreamshaper-8")!!
+        val entry = base.copy(
+            artifactUrl = "https://example.invalid/model.safetensors",
+            downloadBytes = modelFile.length(),
+            installedBytes = modelFile.length(),
+            artifactRevision = "test",
+            artifactSha256 = LocalImageBundleValidator.sha256Of(modelFile),
+        )
+        var smokeCalls = 0
+        val installed = installer(smokeTest = { smokeCalls++ }).install(entry, modelFile, "raw")
+
+        assertEquals(0, smokeCalls)
+        assertEquals(LocalImageRuntime.STABLE_DIFFUSION_CPP.id, installed.runtime)
+        assertEquals(entry.modelFileName, installed.modelFileName)
+        assertTrue(File(LocalImageDownloadFiles.finalDirectory(context, entry), entry.modelFileName!!).isFile)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalImageModelMigrationTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalImageModelMigrationTest.kt
@@ -1,0 +1,111 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class LocalImageModelMigrationTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val databaseName = "local-image-v14-migration"
+    private lateinit var helper: SupportSQLiteOpenHelper
+
+    @Before
+    fun setUp() {
+        context.deleteDatabase(databaseName)
+        helper = FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(databaseName)
+                .callback(object : SupportSQLiteOpenHelper.Callback(14) {
+                    override fun onCreate(db: SupportSQLiteDatabase) {
+                        db.execSQL(
+                            "CREATE TABLE local_image_models (" +
+                                "id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, " +
+                                "directoryName TEXT NOT NULL, installedBytes INTEGER NOT NULL, " +
+                                "sourceRevision TEXT NOT NULL, sourceCheckpointSha256 TEXT NOT NULL, " +
+                                "bundleSha256 TEXT NOT NULL, licenseId TEXT NOT NULL, " +
+                                "activationPhrase TEXT, defaultNegativePrompt TEXT, " +
+                                "bundleFormatVersion INTEGER NOT NULL, addedAt INTEGER NOT NULL)"
+                        )
+                    }
+
+                    override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+                })
+                .build()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        helper.close()
+        context.deleteDatabase(databaseName)
+        File(context.filesDir, "image_models/stable-diffusion-1.5").deleteRecursively()
+        SettingsRepository(context).saveLocalImageModel("")
+    }
+
+    @Test
+    fun `v14 MediaPipe rows receive runtime default without losing metadata`() {
+        val preservedFile = File(
+            context.filesDir,
+            "image_models/stable-diffusion-1.5/bins/weights.bin",
+        ).apply {
+            parentFile?.mkdirs()
+            writeText("model-data")
+        }
+        SettingsRepository(context).saveLocalImageModel("local-image/stable-diffusion-1.5")
+        val database = helper.writableDatabase
+        database.execSQL(
+            "INSERT INTO local_image_models VALUES (" +
+                "'local-image/stable-diffusion-1.5', 'Stable Diffusion 1.5', 'stable-diffusion-1.5', " +
+                "100, 'revision', 'source-hash', 'bundle-hash', 'license', NULL, 'negative', 1, 123)"
+        )
+
+        AppDatabase.MIGRATION_14_15.migrate(database)
+
+        database.query(
+            "SELECT id, name, directoryName, installedBytes, sourceRevision, " +
+                "sourceCheckpointSha256, bundleSha256, licenseId, activationPhrase, " +
+                "defaultNegativePrompt, bundleFormatVersion, addedAt, runtime, modelFileName " +
+                "FROM local_image_models"
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("local-image/stable-diffusion-1.5", cursor.getString(0))
+            assertEquals("Stable Diffusion 1.5", cursor.getString(1))
+            assertEquals("stable-diffusion-1.5", cursor.getString(2))
+            assertEquals(100L, cursor.getLong(3))
+            assertEquals("revision", cursor.getString(4))
+            assertEquals("source-hash", cursor.getString(5))
+            assertEquals("bundle-hash", cursor.getString(6))
+            assertEquals("license", cursor.getString(7))
+            assertNull(cursor.getString(8))
+            assertEquals("negative", cursor.getString(9))
+            assertEquals(1, cursor.getInt(10))
+            assertEquals(123L, cursor.getLong(11))
+            assertEquals(LocalImageRuntime.MEDIAPIPE.id, cursor.getString(12))
+            assertNull(cursor.getString(13))
+            assertTrue(
+                LocalImageInstalledModelFiles.isInstalled(
+                    File(context.filesDir, "image_models/${cursor.getString(2)}"),
+                    cursor.getString(12),
+                    cursor.getString(13),
+                )
+            )
+        }
+        assertEquals("model-data", preservedFile.readText())
+        assertEquals(
+            "local-image/stable-diffusion-1.5",
+            SettingsRepository(context).getLocalImageModelDirect(),
+        )
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalImagePromptComposerTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalImagePromptComposerTest.kt
@@ -1,0 +1,46 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class LocalImagePromptComposerTest {
+    @Test fun `activation phrase prefixes the prompt without duplicating`() {
+        assertEquals(
+            "analog style, a portrait at dusk",
+            LocalImagePromptComposer.composePrompt("analog style", "a portrait at dusk"),
+        )
+        assertEquals(
+            "analog style portrait",
+            LocalImagePromptComposer.composePrompt("analog style", "analog style portrait"),
+        )
+        assertEquals("a castle", LocalImagePromptComposer.composePrompt(null, "a castle"))
+    }
+
+    @Test fun `negative prompts combine and blanks drop out`() {
+        assertEquals(
+            "blur, haze, low quality, extra fingers",
+            LocalImagePromptComposer.composeNegativePrompt("blur, haze, low quality", "extra fingers"),
+        )
+        assertEquals("blur", LocalImagePromptComposer.composeNegativePrompt("blur", null))
+        assertEquals("extra fingers", LocalImagePromptComposer.composeNegativePrompt("  ", "extra fingers"))
+        assertEquals("", LocalImagePromptComposer.composeNegativePrompt(null, null))
+    }
+
+    @Test fun `iterations clamp to the supported range`() {
+        assertEquals(10, LocalImagePromptComposer.clampIterations(1))
+        assertEquals(20, LocalImagePromptComposer.clampIterations(20))
+        assertEquals(30, LocalImagePromptComposer.clampIterations(400))
+    }
+
+    @Test fun `fixed seed passes through and random draws fresh non-negative seeds`() {
+        assertEquals(7, LocalImagePromptComposer.resolveSeed(7))
+        val random = Random(42)
+        val first = LocalImagePromptComposer.resolveSeed(null, random)
+        val second = LocalImagePromptComposer.resolveSeed(null, random)
+        assertTrue(first >= 0 && second >= 0)
+        assertNotEquals(first, second)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalInferenceGateTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalInferenceGateTest.kt
@@ -1,0 +1,65 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class LocalInferenceGateTest {
+    @Test fun `a second local task fails fast while the first holds the gate`() = runTest {
+        val gate = LocalInferenceGate()
+        val holding = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val first = launch {
+            gate.withExclusive("a chat reply") {
+                holding.complete(Unit)
+                release.await()
+            }
+        }
+        holding.await()
+        assertTrue(gate.isBusy)
+        assertEquals("a chat reply", gate.currentHolder)
+        try {
+            gate.withExclusive("image generation") { fail("must not run") }
+            fail("expected LocalInferenceBusy")
+        } catch (e: LocalInferenceBusy) {
+            assertTrue(e.message!!.contains("a chat reply"))
+        }
+        release.complete(Unit)
+        first.join()
+        assertFalse(gate.isBusy)
+    }
+
+    @Test fun `the gate releases after success, failure and cancellation`() = runTest {
+        val gate = LocalInferenceGate()
+        assertEquals(1, gate.withExclusive("ok") { 1 })
+        assertFalse(gate.isBusy)
+
+        try {
+            gate.withExclusive("boom") { throw IllegalStateException("boom") }
+            fail("expected failure")
+        } catch (_: IllegalStateException) { }
+        assertFalse(gate.isBusy)
+
+        val holding = CompletableDeferred<Unit>()
+        val job = async {
+            gate.withExclusive("cancelled") {
+                holding.complete(Unit)
+                CompletableDeferred<Unit>().await() // suspend forever
+            }
+        }
+        holding.await()
+        assertTrue(gate.isBusy)
+        job.cancelAndJoin()
+        assertFalse(gate.isBusy)
+
+        // Fully usable again after every release path.
+        assertEquals(2, gate.withExclusive("again") { 2 })
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ResumableArtifactDownloaderTest.kt
+++ b/app/src/test/java/com/echoflow/data/ResumableArtifactDownloaderTest.kt
@@ -1,0 +1,105 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ResumableArtifactDownloaderTest {
+    private val bytes = "0123456789".toByteArray()
+    private val entry = LocalImageModelCatalog.entries.first().copy(
+        artifactUrl = "https://example.invalid/model.zip",
+        downloadBytes = bytes.size.toLong(),
+        installedBytes = bytes.size.toLong(),
+        artifactRevision = "test",
+        artifactSha256 = "a".repeat(64),
+    )
+
+    @Test
+    fun `partial file resumes with validated HTTP Range`() = runBlocking {
+        val part = File.createTempFile("range-resume", ".part").apply {
+            writeBytes(bytes.copyOfRange(0, 4))
+            deleteOnExit()
+        }
+        var requestedRange: String? = null
+        val downloader = ResumableArtifactDownloader(client { request ->
+            requestedRange = request.header("Range")
+            response(
+                request = request,
+                code = 206,
+                body = bytes.copyOfRange(4, bytes.size),
+                contentRange = "bytes 4-9/10",
+            )
+        })
+
+        downloader.download(entry, part) { _, _ -> }
+
+        assertEquals("bytes=4-", requestedRange)
+        assertTrue(bytes.contentEquals(part.readBytes()))
+    }
+
+    @Test
+    fun `server ignoring Range truncates partial before writing full response`() = runBlocking {
+        val part = File.createTempFile("range-ignored", ".part").apply {
+            writeBytes(bytes.copyOfRange(0, 4))
+            deleteOnExit()
+        }
+        val downloader = ResumableArtifactDownloader(client { request ->
+            assertEquals("bytes=4-", request.header("Range"))
+            response(request, 200, bytes)
+        })
+
+        downloader.download(entry, part) { _, _ -> }
+
+        assertEquals(bytes.size.toLong(), part.length())
+        assertTrue(bytes.contentEquals(part.readBytes()))
+    }
+
+    @Test
+    fun `invalid Content-Range deletes incompatible partial and requests retry`() = runBlocking {
+        val part = File.createTempFile("range-invalid", ".part").apply {
+            writeBytes(bytes.copyOfRange(0, 4))
+            deleteOnExit()
+        }
+        val downloader = ResumableArtifactDownloader(client { request ->
+            response(
+                request = request,
+                code = 206,
+                body = bytes.copyOfRange(4, bytes.size),
+                contentRange = "bytes 3-8/10",
+            )
+        })
+
+        try {
+            downloader.download(entry, part) { _, _ -> }
+            throw AssertionError("expected retryable range failure")
+        } catch (error: RetryableModelDownloadException) {
+            assertTrue(error.message!!.contains("changed") || error.message!!.contains("invalid"))
+        }
+        assertFalse(part.exists())
+    }
+
+    private fun client(block: (okhttp3.Request) -> Response): OkHttpClient =
+        OkHttpClient.Builder().addInterceptor(Interceptor { chain -> block(chain.request()) }).build()
+
+    private fun response(
+        request: okhttp3.Request,
+        code: Int,
+        body: ByteArray,
+        contentRange: String? = null,
+    ): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message("test")
+        .body(body.toResponseBody())
+        .apply { contentRange?.let { header("Content-Range", it) } }
+        .build()
+}

--- a/app/src/test/java/com/echoflow/data/StableDiffusionRequestValidatorTest.kt
+++ b/app/src/test/java/com/echoflow/data/StableDiffusionRequestValidatorTest.kt
@@ -1,0 +1,34 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StableDiffusionRequestValidatorTest {
+    @Test
+    fun `accepts the bounded request used by the app`() {
+        StableDiffusionRequestValidator.validate(
+            prompt = "a lighthouse at dusk",
+            negativePrompt = "distorted",
+            width = 512,
+            height = 512,
+            steps = 20,
+            cfgScale = 7f,
+        )
+    }
+
+    @Test
+    fun `rejects unsafe native boundary values`() {
+        val invalidCalls = listOf<() -> Unit>(
+            { StableDiffusionRequestValidator.validate("prompt", "", 513, 512, 20, 7f) },
+            { StableDiffusionRequestValidator.validate("prompt", "", 512, 512, 0, 7f) },
+            { StableDiffusionRequestValidator.validate("prompt", "", 512, 512, 20, Float.NaN) },
+            { StableDiffusionRequestValidator.validate("", "", 512, 512, 20, 7f) },
+            { StableDiffusionRequestValidator.validate("a".repeat(8_193), "", 512, 512, 20, 7f) },
+        )
+
+        invalidCalls.forEach { call ->
+            val failed = runCatching(call).exceptionOrNull()
+            assertTrue(failed is IllegalArgumentException)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ navigationCompose = "2.8.9"
 roomRuntime = "2.7.0"
 roomKtx = "2.7.0"
 roomCompiler = "2.7.0"
+workManager = "2.11.2"
 kotlinxCoroutinesTest = "1.10.2"
 core = "1.6.1"
 runner = "1.6.2"
@@ -39,12 +40,18 @@ okhttp = "4.10.0"
 # 0.10.35 (Apr 2026) — required for Gemma 4 / newer .litertlm bundles; the 0.10.2x
 # runtimes abort natively when loading them.
 mediapipeTasksGenai = "0.10.35"
+# On-device diffusion (Image Generator) ships in its own artifact, NOT in tasks-genai.
+# It also has its own release cadence: 0.10.26.1 is the newest published version —
+# 0.10.35 exists only for tasks-genai (verified against the Google Maven metadata).
+mediapipeImageGenerator = "0.10.26.1"
 # Standalone LiteRT-LM engine — what AI Edge Gallery actually runs .litertlm bundles on
 # (gemma-4 crashes under the MediaPipe wrapper even at 0.10.35). Gallery pins 0.11.0.
 litertlm = "0.11.0"
 # llama.cpp-backed GGUF runtime (prebuilt arm64-v8a + x86_64 .so via the published AAR).
 # Used only for .gguf models; .task/.litertlm keep their existing runtimes.
 llamacppKotlin = "0.4.0"
+# Prebuilt Android binding for stable-diffusion.cpp. Kept behind the experimental-model toggle.
+llamatik = "1.9.0"
 moshiKotlin = "1.15.2"
 moshiKotlinCodegen = "1.15.2"
 datastorePreferences = "1.1.7"
@@ -75,6 +82,8 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomKtx" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "roomRuntime" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workManager" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-core = { group = "androidx.test", name = "core", version.ref = "core" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
@@ -101,8 +110,10 @@ androidx-camera-core = { group = "androidx.camera", name = "camera-core", versio
 logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "loggingInterceptor" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 mediapipe-tasks-genai = { group = "com.google.mediapipe", name = "tasks-genai", version.ref = "mediapipeTasksGenai" }
+mediapipe-tasks-vision-image-generator = { group = "com.google.mediapipe", name = "tasks-vision-image-generator", version.ref = "mediapipeImageGenerator" }
 litertlm-android = { group = "com.google.ai.edge.litertlm", name = "litertlm-android", version.ref = "litertlm" }
 llamacpp-kotlin = { group = "io.github.ljcamargo", name = "llamacpp-kotlin", version.ref = "llamacppKotlin" }
+llamatik = { group = "com.llamatik", name = "library-android", version.ref = "llamatik" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }


### PR DESCRIPTION
## What changed

- keeps OpenRouter image generation and adds a separate on-device engine
- offers four curated phone-friendly models, with Stable Diffusion 1.5 recommended and three opt-in experimental models
- runs the recommended model through MediaPipe and experimental checkpoints through an isolated stable-diffusion.cpp service
- downloads, verifies, extracts, installs, resumes, and recovers models through foreground WorkManager jobs
- preserves installed models and selections across application updates with Room migrations and app-private storage
- reuses the existing image-generation settings and chat UI
- removes the rejected app-side model conversion workflow

## Data and failure safety

- artifacts are pinned by revision, byte count, and SHA-256
- ZIP extraction rejects traversal and excessive expansion
- directory swaps retain the previous working install until Room is committed
- startup recovery handles process death during installation and preserves retired catalog models
- experimental native generation runs in a private process so a native crash does not terminate the main app

## Validation

- `./gradlew :app:testDebugUnitTest --no-daemon --no-configuration-cache`
- 103 debug unit tests passed
- debug Kotlin/AIDL/Room compilation passed as part of the test task
- no APK or release build was run

## Prerelease note

Real multi-gigabyte downloads and device-native MediaPipe/JNI generation still require physical-device prerelease testing. Normal app dismissal, process death, and reboot are resumable; Android force-stop cannot resume WorkManager until the app is opened again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds persistent on-device image generation alongside the existing cloud flow. The main changes are:

- Adds curated MediaPipe and isolated stable-diffusion.cpp model runtimes.
- Adds resumable downloads, validation, installation recovery, and Room migrations.
- Adds local image settings and chat generation routing.
- Keeps the product direction strong by supporting private generation without removing cloud generation.

<h3>Confidence Score: 4/5</h3>

The experimental model rollback path can discard a verified download.

- A failed filesystem rollback can delete the only staged checkpoint.
- The persistence, migration, routing, and private-process generation paths otherwise handle their main states consistently.

app/src/main/java/com/echoflow/data/LocalImageModelManager.kt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/LocalImageModelManager.kt | Adds model storage, installation, recovery, scheduling, and local-device checks; rollback can discard a verified single-file model. |
| app/src/main/java/com/echoflow/data/LocalImageModelDownloadWorker.kt | Adds resumable foreground download, checksum verification, installation orchestration, and progress reporting. |
| app/src/main/java/com/echoflow/data/StableDiffusionCppImageGenerationEngine.kt | Adds a private-process Binder client for experimental image generation and cancellation. |
| app/src/main/java/com/echoflow/data/StableDiffusionGenerationService.kt | Adds isolated native generation, request validation, result-file creation, and process cleanup. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Routes local and cloud image generation through the chat flow and serializes local inference. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Adds persisted local-image model metadata and migrations for mixed runtime support. |

<sub>Reviews (1): Last reviewed commit: ["test(image-gen): cover runtimes download..."](https://github.com/adityavardhansharma/echoflow/commit/27e1dc9665456ef4380e27f40d8aa3008e4388d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43902957)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-device image generation with supported local runtimes.
  * Added a curated model catalog with download, installation, cancellation, retry, and deletion controls.
  * Added settings to switch between cloud and on-device image generation, select models, configure iterations, and choose seed behavior.
  * Added local model details, licensing information, download progress, and compatibility messaging.
  * Added support for saving generated images reliably, including images produced by on-device generation.
* **Bug Fixes**
  * Improved recovery of interrupted downloads and installations.
  * Prevented simultaneous on-device language and image generation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->