### PR TITLE
Video generation via OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### A privacy-first Android AI workspace
 
-Chat, local models, custom endpoints, web search, deep research, agents, and artifacts — no backend, no account, no telemetry.
+Chat, local models, custom endpoints, web search, deep research, agents, artifacts, and image/video generation — no backend, no account, no telemetry.
 
 [![Release](https://img.shields.io/github/v/release/adityavardhansharma/EchoFlow?style=flat-square&color=000000&label=release)](https://github.com/adityavardhansharma/EchoFlow/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-000000?style=flat-square)](LICENSE.txt)
@@ -73,6 +73,10 @@ Web search (Exa, Parallel, Firecrawl) and OpenRouter's own server-side search wo
 
 **Artifacts** — generate and revise self-contained pages, reports, and documents, versioned as you iterate.
 
+**Image generation** — describe an image, then edit it conversationally ("make the sky purple"). Runs on OpenRouter, or entirely on-device with a downloaded diffusion model.
+
+**Video generation** — describe a short clip and get it back in the conversation. Rendering takes minutes, so it keeps going with the app closed and picks itself back up if the app is killed mid-render. You choose the shape; the model chooses the length. See [docs/video-generation.md](docs/video-generation.md).
+
 **Echo Adviser** — let your model call in a stronger or more specialized model mid-answer when it's stuck.
 
 **Echo Fusion** — run several models on the same prompt and have a judge model compare and merge their answers.
@@ -95,7 +99,7 @@ Kotlin and Jetpack Compose (Material 3 Expressive), targeting Android 24+. Netwo
 
 ```text
 app/src/main/java/com/echoflow
-├── data           # Room entities/DAOs, provider services, settings, research, agents, browser, artifacts, local models
+├── data           # Room entities/DAOs, provider services, settings, research, agents, browser, artifacts, image/video generation, local models
 ├── ui             # ViewModels and app state
 ├── ui/components  # cards, reports, markdown, browser/data/research result UI
 ├── ui/screens     # chat and settings screens

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,8 @@ dependencies {
   implementation(libs.androidx.work.runtime.ktx)
   implementation(libs.androidx.security.crypto)
   implementation(libs.coil.compose)
+  implementation(libs.androidx.media3.exoplayer)
+  implementation(libs.androidx.media3.ui.compose)
   implementation(libs.converter.moshi)
   // implementation(libs.firebase.ai)
   implementation(libs.kotlinx.coroutines.android)

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!--
+      media3 marks most of its surface @UnstableApi, including PlayerSurface and the Compose
+      player state helpers that the generated-video card is built from. Kotlin's own
+      @OptIn(UnstableApi::class) satisfies the compiler but not this lint check, which only
+      recognizes the Java @androidx.annotation.OptIn form. Opting in here — the mechanism the
+      check itself documents — keeps the acknowledgement in one visible place instead of
+      sprinkling a second, redundant annotation across every player composable.
+    -->
+    <issue id="UnsafeOptInUsageError">
+        <option name="opt-in" value="androidx.media3.common.util.UnstableApi" />
+    </issue>
+</lint>

--- a/app/schemas/com.echoflow.data.AppDatabase/16.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/16.json
@@ -1,0 +1,1280 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "8ade5628941b254cb3fef1c1ce2c38a8",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `directoryName` TEXT NOT NULL, `installedBytes` INTEGER NOT NULL, `sourceRevision` TEXT NOT NULL, `sourceCheckpointSha256` TEXT NOT NULL, `bundleSha256` TEXT NOT NULL, `licenseId` TEXT NOT NULL, `activationPhrase` TEXT, `defaultNegativePrompt` TEXT, `bundleFormatVersion` INTEGER NOT NULL, `runtime` TEXT NOT NULL DEFAULT 'mediapipe', `modelFileName` TEXT, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryName",
+            "columnName": "directoryName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedBytes",
+            "columnName": "installedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRevision",
+            "columnName": "sourceRevision",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceCheckpointSha256",
+            "columnName": "sourceCheckpointSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleSha256",
+            "columnName": "bundleSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseId",
+            "columnName": "licenseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activationPhrase",
+            "columnName": "activationPhrase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultNegativePrompt",
+            "columnName": "defaultNegativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bundleFormatVersion",
+            "columnName": "bundleFormatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'mediapipe'"
+          },
+          {
+            "fieldPath": "modelFileName",
+            "columnName": "modelFileName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8ade5628941b254cb3fef1c1ce2c38a8')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -63,6 +63,7 @@ class EchoFlowAppGraph(application: Application) {
             database.generatedImageDao(),
             database.localImageModelDao(),
             localImageModelManager,
+            database.generatedVideoDao(),
             localInferenceGate,
         )
     }

--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -39,6 +39,7 @@ class EchoFlowAppGraph(application: Application) {
             database.imageModelDao(),
             database.localImageModelDao(),
             localImageModelManager,
+            database.videoModelDao(),
             localInferenceGate,
         )
     }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -13,9 +13,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         DeepResearchModel::class, ResearchRun::class, AdvisorProfile::class, FusionPanel::class,
         AgentProfile::class, BrowserSession::class, BrowserStep::class,
         Artifact::class, ArtifactVersion::class,
-        ImageModel::class, GeneratedImage::class, LocalImageModel::class
+        ImageModel::class, GeneratedImage::class, LocalImageModel::class,
+        VideoModel::class, GeneratedVideo::class
     ],
-    version = 15, // v15: runtime metadata for mixed local image engines
+    version = 16, // v16: OpenRouter video generation (models + async job/result rows)
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -35,6 +36,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun imageModelDao(): ImageModelDao
     abstract fun generatedImageDao(): GeneratedImageDao
     abstract fun localImageModelDao(): LocalImageModelDao
+    abstract fun videoModelDao(): VideoModelDao
+    abstract fun generatedVideoDao(): GeneratedVideoDao
 
     companion object {
         @Volatile
@@ -291,6 +294,41 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Video generation. `generated_videos` doubles as the async job store, so it carries
+         * the provider job id and polling URL alongside the downloaded file path — a run
+         * interrupted by a kill is resumable from these rows alone.
+         */
+        internal val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS video_models (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "addedAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS generated_videos (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "chatId TEXT NOT NULL, " +
+                        "prompt TEXT NOT NULL, " +
+                        "modelId TEXT NOT NULL, " +
+                        "jobId TEXT, " +
+                        "pollingUrl TEXT, " +
+                        "status TEXT NOT NULL, " +
+                        "filePath TEXT, " +
+                        "aspectRatio TEXT, " +
+                        "resolution TEXT, " +
+                        "error TEXT, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(chatId) REFERENCES chat_threads(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_generated_videos_chatId ON generated_videos (chatId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_generated_videos_status ON generated_videos (status)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -313,6 +351,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_12_13,
                     MIGRATION_13_14,
                     MIGRATION_14_15,
+                    MIGRATION_15_16,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ChatMode.kt
+++ b/app/src/main/java/com/echoflow/data/ChatMode.kt
@@ -12,5 +12,6 @@ sealed interface ChatMode {
     data object BrowserFlow : ChatMode
     data object Artifact : ChatMode
     data object ImageGen : ChatMode
+    data object VideoGen : ChatMode
 }
 

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -96,6 +96,31 @@ sealed class StreamChunk {
         val filePath: String? = null,
         val imageId: String? = null,
     ) : StreamChunk()
+
+    // ── Video generation (OpenRouter async job API) ──────────────────────────────────
+    /**
+     * A video-mode turn is in flight — the placeholder card shows immediately. [videoId] is
+     * the durable job row, known before the provider is even called, so the card survives a
+     * process death and can pick the run back up. [aspectRatio] is what the placeholder
+     * expands to once the clip lands.
+     */
+    data class VideoGenStarted(
+        val videoId: String,
+        val pattern: String,
+        val aspectRatio: String,
+    ) : StreamChunk()
+
+    /** The job moved to a new non-terminal state ("in_progress", "downloading", …). */
+    data class VideoGenProgress(
+        val videoId: String,
+        val status: String,
+    ) : StreamChunk()
+
+    /** The clip finished and the MP4 is on disk at [filePath]. */
+    data class VideoGenerated(
+        val videoId: String,
+        val filePath: String,
+    ) : StreamChunk()
 }
 
 // ── Echo Adviser / Echo Fusion result records ──────────────────────────────────────
@@ -189,12 +214,23 @@ data class ImageRef(
 )
 
 /**
+ * A reference to a persisted [com.echoflow.data.GeneratedVideo], embedded in a reply's
+ * timeline. Unlike [ImageRef] this stores the row id rather than only a path: a video row can
+ * still be mid-render when the message is written, so the renderer resolves the current state
+ * (and file) from the database rather than trusting a snapshot.
+ */
+data class VideoRef(
+    val videoId: String,
+    val filePath: String? = null,
+)
+
+/**
  * One block of a finished reply, persisted in arrival order so the rendered timeline
  * (reason → search → reason → search → answer) survives exactly as it streamed instead
  * of being merged into "all reasoning, then all searches, then text".
  */
 data class PersistedSegment(
-    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact" | "image" | "stopped"
+    val type: String, // "text" | "reasoning" | "search" | "advisor" | "fusion" | "subagent" | "artifact" | "image" | "video" | "stopped"
     val text: String? = null,
     val query: String? = null,
     val sources: List<SearchSource>? = null,
@@ -202,7 +238,8 @@ data class PersistedSegment(
     val fusion: FusionAnalysis? = null, // present when type == "fusion"
     val subagent: SubagentResult? = null, // present when type == "subagent"
     val artifact: ArtifactRef? = null, // present when type == "artifact"
-    val image: ImageRef? = null // present when type == "image"
+    val image: ImageRef? = null, // present when type == "image"
+    val video: VideoRef? = null // present when type == "video"
 )
 
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -110,10 +110,15 @@ sealed class StreamChunk {
         val aspectRatio: String,
     ) : StreamChunk()
 
-    /** The job moved to a new non-terminal state ("in_progress", "downloading", …). */
+    /**
+     * The job changed state. Mostly non-terminal progress ("in_progress", "downloading"), but
+     * a failure is also delivered here — with the provider's [error] — so the card can settle
+     * into its failed form instead of dancing on forever behind an error banner.
+     */
     data class VideoGenProgress(
         val videoId: String,
         val status: String,
+        val error: String? = null,
     ) : StreamChunk()
 
     /** The clip finished and the MP4 is on disk at [filePath]. */

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -176,6 +176,46 @@ interface GeneratedImageDao {
 }
 
 @Dao
+interface VideoModelDao {
+    @Query("SELECT * FROM video_models ORDER BY addedAt ASC")
+    fun getAll(): Flow<List<VideoModel>>
+
+    @Query("SELECT * FROM video_models ORDER BY addedAt ASC")
+    suspend fun getAllSync(): List<VideoModel>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(model: VideoModel)
+
+    @Query("DELETE FROM video_models WHERE id = :modelId")
+    suspend fun delete(modelId: String)
+}
+
+@Dao
+interface GeneratedVideoDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(video: GeneratedVideo)
+
+    @Query("SELECT * FROM generated_videos WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): GeneratedVideo?
+
+    @Query("SELECT * FROM generated_videos WHERE id = :id LIMIT 1")
+    fun observeById(id: String): Flow<GeneratedVideo?>
+
+    @Query("SELECT * FROM generated_videos WHERE chatId = :chatId ORDER BY createdAt ASC")
+    suspend fun getForChat(chatId: String): List<GeneratedVideo>
+
+    @Query("SELECT * FROM generated_videos WHERE chatId = :chatId ORDER BY createdAt DESC LIMIT 1")
+    suspend fun getLatestForChat(chatId: String): GeneratedVideo?
+
+    /** Jobs left mid-flight by a kill or crash — polling resumes from these on next launch. */
+    @Query("SELECT * FROM generated_videos WHERE status NOT IN ('completed','failed','cancelled','expired')")
+    suspend fun getUnfinished(): List<GeneratedVideo>
+
+    @Query("DELETE FROM generated_videos WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
 interface ResearchRunDao {
     @Query("SELECT * FROM research_runs WHERE chatId = :chatId AND status NOT IN ('completed','failed','cancelled') ORDER BY createdAt DESC LIMIT 1")
     fun observeActiveForChat(chatId: String): Flow<ResearchRun?>

--- a/app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt
+++ b/app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt
@@ -1,0 +1,118 @@
+package com.echoflow.data
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+
+/**
+ * Owns generated-video persistence. Unlike images (one synchronous stream, one file) a video
+ * is an asynchronous job, so the [GeneratedVideo] row is created BEFORE anything is generated
+ * and is updated through its whole life — queued → pending/in_progress → downloading →
+ * completed. That makes the row the resume point after a process death.
+ *
+ * The MP4 itself lands under filesDir/generated_videos/ and only the path is ever stored.
+ */
+class GeneratedVideoStore(
+    context: Context,
+    private val dao: GeneratedVideoDao,
+) {
+    private val videosDir = File(context.filesDir, "generated_videos")
+
+    /** Creates the durable job row for a turn that is about to be submitted. */
+    suspend fun createJob(
+        chatId: String,
+        prompt: String,
+        modelId: String,
+        aspectRatio: String?,
+        resolution: String?,
+    ): GeneratedVideo {
+        val now = System.currentTimeMillis()
+        val video = GeneratedVideo(
+            id = UUID.randomUUID().toString(),
+            chatId = chatId,
+            prompt = prompt,
+            modelId = modelId,
+            status = GeneratedVideo.STATUS_QUEUED,
+            aspectRatio = aspectRatio,
+            resolution = resolution,
+            createdAt = now,
+            updatedAt = now,
+        )
+        dao.upsert(video)
+        return video
+    }
+
+    /** Records the provider's job handle so a cold start can resume polling this run. */
+    suspend fun markSubmitted(video: GeneratedVideo, jobId: String, pollingUrl: String): GeneratedVideo =
+        update(video.copy(jobId = jobId, pollingUrl = pollingUrl, status = GeneratedVideo.STATUS_PENDING))
+
+    suspend fun markStatus(video: GeneratedVideo, status: String): GeneratedVideo =
+        if (video.status == status) video else update(video.copy(status = status))
+
+    suspend fun markFailed(video: GeneratedVideo, status: String, error: String?): GeneratedVideo =
+        update(video.copy(status = status, error = error))
+
+    /**
+     * Streams the finished MP4 to disk and completes the row. The download writes to a
+     * temporary file and is renamed into place only once it is whole, so a connection dropped
+     * mid-transfer can never leave a truncated clip that the row claims is playable.
+     */
+    suspend fun completeWithDownload(
+        video: GeneratedVideo,
+        body: InputStream,
+    ): GeneratedVideo = withContext(Dispatchers.IO) {
+        videosDir.mkdirs()
+        val finalFile = File(videosDir, "${video.id}.mp4")
+        val tempFile = File(videosDir, "${video.id}.mp4.tmp")
+        try {
+            tempFile.outputStream().use { out -> body.use { it.copyTo(out) } }
+            if (tempFile.length() == 0L) throw Exception("The downloaded video was empty.")
+            if (!tempFile.renameTo(finalFile)) {
+                tempFile.copyTo(finalFile, overwrite = true)
+                tempFile.delete()
+            }
+        } catch (e: Exception) {
+            tempFile.delete()
+            finalFile.delete()
+            throw e
+        }
+        update(
+            video.copy(
+                filePath = finalFile.absolutePath,
+                status = GeneratedVideo.STATUS_COMPLETED,
+                error = null,
+            )
+        )
+    }
+
+    /** The newest playable clip in this chat — what a follow-up turn continues from. */
+    suspend fun latestForChat(chatId: String): GeneratedVideo? {
+        val latest = dao.getLatestForChat(chatId) ?: return null
+        return latest.takeIf { it.filePath != null && File(it.filePath).exists() }
+    }
+
+    suspend fun byId(id: String): GeneratedVideo? = dao.getById(id)
+
+    /** Runs interrupted by a process kill, newest first. */
+    suspend fun unfinished(): List<GeneratedVideo> = dao.getUnfinished().sortedByDescending { it.createdAt }
+
+    /**
+     * Removes this chat's video files from disk. Must run BEFORE the chat thread row is
+     * deleted — the generated_videos rows cascade away with it, and MP4s are large enough
+     * that orphaning them would visibly grow app storage.
+     */
+    suspend fun deleteFilesForChat(chatId: String) = withContext(Dispatchers.IO) {
+        dao.getForChat(chatId).forEach { video ->
+            video.filePath?.let { path -> runCatching { File(path).delete() } }
+        }
+    }
+
+    private suspend fun update(video: GeneratedVideo): GeneratedVideo {
+        val updated = video.copy(updatedAt = System.currentTimeMillis())
+        dao.upsert(updated)
+        return updated
+    }
+}

--- a/app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt
+++ b/app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt
@@ -67,25 +67,31 @@ class GeneratedVideoStore(
         videosDir.mkdirs()
         val finalFile = File(videosDir, "${video.id}.mp4")
         val tempFile = File(videosDir, "${video.id}.mp4.tmp")
+        // The row write is inside the guarded block, not after it: if the job disappears (or
+        // the coroutine is cancelled) between the rename and the update, an unguarded write
+        // would leave a finished MP4 on disk that no row points at and no cleanup can find.
         try {
             tempFile.outputStream().use { out -> body.use { it.copyTo(out) } }
             if (tempFile.length() == 0L) throw Exception("The downloaded video was empty.")
+            // A multi-megabyte download can still be in flight when the user deletes the
+            // conversation and its rows cascade away.
+            requireJobStillExists(video)
             if (!tempFile.renameTo(finalFile)) {
                 tempFile.copyTo(finalFile, overwrite = true)
                 tempFile.delete()
             }
+            update(
+                video.copy(
+                    filePath = finalFile.absolutePath,
+                    status = GeneratedVideo.STATUS_COMPLETED,
+                    error = null,
+                )
+            )
         } catch (e: Exception) {
             tempFile.delete()
             finalFile.delete()
             throw e
         }
-        update(
-            video.copy(
-                filePath = finalFile.absolutePath,
-                status = GeneratedVideo.STATUS_COMPLETED,
-                error = null,
-            )
-        )
     }
 
     /** The newest playable clip in this chat — what a follow-up turn continues from. */
@@ -103,16 +109,33 @@ class GeneratedVideoStore(
      * Removes this chat's video files from disk. Must run BEFORE the chat thread row is
      * deleted — the generated_videos rows cascade away with it, and MP4s are large enough
      * that orphaning them would visibly grow app storage.
+     *
+     * Files are located by row id rather than only by the recorded path, so a download that a
+     * process kill left half-written is swept up too: its row never got a filePath, but the
+     * partial file is named after the job and would otherwise sit there forever.
      */
     suspend fun deleteFilesForChat(chatId: String) = withContext(Dispatchers.IO) {
         dao.getForChat(chatId).forEach { video ->
             video.filePath?.let { path -> runCatching { File(path).delete() } }
+            runCatching { File(videosDir, "${video.id}.mp4").delete() }
+            runCatching { File(videosDir, "${video.id}.mp4.tmp").delete() }
         }
     }
 
     private suspend fun update(video: GeneratedVideo): GeneratedVideo {
+        requireJobStillExists(video)
         val updated = video.copy(updatedAt = System.currentTimeMillis())
         dao.upsert(updated)
         return updated
+    }
+
+    /**
+     * Every write after [createJob] is an update to a row that may no longer exist: deleting a
+     * conversation cascades its video rows away while the render is still running. The DAO
+     * upsert would happily re-insert one, either failing the foreign key or resurrecting a job
+     * pointing at a dead chat — so the caller is told to stop instead.
+     */
+    private suspend fun requireJobStillExists(video: GeneratedVideo) {
+        if (dao.getById(video.id) == null) throw VideoGenerationException.JobRemoved()
     }
 }

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -183,6 +183,73 @@ data class GeneratedImage(
 )
 
 /**
+ * A cloud model the user has whitelisted for video generation. Separate from [ImageModel]
+ * because video runs on a different OpenRouter surface entirely (`/api/v1/videos`, an async
+ * job API) and its directory carries per-model capability sets rather than chat modalities.
+ */
+@Entity(tableName = "video_models")
+data class VideoModel(
+    @PrimaryKey val id: String, // OpenRouter id, e.g. "google/veo-3.1"
+    val name: String,
+    val addedAt: Long,
+)
+
+/**
+ * One video generation, from submitted job to downloaded MP4. Unlike images (a single
+ * synchronous stream) OpenRouter video is asynchronous — submit, poll, download — and a
+ * clip takes minutes, so this row is the durable job record as well as the result: the app
+ * can be killed mid-generation and resume polling [pollingUrl] from here on next launch.
+ *
+ * The MP4 lives as a file under filesDir/generated_videos/; [filePath] is only set once the
+ * download finished. Video bytes never enter Room or segmentsJson.
+ */
+@Entity(
+    tableName = "generated_videos",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatThread::class,
+            parentColumns = ["id"],
+            childColumns = ["chatId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("chatId"), Index("status")]
+)
+data class GeneratedVideo(
+    @PrimaryKey val id: String, // UUID — our row id, not the provider's job id
+    val chatId: String,
+    val prompt: String, // the user turn that produced this clip
+    val modelId: String, // the OpenRouter video model that ran
+    val jobId: String? = null, // provider job id, set once the submit call returns
+    val pollingUrl: String? = null, // absolute URL to poll; resumes a run after a cold start
+    val status: String = STATUS_QUEUED,
+    val filePath: String? = null, // absolute path of the MP4 once downloaded
+    val aspectRatio: String? = null, // the ratio we asked for (duration is always the model's call)
+    val resolution: String? = null,
+    val error: String? = null,
+    val createdAt: Long,
+    val updatedAt: Long,
+) {
+    val isTerminal: Boolean get() = status in TERMINAL_STATUSES
+
+    companion object {
+        /** Our own pre-submit state; every other status is OpenRouter's own vocabulary. */
+        const val STATUS_QUEUED = "queued"
+        const val STATUS_PENDING = "pending"
+        const val STATUS_IN_PROGRESS = "in_progress"
+
+        /** Ours: the job completed and we are pulling the MP4 down. */
+        const val STATUS_DOWNLOADING = "downloading"
+        const val STATUS_COMPLETED = "completed"
+        const val STATUS_FAILED = "failed"
+        const val STATUS_CANCELLED = "cancelled"
+        const val STATUS_EXPIRED = "expired"
+
+        val TERMINAL_STATUSES = setOf(STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED, STATUS_EXPIRED)
+    }
+}
+
+/**
  * The durable record of one Deep Research run. This is the single source of truth: the
  * foreground service writes progress here and the UI observes it, so a run survives the
  * Activity/ViewModel being destroyed and can be resumed after the app is force-killed

--- a/app/src/main/java/com/echoflow/data/OpenRouterVideoModelDirectory.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterVideoModelDirectory.kt
@@ -1,0 +1,175 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * One video model from OpenRouter's directory, with the capability sets the submit call must
+ * be validated against. Unlike chat models these differ wildly per model — an out-of-set
+ * aspect ratio or resolution is a hard 400, so the picker and the request policy both read
+ * from here rather than assuming a house default works everywhere.
+ */
+data class OpenRouterVideoModelInfo(
+    val id: String,
+    val name: String,
+    val description: String? = null,
+    val resolutions: List<String> = emptyList(),
+    val aspectRatios: List<String> = emptyList(),
+    /** Durations the model offers. Informational only — EchoFlow never sends a duration. */
+    val durations: List<Int> = emptyList(),
+    val frameImageTypes: List<String> = emptyList(),
+    val supportsAudio: Boolean = false,
+    /** Every priced variant, normalized to USD per output second. Empty when unpriced. */
+    val prices: List<VideoPrice> = emptyList(),
+) {
+    /** True when the model can animate a starting image, not just a text prompt. */
+    val supportsFirstFrame: Boolean get() = frameImageTypes.any { it.equals("first_frame", ignoreCase = true) }
+
+    /**
+     * "~$0.10/sec at 720p" — the one number that decides whether a user picks this model.
+     * Matches the user's actual settings where the provider prices them separately, and falls
+     * back to the cheapest variant so the quote is never an unpleasant surprise.
+     */
+    fun priceHint(resolution: String?, audio: Boolean? = null): String? {
+        val price = bestPrice(resolution, audio) ?: return null
+        val qualifier = listOfNotNull(
+            price.resolution?.let { "at $it" },
+            when (price.audio) {
+                true -> "with audio"
+                false -> "without audio"
+                null -> null
+            },
+        ).joinToString(", ")
+        return "~$" + String.format("%.2f", price.usdPerSecond) + "/sec" +
+            if (qualifier.isEmpty()) "" else " $qualifier"
+    }
+
+    /** The variant closest to what the user has configured, cheapest-first among equals. */
+    fun bestPrice(resolution: String?, audio: Boolean? = null): VideoPrice? {
+        if (prices.isEmpty()) return null
+        fun pick(predicate: (VideoPrice) -> Boolean) = prices.filter(predicate).minByOrNull { it.usdPerSecond }
+        return pick { it.resolution == resolution && it.audio == audio }
+            ?: pick { it.resolution == resolution && it.audio == null }
+            ?: pick { it.resolution == null && it.audio == audio }
+            ?: pick { it.resolution == resolution }
+            ?: prices.minByOrNull { it.usdPerSecond }
+    }
+}
+
+/**
+ * One priced variant of a video model. Providers bill per output second but slice that price
+ * by resolution, by audio, or by both — null on either axis means "this price applies
+ * regardless of that setting".
+ */
+data class VideoPrice(
+    val resolution: String?,
+    val audio: Boolean?,
+    val usdPerSecond: Double,
+)
+
+/**
+ * Fetches OpenRouter's public video-model directory
+ * (https://openrouter.ai/api/v1/videos/models — no auth needed) once per process and serves
+ * it from memory, so the add-model search filters instantly as the user types.
+ */
+class OpenRouterVideoModelDirectory {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val adapter = moshi.adapter(VideoDirectoryResponse::class.java)
+
+    @Volatile
+    private var cache: List<OpenRouterVideoModelInfo>? = null
+
+    suspend fun allModels(): List<OpenRouterVideoModelInfo> = withContext(Dispatchers.IO) {
+        cache?.let { return@withContext it }
+
+        val request = Request.Builder().url("https://openrouter.ai/api/v1/videos/models").build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw Exception("Could not load the video model directory (HTTP ${response.code}).")
+            }
+            val body = response.body?.string().orEmpty()
+            val models = adapter.fromJson(body)?.data.orEmpty()
+                .mapNotNull { raw -> raw.id?.let { toInfo(it, raw) } }
+                .sortedBy { it.name.lowercase() }
+            cache = models
+            models
+        }
+    }
+
+    /** The capability record for one model, or null if it is not (or no longer) offered. */
+    suspend fun capabilities(modelId: String): OpenRouterVideoModelInfo? =
+        allModels().firstOrNull { it.id == modelId }
+
+    private fun toInfo(id: String, raw: RawVideoModel) = OpenRouterVideoModelInfo(
+        id = id,
+        name = raw.name ?: id,
+        description = raw.description,
+        resolutions = raw.supportedResolutions.orEmpty(),
+        aspectRatios = raw.supportedAspectRatios.orEmpty(),
+        durations = raw.supportedDurations.orEmpty(),
+        frameImageTypes = raw.supportedFrameImages.orEmpty(),
+        supportsAudio = raw.generateAudio == true,
+        prices = parsePricing(raw.pricingSkus.orEmpty()),
+    )
+
+    companion object {
+        private const val CENTS_PREFIX = "cents_per_video_output_second_"
+        private const val DOLLARS_PREFIX = "duration_seconds_"
+        private val RESOLUTION_TOKEN = Regex("^\\d+p$|^\\d+k$", RegexOption.IGNORE_CASE)
+
+        /**
+         * OpenRouter prices video per output second under several SKU spellings in the very
+         * same response: `cents_per_video_output_second_720p` (cents, resolution only) and
+         * `duration_seconds_…` (dollars) which may carry a resolution, an audio variant
+         * (`with_audio`, `without_audio_4k`), or neither. Everything normalizes to USD per
+         * second here; anything unrecognized is dropped rather than shown as free.
+         */
+        fun parsePricing(skus: Map<String, String>): List<VideoPrice> = skus.mapNotNull { (key, value) ->
+            val amount = value.toDoubleOrNull() ?: return@mapNotNull null
+            when {
+                key.startsWith(CENTS_PREFIX) ->
+                    VideoPrice(normalizeResolution(key.removePrefix(CENTS_PREFIX)), null, amount / 100.0)
+                key.startsWith(DOLLARS_PREFIX) -> {
+                    var rest = key.removePrefix(DOLLARS_PREFIX)
+                    val audio = when {
+                        rest.startsWith("with_audio") -> true.also { rest = rest.removePrefix("with_audio") }
+                        rest.startsWith("without_audio") -> false.also { rest = rest.removePrefix("without_audio") }
+                        else -> null
+                    }
+                    VideoPrice(normalizeResolution(rest.trim('_')), audio, amount)
+                }
+                else -> null
+            }
+        }.distinct()
+
+        /** "720p"/"4k" stay; anything that is not a resolution token becomes null. */
+        private fun normalizeResolution(token: String): String? = token
+            .takeIf { it.isNotBlank() && RESOLUTION_TOKEN.matches(it) }
+            ?.let { if (it.endsWith("k", ignoreCase = true)) it.uppercase() else it.lowercase() }
+    }
+}
+
+private data class VideoDirectoryResponse(val data: List<RawVideoModel>? = null)
+
+private data class RawVideoModel(
+    val id: String? = null,
+    val name: String? = null,
+    val description: String? = null,
+    @Json(name = "supported_resolutions") val supportedResolutions: List<String>? = null,
+    @Json(name = "supported_aspect_ratios") val supportedAspectRatios: List<String>? = null,
+    @Json(name = "supported_durations") val supportedDurations: List<Int>? = null,
+    @Json(name = "supported_frame_images") val supportedFrameImages: List<String>? = null,
+    @Json(name = "generate_audio") val generateAudio: Boolean? = null,
+    @Json(name = "pricing_skus") val pricingSkus: Map<String, String>? = null,
+)

--- a/app/src/main/java/com/echoflow/data/OpenRouterVideoModelDirectory.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterVideoModelDirectory.kt
@@ -46,7 +46,9 @@ data class OpenRouterVideoModelInfo(
                 null -> null
             },
         ).joinToString(", ")
-        return "~$" + String.format("%.2f", price.usdPerSecond) + "/sec" +
+        // Locale-fixed: the figure is quoted in USD alongside a "$", so a locale that swaps
+        // in a decimal comma would read as a different currency convention entirely.
+        return "~$" + String.format(java.util.Locale.US, "%.2f", price.usdPerSecond) + "/sec" +
             if (qualifier.isEmpty()) "" else " $qualifier"
     }
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
@@ -1,0 +1,207 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.InputStream
+import java.util.concurrent.TimeUnit
+
+/** The provider job handle returned by a submit, and the resume point after a process kill. */
+data class VideoJobHandle(
+    val id: String,
+    val pollingUrl: String,
+    val status: String,
+)
+
+/** One poll of a running job. [downloadUrls] are the provider's authenticated direct links. */
+data class VideoJobState(
+    val id: String,
+    val status: String,
+    val error: String? = null,
+    val downloadUrls: List<String> = emptyList(),
+) {
+    val isTerminal: Boolean get() = status in GeneratedVideo.TERMINAL_STATUSES
+    val succeeded: Boolean get() = status == GeneratedVideo.STATUS_COMPLETED
+}
+
+/** Typed domain errors so routing/UI can react without string-matching messages. */
+sealed class VideoGenerationException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+    class MissingApiKey(message: String) : VideoGenerationException(message)
+    class SubmitFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
+    class GenerationFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
+    class DownloadFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
+}
+
+/**
+ * OpenRouter's asynchronous video API (`/api/v1/videos`). Video generation cannot use the
+ * chat-completions path at all: a clip takes 30s–several minutes, so the contract is
+ * submit → poll → download, with the job id being the only thing that survives in between.
+ *
+ * Deliberately absent from every request: `duration`. The model picks the clip's length
+ * itself — the app only ever expresses framing (aspect ratio / resolution).
+ */
+class OpenRouterVideoService {
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(45, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
+
+    // Downloads are tens of megabytes over mobile links; they get their own generous budget.
+    private val downloadClient = OkHttpClient.Builder()
+        .connectTimeout(45, TimeUnit.SECONDS)
+        .readTimeout(300, TimeUnit.SECONDS)
+        .callTimeout(600, TimeUnit.SECONDS)
+        .build()
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val dynamicAdapter = moshi.adapter(Any::class.java)
+
+    /**
+     * Submits one generation. [frameImageDataUrl] animates an existing image (first frame);
+     * omitting it makes this a text-to-video request. Only parameters the caller already
+     * validated against the model's capabilities should be passed — an unsupported value is
+     * a 400, not a silent downgrade.
+     */
+    suspend fun submit(
+        apiKey: String,
+        model: String,
+        prompt: String,
+        aspectRatio: String? = null,
+        resolution: String? = null,
+        generateAudio: Boolean? = null,
+        frameImageDataUrl: String? = null,
+    ): VideoJobHandle = withContext(Dispatchers.IO) {
+        if (apiKey.isBlank()) {
+            throw VideoGenerationException.MissingApiKey(
+                "Video generation uses OpenRouter. Add your API key in Settings → Cloud models."
+            )
+        }
+        val payload = buildMap<String, Any> {
+            put("model", model)
+            put("prompt", prompt)
+            aspectRatio?.takeIf { it.isNotBlank() }?.let { put("aspect_ratio", it) }
+            resolution?.takeIf { it.isNotBlank() }?.let { put("resolution", it) }
+            generateAudio?.let { put("generate_audio", it) }
+            frameImageDataUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                put(
+                    "frame_images",
+                    listOf(
+                        mapOf(
+                            "type" to "image_url",
+                            "image_url" to mapOf("url" to url),
+                            "frame_type" to "first_frame",
+                        )
+                    )
+                )
+            }
+        }
+        val request = Request.Builder()
+            .url("$BASE_URL/videos")
+            .headers(authHeaders(apiKey))
+            .post(dynamicAdapter.toJson(payload).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw VideoGenerationException.SubmitFailed(submitErrorMessage(response.code, body, model))
+            }
+            val map = parseObject(body)
+                ?: throw VideoGenerationException.SubmitFailed("OpenRouter returned an unreadable video job.")
+            val id = map["id"] as? String
+                ?: throw VideoGenerationException.SubmitFailed("OpenRouter did not return a video job id.")
+            VideoJobHandle(
+                id = id,
+                // A job is always pollable at its canonical URL; the returned one is preferred
+                // because OpenRouter may route a job to a provider-specific host.
+                pollingUrl = (map["polling_url"] as? String)?.takeIf { it.isNotBlank() } ?: "$BASE_URL/videos/$id",
+                status = (map["status"] as? String) ?: GeneratedVideo.STATUS_PENDING,
+            )
+        }
+    }
+
+    /** One status check. Non-terminal statuses simply mean "keep waiting". */
+    suspend fun poll(apiKey: String, pollingUrl: String): VideoJobState = withContext(Dispatchers.IO) {
+        val request = Request.Builder().url(pollingUrl).headers(authHeaders(apiKey)).get().build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw VideoGenerationException.GenerationFailed(
+                    ProviderHttpSupport.errorMessage("OpenRouter", response.code, body)
+                )
+            }
+            val map = parseObject(body)
+                ?: throw VideoGenerationException.GenerationFailed("OpenRouter returned an unreadable job status.")
+            VideoJobState(
+                id = (map["id"] as? String).orEmpty(),
+                status = (map["status"] as? String) ?: GeneratedVideo.STATUS_IN_PROGRESS,
+                error = errorText(map["error"]),
+                downloadUrls = (map["unsigned_urls"] as? List<*>).orEmpty().filterIsInstance<String>(),
+            )
+        }
+    }
+
+    /**
+     * Streams the finished MP4. The body is handed to [block] and closed afterwards, so the
+     * bytes go straight to disk and a whole clip never has to sit in memory.
+     */
+    suspend fun <T> withVideoContent(
+        apiKey: String,
+        jobId: String,
+        index: Int = 0,
+        block: suspend (InputStream) -> T,
+    ): T = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url("$BASE_URL/videos/$jobId/content?index=$index")
+            .headers(authHeaders(apiKey))
+            .get()
+            .build()
+        downloadClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw VideoGenerationException.DownloadFailed(
+                    ProviderHttpSupport.errorMessage("OpenRouter", response.code, response.body?.string().orEmpty())
+                )
+            }
+            val stream = response.body?.byteStream()
+                ?: throw VideoGenerationException.DownloadFailed("OpenRouter returned an empty video.")
+            block(stream)
+        }
+    }
+
+    private fun authHeaders(apiKey: String) = okhttp3.Headers.Builder()
+        .add("Authorization", "Bearer $apiKey")
+        .add("HTTP-Referer", "https://localhost")
+        .add("X-Title", "EchoFlow")
+        .build()
+
+    private fun parseObject(body: String): Map<*, *>? =
+        runCatching { dynamicAdapter.fromJson(body) as? Map<*, *> }.getOrNull()
+
+    private fun errorText(raw: Any?): String? = when (raw) {
+        is String -> raw.takeIf { it.isNotBlank() }
+        is Map<*, *> -> (raw["message"] as? String)?.takeIf { it.isNotBlank() }
+        else -> null
+    }
+
+    private fun submitErrorMessage(code: Int, body: String, model: String): String = when (code) {
+        400 -> ProviderHttpSupport.errorMessage("OpenRouter", code, body)
+            .takeIf { !it.endsWith("HTTP $code.") }
+            ?: "$model rejected these settings. Try a different aspect ratio or resolution."
+        401 -> "OpenRouter rejected your API key. Check it in Settings → Cloud models."
+        402, 403 -> "OpenRouter refused the request — your credit may be depleted."
+        404 -> "$model is not available for video generation."
+        else -> ProviderHttpSupport.errorMessage("OpenRouter", code, body)
+    }
+
+    private companion object {
+        const val BASE_URL = "https://openrouter.ai/api/v1"
+        val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    }
+}

--- a/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -35,6 +36,12 @@ sealed class VideoGenerationException(message: String, cause: Throwable? = null)
     class SubmitFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
     class GenerationFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
     class DownloadFailed(message: String, cause: Throwable? = null) : VideoGenerationException(message, cause)
+
+    /**
+     * The job's row is gone — its conversation was deleted while the clip was rendering.
+     * Distinct from a failure because nothing went wrong and there is no one left to tell.
+     */
+    class JobRemoved : VideoGenerationException("The video's conversation was deleted.")
 }
 
 /**
@@ -119,17 +126,22 @@ class OpenRouterVideoService {
                 ?: throw VideoGenerationException.SubmitFailed("OpenRouter did not return a video job id.")
             VideoJobHandle(
                 id = id,
-                // A job is always pollable at its canonical URL; the returned one is preferred
-                // because OpenRouter may route a job to a provider-specific host.
-                pollingUrl = (map["polling_url"] as? String)?.takeIf { it.isNotBlank() } ?: "$BASE_URL/videos/$id",
+                pollingUrl = trustedPollingUrl(map["polling_url"] as? String, id),
                 status = (map["status"] as? String) ?: GeneratedVideo.STATUS_PENDING,
             )
         }
     }
 
-    /** One status check. Non-terminal statuses simply mean "keep waiting". */
-    suspend fun poll(apiKey: String, pollingUrl: String): VideoJobState = withContext(Dispatchers.IO) {
-        val request = Request.Builder().url(pollingUrl).headers(authHeaders(apiKey)).get().build()
+    /**
+     * One status check. Non-terminal statuses simply mean "keep waiting".
+     *
+     * [pollingUrl] is re-checked against the trusted origin on every call rather than only
+     * where it was first received: it is persisted between launches, so trusting the stored
+     * value would leave the bearer token one bad row away from a foreign host.
+     */
+    suspend fun poll(apiKey: String, pollingUrl: String, jobId: String): VideoJobState = withContext(Dispatchers.IO) {
+        val url = trustedPollingUrl(pollingUrl, jobId)
+        val request = Request.Builder().url(url).headers(authHeaders(apiKey)).get().build()
         client.newCall(request).execute().use { response ->
             val body = response.body?.string().orEmpty()
             if (!response.isSuccessful) {
@@ -200,8 +212,27 @@ class OpenRouterVideoService {
         else -> ProviderHttpSupport.errorMessage("OpenRouter", code, body)
     }
 
-    private companion object {
-        const val BASE_URL = "https://openrouter.ai/api/v1"
-        val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    companion object {
+        private const val API_HOST = "openrouter.ai"
+        private const val BASE_URL = "https://$API_HOST/api/v1"
+        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+
+        /**
+         * The only place the bearer token is allowed to go. `polling_url` is an absolute URL
+         * chosen by the response body, so forwarding it unchecked would turn any tampered,
+         * proxied or compromised response into a credential exfiltration path — the request
+         * carries the user's OpenRouter key.
+         *
+         * Anything that is not HTTPS on openrouter.ai (or a subdomain of it) is discarded in
+         * favour of the canonical job URL, which is always pollable anyway. Downgrading rather
+         * than failing keeps a legitimate response-shape change from breaking generation.
+         */
+        internal fun trustedPollingUrl(candidate: String?, jobId: String): String {
+            val url = candidate?.trim()?.takeIf { it.isNotEmpty() }?.toHttpUrlOrNull()
+            val trusted = url != null &&
+                url.scheme == "https" &&
+                (url.host == API_HOST || url.host.endsWith(".$API_HOST"))
+            return if (trusted) url.toString() else "$BASE_URL/videos/$jobId"
+        }
     }
 }

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -118,6 +118,20 @@ class SettingsRepository(context: Context) {
     private val _experimentalImageModelsEnabled = MutableStateFlow(getExperimentalImageModelsEnabledDirect())
     val experimentalImageModelsEnabled: StateFlow<Boolean> = _experimentalImageModelsEnabled.asStateFlow()
 
+    // Video generation: OpenRouter-only. Framing and audio are the user's; length is the
+    // model's — there is no duration preference here on purpose.
+    private val _videoGenModel = MutableStateFlow(getVideoGenModelDirect())
+    val videoGenModel: StateFlow<String> = _videoGenModel.asStateFlow()
+
+    private val _videoAspectRatio = MutableStateFlow(getVideoAspectRatioDirect())
+    val videoAspectRatio: StateFlow<String> = _videoAspectRatio.asStateFlow()
+
+    private val _videoResolution = MutableStateFlow(getVideoResolutionDirect())
+    val videoResolution: StateFlow<String> = _videoResolution.asStateFlow()
+
+    private val _videoAudioEnabled = MutableStateFlow(getVideoAudioEnabledDirect())
+    val videoAudioEnabled: StateFlow<Boolean> = _videoAudioEnabled.asStateFlow()
+
     // Echo Adviser / Echo Fusion: which saved profile/panel is currently active in chat.
     private val _echoAdviserProfileId = MutableStateFlow(getEchoAdviserProfileIdDirect())
     val echoAdviserProfileId: StateFlow<String> = _echoAdviserProfileId.asStateFlow()
@@ -625,6 +639,49 @@ class SettingsRepository(context: Context) {
         _experimentalImageModelsEnabled.value = enabled
     }
 
+    // ── Video generation ───────────────────────────────────────────────────────────────
+    // Cloud only: OpenRouter is the sole route. There is deliberately no duration setting —
+    // the model decides how long each clip runs.
+
+    fun getVideoGenModelDirect(): String =
+        prefs.getString("video_gen_model", DEFAULT_VIDEO_MODEL_ID).orEmpty()
+            .ifBlank { DEFAULT_VIDEO_MODEL_ID }
+
+    fun saveVideoGenModel(id: String) {
+        prefs.edit().putString("video_gen_model", id).apply()
+        _videoGenModel.value = id
+    }
+
+    fun getVideoAspectRatioDirect(): String =
+        prefs.getString("video_aspect_ratio", VideoRequestPolicy.DEFAULT_ASPECT_RATIO).orEmpty()
+            .takeIf { it in VideoRequestPolicy.ASPECT_RATIOS } ?: VideoRequestPolicy.DEFAULT_ASPECT_RATIO
+
+    fun saveVideoAspectRatio(ratio: String) {
+        val clean = ratio.takeIf { it in VideoRequestPolicy.ASPECT_RATIOS }
+            ?: VideoRequestPolicy.DEFAULT_ASPECT_RATIO
+        prefs.edit().putString("video_aspect_ratio", clean).apply()
+        _videoAspectRatio.value = clean
+    }
+
+    fun getVideoResolutionDirect(): String =
+        prefs.getString("video_resolution", VideoRequestPolicy.DEFAULT_RESOLUTION).orEmpty()
+            .takeIf { it in VideoRequestPolicy.RESOLUTIONS } ?: VideoRequestPolicy.DEFAULT_RESOLUTION
+
+    fun saveVideoResolution(resolution: String) {
+        val clean = resolution.takeIf { it in VideoRequestPolicy.RESOLUTIONS }
+            ?: VideoRequestPolicy.DEFAULT_RESOLUTION
+        prefs.edit().putString("video_resolution", clean).apply()
+        _videoResolution.value = clean
+    }
+
+    /** Audio roughly doubles the per-second price, so it starts off and is opt-in. */
+    fun getVideoAudioEnabledDirect(): Boolean = prefs.getBoolean("video_generate_audio", false)
+
+    fun saveVideoAudioEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("video_generate_audio", enabled).apply()
+        _videoAudioEnabled.value = enabled
+    }
+
     /** Minutes of inactivity before Browser Flow auto-stops the session (cost guard). 0 = off. */
     fun getBrowserIdleMinutesDirect(): Int =
         prefs.getInt("browser_idle_minutes", 3)
@@ -641,6 +698,10 @@ class SettingsRepository(context: Context) {
         private const val KEY_EXPERIMENTAL_IMAGE_MODELS_ENABLED = "experimental_image_models_enabled"
         const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
         const val DEFAULT_IMAGE_MODEL_ID = "google/gemini-2.5-flash-image"
+
+        /** Veo 3.1 Fast: good quality without the flagship's per-second price. */
+        const val DEFAULT_VIDEO_MODEL_ID = "google/veo-3.1-fast"
+        const val DEFAULT_VIDEO_MODEL_NAME = "Veo 3.1 Fast"
         const val IMAGE_ENGINE_OPENROUTER = "openrouter"
         const val IMAGE_ENGINE_LOCAL = "local"
         const val LOCAL_IMAGE_ITERATIONS_DEFAULT = 20

--- a/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
@@ -46,6 +46,42 @@ class OpenRouterVideoGenerationEngine(
 ) {
 
     fun generate(request: VideoGenerationRequest): Flow<VideoGenerationEvent> = flow {
+        stopIfJobRemoved { runGeneration(request) }
+    }
+
+    /**
+     * Picks a job back up from its stored handle — used on a cold start, after the process was
+     * killed mid-render. A job with no provider handle never reached OpenRouter and is failed
+     * outright rather than left waiting forever.
+     */
+    fun resume(video: GeneratedVideo, apiKey: String): Flow<VideoGenerationEvent> = flow {
+        stopIfJobRemoved {
+            if (video.jobId == null || video.pollingUrl == null) {
+                store.markFailed(
+                    video, GeneratedVideo.STATUS_FAILED, "The generation was interrupted before it started.",
+                )
+                return@stopIfJobRemoved
+            }
+            emit(VideoGenerationEvent.Progress(video, 0L))
+            awaitAndDownload(video, apiKey, startedAt = video.createdAt)
+        }
+    }
+
+    /**
+     * Ends a run quietly when its row disappears mid-render — the user deleted the
+     * conversation, so there is no failure to report and nowhere left to report it. Wrapping
+     * the whole run rather than individual writes means every store call is covered, including
+     * the ones inside error handling. Every other exception still propagates.
+     */
+    private suspend inline fun stopIfJobRemoved(block: () -> Unit) {
+        try {
+            block()
+        } catch (_: VideoGenerationException.JobRemoved) {
+            return
+        }
+    }
+
+    private suspend fun FlowCollector<VideoGenerationEvent>.runGeneration(request: VideoGenerationRequest) {
         // Capabilities are per-model and an unsupported value is a hard 400, so reconcile the
         // user's framing preferences first. A directory outage is not fatal: the preferences
         // are simply dropped and the provider's own defaults apply.
@@ -90,20 +126,6 @@ class OpenRouterVideoGenerationEngine(
     }
 
     /**
-     * Picks a job back up from its stored handle — used on a cold start, after the process was
-     * killed mid-render. A job with no provider handle never reached OpenRouter and is failed
-     * outright rather than left waiting forever.
-     */
-    fun resume(video: GeneratedVideo, apiKey: String): Flow<VideoGenerationEvent> = flow {
-        if (video.jobId == null || video.pollingUrl == null) {
-            store.markFailed(video, GeneratedVideo.STATUS_FAILED, "The generation was interrupted before it started.")
-            return@flow
-        }
-        emit(VideoGenerationEvent.Progress(video, 0L))
-        awaitAndDownload(video, apiKey, startedAt = video.createdAt)
-    }
-
-    /**
      * Polls until the job reaches a terminal state, then streams the MP4 to disk. The interval
      * ramps from [FIRST_POLL_MS] to [MAX_POLL_MS]: clips rarely land in under half a minute,
      * so a tight loop would only burn battery and rate limit for no earlier result.
@@ -127,7 +149,7 @@ class OpenRouterVideoGenerationEngine(
             delay(interval)
             interval = (interval * 2).coerceAtMost(MAX_POLL_MS)
 
-            val state = service.poll(apiKey, video.pollingUrl!!)
+            val state = service.poll(apiKey, video.pollingUrl!!, video.jobId!!)
             if (state.status != video.status) {
                 video = store.markStatus(video, state.status)
                 emit(VideoGenerationEvent.Progress(video, System.currentTimeMillis() - startedAt))

--- a/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
@@ -78,7 +78,9 @@ class OpenRouterVideoGenerationEngine(
                 frameImageDataUrl = startImage,
             )
         } catch (e: Exception) {
-            store.markFailed(video, GeneratedVideo.STATUS_FAILED, e.message)
+            // Emit the failed row before rethrowing: the card is already on screen showing a
+            // dot field, and an error banner alone would leave it dancing forever.
+            emit(VideoGenerationEvent.Progress(store.markFailed(video, GeneratedVideo.STATUS_FAILED, e.message), 0L))
             throw e
         }
         video = store.markSubmitted(video, handle.id, handle.pollingUrl)
@@ -119,6 +121,7 @@ class OpenRouterVideoGenerationEngine(
                     video, GeneratedVideo.STATUS_FAILED,
                     "The video took longer than ${TIMEOUT_MS / 60_000} minutes and was given up on.",
                 )
+                emit(VideoGenerationEvent.Progress(failed, System.currentTimeMillis() - startedAt))
                 throw VideoGenerationException.GenerationFailed(failed.error.orEmpty())
             }
             delay(interval)
@@ -132,8 +135,12 @@ class OpenRouterVideoGenerationEngine(
             if (!state.isTerminal) continue
 
             if (!state.succeeded) {
-                val message = state.error ?: "The video generation ${state.status}."
-                val failed = store.markFailed(video, state.status, message)
+                // Re-emit after markFailed, not before: the status change above carries no
+                // reason yet, and the card renders the provider's message verbatim.
+                val failed = store.markFailed(
+                    video, state.status, state.error ?: "The video generation ${state.status}.",
+                )
+                emit(VideoGenerationEvent.Progress(failed, System.currentTimeMillis() - startedAt))
                 throw VideoGenerationException.GenerationFailed(failed.error.orEmpty())
             }
 
@@ -144,7 +151,10 @@ class OpenRouterVideoGenerationEngine(
                     store.completeWithDownload(video, stream)
                 }
             } catch (e: Exception) {
-                store.markFailed(video, GeneratedVideo.STATUS_FAILED, e.message ?: "Could not download the video.")
+                val failed = store.markFailed(
+                    video, GeneratedVideo.STATUS_FAILED, e.message ?: "Could not download the video.",
+                )
+                emit(VideoGenerationEvent.Progress(failed, System.currentTimeMillis() - startedAt))
                 throw e
             }
             emit(VideoGenerationEvent.VideoFile(downloaded))

--- a/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt
@@ -1,0 +1,162 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+
+/**
+ * One video-generation turn. Duration is absent by design — the model decides how long the
+ * clip runs; EchoFlow only expresses framing and (where supported) audio.
+ */
+data class VideoGenerationRequest(
+    val chatId: String,
+    val prompt: String,
+    val modelId: String,
+    val apiKey: String,
+    val aspectRatio: String = VideoRequestPolicy.DEFAULT_ASPECT_RATIO,
+    val resolution: String = VideoRequestPolicy.DEFAULT_RESOLUTION,
+    val generateAudio: Boolean = false,
+    /** A data URL to animate as the first frame; null makes this a text-to-video turn. */
+    val startImageDataUrl: String? = null,
+)
+
+/** What the engine emits while a generation runs. Failures surface as flow exceptions. */
+sealed interface VideoGenerationEvent {
+    /** The durable job row exists (id is stable from here on, before the provider is called). */
+    data class Queued(val video: GeneratedVideo) : VideoGenerationEvent
+
+    /** The provider accepted the job, or reported a new non-terminal status while waiting. */
+    data class Progress(val video: GeneratedVideo, val elapsedMs: Long) : VideoGenerationEvent
+
+    /** The clip finished and the MP4 is on disk. */
+    data class VideoFile(val video: GeneratedVideo) : VideoGenerationEvent
+}
+
+/**
+ * Runs OpenRouter's asynchronous video pipeline — validate → submit → poll → download —
+ * writing every state change through [GeneratedVideoStore] as it goes. Because the row is
+ * updated before each await, a run killed at any point is resumable by [resume] with nothing
+ * but its database record.
+ */
+class OpenRouterVideoGenerationEngine(
+    private val service: OpenRouterVideoService,
+    private val directory: OpenRouterVideoModelDirectory,
+    private val store: GeneratedVideoStore,
+) {
+
+    fun generate(request: VideoGenerationRequest): Flow<VideoGenerationEvent> = flow {
+        // Capabilities are per-model and an unsupported value is a hard 400, so reconcile the
+        // user's framing preferences first. A directory outage is not fatal: the preferences
+        // are simply dropped and the provider's own defaults apply.
+        val capabilities = runCatching { directory.capabilities(request.modelId) }.getOrNull()
+        val aspectRatio = VideoRequestPolicy.resolveAspectRatio(
+            request.aspectRatio, capabilities?.aspectRatios.orEmpty()
+        )
+        val resolution = VideoRequestPolicy.resolveResolution(
+            request.resolution, capabilities?.resolutions.orEmpty()
+        )
+        val startImage = request.startImageDataUrl?.takeIf { capabilities?.supportsFirstFrame != false }
+
+        var video = store.createJob(
+            chatId = request.chatId,
+            prompt = request.prompt,
+            modelId = request.modelId,
+            aspectRatio = aspectRatio ?: request.aspectRatio,
+            resolution = resolution,
+        )
+        emit(VideoGenerationEvent.Queued(video))
+
+        val handle = try {
+            service.submit(
+                apiKey = request.apiKey,
+                model = request.modelId,
+                prompt = request.prompt,
+                aspectRatio = aspectRatio,
+                resolution = resolution,
+                generateAudio = request.generateAudio.takeIf { capabilities?.supportsAudio == true },
+                frameImageDataUrl = startImage,
+            )
+        } catch (e: Exception) {
+            store.markFailed(video, GeneratedVideo.STATUS_FAILED, e.message)
+            throw e
+        }
+        video = store.markSubmitted(video, handle.id, handle.pollingUrl)
+        emit(VideoGenerationEvent.Progress(video, 0L))
+
+        awaitAndDownload(video, request.apiKey, startedAt = System.currentTimeMillis())
+    }
+
+    /**
+     * Picks a job back up from its stored handle — used on a cold start, after the process was
+     * killed mid-render. A job with no provider handle never reached OpenRouter and is failed
+     * outright rather than left waiting forever.
+     */
+    fun resume(video: GeneratedVideo, apiKey: String): Flow<VideoGenerationEvent> = flow {
+        if (video.jobId == null || video.pollingUrl == null) {
+            store.markFailed(video, GeneratedVideo.STATUS_FAILED, "The generation was interrupted before it started.")
+            return@flow
+        }
+        emit(VideoGenerationEvent.Progress(video, 0L))
+        awaitAndDownload(video, apiKey, startedAt = video.createdAt)
+    }
+
+    /**
+     * Polls until the job reaches a terminal state, then streams the MP4 to disk. The interval
+     * ramps from [FIRST_POLL_MS] to [MAX_POLL_MS]: clips rarely land in under half a minute,
+     * so a tight loop would only burn battery and rate limit for no earlier result.
+     */
+    private suspend fun FlowCollector<VideoGenerationEvent>.awaitAndDownload(
+        initial: GeneratedVideo,
+        apiKey: String,
+        startedAt: Long,
+    ) {
+        var video = initial
+        var interval = FIRST_POLL_MS
+        while (true) {
+            if (System.currentTimeMillis() - startedAt > TIMEOUT_MS) {
+                val failed = store.markFailed(
+                    video, GeneratedVideo.STATUS_FAILED,
+                    "The video took longer than ${TIMEOUT_MS / 60_000} minutes and was given up on.",
+                )
+                throw VideoGenerationException.GenerationFailed(failed.error.orEmpty())
+            }
+            delay(interval)
+            interval = (interval * 2).coerceAtMost(MAX_POLL_MS)
+
+            val state = service.poll(apiKey, video.pollingUrl!!)
+            if (state.status != video.status) {
+                video = store.markStatus(video, state.status)
+                emit(VideoGenerationEvent.Progress(video, System.currentTimeMillis() - startedAt))
+            }
+            if (!state.isTerminal) continue
+
+            if (!state.succeeded) {
+                val message = state.error ?: "The video generation ${state.status}."
+                val failed = store.markFailed(video, state.status, message)
+                throw VideoGenerationException.GenerationFailed(failed.error.orEmpty())
+            }
+
+            video = store.markStatus(video, GeneratedVideo.STATUS_DOWNLOADING)
+            emit(VideoGenerationEvent.Progress(video, System.currentTimeMillis() - startedAt))
+            val downloaded = try {
+                service.withVideoContent(apiKey, video.jobId!!) { stream ->
+                    store.completeWithDownload(video, stream)
+                }
+            } catch (e: Exception) {
+                store.markFailed(video, GeneratedVideo.STATUS_FAILED, e.message ?: "Could not download the video.")
+                throw e
+            }
+            emit(VideoGenerationEvent.VideoFile(downloaded))
+            return
+        }
+    }
+
+    private companion object {
+        const val FIRST_POLL_MS = 5_000L
+        const val MAX_POLL_MS = 20_000L
+
+        /** Generous, but bounded: a job still running after this is almost certainly stuck. */
+        const val TIMEOUT_MS = 20 * 60_000L
+    }
+}

--- a/app/src/main/java/com/echoflow/data/VideoRequestPolicy.kt
+++ b/app/src/main/java/com/echoflow/data/VideoRequestPolicy.kt
@@ -1,0 +1,72 @@
+package com.echoflow.data
+
+/**
+ * Pure rules for turning the user's video preferences into a request the chosen model will
+ * actually accept. Aspect ratio and resolution are per-model on OpenRouter — an out-of-set
+ * value is a hard 400 — so every preference is reconciled against the model's declared
+ * capabilities before it is sent, and dropped entirely when the model declares nothing.
+ *
+ * Duration is deliberately not part of this: the model decides how long the clip runs.
+ */
+object VideoRequestPolicy {
+
+    /** The ratios EchoFlow offers, widest-to-tallest. Also the fallback preference order. */
+    val ASPECT_RATIOS = listOf("16:9", "9:16", "1:1", "4:3", "3:4", "21:9")
+
+    /** The resolutions EchoFlow offers, cheapest first. */
+    val RESOLUTIONS = listOf("480p", "720p", "1080p")
+
+    const val DEFAULT_ASPECT_RATIO = "16:9"
+    const val DEFAULT_RESOLUTION = "720p"
+
+    /**
+     * The aspect ratio to send. Null means "say nothing and let the provider choose" — the
+     * correct move when a model publishes no ratio set at all (several image-to-video models
+     * derive framing from the input image instead).
+     */
+    fun resolveAspectRatio(preferred: String, supported: List<String>): String? {
+        if (supported.isEmpty()) return null
+        if (preferred in supported) return preferred
+        // Prefer another ratio with the same orientation before flipping the user's framing.
+        val wanted = orientationOf(preferred)
+        return supported.firstOrNull { orientationOf(it) == wanted }
+            ?: ASPECT_RATIOS.firstOrNull { it in supported }
+            ?: supported.first()
+    }
+
+    /**
+     * The resolution to send, falling back to the closest offer so a 1080p preference on a
+     * 720p-only model still runs (at 720p) instead of failing the whole turn.
+     */
+    fun resolveResolution(preferred: String, supported: List<String>): String? {
+        if (supported.isEmpty()) return null
+        if (preferred in supported) return preferred
+        val wanted = heightOf(preferred) ?: return supported.first()
+        return supported.minByOrNull { candidate ->
+            val height = heightOf(candidate) ?: Int.MAX_VALUE
+            kotlin.math.abs(height - wanted)
+        } ?: supported.first()
+    }
+
+    /** Width ÷ height for a "W:H" ratio, used to size the in-chat placeholder and player. */
+    fun aspectRatioValue(ratio: String?): Float {
+        val parts = ratio?.split(":")?.mapNotNull { it.trim().toFloatOrNull() } ?: return DEFAULT_RATIO_VALUE
+        if (parts.size != 2 || parts[1] <= 0f || parts[0] <= 0f) return DEFAULT_RATIO_VALUE
+        return parts[0] / parts[1]
+    }
+
+    /** "landscape" | "portrait" | "square" — what the user actually cares about preserving. */
+    fun orientationOf(ratio: String): String {
+        val value = aspectRatioValue(ratio)
+        return when {
+            value > 1.02f -> "landscape"
+            value < 0.98f -> "portrait"
+            else -> "square"
+        }
+    }
+
+    private fun heightOf(resolution: String): Int? =
+        resolution.trim().removeSuffix("p").removeSuffix("P").toIntOrNull()
+
+    private const val DEFAULT_RATIO_VALUE = 16f / 9f
+}

--- a/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
+++ b/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
@@ -18,7 +18,8 @@ internal object AssistantMessagePersistence {
         val hasDurableCard = normalized.any {
             it is StreamSegment.Advisor || it is StreamSegment.Fusion || it is StreamSegment.Subagent ||
                 (it is StreamSegment.Artifact && it.artifactId != null) ||
-                (it is StreamSegment.Image && it.filePath != null)
+                (it is StreamSegment.Image && it.filePath != null) ||
+                it is StreamSegment.Video
         }
         if (content.isEmpty() && !hasDurableCard && !stopped) return null
         val reasoning = normalized.filterIsInstance<StreamSegment.Reasoning>()
@@ -50,6 +51,9 @@ internal object AssistantMessagePersistence {
         is StreamSegment.Image -> segment.filePath?.let { path ->
             PersistedSegment("image", image = ImageRef(segment.imageId.orEmpty(), path))
         }
+        // Persisted even without a file: a video row may still be rendering when the message
+        // is written, and the id is what lets the card resolve its live state afterwards.
+        is StreamSegment.Video -> PersistedSegment("video", video = VideoRef(segment.videoId, segment.filePath))
         is StreamSegment.Text -> segment.text.trim().takeIf(String::isNotEmpty)?.let { PersistedSegment("text", text = it) }
         is StreamSegment.AgentRun -> null
     }

--- a/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
@@ -1,5 +1,6 @@
 package com.echoflow.ui
 
+import com.echoflow.data.GeneratedVideo
 import com.echoflow.data.StreamChunk
 
 /** Applies provider stream events to the ordered visual reply timeline. */
@@ -205,6 +206,34 @@ internal object ChatSegmentReducer {
                     )
                 }
                 if (idx >= 0) segments[idx] = done else segments.add(done)
+            }
+            is StreamChunk.VideoGenStarted -> {
+                segments.add(
+                    StreamSegment.Video(
+                        videoId = chunk.videoId,
+                        filePath = null,
+                        pattern = chunk.pattern,
+                        aspectRatio = chunk.aspectRatio,
+                        status = GeneratedVideo.STATUS_QUEUED,
+                        generating = true,
+                    )
+                )
+            }
+            is StreamChunk.VideoGenProgress -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Video && it.videoId == chunk.videoId }
+                if (idx >= 0) {
+                    segments[idx] = (segments[idx] as StreamSegment.Video).copy(status = chunk.status)
+                }
+            }
+            is StreamChunk.VideoGenerated -> {
+                val idx = segments.indexOfLast { it is StreamSegment.Video && it.videoId == chunk.videoId }
+                if (idx >= 0) {
+                    segments[idx] = (segments[idx] as StreamSegment.Video).copy(
+                        filePath = chunk.filePath,
+                        status = GeneratedVideo.STATUS_COMPLETED,
+                        generating = false,
+                    )
+                }
             }
             is StreamChunk.ArtifactCompleted -> {
                 val idx = segments.indexOfLast { it is StreamSegment.Artifact && it.building }

--- a/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatSegmentReducer.kt
@@ -222,7 +222,8 @@ internal object ChatSegmentReducer {
             is StreamChunk.VideoGenProgress -> {
                 val idx = segments.indexOfLast { it is StreamSegment.Video && it.videoId == chunk.videoId }
                 if (idx >= 0) {
-                    segments[idx] = (segments[idx] as StreamSegment.Video).copy(status = chunk.status)
+                    segments[idx] = (segments[idx] as StreamSegment.Video)
+                        .copy(status = chunk.status, error = chunk.error)
                 }
             }
             is StreamChunk.VideoGenerated -> {

--- a/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
@@ -82,4 +82,20 @@ sealed class StreamSegment {
         val previousImagePath: String?,
         val generating: Boolean,
     ) : StreamSegment()
+
+    /**
+     * A generated video in the assistant stream: the same dot-field placeholder as images
+     * while [generating], expanding to [aspectRatio] and revealing the player once
+     * [filePath] lands. [videoId] identifies the durable job row, so the card keeps working
+     * across a process death — and [status] is the job's live state, which is worth showing
+     * because a clip takes minutes rather than seconds.
+     */
+    data class Video(
+        val videoId: String,
+        val filePath: String?,
+        val pattern: String,
+        val aspectRatio: String,
+        val status: String,
+        val generating: Boolean,
+    ) : StreamSegment()
 }

--- a/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatStreamUiModels.kt
@@ -97,5 +97,6 @@ sealed class StreamSegment {
         val aspectRatio: String,
         val status: String,
         val generating: Boolean,
+        val error: String? = null,
     ) : StreamSegment()
 }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.echoflow.data.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -258,6 +259,12 @@ class ChatViewModel(
     /** Guards against a second resume pass doubling up on a job already being polled. */
     private val resumingVideoIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
+    /**
+     * Resumed video jobs, by chat. These run outside [streamJobs] because they belong to no
+     * live turn, so deleting a conversation has to be able to find and stop them too.
+     */
+    private val videoResumeJobs = mutableMapOf<String, MutableSet<Job>>()
+
     init {
         viewModelScope.launch { resumeInterruptedVideos() }
     }
@@ -287,7 +294,7 @@ class ChatViewModel(
                 return@forEach
             }
             ensureVideoMessage(video)
-            viewModelScope.launch {
+            val job = viewModelScope.launch {
                 KeepAliveService.acquire(getApplication(), "Finishing a video…")
                 try {
                     videoEngine.resume(video, apiKey).collect { /* the row is the UI's source */ }
@@ -301,6 +308,15 @@ class ChatViewModel(
                 } finally {
                     KeepAliveService.release(getApplication())
                     resumingVideoIds.remove(video.id)
+                }
+            }
+            // Tracked so deleting the conversation can stop it — without this the resume
+            // keeps polling and writing against rows that have already cascaded away.
+            videoResumeJobs.getOrPut(video.chatId) { mutableSetOf() }.add(job)
+            job.invokeOnCompletion {
+                videoResumeJobs[video.chatId]?.let { jobs ->
+                    jobs.remove(job)
+                    if (jobs.isEmpty()) videoResumeJobs.remove(video.chatId)
                 }
             }
         }
@@ -575,6 +591,10 @@ class ChatViewModel(
 
     fun deleteThread(thread: ChatThread) {
         viewModelScope.launch {
+            // Stop anything still writing for this chat and WAIT for it. A video render keeps
+            // running for minutes and would otherwise carry on past the cascade — writing rows
+            // against a chat that no longer exists, and landing an MP4 that nothing points at.
+            cancelWorkForChat(thread.id)
             // Media files live outside Room; remove them while their rows (and paths) still exist.
             generatedImageStore.deleteFilesForChat(thread.id)
             generatedVideoStore.deleteFilesForChat(thread.id)
@@ -583,6 +603,16 @@ class ChatViewModel(
                 selectThread(allThreads.value.firstOrNull { it.id != thread.id }?.id)
             }
         }
+    }
+
+    /**
+     * Cancels the chat's in-flight stream and any video jobs resumed outside it, then joins
+     * them so the caller can safely delete rows and files afterwards. Cancellation alone is
+     * not enough: a coroutine is only stopped once it has actually unwound.
+     */
+    private suspend fun cancelWorkForChat(chatId: String) {
+        streamJobs.remove(chatId)?.cancelAndJoin()
+        videoResumeJobs.remove(chatId)?.forEach { it.cancelAndJoin() }
     }
 
     fun renameThread(thread: ChatThread, newTitle: String) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -40,6 +40,7 @@ class ChatViewModel(
     private val generatedImageDao: GeneratedImageDao,
     private val localImageModelDao: LocalImageModelDao,
     private val localImageModelManager: LocalImageModelManager,
+    private val generatedVideoDao: GeneratedVideoDao,
     private val localInferenceGate: LocalInferenceGate
 ) : AndroidViewModel(application) {
 
@@ -55,6 +56,17 @@ class ChatViewModel(
         LocalImageGenerationEngineRouter(
             mediaPipe = MediaPipeImageGenerationEngine(application, generatedImageStore),
             stableDiffusionCpp = StableDiffusionCppImageGenerationEngine(application, generatedImageStore),
+        )
+    }
+
+    // Video generation: MP4s on disk, async job rows in Room (see GeneratedVideoStore). The
+    // rows are what make a run outlive the process, so the store is created eagerly.
+    private val generatedVideoStore = GeneratedVideoStore(application, generatedVideoDao)
+    private val videoEngine by lazy {
+        OpenRouterVideoGenerationEngine(
+            service = OpenRouterVideoService(),
+            directory = OpenRouterVideoModelDirectory(),
+            store = generatedVideoStore,
         )
     }
 
@@ -232,6 +244,88 @@ class ChatViewModel(
     // Image generation mode: sticky, so follow-up turns keep editing the chat's latest image.
     val imageGenActive: StateFlow<Boolean> = modeIs<ChatMode.ImageGen>()
 
+    // Video generation mode: sticky like image mode, so a run of clips doesn't need the menu
+    // reopened between each one.
+    val videoGenActive: StateFlow<Boolean> = modeIs<ChatMode.VideoGen>()
+
+    /**
+     * The live row behind one video card. Cards resolve their state from here rather than
+     * from the persisted segment, so a clip that was still rendering when its message was
+     * written (or that finished while the app was dead) shows the truth on the next open.
+     */
+    fun observeVideo(videoId: String): Flow<GeneratedVideo?> = generatedVideoDao.observeById(videoId)
+
+    /** Guards against a second resume pass doubling up on a job already being polled. */
+    private val resumingVideoIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
+    init {
+        viewModelScope.launch { resumeInterruptedVideos() }
+    }
+
+    /**
+     * Picks up video jobs that were still rendering when the process last died. The clip is
+     * already paid for and OpenRouter keeps rendering it regardless, so abandoning the job
+     * would silently cost the user money for nothing.
+     *
+     * A run killed before its assistant message was written has no card in the conversation,
+     * so one is inserted here — pointing at the job row, which the card then follows live.
+     */
+    private suspend fun resumeInterruptedVideos() {
+        val unfinished = runCatching { generatedVideoStore.unfinished() }.getOrNull().orEmpty()
+        if (unfinished.isEmpty()) return
+        val apiKey = settingsRepository.getApiKeyDirect()
+
+        unfinished.forEach { video ->
+            if (video.id in resumingVideoIds) return@forEach
+            resumingVideoIds.add(video.id)
+
+            if (apiKey.isBlank() || video.jobId == null) {
+                generatedVideoStore.markFailed(
+                    video, GeneratedVideo.STATUS_FAILED,
+                    "The video was interrupted and could not be resumed.",
+                )
+                return@forEach
+            }
+            ensureVideoMessage(video)
+            viewModelScope.launch {
+                KeepAliveService.acquire(getApplication(), "Finishing a video…")
+                try {
+                    videoEngine.resume(video, apiKey).collect { /* the row is the UI's source */ }
+                    ReplyNotifications.notifyReplyReady(
+                        getApplication(), video.chatId,
+                        title = "Your video is ready",
+                        text = "Tap to watch it in EchoFlow.",
+                    )
+                } catch (_: Exception) {
+                    // The row already carries the failure; the card renders it on next open.
+                } finally {
+                    KeepAliveService.release(getApplication())
+                    resumingVideoIds.remove(video.id)
+                }
+            }
+        }
+    }
+
+    /** Adds the card for a recovered job when the killed turn never got to persist one. */
+    private suspend fun ensureVideoMessage(video: GeneratedVideo) {
+        val alreadyShown = messageDao.getMessagesForChatSync(video.chatId).any { message ->
+            ToolEventJson.segmentsFromJson(message.segmentsJson).any { it.video?.videoId == video.id }
+        }
+        if (alreadyShown) return
+        chatRepository.insertMessage(
+            ChatMessage(
+                id = UUID.randomUUID().toString(),
+                chatId = video.chatId,
+                role = "assistant",
+                content = "",
+                createdAt = System.currentTimeMillis(),
+                segmentsJson = ToolEventJson.segmentsToJson(
+                    listOf(PersistedSegment("video", video = VideoRef(video.id, video.filePath)))
+                ),
+            )
+        )
+    }
+
     /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
     @OptIn(ExperimentalCoroutinesApi::class)
     val currentArtifact: StateFlow<Artifact?> = _currentChatThreadId
@@ -334,6 +428,7 @@ class ChatViewModel(
 
     fun toggleArtifact() = toggleMode(ChatMode.Artifact)
     fun toggleImageGen() = toggleMode(ChatMode.ImageGen)
+    fun toggleVideoGen() = toggleMode(ChatMode.VideoGen)
     fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
     fun toggleWebSearchChip() = toggleMode(ChatMode.WebSearch)
     fun toggleDataAgent() = toggleMode(ChatMode.DataAgent)
@@ -442,6 +537,23 @@ class ChatViewModel(
             }.getOrNull()
         }
 
+    /**
+     * Re-encodes an attached image as a data URL for the video API's `frame_images`. Capped
+     * because the whole payload travels in one JSON submit — an oversized frame would fail
+     * the request rather than degrade, so an image over the cap is simply not sent and the
+     * turn falls back to text-to-video.
+     */
+    private suspend fun attachmentAsDataUrl(uriString: String): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val resolver = getApplication<Application>().contentResolver
+            val uri = Uri.parse(uriString)
+            val mimeType = resolver.getType(uri)?.takeIf { it.startsWith("image/", true) } ?: "image/png"
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@runCatching null
+            if (bytes.isEmpty() || bytes.size > MAX_FRAME_IMAGE_BYTES) return@runCatching null
+            "data:$mimeType;base64," + android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
+        }.getOrNull()
+    }
+
     private fun imageExtensionFor(mimeType: String): String =
         when (mimeType.lowercase()) {
             "image/jpeg", "image/jpg" -> "jpg"
@@ -463,8 +575,9 @@ class ChatViewModel(
 
     fun deleteThread(thread: ChatThread) {
         viewModelScope.launch {
-            // Image files live outside Room; remove them while their rows (and paths) still exist.
+            // Media files live outside Room; remove them while their rows (and paths) still exist.
             generatedImageStore.deleteFilesForChat(thread.id)
+            generatedVideoStore.deleteFilesForChat(thread.id)
             chatDao.deleteThread(thread)
             if (_currentChatThreadId.value == thread.id) {
                 selectThread(allThreads.value.firstOrNull { it.id != thread.id }?.id)
@@ -557,6 +670,7 @@ class ChatViewModel(
             clearError()
 
             val imageGenMode = _chatMode.value is ChatMode.ImageGen
+            val videoGenMode = _chatMode.value is ChatMode.VideoGen
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
             val customProviderConfig = settingsRepository.getCustomProviderConfigDirect()
@@ -589,7 +703,9 @@ class ChatViewModel(
             // Echo Fusion always runs cloud models (the panel + judge), so it never uses the
             // on-device engine even if a local model is the global selection. Image generation
             // likewise always runs its own OpenRouter image model, whatever chat model is picked.
-            val isLocal = selectedModel.startsWith("local/") && _chatMode.value !is ChatMode.EchoFusion && !imageGenMode
+            // Video is the same story, and cloud-only besides — there is no on-device route.
+            val isLocal = selectedModel.startsWith("local/") &&
+                _chatMode.value !is ChatMode.EchoFusion && !imageGenMode && !videoGenMode
 
             val imageEngineLocal = imageGenMode &&
                 settingsRepository.getImageGenEngineDirect() == SettingsRepository.IMAGE_ENGINE_LOCAL
@@ -618,6 +734,21 @@ class ChatViewModel(
                     }
                 } else if (apiKey.isBlank()) {
                     _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                    return@launch
+                }
+            }
+
+            if (videoGenMode) {
+                if (prompt.isEmpty()) {
+                    _errorMessage.value = "Describe the video you want before sending."
+                    return@launch
+                }
+                if (apiKey.isBlank()) {
+                    _errorMessage.value = "Video generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                    return@launch
+                }
+                if (attachmentMime.equals("application/pdf", ignoreCase = true)) {
+                    _errorMessage.value = "Video generation works with image attachments only, not PDFs."
                     return@launch
                 }
             }
@@ -654,11 +785,11 @@ class ChatViewModel(
                 else -> false
             }
             val pendingIsPdf = attachmentMime.equals("application/pdf", ignoreCase = true)
-            if (customProviderActive && !imageGenMode && attachmentUri != null && pendingIsPdf && !customPdfAllowed) {
+            if (customProviderActive && !imageGenMode && !videoGenMode && attachmentUri != null &&pendingIsPdf && !customPdfAllowed) {
                 _errorMessage.value = "PDF is off for this custom endpoint. Turn it on in Settings → Echo Labs → Custom API Endpoint."
                 return@launch
             }
-            if (customProviderActive && !imageGenMode && attachmentUri != null && !pendingIsPdf && !customImageAllowed) {
+            if (customProviderActive && !imageGenMode && !videoGenMode && attachmentUri != null &&!pendingIsPdf && !customImageAllowed) {
                 _errorMessage.value = if (customProvider == "xai") {
                     "$requestModel does not support image attachments. Choose an xAI vision model such as grok-4.5."
                 } else {
@@ -859,7 +990,38 @@ class ChatViewModel(
             val imageEditUrl = if (imageGenMode && !imageEngineLocal) imagePrev?.let { generatedImageStore.asDataUrl(it) } else null
             val imagePattern = if (imageGenMode) listOf("ripple", "rain").random() else ""
 
+            // Video mode: framing comes from Settings; length never does. An image attachment
+            // becomes the clip's first frame where the model supports that.
+            val videoModelId = if (videoGenMode) settingsRepository.getVideoGenModelDirect() else ""
+            val videoAspectRatio = settingsRepository.getVideoAspectRatioDirect()
+            val videoStartImage = if (videoGenMode && attachmentUri != null && !pendingIsPdf) {
+                attachmentAsDataUrl(attachmentUri)
+            } else null
+            val videoPattern = if (videoGenMode) listOf("ripple", "rain").random() else ""
+
             val baseResponseFlow: Flow<StreamChunk> = when {
+                videoGenMode ->
+                    videoEngine.generate(
+                        VideoGenerationRequest(
+                            chatId = chatId,
+                            prompt = prompt,
+                            modelId = videoModelId,
+                            apiKey = apiKey,
+                            aspectRatio = videoAspectRatio,
+                            resolution = settingsRepository.getVideoResolutionDirect(),
+                            generateAudio = settingsRepository.getVideoAudioEnabledDirect(),
+                            startImageDataUrl = videoStartImage,
+                        )
+                    ).map { event ->
+                        when (event) {
+                            is VideoGenerationEvent.Queued ->
+                                StreamChunk.VideoGenStarted(event.video.id, videoPattern, videoAspectRatio)
+                            is VideoGenerationEvent.Progress ->
+                                StreamChunk.VideoGenProgress(event.video.id, event.video.status)
+                            is VideoGenerationEvent.VideoFile ->
+                                StreamChunk.VideoGenerated(event.video.id, event.video.filePath.orEmpty())
+                        }
+                    }
                 imageGenMode ->
                     flow {
                         emit(StreamChunk.ImageGenStarted(imagePattern, imagePrev != null, imagePrev?.filePath))
@@ -1041,9 +1203,13 @@ class ChatViewModel(
                 agentReq != null -> "Echo Agents"
                 advisorReq != null -> "Echo Adviser"
                 fusionReq != null -> "Echo Fusion"
+                // A clip renders for minutes, almost always with the app in the background —
+                // the ping is what tells the user it landed.
+                videoGenMode -> "Video"
                 else -> null
             }
             val keepAliveText = when {
+                videoGenMode -> "Rendering a video…"
                 imageGenMode -> "Creating an image…"
                 agentReq != null -> "Echo Agents — handing tasks to your Echo Agent…"
                 fusionReq != null -> "Echo Fusion — the panel is deliberating…"
@@ -1110,12 +1276,16 @@ class ChatViewModel(
                 if (imageGenMode && segments.any { it is StreamSegment.Image && !it.generating }) {
                     delay(2600)
                 }
+                // Video shares that choreography — the clip is the last chunk too.
+                if (videoGenMode && segments.any { it is StreamSegment.Video && !it.generating }) {
+                    delay(2600)
+                }
                 persistAssistantMessage(chatId, segments, interrupted = null)
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,
-                        title = "$echoLabel reply is ready",
-                        text = "Tap to read the answer in EchoFlow.",
+                        title = if (videoGenMode) "Your video is ready" else "$echoLabel reply is ready",
+                        text = if (videoGenMode) "Tap to watch it in EchoFlow." else "Tap to read the answer in EchoFlow.",
                     )
                 }
             } catch (e: CancellationException) {
@@ -1554,6 +1724,9 @@ class ChatViewModel(
         private const val MAX_LOCAL_SEARCH_ROUNDS = 3
         private const val STREAM_UI_EMIT_MS = 33L
 
+        /** ~6 MB of base64: comfortably a phone photo, well under OpenRouter's body limit. */
+        private const val MAX_FRAME_IMAGE_BYTES = 4 * 1024 * 1024
+
         fun provideFactory(
             application: Application,
             chatDao: ChatDao,
@@ -1572,6 +1745,7 @@ class ChatViewModel(
             generatedImageDao: GeneratedImageDao,
             localImageModelDao: LocalImageModelDao,
             localImageModelManager: LocalImageModelManager,
+            generatedVideoDao: GeneratedVideoDao,
             localInferenceGate: LocalInferenceGate
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
@@ -1580,7 +1754,8 @@ class ChatViewModel(
                     application, chatDao, messageDao, settingsRepository, localModelDao,
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
                     agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao,
-                    generatedImageDao, localImageModelDao, localImageModelManager, localInferenceGate
+                    generatedImageDao, localImageModelDao, localImageModelManager, generatedVideoDao,
+                    localInferenceGate
                 ) as T
             }
         }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1017,7 +1017,7 @@ class ChatViewModel(
                             is VideoGenerationEvent.Queued ->
                                 StreamChunk.VideoGenStarted(event.video.id, videoPattern, videoAspectRatio)
                             is VideoGenerationEvent.Progress ->
-                                StreamChunk.VideoGenProgress(event.video.id, event.video.status)
+                                StreamChunk.VideoGenProgress(event.video.id, event.video.status, event.video.error)
                             is VideoGenerationEvent.VideoFile ->
                                 StreamChunk.VideoGenerated(event.video.id, event.video.filePath.orEmpty())
                         }

--- a/app/src/main/java/com/echoflow/ui/ImageGenAnimation.kt
+++ b/app/src/main/java/com/echoflow/ui/ImageGenAnimation.kt
@@ -133,6 +133,31 @@ internal class PhraseDeck(
     }
 }
 
+/**
+ * The pool shown under the placeholder while a video renders. Kept separate from the image
+ * pool because a clip takes minutes rather than seconds — the same phrase would come round
+ * again long before the wait ends, and the language is film-set rather than paint-and-canvas.
+ */
+internal object VideoGenPhrases {
+    val ALL: List<String> = listOf(
+        "Setting up the shot…", "Blocking the scene…", "Rolling camera…", "Finding the light…",
+        "Storyboarding the beats…", "Rigging the dolly…", "Choosing the lens…", "Marking the tape…",
+        "Rehearsing the move…", "Pulling focus…", "Framing the opening…", "Timing the pan…",
+        "Building the world…", "Casting the shadows…", "Painting the sky…", "Placing the horizon…",
+        "Cueing the motion…", "Easing the camera in…", "Holding the beat…", "Watching the light change…",
+        "Layering the background…", "Animating the foreground…", "Settling the physics…", "Tuning the motion blur…",
+        "Smoothing the frames…", "Checking continuity…", "Matching the colours…", "Grading the highlights…",
+        "Deepening the shadows…", "Balancing the exposure…", "Filling the frame…", "Clearing the frame…",
+        "Sweetening the ambience…", "Placing the sound…", "Syncing the audio…", "Letting the scene breathe…",
+        "Following the action…", "Tracking the subject…", "Widening the shot…", "Pushing in slowly…",
+        "Craning upward…", "Tilting to the sky…", "Finding the reflection…", "Catching the movement…",
+        "Rendering the details…", "Filling in the middle frames…", "Weathering the surfaces…", "Adding the drift…",
+        "Nudging the timing…", "Trimming the tail…", "Holding the last frame…", "Reviewing the take…",
+        "Going again from the top…", "Getting one more take…", "Choosing the best take…", "Cutting it together…",
+        "Smoothing the transition…", "Locking the edit…", "Rendering the final pass…", "Almost in the can…",
+    )
+}
+
 /** The 100-phrase pool shown under the placeholder while an image generates. */
 internal object ImageGenPhrases {
     val ALL: List<String> = listOf(

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -35,7 +35,11 @@ import com.echoflow.data.LocalModelDao
 import com.echoflow.data.ModelDownloadManager
 import com.echoflow.data.OpenRouterModelDirectory
 import com.echoflow.data.OpenRouterModelInfo
+import com.echoflow.data.OpenRouterVideoModelDirectory
+import com.echoflow.data.OpenRouterVideoModelInfo
 import com.echoflow.data.SettingsRepository
+import com.echoflow.data.VideoModel
+import com.echoflow.data.VideoModelDao
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collect
@@ -58,6 +62,7 @@ class SettingsViewModel(
     private val imageModelDao: ImageModelDao,
     private val localImageModelDao: LocalImageModelDao,
     private val localImageModelManager: LocalImageModelManager,
+    private val videoModelDao: VideoModelDao,
     private val localInferenceGate: LocalInferenceGate
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
@@ -148,6 +153,14 @@ class SettingsViewModel(
     private val _localImageMessage = MutableStateFlow<String?>(null)
     val localImageMessage: StateFlow<String?> = _localImageMessage.asStateFlow()
 
+    // Video generation (OpenRouter only)
+    val videoGenModelId: StateFlow<String> = repository.videoGenModel
+    val videoAspectRatio: StateFlow<String> = repository.videoAspectRatio
+    val videoResolution: StateFlow<String> = repository.videoResolution
+    val videoAudioEnabled: StateFlow<Boolean> = repository.videoAudioEnabled
+    val videoModels: StateFlow<List<VideoModel>> = videoModelDao.getAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     // Echo Adviser / Echo Fusion
     val echoAdviserProfileId: StateFlow<String> = repository.echoAdviserProfileId
     val echoFusionPanelId: StateFlow<String> = repository.echoFusionPanelId
@@ -221,6 +234,39 @@ class SettingsViewModel(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList()
         )
+
+    // OpenRouter video-model directory. Separate from the chat directory: video models live on
+    // their own endpoint and carry capability sets (ratios, resolutions, audio) instead of
+    // context lengths and token pricing.
+    private val videoDirectory = OpenRouterVideoModelDirectory()
+
+    private val _orVideoModels = MutableStateFlow<List<OpenRouterVideoModelInfo>>(emptyList())
+
+    private val _videoModelQuery = MutableStateFlow("")
+    val videoModelQuery: StateFlow<String> = _videoModelQuery.asStateFlow()
+
+    private val _videoDirectoryLoading = MutableStateFlow(false)
+    val videoDirectoryLoading: StateFlow<Boolean> = _videoDirectoryLoading.asStateFlow()
+
+    private val _videoDirectoryError = MutableStateFlow<String?>(null)
+    val videoDirectoryError: StateFlow<String?> = _videoDirectoryError.asStateFlow()
+
+    /** Directory filtered live as the user types; capped so the sheet stays snappy. */
+    val videoModelResults: StateFlow<List<OpenRouterVideoModelInfo>> =
+        combine(_orVideoModels, _videoModelQuery) { all, query ->
+            val q = query.trim()
+            if (q.isEmpty()) all
+            else all.filter { it.id.contains(q, true) || it.name.contains(q, true) }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * Capabilities of the selected video model, so the settings page can grey out ratios and
+     * resolutions it does not support instead of letting the user pick a guaranteed 400.
+     */
+    val selectedVideoModelCapabilities: StateFlow<OpenRouterVideoModelInfo?> =
+        combine(_orVideoModels, repository.videoGenModel) { all, selected ->
+            all.firstOrNull { it.id == selected }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val customModels: StateFlow<List<CustomModel>> = customModelDao.getAllCustomModels()
         .stateIn(
@@ -518,6 +564,52 @@ class SettingsViewModel(
         }
     }
 
+    // ── Video generation ─────────────────────────────────────────────────────────────────
+
+    fun saveVideoGenModel(id: String) = repository.saveVideoGenModel(id)
+    fun saveVideoAspectRatio(ratio: String) = repository.saveVideoAspectRatio(ratio)
+    fun saveVideoResolution(resolution: String) = repository.saveVideoResolution(resolution)
+    fun saveVideoAudioEnabled(enabled: Boolean) = repository.saveVideoAudioEnabled(enabled)
+
+    fun updateVideoModelQuery(query: String) {
+        _videoModelQuery.value = query
+    }
+
+    /** Loads the video directory once; safe to call every time the sheet or page opens. */
+    fun loadVideoModelDirectory() {
+        if (_orVideoModels.value.isNotEmpty() || _videoDirectoryLoading.value) return
+        viewModelScope.launch {
+            _videoDirectoryLoading.value = true
+            _videoDirectoryError.value = null
+            try {
+                _orVideoModels.value = videoDirectory.allModels()
+            } catch (e: Exception) {
+                _videoDirectoryError.value = e.message ?: "Could not load the video model directory."
+            } finally {
+                _videoDirectoryLoading.value = false
+            }
+        }
+    }
+
+    fun addVideoModel(id: String, name: String) {
+        viewModelScope.launch {
+            val cleanId = id.trim()
+            val cleanName = name.trim().ifEmpty { cleanId.substringAfterLast("/") }
+            if (cleanId.isNotEmpty()) {
+                videoModelDao.insert(VideoModel(cleanId, cleanName, System.currentTimeMillis()))
+            }
+        }
+    }
+
+    fun deleteVideoModel(id: String) {
+        viewModelScope.launch {
+            videoModelDao.delete(id)
+            if (repository.getVideoGenModelDirect() == id) {
+                repository.saveVideoGenModel(SettingsRepository.DEFAULT_VIDEO_MODEL_ID)
+            }
+        }
+    }
+
     fun addDeepResearchModel(id: String, name: String) {
         viewModelScope.launch {
             val cleanId = id.trim()
@@ -688,11 +780,12 @@ class SettingsViewModel(
             imageModelDao: ImageModelDao,
             localImageModelDao: LocalImageModelDao,
             localImageModelManager: LocalImageModelManager,
+            videoModelDao: VideoModelDao,
             localInferenceGate: LocalInferenceGate
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao, localImageModelDao, localImageModelManager, localInferenceGate) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao, localImageModelDao, localImageModelManager, videoModelDao, localInferenceGate) as T
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -315,9 +315,12 @@ internal fun GeneratedImageActions(
  * The 21×21 dot field. All color comes from the Material scheme (dynamic color + dark mode
  * adaptive). [revealFraction] is read lazily in the draw phase: dots above the scanline are
  * gone, dots below it fade as the sweep approaches the bottom.
+ *
+ * Shared with video generation, which runs the same generating → stretch → reveal
+ * choreography onto a clip's aspect ratio.
  */
 @Composable
-private fun DotFieldCanvas(
+internal fun DotFieldCanvas(
     pattern: String,
     revealFraction: () -> Float,
     stretchFraction: () -> Float = { 0f },
@@ -400,19 +403,23 @@ private fun DotFieldCanvas(
     }
 }
 
-/** Shuffled-deck status phrases: no repeats until all 100 have been shown. */
+/** Shuffled-deck status phrases: no repeats until the whole pool has been shown. */
 @Composable
-private fun GeneratingPhraseLine(modifier: Modifier = Modifier) {
-    val deck = remember { PhraseDeck() }
-    var phrase by remember { mutableStateOf(ImageGenPhrases.ALL.first()) }
-    LaunchedEffect(Unit) {
+internal fun GeneratingPhraseLine(
+    phrases: List<String> = ImageGenPhrases.ALL,
+    intervalMs: Long = 2800,
+    modifier: Modifier = Modifier,
+) {
+    val deck = remember(phrases) { PhraseDeck(phrases) }
+    var phrase by remember(phrases) { mutableStateOf(phrases.first()) }
+    LaunchedEffect(phrases) {
         phrase = deck.next()
         while (true) {
-            delay(2800)
+            delay(intervalMs)
             phrase = deck.next()
         }
     }
-    Crossfade(targetState = phrase, label = "image-gen-phrase") { current ->
+    Crossfade(targetState = phrase, label = "generating-phrase") { current ->
         Text(
             current,
             style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
@@ -85,7 +85,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.media3.common.MediaItem
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.compose.PlayerSurface
 import androidx.media3.ui.compose.SURFACE_TYPE_TEXTURE_VIEW
@@ -352,7 +351,6 @@ internal fun GeneratedVideoActions(
  * is used rather than a SurfaceView so the player clips correctly to the card's rounded
  * corners and scrolls with the message list instead of punching through it.
  */
-@OptIn(UnstableApi::class)
 @Composable
 private fun InlineVideoPlayer(filePath: String, modifier: Modifier = Modifier) {
     val context = LocalContext.current
@@ -386,7 +384,6 @@ private fun InlineVideoPlayer(filePath: String, modifier: Modifier = Modifier) {
 }
 
 /** Fullscreen playback, matching the workspace overlays' dark treatment. */
-@OptIn(UnstableApi::class)
 @Composable
 fun GeneratedVideoViewer(filePath: String, onDismiss: () -> Unit) {
     val context = LocalContext.current

--- a/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
@@ -1,0 +1,543 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.compose.PlayerSurface
+import androidx.media3.ui.compose.SURFACE_TYPE_TEXTURE_VIEW
+import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
+import com.echoflow.data.GeneratedVideo
+import com.echoflow.data.VideoRequestPolicy
+import com.echoflow.ui.VideoGenPhrases
+import com.echoflow.ui.theme.Spacing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/** The compact side of the placeholder square while the clip is still rendering. */
+private val PlaceholderSize = 216.dp
+
+/** The widest a settled clip may render inside the reply. */
+private val SettledMaxWidth = 340.dp
+
+/** The tallest a settled clip may render; taller aspects are capped. */
+private val SettledMaxHeight = 420.dp
+
+/** The clip's real dimensions and opening frame, read once from the file. */
+private data class VideoPoster(val aspect: Float, val frame: ImageBitmap?)
+
+/**
+ * One generated video through its whole life, deliberately reusing the image generator's
+ * choreography so the two features feel like one idea:
+ *
+ *   Rendering  — compact dot-field square, shuffled film-set phrases and the live job state.
+ *                A clip takes minutes, not seconds, so the status line is real information.
+ *   Stretching — the file landed; the SAME card grows to the clip's true aspect ratio, dots
+ *                still dancing.
+ *   Revealing  — the scanline sweeps down over the opening frame, then a small spring settle.
+ *   Settled    — poster frame with a play button; tapping mounts the player. Persisted chats
+ *                ([animate] = false) start here directly with zero motion.
+ *
+ * [aspectRatio] is what was *asked* for and only frames the placeholder; the stretch always
+ * targets the ratio the model actually produced.
+ */
+@Composable
+fun GeneratedVideoSegment(
+    videoId: String,
+    filePath: String?,
+    pattern: String,
+    aspectRatio: String,
+    status: String,
+    animate: Boolean,
+    errorMessage: String? = null,
+    onCopy: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var viewerOpen by remember { mutableStateOf(false) }
+    var playing by remember(filePath) { mutableStateOf(false) }
+
+    if (status == GeneratedVideo.STATUS_FAILED || status == GeneratedVideo.STATUS_CANCELLED ||
+        status == GeneratedVideo.STATUS_EXPIRED
+    ) {
+        VideoFailureCard(status, errorMessage, modifier)
+        return
+    }
+
+    // The clip's real dimensions and opening frame — one retriever pass, no decode of the
+    // whole file. Falls back to the requested ratio if the file cannot be read.
+    val requestedAspect = VideoRequestPolicy.aspectRatioValue(aspectRatio)
+    val poster by produceState<VideoPoster?>(initialValue = null, filePath) {
+        value = filePath?.let { path -> withContext(Dispatchers.IO) { readVideoPoster(path, requestedAspect) } }
+    }
+
+    val minAspect = SettledMaxWidth.value / SettledMaxHeight.value
+    val displayAspect = (poster?.aspect ?: requestedAspect).coerceAtLeast(minAspect)
+
+    var settled by rememberSaveable(filePath) { mutableStateOf(!animate && filePath != null) }
+    val stretch = remember(filePath) { Animatable(if (settled) 1f else 0f) }
+    val reveal = remember(filePath) { Animatable(if (settled) 1f else 0f) }
+    LaunchedEffect(filePath, poster) {
+        if (filePath != null && poster != null && !settled) {
+            // Tweens, not springs: overshoot on LAYOUT size re-measures past the target and
+            // back, which reads as jitter. The bounce lives in the scale settle instead.
+            stretch.animateTo(1f, tween(durationMillis = 700, easing = FastOutSlowInEasing))
+            delay(150) // a breath at full size before the unveil
+            reveal.animateTo(1f, tween(durationMillis = 1200, easing = FastOutSlowInEasing))
+            settled = true
+        }
+    }
+    val settleScale by animateFloatAsState(
+        targetValue = if (reveal.value > 0f && reveal.value < 1f) 0.985f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
+        label = "video-settle",
+    )
+    val scanColor = MaterialTheme.colorScheme.primary
+
+    val morphMaxWidth = (PlaceholderSize.value + (SettledMaxWidth.value - PlaceholderSize.value) * stretch.value).dp
+    val morphAspect = 1f + (displayAspect - 1f) * stretch.value
+
+    // Persisted history starts settled with the poster still decoding for a few ms — hold the
+    // card that beat instead of flashing a square that reflows to the real ratio.
+    if (settled && poster == null) return
+
+    Column(modifier.fillMaxWidth()) {
+        Box(
+            Modifier
+                .widthIn(max = morphMaxWidth)
+                .fillMaxWidth()
+                .aspectRatio(morphAspect)
+                .scale(settleScale)
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            if (filePath != null) {
+                Box(
+                    Modifier
+                        .matchParentSize()
+                        .drawWithContent {
+                            val fraction = reveal.value
+                            clipRect(bottom = size.height * fraction) { this@drawWithContent.drawContent() }
+                            if (fraction > 0f && fraction < 1f) {
+                                val y = size.height * fraction
+                                // Density-aware: raw px would be a near-invisible hairline.
+                                val lineHeight = 2.5.dp.toPx()
+                                val glowHeight = 40.dp.toPx()
+                                drawRect(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(Color.Transparent, scanColor.copy(alpha = 0.4f)),
+                                        startY = (y - glowHeight).coerceAtLeast(0f),
+                                        endY = y,
+                                    ),
+                                    topLeft = Offset(0f, (y - glowHeight).coerceAtLeast(0f)),
+                                    size = Size(size.width, glowHeight.coerceAtMost(y)),
+                                )
+                                drawRect(
+                                    color = scanColor,
+                                    topLeft = Offset(0f, y - lineHeight / 2f),
+                                    size = Size(size.width, lineHeight),
+                                )
+                            }
+                        },
+                ) {
+                    // The player is only built once the user asks for it: a chat can hold many
+                    // clips, and a decoder per card would exhaust the device's codecs.
+                    if (playing) {
+                        InlineVideoPlayer(filePath, Modifier.matchParentSize())
+                    } else {
+                        poster?.frame?.let { frame ->
+                            Image(
+                                bitmap = frame,
+                                contentDescription = "Generated video",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.matchParentSize(),
+                            )
+                        }
+                        if (settled) {
+                            Box(
+                                Modifier
+                                    .matchParentSize()
+                                    .clickable { playing = true },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Surface(shape = CircleShape, color = Color.Black.copy(alpha = 0.55f)) {
+                                    Icon(
+                                        Icons.Default.PlayArrow,
+                                        "Play video",
+                                        Modifier.padding(Spacing.m).size(32.dp),
+                                        tint = Color.White,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (!settled) {
+                DotFieldCanvas(
+                    pattern = pattern,
+                    revealFraction = { reveal.value },
+                    stretchFraction = { stretch.value },
+                    modifier = Modifier.matchParentSize(),
+                )
+            }
+        }
+
+        // Status phrases only while the clip is still rendering; they collapse the moment the
+        // stretch begins so the card is the sole focus of the handoff.
+        AnimatedVisibility(visible = filePath == null, exit = shrinkVertically() + fadeOut()) {
+            Column {
+                Spacer(Modifier.height(Spacing.s))
+                GeneratingPhraseLine(phrases = VideoGenPhrases.ALL, intervalMs = 4000)
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    videoStatusLabel(status),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        AnimatedVisibility(visible = settled, enter = fadeIn()) {
+            Column {
+                Spacer(Modifier.height(Spacing.xs))
+                GeneratedVideoActions(
+                    onCopy = onCopy,
+                    onFullscreen = { viewerOpen = true },
+                    onDownload = {
+                        filePath?.let { path ->
+                            scope.launch {
+                                val ok = withContext(Dispatchers.IO) { saveGeneratedVideoToGallery(context, path) != null }
+                                Toast.makeText(
+                                    context,
+                                    if (ok) "Saved to Movies/EchoFlow" else "Couldn't save the video",
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            }
+                        }
+                    },
+                    onShare = { filePath?.let { scope.launch { shareGeneratedVideo(context, it) } } },
+                )
+            }
+        }
+    }
+
+    if (viewerOpen && filePath != null) {
+        GeneratedVideoViewer(filePath = filePath, onDismiss = { viewerOpen = false })
+    }
+}
+
+@Composable
+internal fun GeneratedVideoActions(
+    onCopy: (() -> Unit)?,
+    onFullscreen: () -> Unit,
+    onDownload: () -> Unit,
+    onShare: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier, horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+        onCopy?.let { copy ->
+            FilledTonalIconButton(
+                onClick = copy,
+                modifier = Modifier.size(48.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(20.dp)) }
+        }
+        FilledTonalIconButton(
+            onClick = onFullscreen,
+            modifier = Modifier.size(48.dp),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) { Icon(Icons.Default.Fullscreen, "Play fullscreen", Modifier.size(20.dp)) }
+        FilledTonalIconButton(
+            onClick = onDownload,
+            modifier = Modifier.size(48.dp),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) { Icon(Icons.Default.Download, "Save to gallery", Modifier.size(20.dp)) }
+        FilledTonalIconButton(
+            onClick = onShare,
+            modifier = Modifier.size(48.dp),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) { Icon(Icons.Default.Share, "Share", Modifier.size(20.dp)) }
+    }
+}
+
+/**
+ * An ExoPlayer bound to one local file, released with the composable. A TextureView surface
+ * is used rather than a SurfaceView so the player clips correctly to the card's rounded
+ * corners and scrolls with the message list instead of punching through it.
+ */
+@OptIn(UnstableApi::class)
+@Composable
+private fun InlineVideoPlayer(filePath: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val player = remember(filePath) {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(Uri.fromFile(File(filePath))))
+            prepare()
+            playWhenReady = true
+        }
+    }
+    DisposableEffect(player) { onDispose { player.release() } }
+
+    val playPause = rememberPlayPauseButtonState(player)
+    Box(modifier) {
+        PlayerSurface(player, Modifier.matchParentSize(), SURFACE_TYPE_TEXTURE_VIEW)
+        Box(
+            Modifier.matchParentSize().clickable { playPause.onClick() },
+            contentAlignment = Alignment.Center,
+        ) {
+            // The control only appears while paused; playback stays unobstructed.
+            if (playPause.showPlay) {
+                Surface(shape = CircleShape, color = Color.Black.copy(alpha = 0.55f)) {
+                    Icon(
+                        Icons.Default.PlayArrow, "Play", Modifier.padding(Spacing.m).size(32.dp),
+                        tint = Color.White,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Fullscreen playback, matching the workspace overlays' dark treatment. */
+@OptIn(UnstableApi::class)
+@Composable
+fun GeneratedVideoViewer(filePath: String, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val player = remember(filePath) {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(Uri.fromFile(File(filePath))))
+            prepare()
+            playWhenReady = true
+        }
+    }
+    DisposableEffect(player) { onDispose { player.release() } }
+    val playPause = rememberPlayPauseButtonState(player)
+
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.94f))) {
+            PlayerSurface(
+                player,
+                Modifier.fillMaxSize().padding(Spacing.base).clickable { playPause.onClick() },
+                SURFACE_TYPE_TEXTURE_VIEW,
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd).padding(Spacing.base),
+            ) { Icon(Icons.Default.Close, "Close", tint = Color.White) }
+            Row(
+                Modifier.align(Alignment.BottomCenter).padding(Spacing.xl),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.base),
+            ) {
+                FilledTonalIconButton(onClick = { playPause.onClick() }) {
+                    Icon(
+                        if (playPause.showPlay) Icons.Default.PlayArrow else Icons.Default.Pause,
+                        if (playPause.showPlay) "Play" else "Pause",
+                    )
+                }
+                FilledTonalIconButton(onClick = {
+                    scope.launch {
+                        val ok = withContext(Dispatchers.IO) { saveGeneratedVideoToGallery(context, filePath) != null }
+                        Toast.makeText(
+                            context,
+                            if (ok) "Saved to Movies/EchoFlow" else "Couldn't save the video",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                }) { Icon(Icons.Default.Download, "Save to gallery") }
+                FilledTonalIconButton(onClick = { scope.launch { shareGeneratedVideo(context, filePath) } }) {
+                    Icon(Icons.Default.Share, "Share")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VideoFailureCard(status: String, errorMessage: String?, modifier: Modifier = Modifier) {
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        modifier = modifier.fillMaxWidth().widthIn(max = SettledMaxWidth),
+    ) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.ErrorOutline, null, tint = MaterialTheme.colorScheme.onErrorContainer)
+            Spacer(Modifier.width(Spacing.m))
+            Column {
+                Text(
+                    when (status) {
+                        GeneratedVideo.STATUS_CANCELLED -> "The video was cancelled"
+                        GeneratedVideo.STATUS_EXPIRED -> "The video expired before it downloaded"
+                        else -> "The video couldn't be generated"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                errorMessage?.takeIf { it.isNotBlank() }?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        textAlign = TextAlign.Start,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Human wording for the job state. Worth showing: a clip renders for minutes. */
+internal fun videoStatusLabel(status: String): String = when (status) {
+    GeneratedVideo.STATUS_QUEUED -> "Sending to OpenRouter…"
+    GeneratedVideo.STATUS_PENDING -> "Queued with the provider…"
+    GeneratedVideo.STATUS_IN_PROGRESS -> "Rendering — this takes a few minutes"
+    GeneratedVideo.STATUS_DOWNLOADING -> "Downloading the clip…"
+    else -> "Working…"
+}
+
+/**
+ * Reads the clip's dimensions and opening frame in one retriever pass. The frame is what the
+ * scanline reveals onto, so the reveal never lands on a black rectangle waiting for a decoder.
+ */
+private fun readVideoPoster(filePath: String, fallbackAspect: Float): VideoPoster {
+    val retriever = MediaMetadataRetriever()
+    return try {
+        retriever.setDataSource(filePath)
+        val width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
+        val height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
+        // Portrait clips are stored landscape with a rotation tag; ignoring it renders them
+        // in the wrong box entirely.
+        val rotation = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0
+        val rotated = rotation == 90 || rotation == 270
+        val aspect = if (width > 0 && height > 0) {
+            if (rotated) height.toFloat() / width else width.toFloat() / height
+        } else {
+            fallbackAspect
+        }
+        VideoPoster(aspect, retriever.frameAtTime?.asImageBitmap())
+    } catch (_: Exception) {
+        VideoPoster(fallbackAspect, null)
+    } finally {
+        runCatching { retriever.release() }
+    }
+}
+
+/** Copies the MP4 into MediaStore (Movies/EchoFlow); returns the new content Uri or null. */
+private fun saveGeneratedVideoToGallery(context: Context, filePath: String): Uri? = runCatching {
+    val file = File(filePath)
+    if (!file.exists()) return null
+    val values = ContentValues().apply {
+        put(MediaStore.Video.Media.DISPLAY_NAME, "EchoFlow_${System.currentTimeMillis()}.mp4")
+        put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(MediaStore.Video.Media.RELATIVE_PATH, "Movies/EchoFlow")
+        }
+    }
+    val uri = context.contentResolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values) ?: return null
+    context.contentResolver.openOutputStream(uri)?.use { out ->
+        file.inputStream().use { it.copyTo(out) }
+    } ?: return null
+    uri
+}.getOrNull()
+
+/** Shares via a MediaStore copy — no FileProvider needed, works on every API level we ship. */
+private suspend fun shareGeneratedVideo(context: Context, filePath: String) {
+    val uri = withContext(Dispatchers.IO) { saveGeneratedVideoToGallery(context, filePath) }
+    if (uri == null) {
+        Toast.makeText(context, "Couldn't share the video", Toast.LENGTH_SHORT).show()
+        return
+    }
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "video/mp4"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(Intent.createChooser(intent, "Share video"))
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -145,6 +145,8 @@ internal fun InputToolbar(
     onToggleArtifact: () -> Unit,
     imageGenActive: Boolean,
     onToggleImageGen: () -> Unit,
+    videoGenActive: Boolean,
+    onToggleVideoGen: () -> Unit,
     browserSession: com.echoflow.data.BrowserSession?,
     browserSteps: List<com.echoflow.data.BrowserStep>,
     onBrowserOpen: () -> Unit,
@@ -230,7 +232,7 @@ internal fun InputToolbar(
         }
 
         // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive || imageGenActive) {
+        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive || imageGenActive || videoGenActive) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
@@ -247,6 +249,9 @@ internal fun InputToolbar(
                 }
                 if (imageGenActive) {
                     CapabilityChip(Icons.Default.Brush, "Create image", onRemove = onToggleImageGen)
+                }
+                if (videoGenActive) {
+                    CapabilityChip(Icons.Default.Movie, "Create video", onRemove = onToggleVideoGen)
                 }
                 if (echoAdviserActive) {
                     CapabilityChip(
@@ -339,6 +344,8 @@ internal fun InputToolbar(
                         artifactOn = artifactActive,
                         imageGenOn = imageGenActive,
                         onToggleImageGen = { plusMenuOpen = false; onToggleImageGen() },
+                        videoGenOn = videoGenActive,
+                        onToggleVideoGen = { plusMenuOpen = false; onToggleVideoGen() },
                         onImage = { plusMenuOpen = false; onAttach() },
                         onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
@@ -364,6 +371,7 @@ internal fun InputToolbar(
                                 deepResearchActive -> "Research a topic…"
                                 artifactActive -> "Describe an artifact to build…"
                                 imageGenActive -> "Describe an image — or a change…"
+                                videoGenActive -> "Describe a video…"
                                 else -> "Ask anything…"
                             }
                         )
@@ -418,6 +426,8 @@ internal fun PlusMenu(
     artifactOn: Boolean,
     imageGenOn: Boolean,
     onToggleImageGen: () -> Unit,
+    videoGenOn: Boolean,
+    onToggleVideoGen: () -> Unit,
     onImage: () -> Unit,
     onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
@@ -470,6 +480,13 @@ internal fun PlusMenu(
             leadingIcon = { Icon(Icons.Default.Brush, null) },
             trailingIcon = { if (imageGenOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleImageGen,
+        )
+        // Create video — render a short clip through OpenRouter's async video models.
+        DropdownMenuItem(
+            text = { Text("Create video") },
+            leadingIcon = { Icon(Icons.Default.Movie, null) },
+            trailingIcon = { if (videoGenOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
+            onClick = onToggleVideoGen,
         )
         // Data Agent only appears once it's enabled in Settings and a Firecrawl key exists.
         if (dataAgentAvailable) {

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -315,6 +315,7 @@ internal fun StreamingAssistantBubble(
                             aspectRatio = segment.aspectRatio,
                             status = segment.status,
                             animate = true,
+                            errorMessage = segment.error,
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -77,6 +77,7 @@ import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
 import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
+import com.echoflow.data.GeneratedVideo
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
@@ -101,6 +102,8 @@ import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.Spacing
 import com.echoflow.ui.theme.rememberMorph
 import com.echoflow.ui.theme.rememberMorphProgress
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
 
@@ -124,6 +127,7 @@ internal fun MessagesPane(
     bottomInset: Dp = Spacing.l,
     onCopy: (String) -> Unit,
     onArtifactOpen: () -> Unit = {},
+    observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
 ) {
     val listState = rememberLazyListState()
     var autoFollow by remember { mutableStateOf(true) }
@@ -161,7 +165,12 @@ internal fun MessagesPane(
         contentPadding = PaddingValues(start = Spacing.base, end = Spacing.base, top = topInset, bottom = bottomInset),
     ) {
         items(messages, key = { it.id }) { msg ->
-            MessageBubble(msg, onCopy = { onCopy(msg.content) }, onArtifactOpen = onArtifactOpen)
+            MessageBubble(
+                msg,
+                onCopy = { onCopy(msg.content) },
+                onArtifactOpen = onArtifactOpen,
+                observeVideo = observeVideo,
+            )
         }
         researchRun?.let { run ->
             item(key = "research") { ResearchProgressCard(run = run, onCancel = onCancelResearch) }
@@ -298,6 +307,17 @@ internal fun StreamingAssistantBubble(
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }
+                    is StreamSegment.Video -> {
+                        com.echoflow.ui.components.GeneratedVideoSegment(
+                            videoId = segment.videoId,
+                            filePath = segment.filePath,
+                            pattern = segment.pattern,
+                            aspectRatio = segment.aspectRatio,
+                            status = segment.status,
+                            animate = true,
+                        )
+                        Spacer(Modifier.height(Spacing.s))
+                    }
                     is StreamSegment.Text -> {
                         SmoothStreamingText(segment.text, Modifier.fillMaxWidth())
                         if (!isLast) Spacer(Modifier.height(Spacing.s))
@@ -385,7 +405,14 @@ internal fun ErrorBanner(message: String, onDismiss: () -> Unit) {
 }
 
 @Composable
-internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, streaming: Boolean = false, onArtifactOpen: () -> Unit = {}, onCopy: () -> Unit) {
+internal fun MessageBubble(
+    message: ChatMessage,
+    modifier: Modifier = Modifier,
+    streaming: Boolean = false,
+    onArtifactOpen: () -> Unit = {},
+    observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
+    onCopy: () -> Unit,
+) {
     val isUser = message.role == "user"
     if (isUser) {
         Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -421,8 +448,11 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
             // reason → search → reason → search → answer keeps exactly the layout it
             // streamed with instead of merging all reasoning into one block.
             val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
-            val lastGeneratedImageIndex = persistedSegments.indexOfLast { segment ->
-                segment.type == "image" && segment.image != null
+            // Generated media carries its own copy/save/share row, so the bubble's own copy
+            // button is suppressed when a clip or image is the reply's last word.
+            val lastGeneratedMediaIndex = persistedSegments.indexOfLast { segment ->
+                (segment.type == "image" && segment.image != null) ||
+                    (segment.type == "video" && segment.video != null)
             }
 
             message.localAttachmentUri?.let { uri ->
@@ -512,7 +542,34 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
                                         pattern = "ripple",
                                         previousImagePath = null,
                                         animate = false,
-                                        onCopy = onCopy.takeIf { index == lastGeneratedImageIndex },
+                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
+                                    )
+                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                                }
+                            }
+                            "video" -> {
+                                segment.video?.let { ref ->
+                                    // The row, not the segment, is the truth: a clip can still be
+                                    // rendering when its message is written (or finish while the
+                                    // app is dead), so the card follows the job live.
+                                    val live by remember(ref.videoId) { observeVideo(ref.videoId) }
+                                        .collectAsState(initial = null)
+                                    com.echoflow.ui.components.GeneratedVideoSegment(
+                                        videoId = ref.videoId,
+                                        filePath = live?.filePath ?: ref.filePath,
+                                        pattern = "ripple",
+                                        aspectRatio = live?.aspectRatio
+                                            ?: com.echoflow.data.VideoRequestPolicy.DEFAULT_ASPECT_RATIO,
+                                        status = live?.status ?: if (ref.filePath != null) {
+                                            GeneratedVideo.STATUS_COMPLETED
+                                        } else {
+                                            GeneratedVideo.STATUS_IN_PROGRESS
+                                        },
+                                        // A message written before the file existed means the clip
+                                        // lands in front of the user — that one gets the reveal.
+                                        animate = ref.filePath == null,
+                                        errorMessage = live?.error,
+                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
                                     )
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
@@ -563,7 +620,7 @@ internal fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, 
                 }
             }
 
-            if (!streaming && lastGeneratedImageIndex == -1) {
+            if (!streaming && lastGeneratedMediaIndex == -1) {
                 Spacer(Modifier.height(Spacing.xs))
                 FilledTonalIconButton(
                     onClick = onCopy,

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -188,6 +188,18 @@ fun ChatScreen(
     } else {
         imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
     }
+    // "Create video" swaps the model picker to OpenRouter video models. Cloud only — there is
+    // no on-device route — so the local section of the picker stays empty.
+    val videoGenActive by chatViewModel.videoGenActive.collectAsState()
+    val videoGenModelId by settingsViewModel.videoGenModelId.collectAsState()
+    val videoModels by settingsViewModel.videoModels.collectAsState()
+    val videoModelEntries = remember(videoModels) {
+        val default = com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID to
+            com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
+        listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
+    }
+    val videoModelLabel = videoModelEntries.firstOrNull { it.first == videoGenModelId }?.second ?: videoGenModelId
+
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
     val browserSession by chatViewModel.currentBrowserSession.collectAsState()
@@ -350,6 +362,7 @@ fun ChatScreen(
                         bottomInset = messageBottomInset,
                         onCopy = { clipboard.setText(AnnotatedString(it)) },
                         onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
+                        observeVideo = chatViewModel::observeVideo,
                     )
                 }
             }
@@ -358,6 +371,7 @@ fun ChatScreen(
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
                 modelName = when {
+                    videoGenActive -> videoModelLabel
                     imageGenActive -> imageModelLabel
                     echoFusionActive -> activePanel?.name ?: "Choose panel"
                     echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
@@ -415,6 +429,8 @@ fun ChatScreen(
                 onToggleArtifact = { chatViewModel.toggleArtifact() },
                 imageGenActive = imageGenActive,
                 onToggleImageGen = { chatViewModel.toggleImageGen() },
+                videoGenActive = videoGenActive,
+                onToggleVideoGen = { chatViewModel.toggleVideoGen() },
                 browserSession = browserSession,
                 browserSteps = browserSteps,
                 onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },
@@ -482,7 +498,16 @@ fun ChatScreen(
     }
 
     if (showModelMenu) {
-        if (imageGenActive) {
+        if (videoGenActive) {
+            ModelPickerSheet(
+                models = videoModelEntries,
+                localModels = emptyList(),
+                selectedId = videoGenModelId,
+                onSelect = { settingsViewModel.saveVideoGenModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (imageGenActive) {
             ModelPickerSheet(
                 models = imageModelEntries,
                 localModels = localImageEntries,

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Psychology
@@ -147,6 +148,7 @@ internal const val PageWebSearch = "web_search"
 internal const val PageLocalModels = "local_models"
 internal const val PageDeepResearch = "deep_research"
 internal const val PageImageGen = "image_gen"
+internal const val PageVideoGen = "video_gen"
 internal const val PageDataAgent = "data_agent"
 internal const val PageBrowserFlow = "browser_flow"
 internal const val PageEchoLabs = "echo_labs"
@@ -214,6 +216,7 @@ fun SettingsScreen(
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
             PageImageGen -> ImageGenPage(viewModel, onBack = { page = PageHome })
+            PageVideoGen -> VideoGenPage(viewModel, onBack = { page = PageHome })
             PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = { page = PageHome })
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageEchoLabs })
             PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageEchoLabs })
@@ -305,6 +308,17 @@ internal fun SettingsHomePage(
             ?: if (imageGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID) "Gemini 2.5 Flash Image"
             else imageGenModelId
     }
+    val videoGenModelId by viewModel.videoGenModelId.collectAsState()
+    val videoModelsHome by viewModel.videoModels.collectAsState()
+    val videoAspectRatioHome by viewModel.videoAspectRatio.collectAsState()
+    val videoResolutionHome by viewModel.videoResolution.collectAsState()
+    val videoModelName = videoModelsHome.firstOrNull { it.id == videoGenModelId }?.name
+        ?: if (videoGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID) {
+            com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
+        } else {
+            videoGenModelId
+        }
+    val videoGenSubtitle = "$videoModelName · $videoAspectRatioHome · $videoResolutionHome"
     val deepResearchSubtitle = when {
         deepResearchModelId.isBlank() -> "No engine selected"
         else -> DeepResearchCatalog.providerEngineById(deepResearchModelId)?.name
@@ -354,7 +368,7 @@ internal fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 7,
+                index = 0, count = 8,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -364,7 +378,7 @@ internal fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 7,
+                index = 1, count = 8,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -374,7 +388,7 @@ internal fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 2, count = 7,
+                index = 2, count = 8,
                 onClick = { onOpen(PageLocalModels) },
             )
             SettingsNavRow(
@@ -384,7 +398,7 @@ internal fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 3, count = 7,
+                index = 3, count = 8,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -394,7 +408,7 @@ internal fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 4, count = 7,
+                index = 4, count = 8,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
@@ -404,8 +418,18 @@ internal fun SettingsHomePage(
                 subtitle = imageGenSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 7,
+                index = 5, count = 8,
                 onClick = { onOpen(PageImageGen) },
+            )
+            SettingsNavRow(
+                icon = Icons.Default.Movie,
+                polygon = MaterialShapes.Cookie6Sided,
+                title = "Video generation",
+                subtitle = videoGenSubtitle,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
+                index = 6, count = 8,
+                onClick = { onOpen(PageVideoGen) },
             )
             SettingsNavRow(
                 icon = Icons.Default.AutoAwesome,
@@ -414,7 +438,7 @@ internal fun SettingsHomePage(
                 subtitle = echoLabsSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 6, count = 7,
+                index = 7, count = 8,
                 onClick = { onOpen(PageEchoLabs) },
             )
         }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsVideoGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsVideoGen.kt
@@ -1,0 +1,510 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.OpenRouterVideoModelInfo
+import com.echoflow.data.SettingsRepository
+import com.echoflow.data.VideoRequestPolicy
+import com.echoflow.ui.SettingsViewModel
+import com.echoflow.ui.components.GroupedItemGap
+import com.echoflow.ui.components.groupedItemShape
+import com.echoflow.ui.theme.RoundedPolygonShape
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * Video generation settings. Cloud only — OpenRouter is the sole route, because video needs
+ * a datacentre GPU for minutes at a time and there is no on-device equivalent to offer.
+ *
+ * The page deliberately has no length control: the model decides how long each clip runs.
+ * What the user does choose is framing (aspect ratio, resolution) and audio, and all three
+ * are reconciled against the selected model's declared capabilities — an unsupported value
+ * would be a hard 400 from OpenRouter, so unsupported chips are disabled rather than shown
+ * as choices that silently fail.
+ */
+@Composable
+internal fun VideoGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val videoModels by viewModel.videoModels.collectAsState()
+    val selectedId by viewModel.videoGenModelId.collectAsState()
+    val aspectRatio by viewModel.videoAspectRatio.collectAsState()
+    val resolution by viewModel.videoResolution.collectAsState()
+    val audioEnabled by viewModel.videoAudioEnabled.collectAsState()
+    val capabilities by viewModel.selectedVideoModelCapabilities.collectAsState()
+
+    val query by viewModel.videoModelQuery.collectAsState()
+    val results by viewModel.videoModelResults.collectAsState()
+    val loading by viewModel.videoDirectoryLoading.collectAsState()
+    val error by viewModel.videoDirectoryError.collectAsState()
+
+    var showDirectory by remember { mutableStateOf(false) }
+
+    // Capabilities drive the whole page, so fetch the directory on open rather than waiting
+    // for the user to go looking for the search sheet.
+    LaunchedEffect(Unit) { viewModel.loadVideoModelDirectory() }
+
+    // The shipped default is always offered, ahead of whatever the user has added.
+    val entries = remember(videoModels) {
+        val default = SettingsRepository.DEFAULT_VIDEO_MODEL_ID to SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
+        listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
+    }
+
+    SettingsPageScaffold(title = "Video generation", subtitle = "Create short clips in chat", onBack = onBack) {
+        PageSection("How it works", null)
+        Text(
+            "Turn on “Create video” from the + menu in chat, then describe a clip. Generation " +
+                "runs on OpenRouter and takes a few minutes — you can leave the chat or the app " +
+                "and it keeps going. The model decides how long the clip should be.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Default model", "The model every video turn uses")
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            entries.forEachIndexed { index, (id, name) ->
+                VideoModelRow(
+                    id = id,
+                    name = name,
+                    index = index,
+                    count = entries.size,
+                    selected = id == selectedId,
+                    priceHint = results.firstOrNull { it.id == id }?.priceHint(resolution, audioEnabled),
+                    onSelect = { viewModel.saveVideoGenModel(id) },
+                    onDelete = { viewModel.deleteVideoModel(id) }
+                        .takeIf { id != SettingsRepository.DEFAULT_VIDEO_MODEL_ID },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.l))
+        Button(
+            onClick = {
+                showDirectory = true
+                viewModel.loadVideoModelDirectory()
+            },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Search, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Browse video models")
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            "Every model OpenRouter can generate video with, with what it costs per second.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Shape", "How the clip is framed")
+        CapabilityChipRow(
+            values = VideoRequestPolicy.ASPECT_RATIOS,
+            selected = aspectRatio,
+            supported = capabilities?.aspectRatios,
+            onSelect = viewModel::saveVideoAspectRatio,
+        )
+
+        Spacer(Modifier.height(Spacing.l))
+        PageSection("Resolution", "Higher costs more per second")
+        CapabilityChipRow(
+            values = VideoRequestPolicy.RESOLUTIONS,
+            selected = resolution,
+            supported = capabilities?.resolutions,
+            onSelect = viewModel::saveVideoResolution,
+        )
+
+        Spacer(Modifier.height(Spacing.l))
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Generate audio",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        when {
+                            capabilities == null -> "Roughly doubles the cost per second."
+                            capabilities?.supportsAudio == true ->
+                                "Adds dialogue and ambience. Roughly doubles the cost per second."
+                            else -> "The selected model always generates silent clips."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(
+                    checked = audioEnabled && capabilities?.supportsAudio != false,
+                    onCheckedChange = viewModel::saveVideoAudioEnabled,
+                    enabled = capabilities?.supportsAudio != false,
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.l))
+        Text(
+            "Clip length is always the model's own call — EchoFlow never asks for a duration.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (showDirectory) {
+        VideoModelDirectorySheet(
+            query = query,
+            results = results,
+            loading = loading,
+            error = error,
+            resolution = resolution,
+            audioEnabled = audioEnabled,
+            addedIds = videoModels.map { it.id }.toSet() + SettingsRepository.DEFAULT_VIDEO_MODEL_ID,
+            onQueryChange = viewModel::updateVideoModelQuery,
+            onRetry = viewModel::loadVideoModelDirectory,
+            onAdd = { info -> viewModel.addVideoModel(info.id, info.name.substringAfter(": ")) },
+            onRemove = viewModel::deleteVideoModel,
+            onDismiss = { showDirectory = false },
+        )
+    }
+}
+
+/**
+ * A row of framing choices where a value the selected model does not offer is disabled, not
+ * hidden — hiding it would make the page silently rearrange every time the model changes.
+ * A null [supported] means the directory has not loaded yet, so nothing is disabled.
+ */
+@Composable
+private fun CapabilityChipRow(
+    values: List<String>,
+    selected: String,
+    supported: List<String>?,
+    onSelect: (String) -> Unit,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        values.forEach { value ->
+            // An empty capability set means the model takes framing from its input instead of
+            // a parameter, so every choice stays live and is simply not sent.
+            val enabled = supported.isNullOrEmpty() || value in supported
+            FilterChip(
+                selected = value == selected,
+                onClick = { onSelect(value) },
+                enabled = enabled,
+                label = { Text(value) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun VideoModelRow(
+    id: String,
+    name: String,
+    index: Int,
+    count: Int,
+    selected: Boolean,
+    priceHint: String?,
+    onSelect: () -> Unit,
+    onDelete: (() -> Unit)?,
+) {
+    Surface(
+        onClick = onSelect,
+        shape = groupedItemShape(index, count),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.s, top = Spacing.m, bottom = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .clip(RoundedPolygonShape(MaterialShapes.Cookie6Sided))
+                    .background(
+                        if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.tertiaryContainer
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Movie, null, Modifier.size(20.dp),
+                    tint = if (selected) MaterialTheme.colorScheme.onPrimary
+                    else MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Spacer(Modifier.width(Spacing.base))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    priceHint ?: id,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (selected) {
+                Icon(Icons.Default.CheckCircle, "Selected", tint = MaterialTheme.colorScheme.primary)
+            } else if (onDelete != null) {
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.DeleteOutline, "Remove", tint = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Live video-model directory: search-as-you-type over OpenRouter's video endpoint, showing
+ * the capabilities and per-second price that actually decide the choice.
+ */
+@Composable
+internal fun VideoModelDirectorySheet(
+    query: String,
+    results: List<OpenRouterVideoModelInfo>,
+    loading: Boolean,
+    error: String?,
+    resolution: String,
+    audioEnabled: Boolean,
+    addedIds: Set<String>,
+    onQueryChange: (String) -> Unit,
+    onRetry: () -> Unit,
+    onAdd: (OpenRouterVideoModelInfo) -> Unit,
+    onRemove: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        // Full height from the moment it opens — the sheet must not jump taller when results
+        // stream in.
+        modifier = Modifier.fillMaxHeight(0.94f),
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = Spacing.base)
+                .imePadding()
+                .navigationBarsPadding(),
+        ) {
+            Text("Video models", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(Spacing.xs))
+            Text(
+                "Live from openrouter.ai — tap a model to add it to your picker.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.base))
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                placeholder = { Text("Veo, Sora, Kling, Seedance…") },
+                leadingIcon = { Icon(Icons.Default.Search, null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) { Icon(Icons.Default.Close, "Clear") }
+                    }
+                },
+                shape = CircleShape,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.m))
+            Box(Modifier.fillMaxWidth().weight(1f)) {
+                when {
+                    loading -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        CircularWavyProgressIndicator()
+                        Spacer(Modifier.height(Spacing.m))
+                        Text(
+                            "Loading video models…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    error != null -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.l),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(Modifier.height(Spacing.m))
+                        FilledTonalButton(onClick = onRetry, shape = CircleShape) {
+                            Icon(Icons.Default.Refresh, null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(Spacing.s))
+                            Text("Try again")
+                        }
+                    }
+                    results.isEmpty() -> Column(
+                        Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Icon(Icons.Default.SearchOff, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Spacer(Modifier.height(Spacing.s))
+                        Text(
+                            "No video model matches “$query”.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(GroupedItemGap),
+                    ) {
+                        items(results.size) { index ->
+                            val info = results[index]
+                            VideoDirectoryRow(
+                                info = info,
+                                index = index,
+                                count = results.size,
+                                added = info.id in addedIds,
+                                resolution = resolution,
+                                audioEnabled = audioEnabled,
+                                onAdd = { onAdd(info) },
+                                onRemove = { onRemove(info.id) },
+                            )
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(Spacing.xl))
+        }
+    }
+}
+
+@Composable
+private fun VideoDirectoryRow(
+    info: OpenRouterVideoModelInfo,
+    index: Int,
+    count: Int,
+    added: Boolean,
+    resolution: String,
+    audioEnabled: Boolean,
+    onAdd: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Surface(
+        onClick = { if (added) onRemove() else onAdd() },
+        shape = groupedItemShape(index, count),
+        color = if (added) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.m, top = Spacing.m, bottom = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    info.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (added) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    info.id,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (added) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(Spacing.xs))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                ) {
+                    info.priceHint(resolution, audioEnabled)?.let { InfoPill(it, added) }
+                    info.resolutions.takeIf { it.isNotEmpty() }?.let { InfoPill(it.joinToString(" · "), added) }
+                    if (info.supportsAudio) InfoPill("Audio", added)
+                }
+            }
+            Spacer(Modifier.width(Spacing.s))
+            if (added) {
+                Icon(Icons.Default.CheckCircle, "Added", tint = MaterialTheme.colorScheme.primary)
+            } else {
+                FilledTonalIconButton(onClick = onAdd, modifier = Modifier.size(36.dp)) {
+                    Icon(Icons.Default.Add, "Add ${info.name}", Modifier.size(18.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,7 +56,7 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version fifteen without data loss`() {
+    fun `production database upgrades version one through version sixteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
 
         // v13 tables exist and are queryable after the chained migration.
@@ -70,6 +70,14 @@ class DatabaseUpgradeTest {
         database.openHelper.readableDatabase.query(
             "SELECT runtime, modelFileName FROM local_image_models LIMIT 0"
         ).use { /* v15 columns are queryable */ }
+        // v16: video generation tables are created and start empty.
+        database.openHelper.readableDatabase.query("SELECT COUNT(*) FROM video_models").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        database.openHelper.readableDatabase.query(
+            "SELECT jobId, pollingUrl, status, filePath FROM generated_videos LIMIT 0"
+        ).use { /* v16 job columns are queryable */ }
 
         database.openHelper.readableDatabase.query(
             "SELECT content, reasoning, localAttachmentUri, localAttachmentName " +

--- a/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
+++ b/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
@@ -101,6 +101,60 @@ class GeneratedVideoStoreTest {
         assertNull(database.generatedVideoDao().getById(submitted.id)?.filePath)
     }
 
+    @Test fun `a job whose chat was deleted mid-download leaves no orphan MP4`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        val submitted = store.markSubmitted(job, "job-42", "https://openrouter.ai/api/v1/videos/job-42")
+
+        // The conversation goes away while the download is in flight; the row cascades with it.
+        database.chatDao().deleteThread(ChatThread("chat-1", "Chat", 1L, 1L))
+        assertNull(database.generatedVideoDao().getById(submitted.id))
+
+        try {
+            store.completeWithDownload(submitted, ByteArrayInputStream(ByteArray(4096)))
+            throw AssertionError("Expected the removed job to be refused")
+        } catch (_: VideoGenerationException.JobRemoved) {
+            // Expected — the clip has nowhere to belong.
+        }
+
+        // Neither the finished file nor a temp file may survive, and the row must not come back.
+        assertTrue(File(context.filesDir, "generated_videos").listFiles().orEmpty().isEmpty())
+        assertNull(database.generatedVideoDao().getById(submitted.id))
+    }
+
+    @Test fun `status writes never resurrect a job whose chat was deleted`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        val submitted = store.markSubmitted(job, "job-42", "https://openrouter.ai/api/v1/videos/job-42")
+        database.chatDao().deleteThread(ChatThread("chat-1", "Chat", 1L, 1L))
+
+        // Both a progress update and a failure update would otherwise re-insert the row via
+        // the DAO's REPLACE strategy, pointing at a chat that no longer exists.
+        try {
+            store.markStatus(submitted, GeneratedVideo.STATUS_IN_PROGRESS)
+            throw AssertionError("Expected the removed job to be refused")
+        } catch (_: VideoGenerationException.JobRemoved) {
+        }
+        try {
+            store.markFailed(submitted, GeneratedVideo.STATUS_FAILED, "boom")
+            throw AssertionError("Expected the removed job to be refused")
+        } catch (_: VideoGenerationException.JobRemoved) {
+        }
+
+        assertNull(database.generatedVideoDao().getById(submitted.id))
+        assertTrue(store.unfinished().isEmpty())
+    }
+
+    @Test fun `deleting a chat sweeps partial downloads, not just recorded paths`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        // A process kill can leave a half-written temp file behind: the row never got a
+        // filePath, so path-based cleanup alone would never find it.
+        val dir = File(context.filesDir, "generated_videos").apply { mkdirs() }
+        val partial = File(dir, "${job.id}.mp4.tmp").apply { writeBytes(ByteArray(32)) }
+
+        store.deleteFilesForChat("chat-1")
+
+        assertFalse(partial.exists())
+    }
+
     @Test fun `deleting a chat's files removes the MP4s before the rows cascade away`() = runBlocking {
         val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
         val done = store.completeWithDownload(job, ByteArrayInputStream(ByteArray(16)))

--- a/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
+++ b/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
@@ -1,0 +1,113 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+
+@RunWith(RobolectricTestRunner::class)
+class GeneratedVideoStoreTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var database: AppDatabase
+    private lateinit var store: GeneratedVideoStore
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        store = GeneratedVideoStore(context, database.generatedVideoDao())
+        runBlocking { database.chatDao().insertThread(ChatThread("chat-1", "Chat", 1L, 1L)) }
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        File(context.filesDir, "generated_videos").deleteRecursively()
+    }
+
+    @Test fun `a job row exists before the provider is ever called`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite over dunes", "google/veo-3.1", "16:9", "720p")
+
+        assertEquals(GeneratedVideo.STATUS_QUEUED, job.status)
+        assertNull(job.filePath)
+        assertEquals(job.id, database.generatedVideoDao().getById(job.id)?.id)
+        // Nothing playable yet, so the chat must not treat it as the latest clip.
+        assertNull(store.latestForChat("chat-1"))
+    }
+
+    @Test fun `the provider handle is stored so a cold start can resume the run`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        store.markSubmitted(job, jobId = "job-42", pollingUrl = "https://openrouter.ai/api/v1/videos/job-42")
+
+        val unfinished = store.unfinished()
+        assertEquals(1, unfinished.size)
+        assertEquals("job-42", unfinished.first().jobId)
+        assertEquals("https://openrouter.ai/api/v1/videos/job-42", unfinished.first().pollingUrl)
+        assertEquals(GeneratedVideo.STATUS_PENDING, unfinished.first().status)
+    }
+
+    @Test fun `download completes the row and leaves no partial file`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        val submitted = store.markSubmitted(job, "job-42", "https://example.test/job-42")
+
+        val done = store.completeWithDownload(submitted, ByteArrayInputStream(ByteArray(2048) { 7 }))
+
+        val file = File(done.filePath!!)
+        assertTrue(file.isFile)
+        assertEquals(2048L, file.length())
+        assertTrue(file.name.endsWith(".mp4"))
+        assertFalse(file.parentFile!!.listFiles()!!.any { it.name.endsWith(".tmp") })
+        assertEquals(GeneratedVideo.STATUS_COMPLETED, done.status)
+        assertEquals(done.id, store.latestForChat("chat-1")?.id)
+        // A completed run is no longer a resume candidate.
+        assertTrue(store.unfinished().isEmpty())
+    }
+
+    @Test fun `a connection dropped mid-download leaves neither file nor completed row`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        val submitted = store.markSubmitted(job, "job-42", "https://example.test/job-42")
+
+        val truncating: InputStream = object : InputStream() {
+            private var served = 0
+            override fun read(): Int = throw java.io.IOException("connection reset")
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                if (served >= 512) throw java.io.IOException("connection reset")
+                served += len.coerceAtMost(512)
+                return len.coerceAtMost(512)
+            }
+        }
+
+        try {
+            store.completeWithDownload(submitted, truncating)
+            throw AssertionError("Expected the interrupted download to fail")
+        } catch (_: java.io.IOException) {
+            // Expected — a half-written clip must never be presented as playable.
+        }
+
+        val dir = File(context.filesDir, "generated_videos")
+        assertTrue(dir.listFiles().orEmpty().isEmpty())
+        assertNull(database.generatedVideoDao().getById(submitted.id)?.filePath)
+    }
+
+    @Test fun `deleting a chat's files removes the MP4s before the rows cascade away`() = runBlocking {
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        val done = store.completeWithDownload(job, ByteArrayInputStream(ByteArray(16)))
+        assertTrue(File(done.filePath!!).exists())
+
+        store.deleteFilesForChat("chat-1")
+
+        assertFalse(File(done.filePath).exists())
+    }
+}

