### PR TITLE
Keep generated image actions on one line

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -114,7 +115,7 @@ private val SettledMaxHeight = 420.dp
  *                dots still dancing. The unhurried "something finished" beat.
  *   Revealing  — the scanline sweeps down: image unmasked above the line, dots dissolving
  *                as it passes them, then a small spring settle.
- *   Settled    — plain image with save/share and the fullscreen viewer. Persisted chats
+ *   Settled    — plain image with copy/save/share and the fullscreen viewer. Persisted chats
  *                ([animate] = false) start here directly with zero motion.
  */
 @Composable
@@ -123,6 +124,7 @@ fun GeneratedImageSegment(
     pattern: String,
     previousImagePath: String?,
     animate: Boolean,
+    onCopy: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -257,30 +259,55 @@ fun GeneratedImageSegment(
         AnimatedVisibility(visible = settled, enter = fadeIn()) {
             Column {
                 Spacer(Modifier.height(Spacing.xs))
-                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
-                    FilledTonalIconButton(
-                        onClick = {
-                            filePath ?: return@FilledTonalIconButton
+                GeneratedImageActions(
+                    onCopy = onCopy,
+                    onDownload = {
+                        filePath?.let { path ->
                             scope.launch {
-                                val ok = withContext(Dispatchers.IO) { saveGeneratedImageToGallery(context, filePath) != null }
+                                val ok = withContext(Dispatchers.IO) { saveGeneratedImageToGallery(context, path) != null }
                                 Toast.makeText(context, if (ok) "Saved to Pictures/EchoFlow" else "Couldn't save the image", Toast.LENGTH_SHORT).show()
                             }
-                        },
-                        modifier = Modifier.size(32.dp),
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                    ) { Icon(Icons.Default.Download, "Save to gallery", Modifier.size(16.dp)) }
-                    FilledTonalIconButton(
-                        onClick = { filePath?.let { scope.launch { shareGeneratedImage(context, it) } } },
-                        modifier = Modifier.size(32.dp),
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                    ) { Icon(Icons.Default.Share, "Share", Modifier.size(16.dp)) }
-                }
+                        }
+                    },
+                    onShare = { filePath?.let { scope.launch { shareGeneratedImage(context, it) } } },
+                )
             }
         }
     }
 
     if (viewerOpen && filePath != null) {
         GeneratedImageViewer(filePath = filePath, onDismiss = { viewerOpen = false })
+    }
+}
+
+@Composable
+internal fun GeneratedImageActions(
+    onCopy: (() -> Unit)?,
+    onDownload: () -> Unit,
+    onShare: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        onCopy?.let { copy ->
+            FilledTonalIconButton(
+                onClick = copy,
+                modifier = Modifier.size(48.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(20.dp)) }
+        }
+        FilledTonalIconButton(
+            onClick = onDownload,
+            modifier = Modifier.size(48.dp),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) { Icon(Icons.Default.Download, "Save to gallery", Modifier.size(20.dp)) }
+        FilledTonalIconButton(
+            onClick = onShare,
+            modifier = Modifier.size(48.dp),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) { Icon(Icons.Default.Share, "Share", Modifier.size(20.dp)) }
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -421,6 +421,9 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
             // reason → search → reason → search → answer keeps exactly the layout it
             // streamed with instead of merging all reasoning into one block.
             val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
+            val lastGeneratedImageIndex = persistedSegments.indexOfLast { segment ->
+                segment.type == "image" && segment.image != null
+            }
 
             message.localAttachmentUri?.let { uri ->
                 MessageAttachmentPreview(
@@ -509,6 +512,7 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
                                         pattern = "ripple",
                                         previousImagePath = null,
                                         animate = false,
+                                        onCopy = onCopy.takeIf { index == lastGeneratedImageIndex },
                                     )
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
@@ -559,7 +563,7 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
                 }
             }
 
-            if (!streaming) {
+            if (!streaming && lastGeneratedImageIndex == -1) {
                 Spacer(Modifier.height(Spacing.xs))
                 FilledTonalIconButton(
                     onClick = onCopy,

--- a/app/src/test/java/com/echoflow/ui/components/GeneratedImageActionsTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/GeneratedImageActionsTest.kt
@@ -1,0 +1,40 @@
+package com.echoflow.ui.components
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.echoflow.ui.theme.EchoFlowTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class GeneratedImageActionsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun copyDownloadAndShareStayOnTheSameRow() {
+        composeRule.setContent {
+            EchoFlowTheme {
+                GeneratedImageActions(
+                    onCopy = {},
+                    onDownload = {},
+                    onShare = {},
+                )
+            }
+        }
+
+        val copy = composeRule.onNodeWithContentDescription("Copy").assertHasClickAction()
+        val download = composeRule.onNodeWithContentDescription("Save to gallery").assertHasClickAction()
+        val share = composeRule.onNodeWithContentDescription("Share").assertHasClickAction()
+
+        val copyTop = copy.fetchSemanticsNode().boundsInRoot.top
+        assertEquals(copyTop, download.fetchSemanticsNode().boundsInRoot.top, 0.5f)
+        assertEquals(copyTop, share.fetchSemanticsNode().boundsInRoot.top, 0.5f)
+    }
+}


### PR DESCRIPTION
## What
- move Copy into the generated-image action row beside Save and Share
- suppress the separate message-level Copy button for generated-image replies
- use 48dp action targets with existing EchoFlow spacing and styling
- add a Compose regression test that verifies all three controls share the same vertical position

## Why
Copy was owned by `MessageBubble`, while Save and Share were owned by `GeneratedImageSegment`. That split forced Copy onto a second line after an image finished generating.

## Impact
Generated-image actions now remain together in one row. Non-image assistant replies retain their existing standalone Copy action. If a reply contains multiple generated images, Copy is attached only to the final image action row to avoid duplication.

## Checks
- `./gradlew.bat --no-daemon testDebugUnitTest --tests "com.echoflow.ui.components.GeneratedImageActionsTest"`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR cleanly consolidates generated-image actions into one accessible 48dp row, which is a good product-direction improvement because related controls now remain visually grouped and non-image replies preserve their existing Copy action.
- Adds an optional message-copy action to `GeneratedImageSegment` and groups Copy, Save, and Share in a reusable action-row composable.
- Attaches Copy only to the final generated image in multi-image replies and suppresses the redundant message-level button.
- Adds a Compose regression test confirming that all three controls share the same vertical position.
- A useful next implementation improvement would be to test the two-control state where Copy is absent and clarify through labeling or semantics that Copy still copies the message text rather than the image itself.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with generated-image actions consistently grouped and no concrete blocking or non-blocking defect identified.

The final persisted generated image receives the existing message-copy callback while replies without generated images retain the standalone Copy action, and the new action row preserves Save and Share behavior with larger touch targets.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt | Extracts a reusable, accessible generated-image action row and expands its action targets without introducing a concrete failure. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Routes the existing message-copy callback to the final generated image and retains standalone Copy for replies without generated images. |
| app/src/test/java/com/echoflow/ui/components/GeneratedImageActionsTest.kt | Adds focused regression coverage proving that Copy, Save, and Share remain vertically aligned. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Assistant reply] --> B{Contains persisted generated image?}
    B -- No --> C[Message-level Copy]
    B -- Yes --> D[Render generated images]
    D --> E{Final generated image?}
    E -- No --> F[Save and Share]
    E -- Yes --> G[Copy, Save, and Share on one row]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(image): keep generated image actions..."](https://github.com/adityavardhansharma/echoflow/commit/322754515bfdddd79008baba4d4ae83713d4db2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47426307)</sub>

<!-- /greptile_comment -->