### PR TITLE
fix(video): register a resumed job before it can start running

### DIFF
--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -232,6 +232,14 @@ data class GeneratedVideo(
 ) {
     val isTerminal: Boolean get() = status in TERMINAL_STATUSES
 
+    /**
+     * There is a clip to show. Deliberately stricter than [isTerminal]: a run can reach a
+     * terminal state with nothing to play (failed, cancelled, expired), and a run whose
+     * conversation was deleted mid-render ends without ever getting a file — so "the job
+     * finished" is never the same question as "there is a video".
+     */
+    val isPlayable: Boolean get() = status == STATUS_COMPLETED && filePath != null
+
     companion object {
         /** Our own pre-submit state; every other status is OpenRouter's own vocabulary. */
         const val STATUS_QUEUED = "queued"

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import com.echoflow.data.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -262,8 +263,14 @@ class ChatViewModel(
     /**
      * Resumed video jobs, by chat. These run outside [streamJobs] because they belong to no
      * live turn, so deleting a conversation has to be able to find and stop them too.
+     *
+     * Concurrent rather than plain: entries are removed from job-completion handlers, which
+     * are not guaranteed to run on the dispatcher that registered them.
      */
-    private val videoResumeJobs = mutableMapOf<String, MutableSet<Job>>()
+    private val videoResumeJobs = java.util.concurrent.ConcurrentHashMap<String, MutableSet<Job>>()
+
+    private fun concurrentJobSet(): MutableSet<Job> =
+        java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap<Job, Boolean>())
 
     init {
         viewModelScope.launch { resumeInterruptedVideos() }
@@ -294,15 +301,15 @@ class ChatViewModel(
                 return@forEach
             }
             ensureVideoMessage(video)
-            val job = viewModelScope.launch {
+            // LAZY, then registered, then started. Launching eagerly would leave a window —
+            // however brief, and however much the current dispatcher happens to close it —
+            // where the writer is running but cancelWorkForChat cannot see it, so deleting
+            // the conversation would race a job it has no way to cancel or join.
+            val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
                 KeepAliveService.acquire(getApplication(), "Finishing a video…")
                 try {
                     videoEngine.resume(video, apiKey).collect { /* the row is the UI's source */ }
-                    ReplyNotifications.notifyReplyReady(
-                        getApplication(), video.chatId,
-                        title = "Your video is ready",
-                        text = "Tap to watch it in EchoFlow.",
-                    )
+                    notifyIfVideoReady(video.id)
                 } catch (_: Exception) {
                     // The row already carries the failure; the card renders it on next open.
                 } finally {
@@ -310,20 +317,38 @@ class ChatViewModel(
                     resumingVideoIds.remove(video.id)
                 }
             }
-            // Tracked so deleting the conversation can stop it — without this the resume
-            // keeps polling and writing against rows that have already cascaded away.
-            videoResumeJobs.getOrPut(video.chatId) { mutableSetOf() }.add(job)
+            videoResumeJobs.getOrPut(video.chatId) { concurrentJobSet() }.add(job)
             job.invokeOnCompletion {
                 videoResumeJobs[video.chatId]?.let { jobs ->
                     jobs.remove(job)
                     if (jobs.isEmpty()) videoResumeJobs.remove(video.chatId)
                 }
             }
+            job.start()
         }
+    }
+
+    /**
+     * Announces a finished clip only when one actually exists. The resume flow also ends
+     * *normally* when its row was deleted mid-render, so keying the notification off "the
+     * flow completed" would announce a video for a conversation the user just deleted — and
+     * tapping it would open nothing.
+     */
+    private suspend fun notifyIfVideoReady(videoId: String) {
+        val finished = runCatching { generatedVideoStore.byId(videoId) }.getOrNull() ?: return
+        if (!finished.isPlayable) return
+        ReplyNotifications.notifyReplyReady(
+            getApplication(), finished.chatId,
+            title = "Your video is ready",
+            text = "Tap to watch it in EchoFlow.",
+        )
     }
 
     /** Adds the card for a recovered job when the killed turn never got to persist one. */
     private suspend fun ensureVideoMessage(video: GeneratedVideo) {
+        // The conversation can be deleted between reading the unfinished rows and getting
+        // here; inserting into it would fail the foreign key and take the resume pass with it.
+        if (chatDao.getThreadById(video.chatId) == null) return
         val alreadyShown = messageDao.getMessagesForChatSync(video.chatId).any { message ->
             ToolEventJson.segmentsFromJson(message.segmentsJson).any { it.video?.videoId == video.id }
         }
@@ -1311,11 +1336,17 @@ class ChatViewModel(
                     delay(2600)
                 }
                 persistAssistantMessage(chatId, segments, interrupted = null)
-                if (echoLabel != null) {
+                if (videoGenMode) {
+                    // The video flow also completes normally when its row was deleted
+                    // mid-render, so announce a clip only once one actually exists.
+                    segments.filterIsInstance<StreamSegment.Video>()
+                        .lastOrNull { it.filePath != null }
+                        ?.let { notifyIfVideoReady(it.videoId) }
+                } else if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,
-                        title = if (videoGenMode) "Your video is ready" else "$echoLabel reply is ready",
-                        text = if (videoGenMode) "Tap to watch it in EchoFlow." else "Tap to read the answer in EchoFlow.",
+                        title = "$echoLabel reply is ready",
+                        text = "Tap to read the answer in EchoFlow.",
                     )
                 }
             } catch (e: CancellationException) {

--- a/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
+++ b/app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt
@@ -101,6 +101,24 @@ class GeneratedVideoStoreTest {
         assertNull(database.generatedVideoDao().getById(submitted.id)?.filePath)
     }
 
+    @Test fun `only a downloaded clip counts as playable`() = runBlocking {
+        // What gates the "your video is ready" notification. A finished flow is not the same
+        // question as a finished video: a run whose chat was deleted mid-render ends normally
+        // and never gets a file, and announcing that would point the user at nothing.
+        val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
+        assertFalse(job.isPlayable)
+        assertFalse(store.markStatus(job, GeneratedVideo.STATUS_IN_PROGRESS).isPlayable)
+        assertFalse(store.markFailed(job, GeneratedVideo.STATUS_FAILED, "boom").isPlayable)
+        // Completed but file-less can only be a bug; it must still not read as playable.
+        assertFalse(job.copy(status = GeneratedVideo.STATUS_COMPLETED, filePath = null).isPlayable)
+
+        val done = store.completeWithDownload(
+            store.markStatus(job, GeneratedVideo.STATUS_DOWNLOADING),
+            ByteArrayInputStream(ByteArray(64)),
+        )
+        assertTrue(done.isPlayable)
+    }
+
     @Test fun `a job whose chat was deleted mid-download leaves no orphan MP4`() = runBlocking {
         val job = store.createJob("chat-1", "a kite", "google/veo-3.1", "16:9", "720p")
         val submitted = store.markSubmitted(job, "job-42", "https://openrouter.ai/api/v1/videos/job-42")

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -58,6 +58,16 @@ The store defends the same boundary independently, because cancellation always h
 `VideoGenerationException.JobRemoved` ends the run quietly — the conversation is gone, so
 there is no failure to report and nowhere to report it.
 
+Two consequences of that quiet ending are easy to get wrong:
+
+- Resumed jobs are started **lazily**, registered, and only then started, so a job can never
+  be running before the map that `cancelWorkForChat` consults knows about it. Launching
+  eagerly leaves a window whose width depends on dispatcher internals.
+- The "your video is ready" notification is gated on `GeneratedVideo.isPlayable`, not on the
+  flow completing. A run whose chat was deleted mid-render *completes normally* and has no
+  file, so keying off completion would announce a clip for a conversation that no longer
+  exists — and tapping it would open nothing.
+
 ### Length is the model's call
 
 EchoFlow never sends `duration`. Models publish discrete supported lengths (Veo offers 4, 6


### PR DESCRIPTION
Follow-up to #73. Fixes the P1 raised in review, plus a wrong signal the same delete path exposed.

## The race

A resumed render was launched and only then added to the map `cancelWorkForChat` consults:

```kotlin
val job = viewModelScope.launch { … }   // running
videoResumeJobs.getOrPut(chatId) { … }.add(job)   // …only now visible
```

Deleting the conversation in that window left a writer nothing could cancel or join. It then overlapped file cleanup and row deletion — publishing its final MP4 *after* the sweep had already run, with no row left to point at it.

The window is narrow, and on `Dispatchers.Main.immediate` arguably closed today, but that's a property of the dispatcher rather than of this code — any refactor reopens it silently. The job is now created `LAZY`, registered, and only then started, so it provably cannot run before it is visible.

## The wrong signal

The same delete exposed a second bug. `JobRemoved` ends the flow **normally**, so keying the "your video is ready" notification off flow completion announced a clip for a conversation the user had just deleted — and tapping it opened nothing.

Both the resume path and the live send path now gate on `GeneratedVideo.isPlayable` (`status == completed && filePath != null`). "The job finished" was never the same question as "there is a video": a run can reach a terminal state with nothing to play, and a cascaded-away run gets no file at all.

## Also

- `ensureVideoMessage` skips a chat that has already gone. That insert would fail the foreign key and take the whole resume pass down with it — the pass runs from `init`, so it would surface as a crash on launch.
- `videoResumeJobs` is now concurrent. Its entries are removed from job-completion handlers, which are not guaranteed to run on the thread that registered them — the same class of dispatcher assumption as the bug above.

## Verification

`testDebugUnitTest` and `lintDebug` clean. New coverage for `isPlayable` across every state a job passes through, including the two that would otherwise read as ready: a terminal-but-failed run, and a completed row with no file.

The ordering guarantee itself is structural rather than unit-testable without standing up the whole ViewModel graph; `CoroutineStart.LAZY` is what makes it hold by construction instead of by timing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens resumed-video lifecycle handling and notification correctness.

- I liked the product direction of treating durable playability—not coroutine completion—as the source of truth; it avoids misleading users after deletion or failed renders.
- It adds lazy registration before resumed work starts, concurrent tracking collections, recovery-card existence checks, and explicit `isPlayable` coverage.
- The tracking lifecycle and recovery-card insertion can be better implemented as atomic operations so deletion cannot interleave between their checks and mutations.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until resumed-job tracking and recovery-card insertion remain safe when conversation deletion interleaves with them.

Concurrent collections do not make the compound registration and cleanup sequence atomic, and the separate chat-existence check still permits a foreign-key failure to abort the shared resume pass.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/ChatViewModel.kt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/Models.kt | Adds a clear isPlayable invariant requiring both completed status and a persisted file path. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Improves registration ordering and notification gating, but compound tracking operations and the recovery-card existence check retain deletion races. |
| app/src/test/java/com/echoflow/data/GeneratedVideoStoreTest.kt | Covers playability across lifecycle states, though it does not exercise the ViewModel concurrency paths. |
| docs/video-generation.md | Documents durable job recovery, deletion ordering, lazy registration, and playable-only notifications consistently with the intended design. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Resume as Resume pass
    participant Map as videoResumeJobs
    participant Done as Completion callback
    participant Delete as Delete conversation
    Resume->>Map: obtain existing set
    Done->>Map: remove old job
    Done->>Map: observe empty and remove entry
    Resume->>Resume: add new job to detached set
    Delete->>Map: remove(chatId)
    Map-->>Delete: no tracked jobs
    Note over Resume,Delete: New resumed job continues unjoined
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(video): register a resumed job befor..."](https://github.com/adityavardhansharma/echoflow/commit/75e099193e19aa89c9ce81aea02973efca334f40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47600147)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video-ready notifications now appear only when a completed video has a playable file.
  * Prevented notifications for deleted videos or conversations.
  * Improved resumed video generation handling to avoid missed cancellations and stale completion messages.
  * Standard chat responses continue to use their existing notification behavior.

* **Documentation**
  * Clarified video-generation behavior when jobs end due to deletion or cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->