--- a/app/src/test/java/com/echoflow/data/OpenRouterVideoPollingOriginTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterVideoPollingOriginTest.kt
@@ -1,0 +1,58 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The polling URL is an absolute URL chosen by the response body, and the request that uses
+ * it carries the user's OpenRouter bearer token. Every case here is one where trusting that
+ * value would hand the key to somewhere it does not belong.
+ */
+class OpenRouterVideoPollingOriginTest {
+
+    private val canonical = "https://openrouter.ai/api/v1/videos/job-1"
+
+    @Test fun `a legitimate openrouter url is used as given`() {
+        assertEquals(
+            "https://openrouter.ai/api/v1/videos/job-1?poll=1",
+            OpenRouterVideoService.trustedPollingUrl("https://openrouter.ai/api/v1/videos/job-1?poll=1", "job-1"),
+        )
+    }
+
+    @Test fun `openrouter subdomains are trusted`() {
+        assertEquals(
+            "https://api.openrouter.ai/v1/videos/job-1",
+            OpenRouterVideoService.trustedPollingUrl("https://api.openrouter.ai/v1/videos/job-1", "job-1"),
+        )
+    }
+
+    @Test fun `a foreign host never receives the api key`() {
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("https://evil.example/collect", "job-1"))
+    }
+
+    @Test fun `a lookalike host does not pass the suffix check`() {
+        // The classic bypass: a domain that merely *ends with* the trusted name.
+        assertEquals(
+            canonical,
+            OpenRouterVideoService.trustedPollingUrl("https://openrouter.ai.evil.example/x", "job-1"),
+        )
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("https://notopenrouter.ai/x", "job-1"))
+    }
+
+    @Test fun `plaintext http is refused even on the right host`() {
+        // The token must never travel unencrypted, however trusted the destination.
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("http://openrouter.ai/api/v1/videos/job-1", "job-1"))
+    }
+
+    @Test fun `missing, blank and unparseable urls fall back to the canonical job url`() {
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl(null, "job-1"))
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("   ", "job-1"))
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("not a url", "job-1"))
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("/api/v1/videos/job-1", "job-1"))
+    }
+
+    @Test fun `non-http schemes are refused`() {
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("file:///data/secret", "job-1"))
+        assertEquals(canonical, OpenRouterVideoService.trustedPollingUrl("ftp://openrouter.ai/x", "job-1"))
+    }
+}

--- a/app/src/test/java/com/echoflow/data/OpenRouterVideoPricingTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterVideoPricingTest.kt
@@ -1,0 +1,100 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * OpenRouter publishes video pricing under several SKU spellings in one directory response,
+ * in two different units and sliced by resolution and/or audio. Getting that wrong would show
+ * users a price 100× off, or quote a variant they are not buying.
+ */
+class OpenRouterVideoPricingTest {
+
+    @Test fun `cents skus normalize to dollars per second, keyed by resolution`() {
+        // xAI's shape.
+        val prices = OpenRouterVideoModelDirectory.parsePricing(
+            mapOf(
+                "cents_per_image_input" to "1",
+                "cents_per_video_output_second_480p" to "8",
+                "cents_per_video_output_second_720p" to "14",
+                "cents_per_video_output_second_1080p" to "25",
+            )
+        )
+        assertEquals(3, prices.size)
+        assertEquals(0.08, prices.first { it.resolution == "480p" }.usdPerSecond, 0.0001)
+        assertEquals(0.14, prices.first { it.resolution == "720p" }.usdPerSecond, 0.0001)
+        assertEquals(0.25, prices.first { it.resolution == "1080p" }.usdPerSecond, 0.0001)
+        assertTrue(prices.all { it.audio == null })
+    }
+
+    @Test fun `dollar skus are already per second`() {
+        // Sora's shape: resolution only, no audio split.
+        val prices = OpenRouterVideoModelDirectory.parsePricing(
+            mapOf("duration_seconds_720p" to "0.30", "duration_seconds_1080p" to "0.50")
+        )
+        assertEquals(0.30, prices.first { it.resolution == "720p" }.usdPerSecond, 0.0001)
+        assertEquals(0.50, prices.first { it.resolution == "1080p" }.usdPerSecond, 0.0001)
+    }
+
+    @Test fun `audio variants are split out, with and without a resolution`() {
+        // Veo's shape — the awkward one: audio prefixes, sometimes with a resolution suffix.
+        val prices = OpenRouterVideoModelDirectory.parsePricing(
+            mapOf(
+                "duration_seconds_with_audio" to "0.12",
+                "duration_seconds_without_audio" to "0.10",
+                "duration_seconds_with_audio_720p" to "0.10",
+                "duration_seconds_without_audio_720p" to "0.08",
+                "duration_seconds_with_audio_4k" to "0.30",
+                "duration_seconds_without_audio_4k" to "0.25",
+            )
+        )
+        assertEquals(0.12, prices.first { it.audio == true && it.resolution == null }.usdPerSecond, 0.0001)
+        assertEquals(0.08, prices.first { it.audio == false && it.resolution == "720p" }.usdPerSecond, 0.0001)
+        assertEquals(0.30, prices.first { it.audio == true && it.resolution == "4K" }.usdPerSecond, 0.0001)
+    }
+
+    @Test fun `unrecognized and unparseable skus are ignored rather than shown as free`() {
+        val prices = OpenRouterVideoModelDirectory.parsePricing(
+            mapOf(
+                "cents_per_image_input" to "1",
+                "duration_seconds_720p" to "not-a-number",
+                "cents_per_video_output_second_480p" to "5",
+            )
+        )
+        assertEquals(1, prices.size)
+        assertEquals("480p", prices.single().resolution)
+    }
+
+    @Test fun `the hint quotes the variant the user actually configured`() {
+        val veo = OpenRouterVideoModelInfo(
+            id = "google/veo-3.1-fast",
+            name = "Veo 3.1 Fast",
+            prices = OpenRouterVideoModelDirectory.parsePricing(
+                mapOf(
+                    "duration_seconds_with_audio_720p" to "0.10",
+                    "duration_seconds_without_audio_720p" to "0.08",
+                    "duration_seconds_with_audio_4k" to "0.30",
+                )
+            ),
+        )
+        assertEquals("~$0.10/sec at 720p, with audio", veo.priceHint("720p", audio = true))
+        assertEquals("~$0.08/sec at 720p, without audio", veo.priceHint("720p", audio = false))
+        // 1080p is unpriced for this model: fall back rather than showing nothing.
+        assertEquals(0.08, veo.bestPrice("1080p", audio = false)!!.usdPerSecond, 0.0001)
+    }
+
+    @Test fun `an unpriced model has no hint instead of a zero`() {
+        assertNull(OpenRouterVideoModelInfo(id = "x/y", name = "Y").priceHint("720p"))
+    }
+
+    @Test fun `first frame support is read from the declared frame image types`() {
+        assertTrue(
+            OpenRouterVideoModelInfo(id = "x/y", name = "Y", frameImageTypes = listOf("first_frame"))
+                .supportsFirstFrame
+        )
+        assertFalse(OpenRouterVideoModelInfo(id = "x/y", name = "Y").supportsFirstFrame)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/VideoGenSettingsTest.kt
+++ b/app/src/test/java/com/echoflow/data/VideoGenSettingsTest.kt
@@ -1,0 +1,57 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class VideoGenSettingsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetPreferences() {
+        SettingsPreferenceStorage.legacy(context).edit().clear().commit()
+        SettingsPreferenceStorage.secureOrNull(context)?.edit()?.clear()?.commit()
+    }
+
+    @Test fun `a fresh install lands on the cheap Veo default, landscape and silent`() {
+        val repository = SettingsRepository(context)
+        assertEquals(SettingsRepository.DEFAULT_VIDEO_MODEL_ID, repository.getVideoGenModelDirect())
+        assertEquals("16:9", repository.getVideoAspectRatioDirect())
+        assertEquals("720p", repository.getVideoResolutionDirect())
+        // Audio roughly doubles the per-second price, so it must be opt-in.
+        assertEquals(false, repository.getVideoAudioEnabledDirect())
+    }
+
+    @Test fun `framing settings persist across instances`() {
+        val repository = SettingsRepository(context)
+        repository.saveVideoGenModel("openai/sora-2-pro")
+        repository.saveVideoAspectRatio("9:16")
+        repository.saveVideoResolution("1080p")
+        repository.saveVideoAudioEnabled(true)
+
+        val reloaded = SettingsRepository(context)
+        assertEquals("openai/sora-2-pro", reloaded.getVideoGenModelDirect())
+        assertEquals("9:16", reloaded.getVideoAspectRatioDirect())
+        assertEquals("1080p", reloaded.getVideoResolutionDirect())
+        assertEquals(true, reloaded.getVideoAudioEnabledDirect())
+        assertEquals("9:16", reloaded.videoAspectRatio.value)
+    }
+
+    @Test fun `unknown framing values normalize instead of reaching the API`() {
+        val repository = SettingsRepository(context)
+        repository.saveVideoAspectRatio("banana")
+        assertEquals("16:9", repository.getVideoAspectRatioDirect())
+        repository.saveVideoResolution("8K")
+        assertEquals("720p", repository.getVideoResolutionDirect())
+    }
+
+    @Test fun `a blank stored model falls back rather than submitting an empty id`() {
+        SettingsPreferenceStorage.legacy(context).edit().putString("video_gen_model", "").commit()
+        assertEquals(SettingsRepository.DEFAULT_VIDEO_MODEL_ID, SettingsRepository(context).getVideoGenModelDirect())
+    }
+}

--- a/app/src/test/java/com/echoflow/data/VideoRequestPolicyTest.kt
+++ b/app/src/test/java/com/echoflow/data/VideoRequestPolicyTest.kt
@@ -1,0 +1,64 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The request policy is the only thing standing between a user preference and a hard 400 from
+ * OpenRouter, so every fallback path is pinned here.
+ */
+class VideoRequestPolicyTest {
+
+    @Test
+    fun `a model that declares no ratios is sent no ratio at all`() {
+        assertNull(VideoRequestPolicy.resolveAspectRatio("16:9", emptyList()))
+        assertNull(VideoRequestPolicy.resolveResolution("720p", emptyList()))
+    }
+
+    @Test
+    fun `a supported preference is passed through untouched`() {
+        assertEquals("9:16", VideoRequestPolicy.resolveAspectRatio("9:16", listOf("16:9", "9:16", "1:1")))
+        assertEquals("1080p", VideoRequestPolicy.resolveResolution("1080p", listOf("720p", "1080p")))
+    }
+
+    @Test
+    fun `an unsupported ratio falls back to one with the same orientation`() {
+        // The user asked for portrait; 3:4 keeps that intent, 16:9 would flip the whole shot.
+        assertEquals("3:4", VideoRequestPolicy.resolveAspectRatio("9:16", listOf("16:9", "3:4", "21:9")))
+    }
+
+    @Test
+    fun `an unsupported ratio with no matching orientation still yields a supported value`() {
+        val resolved = VideoRequestPolicy.resolveAspectRatio("9:16", listOf("16:9", "21:9"))
+        assertTrue(resolved in listOf("16:9", "21:9"))
+    }
+
+    @Test
+    fun `an unsupported resolution snaps to the closest the model offers`() {
+        assertEquals("720p", VideoRequestPolicy.resolveResolution("1080p", listOf("480p", "720p")))
+        assertEquals("480p", VideoRequestPolicy.resolveResolution("360p", listOf("480p", "1080p")))
+    }
+
+    @Test
+    fun `aspect ratio strings convert to display ratios`() {
+        assertEquals(16f / 9f, VideoRequestPolicy.aspectRatioValue("16:9"), 0.0001f)
+        assertEquals(9f / 16f, VideoRequestPolicy.aspectRatioValue("9:16"), 0.0001f)
+        assertEquals(1f, VideoRequestPolicy.aspectRatioValue("1:1"), 0.0001f)
+    }
+
+    @Test
+    fun `malformed or missing ratios fall back to landscape instead of dividing by zero`() {
+        assertEquals(16f / 9f, VideoRequestPolicy.aspectRatioValue(null), 0.0001f)
+        assertEquals(16f / 9f, VideoRequestPolicy.aspectRatioValue("16:0"), 0.0001f)
+        assertEquals(16f / 9f, VideoRequestPolicy.aspectRatioValue("wide"), 0.0001f)
+    }
+
+    @Test
+    fun `orientation classifies the ratios the picker offers`() {
+        assertEquals("landscape", VideoRequestPolicy.orientationOf("16:9"))
+        assertEquals("portrait", VideoRequestPolicy.orientationOf("9:16"))
+        assertEquals("square", VideoRequestPolicy.orientationOf("1:1"))
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
+++ b/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
@@ -44,6 +44,41 @@ class AssistantMessagePersistenceTest {
         assertNull(draft)
     }
 
+    @Test fun `a finished video persists both its job id and its file`() {
+        val draft = AssistantMessagePersistence.draft(
+            listOf(
+                StreamSegment.Video(
+                    videoId = "vid-1", filePath = "/data/clip.mp4", pattern = "ripple",
+                    aspectRatio = "16:9", status = "completed", generating = false,
+                )
+            ),
+            null, stopped = false,
+        )!!
+        val segment = draft.segments.single()
+        assertEquals("video", segment.type)
+        assertEquals("vid-1", segment.video?.videoId)
+        assertEquals("/data/clip.mp4", segment.video?.filePath)
+    }
+
+    @Test fun `a still-rendering video is persisted anyway so the card can be recovered`() {
+        // The opposite of the image rule on purpose: a clip takes minutes, the job outlives
+        // the turn, and without a row in the conversation there would be nothing pointing at
+        // the (already paid for) render once it finishes.
+        val draft = AssistantMessagePersistence.draft(
+            listOf(
+                StreamSegment.Video(
+                    videoId = "vid-2", filePath = null, pattern = "rain",
+                    aspectRatio = "9:16", status = "in_progress", generating = true,
+                )
+            ),
+            null, stopped = false,
+        )!!
+        val segment = draft.segments.single()
+        assertEquals("video", segment.type)
+        assertEquals("vid-2", segment.video?.videoId)
+        assertNull(segment.video?.filePath)
+    }
+
     @Test fun `normalizes reasoning only answer and appends interruption`() {
         val draft = AssistantMessagePersistence.draft(
             listOf(StreamSegment.Reasoning("work\nAnswer: result")), "timeout", stopped = false,

--- a/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
+++ b/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
@@ -66,6 +66,20 @@ class ChatSegmentReducerTest {
         assertEquals("completed", resolved.status)
     }
 
+    @Test fun `a failing video settles the card instead of leaving it generating`() {
+        // Without this the placeholder dances on forever behind an error banner, which reads
+        // as "still working" rather than "this went wrong".
+        val segments = mutableListOf<StreamSegment>()
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenStarted("vid-1", "ripple", "16:9"))
+        ChatSegmentReducer.reduce(
+            segments,
+            StreamChunk.VideoGenProgress("vid-1", "failed", "the provider ran out of capacity"),
+        )
+        val failed = segments.single() as StreamSegment.Video
+        assertEquals("failed", failed.status)
+        assertEquals("the provider ran out of capacity", failed.error)
+    }
+
     @Test fun `a video event for another job never touches this one's card`() {
         // Two clips can be in flight across chats; matching on id rather than "the last
         // pending card" is what keeps one job's completion from resolving the other's.

--- a/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
+++ b/app/src/test/java/com/echoflow/ui/ChatSegmentReducerTest.kt
@@ -48,6 +48,35 @@ class ChatSegmentReducerTest {
         assertEquals(true, image.generating)
     }
 
+    @Test fun `video generation tracks its job through progress to the finished clip`() {
+        val segments = mutableListOf<StreamSegment>()
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenStarted("vid-1", "rain", "9:16"))
+        val pending = segments.single() as StreamSegment.Video
+        assertEquals("rain", pending.pattern)
+        assertEquals("9:16", pending.aspectRatio)
+        assertEquals(true, pending.generating)
+
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenProgress("vid-1", "in_progress"))
+        assertEquals("in_progress", (segments.single() as StreamSegment.Video).status)
+
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenerated("vid-1", "/clip.mp4"))
+        val resolved = segments.single() as StreamSegment.Video
+        assertFalse(resolved.generating)
+        assertEquals("/clip.mp4", resolved.filePath)
+        assertEquals("completed", resolved.status)
+    }
+
+    @Test fun `a video event for another job never touches this one's card`() {
+        // Two clips can be in flight across chats; matching on id rather than "the last
+        // pending card" is what keeps one job's completion from resolving the other's.
+        val segments = mutableListOf<StreamSegment>()
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenStarted("vid-1", "ripple", "16:9"))
+        ChatSegmentReducer.reduce(segments, StreamChunk.VideoGenerated("vid-other", "/wrong.mp4"))
+        val untouched = segments.single() as StreamSegment.Video
+        assertNull(untouched.filePath)
+        assertEquals(true, untouched.generating)
+    }
+
     @Test fun `real output removes transient agent banner`() {
         val segments = mutableListOf<StreamSegment>()
         assertNull(ChatSegmentReducer.reduce(segments, StreamChunk.AgentRunStarted))

--- a/app/src/test/java/com/echoflow/ui/components/GeneratedVideoActionsTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/GeneratedVideoActionsTest.kt
@@ -1,0 +1,60 @@
+package com.echoflow.ui.components
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.echoflow.data.GeneratedVideo
+import com.echoflow.ui.theme.EchoFlowTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class GeneratedVideoActionsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun everyVideoActionStaysOnTheSameRow() {
+        composeRule.setContent {
+            EchoFlowTheme {
+                GeneratedVideoActions(
+                    onCopy = {},
+                    onFullscreen = {},
+                    onDownload = {},
+                    onShare = {},
+                )
+            }
+        }
+
+        val copy = composeRule.onNodeWithContentDescription("Copy").assertHasClickAction()
+        val fullscreen = composeRule.onNodeWithContentDescription("Play fullscreen").assertHasClickAction()
+        val download = composeRule.onNodeWithContentDescription("Save to gallery").assertHasClickAction()
+        val share = composeRule.onNodeWithContentDescription("Share").assertHasClickAction()
+
+        val copyTop = copy.fetchSemanticsNode().boundsInRoot.top
+        assertEquals(copyTop, fullscreen.fetchSemanticsNode().boundsInRoot.top, 0.5f)
+        assertEquals(copyTop, download.fetchSemanticsNode().boundsInRoot.top, 0.5f)
+        assertEquals(copyTop, share.fetchSemanticsNode().boundsInRoot.top, 0.5f)
+    }
+
+    @Test
+    fun everyWaitingStateHasItsOwnWording() {
+        // Rendering runs for minutes, so a generic "Working…" for every state would leave the
+        // user unable to tell a stuck submit from a download in progress.
+        val labels = listOf(
+            GeneratedVideo.STATUS_QUEUED,
+            GeneratedVideo.STATUS_PENDING,
+            GeneratedVideo.STATUS_IN_PROGRESS,
+            GeneratedVideo.STATUS_DOWNLOADING,
+        ).map(::videoStatusLabel)
+
+        assertEquals(labels.size, labels.distinct().size)
+        assertTrue(labels.none { it == videoStatusLabel("something-new") })
+    }
+}

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -38,6 +38,26 @@ truth whether the clip finished a second ago or while the app was closed.
 If a turn is killed before it can persist a message at all, the resume pass inserts the card
 itself — otherwise the finished clip would have nothing in the conversation pointing at it.
 
+### Deleting a chat has to stop the render first
+
+A render outlives the turn that started it, so `deleteThread` cannot just remove rows. It
+cancels the chat's stream job **and** any resumed video jobs, and *joins* them — cancellation
+alone is not enough, since a coroutine is only stopped once it has unwound. Only then are
+files removed and the thread deleted.
+
+The store defends the same boundary independently, because cancellation always has a window:
+
+- Every write after `createJob` checks the row still exists. The DAO's `REPLACE` strategy
+  would otherwise re-insert a job pointing at a deleted chat.
+- `completeWithDownload` re-checks after the download and does the row write *inside* the
+  guarded block, so a job that disappears between the rename and the update cannot leave a
+  finished MP4 that nothing points at.
+- `deleteFilesForChat` sweeps by row id, not only by recorded path, catching half-written
+  `.tmp` files from a killed download that never got a `filePath`.
+
+`VideoGenerationException.JobRemoved` ends the run quietly — the conversation is gone, so
+there is no failure to report and nowhere to report it.
+
 ### Length is the model's call
 
 EchoFlow never sends `duration`. Models publish discrete supported lengths (Veo offers 4, 6
@@ -59,6 +79,19 @@ against the selected model's declared capabilities before anything is sent:
 
 The settings page disables unsupported chips rather than hiding them, so the page does not
 rearrange itself every time the model changes.
+
+## The API key only goes to OpenRouter
+
+`polling_url` is an **absolute URL supplied by the response body**, and the request that uses
+it carries the user's bearer token. Forwarding it unchecked would turn any tampered, proxied
+or compromised response into a credential exfiltration path.
+
+`OpenRouterVideoService.trustedPollingUrl` accepts only HTTPS on `openrouter.ai` or a
+subdomain of it, and falls back to the canonical `/videos/{id}` URL otherwise — a downgrade
+rather than a hard failure, so a legitimate response-shape change cannot break generation.
+The check runs on **every poll**, not just where the URL is first received: it is persisted
+across launches, and trusting the stored value would leave the token one bad row away from a
+foreign host.
 
 ## Pricing
 

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -1,0 +1,115 @@
+# Video generation
+
+Describe a clip in chat, get it back in the conversation. OpenRouter is the only route —
+there is no on-device path, because a clip needs a datacentre GPU for minutes at a time.
+
+Turn it on with **+ → Create video**. Configure it in **Settings → Video generation**.
+
+## Why this is not "image generation, but longer"
+
+Image generation is one streaming chat completion: request in, base64 out, seconds later.
+Video is a different surface entirely. OpenRouter serves it from `/api/v1/videos` as an
+**asynchronous job API**:
+
+1. `POST /api/v1/videos` → `{ id, polling_url, status }`
+2. `GET <polling_url>` until `status` is terminal (`completed`, `failed`, `cancelled`, `expired`)
+3. `GET /api/v1/videos/{id}/content?index=0` → MP4 bytes
+
+That takes 30 seconds to several minutes. Three consequences drive the whole design.
+
+### The row is the job, not the result
+
+`generated_videos` is written **before** OpenRouter is called and updated at every state
+change, carrying the provider's job id and polling URL. That is what makes an interrupted
+run recoverable: on launch, `ChatViewModel` finds every unfinished row and resumes polling
+it. A clip the user has already paid for is never abandoned because the process died.
+
+`GeneratedVideoStore` owns that lifecycle. The MP4 downloads to a temp file and is renamed
+into place only once whole, so a dropped connection cannot leave a truncated clip that the
+row claims is playable.
+
+### The chat card points at the job, not the file
+
+An image segment persists a file path. A video segment persists the **row id**
+(`VideoRef.videoId`), because the message can be written while the clip is still rendering.
+The card resolves its live state through `ChatViewModel.observeVideo(id)`, so it shows the
+truth whether the clip finished a second ago or while the app was closed.
+
+If a turn is killed before it can persist a message at all, the resume pass inserts the card
+itself — otherwise the finished clip would have nothing in the conversation pointing at it.
+
+### Length is the model's call
+
+EchoFlow never sends `duration`. Models publish discrete supported lengths (Veo offers 4, 6
+and 8 seconds; Sora goes to 20) and picking for the user would mean guessing at both cost and
+pacing. The settings page says so outright, so the absence reads as a decision rather than an
+oversight.
+
+## Framing is validated, not assumed
+
+`supported_resolutions` and `supported_aspect_ratios` differ per model and an out-of-set value
+is a hard 400 — not a silent downgrade. `VideoRequestPolicy` reconciles the user's preference
+against the selected model's declared capabilities before anything is sent:
+
+- Supported preference → passed through.
+- Unsupported → substitute one with the **same orientation** first, so a portrait request
+  never comes back landscape; resolution snaps to the closest offer.
+- Model declares nothing → send nothing. Several image-to-video models take their framing from
+  the input image, and inventing a parameter for them would fail the request.
+
+The settings page disables unsupported chips rather than hiding them, so the page does not
+rearrange itself every time the model changes.
+
+## Pricing
+
+OpenRouter ships three SKU spellings in one directory response, in two units, sliced by
+resolution and/or audio:
+
+| SKU | Unit | Example |
+| --- | --- | --- |
+| `cents_per_video_output_second_720p` | cents | xAI |
+| `duration_seconds_720p` | dollars | Sora |
+| `duration_seconds_with_audio_720p` | dollars | Veo |
+
+`OpenRouterVideoModelDirectory.parsePricing` normalizes all of them to USD per output second.
+Quoting the wrong one would be off by 100×, or quote a variant the user is not buying — hence
+`OpenRouterVideoPricingTest`.
+
+## Background behaviour
+
+A `KeepAliveService` hold spans the render so the process is not frozen mid-poll, and a
+notification fires when the clip lands. Polling backs off from 5s to 20s — clips rarely arrive
+in under half a minute, so a tight loop only burns battery and rate limit. A job still running
+after 20 minutes is given up on.
+
+## In-chat presentation
+
+The card deliberately reuses image generation's choreography — dot-field placeholder, stretch
+to the media's real aspect ratio, scanline reveal — so the two creation modes read as one
+idea. What differs:
+
+- The reveal lands on the clip's **opening frame**, pulled with one `MediaMetadataRetriever`
+  pass, so it never sweeps onto a black rectangle waiting for a decoder. That pass also gives
+  the true aspect ratio, honouring the rotation tag (without it, portrait clips render in a
+  landscape box).
+- The player is built only when the user taps play. A conversation can hold many clips, and a
+  decoder per card would exhaust the device's codecs.
+- The status line is real information: "Rendering — this takes a few minutes" is worth saying
+  when the wait is minutes rather than seconds.
+
+Playback is media3 with a **TextureView** surface, which clips correctly to the card's rounded
+corners inside a scrolling list.
+
+## Files
+
+| Concern | File |
+| --- | --- |
+| Job + result rows | `data/Models.kt` (`GeneratedVideo`, `VideoModel`), `data/Daos.kt` |
+| File and lifecycle | `data/GeneratedVideoStore.kt` |
+| HTTP contract | `data/OpenRouterVideoService.kt` |
+| Capabilities + pricing | `data/OpenRouterVideoModelDirectory.kt` |
+| Framing rules | `data/VideoRequestPolicy.kt` |
+| submit → poll → download | `data/VideoGenerationEngine.kt` |
+| Settings page | `ui/screens/SettingsVideoGen.kt` |
+| In-chat card and player | `ui/components/VideoGenComponents.kt` |
+| Turn routing and resume | `ui/ChatViewModel.kt` |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ kotlinxCoroutinesTest = "1.10.2"
 core = "1.6.1"
 runner = "1.6.2"
 coilCompose = "2.7.0"
+# Playback for generated video clips. media3-ui-compose gives a Compose-native surface, so the
+# player wears EchoFlow's own controls instead of PlayerView's stock chrome.
+media3 = "1.10.1"
 retrofit = "2.12.0"
 converterMoshi = "2.12.0"
 kotlinxCoroutinesAndroid = "1.10.2"
@@ -97,6 +100,8 @@ latex-renderer = { group = "io.github.huarangmeng", name = "latex-renderer", ver
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coilCompose" }
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+androidx-media3-ui-compose = { group = "androidx.media3", name = "media3-ui-compose", version.ref = "media3" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "converterMoshi" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }


### PR DESCRIPTION
Adds **+ → Create video** to chat, backed by OpenRouter's video models, with a Settings page, a searchable model picker, and full background/resume handling.

## Why this isn't "image generation, but longer"

Image generation is one streaming chat completion — request in, base64 out, seconds later. Video is a different surface entirely: OpenRouter serves it from `/api/v1/videos` as an **asynchronous job API** (submit → poll → download) and a clip takes 30 seconds to several minutes. Three consequences shape the design:

**The row is the job, not the result.** `generated_videos` is written *before* OpenRouter is called and carries the provider job id and polling URL. On launch, every unfinished row is resumed. A clip the user has already paid for is never abandoned because the process died.

**The chat card points at the job, not the file.** An image segment persists a path; a video segment persists the row id, because the message can be written while the clip is still rendering. The card resolves live state through the database, so it shows the truth whether the clip finished a second ago or while the app was closed. If a turn is killed before it persists a message at all, the resume pass inserts the card itself.

**Length is the model's call.** EchoFlow never sends `duration`. Models publish discrete supported lengths (Veo offers 4/6/8s, Sora goes to 20) and choosing for the user means guessing at both cost and pacing. The settings page says so outright, so the absence reads as a decision rather than an oversight.

## Framing is validated, not assumed

`supported_resolutions` and `supported_aspect_ratios` differ per model, and an out-of-set value is a hard 400 — not a silent downgrade. `VideoRequestPolicy` reconciles the preference against the selected model's capabilities: substitutes same-orientation first so a portrait request never comes back landscape, snaps resolution to the closest offer, and sends *nothing* when a model declares no set (several image-to-video models take framing from the input image). Unsupported chips in Settings are disabled rather than hidden, so the page doesn't rearrange itself when the model changes.

Pricing needed the same care: the directory ships three SKU spellings in one response, in two units, sliced by resolution and/or audio. Parsing it naively would quote a number 100× off, or quote a variant the user isn't buying.

## In chat

The card reuses image generation's choreography — dot-field placeholder, stretch to the media's real aspect ratio, scanline reveal — so the two creation modes read as one idea. What the medium forces to differ:

- The reveal lands on the clip's **opening frame** (one `MediaMetadataRetriever` pass), so it never sweeps onto a black rectangle waiting for a decoder. That pass also gives the true aspect ratio, honouring the rotation tag — without it, portrait clips render in a landscape box.
- The player is built **only when the user taps play**. A conversation can hold many clips and a decoder per card would exhaust the device's codecs.
- The status line is real information: "Rendering — this takes a few minutes" earns its place when the wait is minutes.

Playback is media3 with a TextureView surface, which clips correctly to the card's rounded corners inside a scrolling list.

## What's in it

| | |
| --- | --- |
| Settings → Video generation | model list + live search over OpenRouter's video endpoint, shape/resolution/audio, per-second pricing |
| Chat | `+ → Create video`, capability chip, model picker and top-bar label swap to video models |
| Background | `KeepAliveService` across the render, notification on completion, resume after process death |
| Storage | Room v16 (`video_models`, `generated_videos`), MP4s under `filesDir/generated_videos/`, cleaned up with the chat |

## Verification

- `./gradlew testDebugUnitTest` — full suite green; 40 tests across the new video paths (framing fallbacks, three pricing SKU shapes, job-row lifecycle including a mid-download disconnect, reducer and persistence rules)
- `./gradlew lintDebug` — clean
- `./gradlew assembleDebug` — clean

The OpenRouter request/response shapes were taken from the live `/api/v1/videos/models` endpoint and OpenRouter's published video skill, but **the submit/poll/download round trip has not been exercised against a real API key** — worth one manual run in Android Studio before merge.

## Notes

- New dependency: `androidx.media3` 1.10.1 (exoplayer + ui-compose).
- `app/lint.xml` opts into media3's `@UnstableApi` surface — Kotlin's own `@OptIn` doesn't satisfy `UnsafeOptInUsageError` and warns it has no effect on that marker.
- Design notes in [`docs/video-generation.md`](docs/video-generation.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversational video generation from chat, including model selection, aspect ratio, resolution, optional audio, and image-based framing.
  * Added background rendering with progress updates and automatic recovery after interruptions or app restarts.
  * Added video playback with fullscreen viewing, gallery saving, sharing, and copy actions.
  * Added video-generation settings and model discovery with pricing and capability details.
* **Documentation**
  * Added video-generation documentation covering workflows, recovery, pricing, and rendering behavior.
  * Updated the README to highlight image and video generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: treating video as a durable asynchronous job makes long-running generation feel native to chat rather than like a stretched image flow.

- Adds OpenRouter video submission, polling, durable recovery, local MP4 storage, and background completion handling.
- Adds video model discovery, capability-aware framing, pricing, settings, and chat model selection.
- Adds lazy video playback, media actions, migration/schema coverage, tests, and design documentation.
- The lifecycle implementation would be better if resumed jobs were registered atomically before they could execute, for example by creating them lazily, inserting them into `videoResumeJobs`, and only then starting them.
- The polling URL fix validates both initial and persisted values against HTTPS OpenRouter origins and closes the previously reported bearer-token path.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because a resumed video can escape chat-deletion cancellation and race media cleanup or emit a false completion notification.

The polling-origin issue is fixed, but `ChatViewModel` starts each resumed coroutine before making it discoverable to `cancelWorkForChat`, so deletion cannot guarantee that all video writers have stopped before files and rows are removed.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/ChatViewModel.kt; app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Adds video-mode orchestration and recovery, but resume-job registration is not atomic with launch, leaving deletion unable to join every writer. |
| app/src/main/java/com/echoflow/data/GeneratedVideoStore.kt | Adds durable video rows and careful temporary-file cleanup, though its correctness during deletion still depends on callers joining writers first. |
| app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt | Implements submit, poll, and download requests while validating provider and persisted polling URLs before attaching credentials. |
| app/src/main/java/com/echoflow/data/VideoGenerationEngine.kt | Implements the asynchronous generation lifecycle, persistence, polling backoff, download, and recovery flow. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Adds the version-16 migration and entities needed for video models and durable generated-video jobs. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as App startup
    participant VM as ChatViewModel
    participant Job as Resume coroutine
    participant Delete as Chat deletion
    participant Store as GeneratedVideoStore
    App->>VM: resumeInterruptedVideos()
    VM->>Job: launch (starts immediately)
    Note over VM,Job: Job is not registered yet
    Delete->>VM: cancelWorkForChat(chatId)
    VM-->>Delete: No registered resume job found
    Delete->>Store: Delete files and chat rows
    VM->>VM: Add job to videoResumeJobs
    Job->>Store: Continue poll/download
    Store-->>Job: Orphan cleanup race or JobRemoved
    Job-->>VM: May post completion notification
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(video): stop a render before its cha..."](https://github.com/adityavardhansharma/echoflow/commit/e3e94931f89bd73469455b74415ea99de0771841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47436854)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->