### PR TITLE
Chat and Imagine: two surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### A privacy-first Android AI workspace
 
-Chat, local models, custom endpoints, web search, deep research, agents, artifacts, and image/video generation — no backend, no account, no telemetry.
+Two surfaces — Chat for conversation, Imagine for images and video. Local models, custom endpoints, web search, deep research, agents, artifacts. No backend, no account, no telemetry.
 
 [![Release](https://img.shields.io/github/v/release/adityavardhansharma/EchoFlow?style=flat-square&color=000000&label=release)](https://github.com/adityavardhansharma/EchoFlow/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-000000?style=flat-square)](LICENSE.txt)
@@ -61,7 +61,7 @@ Web search (Exa, Parallel, Firecrawl) and OpenRouter's own server-side search wo
 
 ## What you can do with it
 
-**Chat** — streaming responses, markdown, code highlighting, reasoning traces, citations, and model switching mid-conversation.
+**Chat** — streaming responses, markdown, code highlighting, reasoning traces, citations, and model switching mid-conversation. Chat and Imagine keep separate histories; conversations that predate the split stay in Chat.
 
 **Web search** — toggle it per message or set a default. OpenRouter's search only works with OpenRouter models; Exa, Parallel, and Firecrawl work with anything.
 
@@ -73,9 +73,7 @@ Web search (Exa, Parallel, Firecrawl) and OpenRouter's own server-side search wo
 
 **Artifacts** — generate and revise self-contained pages, reports, and documents, versioned as you iterate.
 
-**Image generation** — describe an image, then edit it conversationally ("make the sky purple"). Runs on OpenRouter image models.
-
-**Video generation** — describe a short clip and get it back in the conversation. Rendering takes minutes, so it keeps going with the app closed and picks itself back up if the app is killed mid-render. You choose the shape; the model chooses the length. See [docs/video-generation.md](docs/video-generation.md).
+**Imagine** — a separate surface for making things. Describe an image and edit it conversationally ("make the sky purple"), or describe a short clip and get it back as video. Shape, model and audio live beside the prompt; results are presented as a contact sheet rather than a chat log. Rendering a clip takes minutes, so it keeps going with the app closed and picks itself back up if the app is killed mid-render — you choose the shape, the model chooses the length. See [docs/modes.md](docs/modes.md) and [docs/video-generation.md](docs/video-generation.md).
 
 **Echo Adviser** — let your model call in a stronger or more specialized model mid-answer when it's stuck.
 

--- a/app/schemas/com.echoflow.data.AppDatabase/18.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/18.json
@@ -1,0 +1,1193 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "2723b954ea7793f1efd29b274f9ca885",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `kind` TEXT NOT NULL DEFAULT 'chat', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'chat'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2723b954ea7793f1efd29b274f9ca885')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -84,11 +84,12 @@ class MainActivity : ComponentActivity() {
                 factory = appGraph.chatViewModelFactory
             )
 
-            // Notification tap → jump to that conversation once the ViewModel is ready.
+            // Notification tap → jump to that conversation, switching modes if it lives in the
+            // other one (a finished video is routinely waited for from the opposite surface).
             val pendingChat by openChatRequest.collectAsState()
             LaunchedEffect(pendingChat) {
                 pendingChat?.let { chatId ->
-                    chatVm.selectThread(chatId)
+                    chatVm.openThreadFromNotification(chatId)
                     openChatRequest.value = null
                 }
             }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ImageModel::class, GeneratedImage::class,
         VideoModel::class, GeneratedVideo::class
     ],
-    version = 17, // v17: on-device image generation removed
+    version = 18, // v18: conversations belong to a mode (chat | imagine)
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -340,6 +340,18 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Chat and Imagine become separate surfaces, each with its own history. The default
+         * on this column IS the grandfather rule: every conversation that already exists —
+         * including ones full of generated images — becomes a Chat thread, with no content
+         * inspection and nothing rewritten. New threads are stamped from the active mode.
+         */
+        internal val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_threads ADD COLUMN kind TEXT NOT NULL DEFAULT 'chat'")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -364,6 +376,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_14_15,
                     MIGRATION_15_16,
                     MIGRATION_16_17,
+                    MIGRATION_17_18,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/AppMode.kt
+++ b/app/src/main/java/com/echoflow/data/AppMode.kt
@@ -1,0 +1,27 @@
+package com.echoflow.data
+
+/**
+ * The app's top-level surface. Chat and Imagine are not two feature sets — they are two
+ * *shapes* of interaction, which is why they get separate composers, result presentation
+ * and history rather than sharing one screen with a menu toggle:
+ *
+ *  - [Chat] is turn-taking. You ask, the model answers, and the answer is prose you read
+ *    and move past. Every chat capability (search, research, browser, artifacts, the Echo
+ *    modes) is a variation on "make the answer better".
+ *  - [Imagine] is a creative loop. Prompt, render, judge, refine. The output is an artifact
+ *    you keep, with settings that persist across turns and a result that wants to be big.
+ *
+ * A conversation is stamped with the mode it was created in and never changes sides — see
+ * [ChatThread.kind]. Mode is lateral state, not a navigation destination: system back never
+ * switches it.
+ */
+enum class AppMode(val storageKey: String) {
+    Chat("chat"),
+    Imagine("imagine");
+
+    companion object {
+        /** Unknown or absent values fall back to [Chat] — the mode every install starts in. */
+        fun fromStorage(value: String?): AppMode =
+            entries.firstOrNull { it.storageKey == value } ?: Chat
+    }
+}

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -18,18 +18,40 @@ class ChatRepository(
     val artifactVersionDao: ArtifactVersionDao,
 ) {
     fun allThreads(): Flow<List<ChatThread>> = chatDao.getAllThreads()
+
+    /** One mode's conversations. The drawer never mixes the two. */
+    fun threadsForMode(mode: AppMode): Flow<List<ChatThread>> = chatDao.getThreadsByKind(mode.storageKey)
+
+    /** How many of the *other* mode's conversations a search would have matched. */
+    fun searchMatchCount(mode: AppMode, query: String): Flow<Int> =
+        chatDao.countMatchingInKind(mode.storageKey, query)
+
     fun messagesForChat(chatId: String): Flow<List<ChatMessage>> = messageDao.getMessagesForChat(chatId)
     fun searchChatIdsByContent(query: String): Flow<List<String>> = messageDao.searchChatIdsByContent(query)
 
-    suspend fun createThread(title: String = "New Conversation", now: Long = System.currentTimeMillis()): ChatThread {
+    /**
+     * Creates a conversation owned by [mode]. This is the single place a thread's kind is
+     * ever decided; it is immutable afterwards, so there is no drift to keep in sync.
+     */
+    suspend fun createThread(
+        mode: AppMode = AppMode.Chat,
+        title: String = defaultTitleFor(mode),
+        now: Long = System.currentTimeMillis(),
+    ): ChatThread {
         val thread = ChatThread(
             id = UUID.randomUUID().toString(),
             title = title,
             createdAt = now,
             updatedAt = now,
+            kind = mode.storageKey,
         )
         chatDao.insertThread(thread)
         return thread
+    }
+
+    private fun defaultTitleFor(mode: AppMode) = when (mode) {
+        AppMode.Chat -> "New Conversation"
+        AppMode.Imagine -> "New Creation"
     }
 
     suspend fun touchThread(chatId: String, now: Long = System.currentTimeMillis()) {

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -8,6 +8,21 @@ interface ChatDao {
     @Query("SELECT * FROM chat_threads ORDER BY updatedAt DESC")
     fun getAllThreads(): Flow<List<ChatThread>>
 
+    /** The drawer's list: one mode's conversations, newest first. */
+    @Query("SELECT * FROM chat_threads WHERE kind = :kind ORDER BY updatedAt DESC")
+    fun getThreadsByKind(kind: String): Flow<List<ChatThread>>
+
+    /**
+     * How many conversations the *other* mode holds that match a search. Drives the drawer's
+     * "also N results in Imagine" hint, so a filtered list never reads as a lost one.
+     */
+    @Query(
+        "SELECT COUNT(*) FROM chat_threads WHERE kind = :kind AND " +
+            "(title LIKE '%' || :query || '%' OR id IN " +
+            "(SELECT DISTINCT chatId FROM chat_messages WHERE content LIKE '%' || :query || '%'))"
+    )
+    fun countMatchingInKind(kind: String, query: String): Flow<Int>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertThread(thread: ChatThread)
 

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -208,6 +208,18 @@ interface GeneratedVideoDao {
     @Query("SELECT * FROM generated_videos WHERE status NOT IN ('completed','failed','cancelled','expired')")
     suspend fun getUnfinished(): List<GeneratedVideo>
 
+    /**
+     * Conversations with a render in flight. The database is the honest source for this —
+     * it covers live turns and resumed jobs alike, and survives process death, which no
+     * in-memory job registry does. Drives the "still working" pulse in the mode switch and
+     * the drawer.
+     */
+    @Query(
+        "SELECT DISTINCT chatId FROM generated_videos " +
+            "WHERE status NOT IN ('completed','failed','cancelled','expired')"
+    )
+    fun observeRenderingChatIds(): Flow<List<String>>
+
     @Query("DELETE FROM generated_videos WHERE id = :id")
     suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/echoflow/data/ImagineMedia.kt
+++ b/app/src/main/java/com/echoflow/data/ImagineMedia.kt
@@ -1,0 +1,17 @@
+package com.echoflow.data
+
+/**
+ * What Imagine is currently making. Image and video are one surface with a media switch
+ * rather than two modes: they share a prompt, a framing, a result to keep and a refine loop,
+ * and the differences (how long it takes, whether it can be edited, whether it has audio) are
+ * settings, not separate features.
+ */
+enum class ImagineMedia(val storageKey: String) {
+    Image("image"),
+    Video("video");
+
+    companion object {
+        fun fromStorage(value: String?): ImagineMedia =
+            entries.firstOrNull { it.storageKey == value } ?: Image
+    }
+}

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -1,5 +1,6 @@
 package com.echoflow.data
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.ForeignKey
@@ -10,8 +11,20 @@ data class ChatThread(
     @PrimaryKey val id: String,
     val title: String,
     val createdAt: Long,
-    val updatedAt: Long
-)
+    val updatedAt: Long,
+    /**
+     * Which surface this conversation belongs to — [AppMode.storageKey]. Stamped once at
+     * creation from the active mode and never changed afterwards.
+     *
+     * The default is what makes the split safe for existing users: every thread that predates
+     * the two-mode split becomes a Chat thread, including ones full of generated images. We
+     * never inspect a thread's content to classify it — a conversation with forty messages and
+     * three images was a conversation, and reclassifying it would feel like losing it.
+     */
+    @ColumnInfo(defaultValue = "'chat'") val kind: String = AppMode.Chat.storageKey,
+) {
+    val mode: AppMode get() = AppMode.fromStorage(kind)
+}
 
 @Entity(
     tableName = "chat_messages",

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -94,6 +94,10 @@ class SettingsRepository(context: Context) {
     val artifactsOffline: StateFlow<Boolean> = _artifactsOffline.asStateFlow()
 
     // Image generation: which image-output OpenRouter model the "Create image" mode uses.
+    // Which surface the app is on. Persisted so a relaunch resumes where the user left off.
+    private val _appMode = MutableStateFlow(getAppModeDirect())
+    val appMode: StateFlow<AppMode> = _appMode.asStateFlow()
+
     private val _imageGenModel = MutableStateFlow(getImageGenModelDirect())
     val imageGenModel: StateFlow<String> = _imageGenModel.asStateFlow()
 
@@ -553,6 +557,27 @@ class SettingsRepository(context: Context) {
         _artifactsOffline.value = enabled
     }
 
+    // ── App mode ───────────────────────────────────────────────────────────────────────
+
+    fun getAppModeDirect(): AppMode = AppMode.fromStorage(prefs.getString(KEY_APP_MODE, null))
+
+    fun saveAppMode(mode: AppMode) {
+        prefs.edit().putString(KEY_APP_MODE, mode.storageKey).apply()
+        _appMode.value = mode
+    }
+
+    /**
+     * The conversation each mode had open, remembered separately. Without this, switching
+     * Chat → Imagine → Chat would drop the user somewhere other than where they left off,
+     * which reads as losing your place rather than changing rooms.
+     */
+    fun getLastThreadIdDirect(mode: AppMode): String? =
+        prefs.getString("last_thread_${mode.storageKey}", null)?.takeIf { it.isNotBlank() }
+
+    fun saveLastThreadId(mode: AppMode, chatId: String?) {
+        prefs.edit().putString("last_thread_${mode.storageKey}", chatId.orEmpty()).apply()
+    }
+
     // ── Image generation ───────────────────────────────────────────────────────────────
 
     fun getImageGenModelDirect(): String =
@@ -616,6 +641,7 @@ class SettingsRepository(context: Context) {
     }
 
     companion object {
+        private const val KEY_APP_MODE = "app_mode"
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -607,8 +607,14 @@ class SettingsRepository(context: Context) {
     fun getLastThreadIdDirect(mode: AppMode): String? =
         prefs.getString("last_thread_${mode.storageKey}", null)?.takeIf { it.isNotBlank() }
 
-    fun saveLastThreadId(mode: AppMode, chatId: String?) {
-        prefs.edit().putString("last_thread_${mode.storageKey}", chatId.orEmpty()).apply()
+    /**
+     * Only real conversations are remembered. The id is non-null on purpose: writing a blank
+     * here would *erase* the position rather than record one, and an unsaved empty thread is
+     * nothing to come back to anyway — so "no conversation open" must leave the previous
+     * memory intact instead of overwriting it.
+     */
+    fun saveLastThreadId(mode: AppMode, chatId: String) {
+        prefs.edit().putString("last_thread_${mode.storageKey}", chatId).apply()
     }
 
     // ── Image generation ───────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -93,11 +93,20 @@ class SettingsRepository(context: Context) {
     private val _artifactsOffline = MutableStateFlow(getArtifactsOfflineDirect())
     val artifactsOffline: StateFlow<Boolean> = _artifactsOffline.asStateFlow()
 
-    // Image generation: which image-output OpenRouter model the "Create image" mode uses.
     // Which surface the app is on. Persisted so a relaunch resumes where the user left off.
     private val _appMode = MutableStateFlow(getAppModeDirect())
     val appMode: StateFlow<AppMode> = _appMode.asStateFlow()
 
+    // What Imagine is making. Sticky, because a run of clips should not need re-choosing.
+    private val _imagineMedia = MutableStateFlow(getImagineMediaDirect())
+    val imagineMedia: StateFlow<ImagineMedia> = _imagineMedia.asStateFlow()
+
+    // Framing for image turns. Video keeps its own, since the two have different model sets
+    // and an aspect ratio a video model accepts is not one an image model necessarily does.
+    private val _imageAspectRatio = MutableStateFlow(getImageAspectRatioDirect())
+    val imageAspectRatio: StateFlow<String> = _imageAspectRatio.asStateFlow()
+
+    // Which image-output OpenRouter model an image turn uses.
     private val _imageGenModel = MutableStateFlow(getImageGenModelDirect())
     val imageGenModel: StateFlow<String> = _imageGenModel.asStateFlow()
 
@@ -566,6 +575,30 @@ class SettingsRepository(context: Context) {
         _appMode.value = mode
     }
 
+    fun getImagineMediaDirect(): ImagineMedia =
+        ImagineMedia.fromStorage(prefs.getString(KEY_IMAGINE_MEDIA, null))
+
+    fun saveImagineMedia(media: ImagineMedia) {
+        prefs.edit().putString(KEY_IMAGINE_MEDIA, media.storageKey).apply()
+        _imagineMedia.value = media
+    }
+
+    /**
+     * Image framing. Unlike video, OpenRouter image models take their shape from the prompt
+     * rather than a parameter, so this is passed to the model as an instruction — which is why
+     * it is stored as one of our own labels rather than a provider enum.
+     */
+    fun getImageAspectRatioDirect(): String =
+        prefs.getString(KEY_IMAGE_ASPECT, VideoRequestPolicy.DEFAULT_ASPECT_RATIO).orEmpty()
+            .takeIf { it in VideoRequestPolicy.ASPECT_RATIOS } ?: VideoRequestPolicy.DEFAULT_ASPECT_RATIO
+
+    fun saveImageAspectRatio(ratio: String) {
+        val clean = ratio.takeIf { it in VideoRequestPolicy.ASPECT_RATIOS }
+            ?: VideoRequestPolicy.DEFAULT_ASPECT_RATIO
+        prefs.edit().putString(KEY_IMAGE_ASPECT, clean).apply()
+        _imageAspectRatio.value = clean
+    }
+
     /**
      * The conversation each mode had open, remembered separately. Without this, switching
      * Chat → Imagine → Chat would drop the user somewhere other than where they left off,
@@ -642,6 +675,8 @@ class SettingsRepository(context: Context) {
 
     companion object {
         private const val KEY_APP_MODE = "app_mode"
+        private const val KEY_IMAGINE_MEDIA = "imagine_media"
+        private const val KEY_IMAGE_ASPECT = "image_aspect_ratio"
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -292,7 +292,11 @@ object SystemPrompts {
      * text. On edit turns the newest user message carries the previous version, and the model
      * revises exactly what was asked while keeping everything else consistent.
      */
-    fun buildImageGen(editing: Boolean, currentDate: String = currentDate()): String {
+    fun buildImageGen(
+        editing: Boolean,
+        aspectRatio: String? = null,
+        currentDate: String = currentDate(),
+    ): String {
         val base = """
         You are EchoFlow's image generator. Current date: $currentDate.
 
@@ -300,12 +304,18 @@ object SystemPrompts {
         Alongside the image, write one short, friendly sentence about what you made — no
         markdown headers, no lists, no long explanations.
         """.trimIndent()
+        // Image models take framing from the prompt, not a parameter (unlike the video API,
+        // where an unsupported ratio is a hard 400). So the user's choice is stated as an
+        // instruction — best effort by nature, which is why nothing downstream depends on it.
+        val framing = aspectRatio?.takeIf { it.isNotBlank() }?.let {
+            "Compose the image with an aspect ratio of $it."
+        }
         val editRules = """
         The user's newest message includes the current version of their image. This is an EDIT:
         apply only the requested changes and keep everything else — subject, composition,
         style, lighting — as consistent with the provided image as possible.
         """.trimIndent()
-        return if (editing) base + "\n\n" + editRules else base
+        return listOfNotNull(base, framing, editRules.takeIf { editing }).joinToString("\n\n")
     }
 
     /**

--- a/app/src/main/java/com/echoflow/data/VideoJobRecovery.kt
+++ b/app/src/main/java/com/echoflow/data/VideoJobRecovery.kt
@@ -1,0 +1,150 @@
+package com.echoflow.data
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import java.util.Collections
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Owns video renders that outlive the turn that started them.
+ *
+ * A clip takes minutes, so a job routinely survives its own chat turn and sometimes the whole
+ * process. OpenRouter keeps rendering regardless and the user has already paid, so abandoning
+ * an interrupted job would quietly cost them money for nothing. This class picks those jobs
+ * back up on launch, and — just as importantly — knows how to *stop* them when the
+ * conversation they belong to is deleted.
+ *
+ * It lives outside the ViewModel because none of it is about the streaming chat turn: it is
+ * durable-job bookkeeping that happens to end in a chat message.
+ */
+class VideoJobRecovery(
+    private val context: Context,
+    private val store: GeneratedVideoStore,
+    private val engine: OpenRouterVideoGenerationEngine,
+    private val settings: SettingsRepository,
+    private val chatDao: ChatDao,
+    private val messageDao: MessageDao,
+    private val scope: CoroutineScope,
+) {
+    /** Guards against a second resume pass doubling up on a job already being polled. */
+    private val resuming = Collections.synchronizedSet(mutableSetOf<String>())
+
+    /**
+     * Running resume jobs, by chat. Concurrent rather than plain: entries are removed from
+     * job-completion handlers, which are not guaranteed to run on the registering dispatcher.
+     */
+    private val jobsByChat = ConcurrentHashMap<String, MutableSet<Job>>()
+
+    /**
+     * Resumes every job left mid-render by a process death. A run killed before its assistant
+     * message was written has no card in the conversation, so one is inserted here — pointing
+     * at the job row, which the card then follows live.
+     */
+    suspend fun resumeInterrupted() {
+        val unfinished = runCatching { store.unfinished() }.getOrNull().orEmpty()
+        if (unfinished.isEmpty()) return
+        val apiKey = settings.getApiKeyDirect()
+
+        unfinished.forEach { video ->
+            if (!resuming.add(video.id)) return@forEach
+
+            if (apiKey.isBlank() || video.jobId == null) {
+                runCatching {
+                    store.markFailed(
+                        video, GeneratedVideo.STATUS_FAILED,
+                        "The video was interrupted and could not be resumed.",
+                    )
+                }
+                resuming.remove(video.id)
+                return@forEach
+            }
+            ensureCardExists(video)
+            launchResume(video, apiKey)
+        }
+    }
+
+    /**
+     * Cancels and *joins* this chat's resume jobs so the caller can safely delete its rows and
+     * files afterwards. Cancellation alone is not enough — a coroutine is only stopped once it
+     * has actually unwound.
+     */
+    suspend fun cancelForChat(chatId: String) {
+        jobsByChat.remove(chatId)?.forEach { it.cancelAndJoin() }
+    }
+
+    /**
+     * LAZY, registered, then started. Launching eagerly leaves a window — however brief, and
+     * however much the current dispatcher happens to close it — where the writer is running
+     * but [cancelForChat] cannot see it, so deleting the conversation would race a job it has
+     * no way to cancel or join.
+     */
+    private fun launchResume(video: GeneratedVideo, apiKey: String) {
+        val job = scope.launch(start = CoroutineStart.LAZY) {
+            KeepAliveService.acquire(context, "Finishing a video…")
+            try {
+                engine.resume(video, apiKey).collect { /* the row is the UI's source of truth */ }
+                notifyIfReady(video.id)
+            } catch (_: Exception) {
+                // The row already carries the failure; the card renders it on next open.
+            } finally {
+                KeepAliveService.release(context)
+                resuming.remove(video.id)
+            }
+        }
+        jobsByChat.getOrPut(video.chatId) { newJobSet() }.add(job)
+        job.invokeOnCompletion {
+            jobsByChat[video.chatId]?.let { jobs ->
+                jobs.remove(job)
+                if (jobs.isEmpty()) jobsByChat.remove(video.chatId)
+            }
+        }
+        job.start()
+    }
+
+    /**
+     * Announces a finished clip only when one actually exists. The resume flow also ends
+     * *normally* when its row was deleted mid-render, so keying the notification off "the flow
+     * completed" would announce a video for a conversation the user just deleted — and tapping
+     * it would open nothing.
+     */
+    private suspend fun notifyIfReady(videoId: String) {
+        val finished = runCatching { store.byId(videoId) }.getOrNull() ?: return
+        if (!finished.isPlayable) return
+        ReplyNotifications.notifyReplyReady(
+            context, finished.chatId,
+            title = "Your video is ready",
+            text = "Tap to watch it in EchoFlow.",
+        )
+    }
+
+    /** Adds the card for a recovered job when the killed turn never got to persist one. */
+    private suspend fun ensureCardExists(video: GeneratedVideo) {
+        // The conversation can be deleted between reading the unfinished rows and getting
+        // here; inserting into it would fail the foreign key and take the resume pass with it.
+        if (chatDao.getThreadById(video.chatId) == null) return
+        val alreadyShown = messageDao.getMessagesForChatSync(video.chatId).any { message ->
+            ToolEventJson.segmentsFromJson(message.segmentsJson).any { it.video?.videoId == video.id }
+        }
+        if (alreadyShown) return
+        messageDao.insertMessage(
+            ChatMessage(
+                id = UUID.randomUUID().toString(),
+                chatId = video.chatId,
+                role = "assistant",
+                content = "",
+                createdAt = System.currentTimeMillis(),
+                segmentsJson = ToolEventJson.segmentsToJson(
+                    listOf(PersistedSegment("video", video = VideoRef(video.id, video.filePath)))
+                ),
+            )
+        )
+    }
+
+    private fun newJobSet(): MutableSet<Job> =
+        Collections.newSetFromMap(ConcurrentHashMap<Job, Boolean>())
+}

--- a/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
@@ -62,14 +62,27 @@ fun AdaptiveChatWorkspace(
     val threads by chatViewModel.filteredThreads.collectAsState()
     val query by chatViewModel.drawerSearchQuery.collectAsState()
     val selectedId by chatViewModel.currentChatThreadId.collectAsState()
+    val mode by chatViewModel.appMode.collectAsState()
+    val renderingChatIds by chatViewModel.renderingChatIds.collectAsState()
+    val otherModeMatches by chatViewModel.otherModeMatchCount.collectAsState()
     BoxWithConstraints(Modifier.fillMaxSize()) {
         if (maxWidth >= 600.dp) {
             Row(Modifier.fillMaxSize()) {
                 Box(Modifier.fillMaxHeight().width(320.dp)) {
-                    ChatDrawerContent(threads, selectedId, chatViewModel::selectThread,
-                        chatViewModel::startNewChat, chatViewModel::deleteThread,
-                        chatViewModel::renameThread, onSettingsClicked,
-                        searchQuery = query, onSearchQueryChange = chatViewModel::setDrawerSearchQuery)
+                    ChatDrawerContent(
+                        mode = mode,
+                        allThreads = threads,
+                        currentThreadId = selectedId,
+                        renderingChatIds = renderingChatIds,
+                        otherModeMatchCount = otherModeMatches,
+                        onThreadSelected = chatViewModel::selectThread,
+                        onNewChatClicked = chatViewModel::startNewChat,
+                        onDeleteThread = chatViewModel::deleteThread,
+                        onRenameThread = chatViewModel::renameThread,
+                        onSettingsClicked = onSettingsClicked,
+                        searchQuery = query,
+                        onSearchQueryChange = chatViewModel::setDrawerSearchQuery,
+                    )
                 }
                 VerticalDivider(Modifier.fillMaxHeight(), color = MaterialTheme.colorScheme.outlineVariant)
                 Box(Modifier.weight(1f)) {
@@ -84,11 +97,21 @@ fun AdaptiveChatWorkspace(
                     drawerShape = androidx.compose.foundation.shape.RoundedCornerShape(topEnd = 28.dp, bottomEnd = 28.dp),
                     modifier = Modifier.widthIn(max = 340.dp),
                 ) {
-                    ChatDrawerContent(threads, selectedId, chatViewModel::selectThread,
-                        chatViewModel::startNewChat, chatViewModel::deleteThread,
-                        chatViewModel::renameThread, onSettingsClicked,
-                        { scope.launch { drawerState.close() } }, query,
-                        chatViewModel::setDrawerSearchQuery)
+                    ChatDrawerContent(
+                        mode = mode,
+                        allThreads = threads,
+                        currentThreadId = selectedId,
+                        renderingChatIds = renderingChatIds,
+                        otherModeMatchCount = otherModeMatches,
+                        onThreadSelected = chatViewModel::selectThread,
+                        onNewChatClicked = chatViewModel::startNewChat,
+                        onDeleteThread = chatViewModel::deleteThread,
+                        onRenameThread = chatViewModel::renameThread,
+                        onSettingsClicked = onSettingsClicked,
+                        onCloseDrawer = { scope.launch { drawerState.close() } },
+                        searchQuery = query,
+                        onSearchQueryChange = chatViewModel::setDrawerSearchQuery,
+                    )
                 }
             }) {
                 ChatScreen(chatViewModel, settingsViewModel,

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1090,7 +1090,10 @@ class ChatViewModel(
                             previousImage = imagePrev,
                             apiKey = apiKey,
                             history = fullHistory,
-                            systemPrompt = SystemPrompts.buildImageGen(editing = imageEditUrl != null),
+                            systemPrompt = SystemPrompts.buildImageGen(
+                                editing = imageEditUrl != null,
+                                aspectRatio = settingsRepository.getImageAspectRatioDirect(),
+                            ),
                             editImageDataUrl = imageEditUrl,
                             params = inferenceParams,
                         )

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -126,8 +126,16 @@ class ChatViewModel(
      * clip takes minutes and is usually started in one mode and waited for in another;
      * without this the split would simply hide the activity.
      */
+    /**
+     * Conversations with a clip in flight. Reads from the database rather than a job registry,
+     * which is the only source covering live turns, resumed jobs and process death alike.
+     */
+    val renderingChatIds: StateFlow<Set<String>> = generatedVideoDao.observeRenderingChatIds()
+        .map { it.toSet() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
     @OptIn(ExperimentalCoroutinesApi::class)
-    val renderingModes: StateFlow<Set<AppMode>> = generatedVideoDao.observeRenderingChatIds()
+    val renderingModes: StateFlow<Set<AppMode>> = renderingChatIds
         .flatMapLatest { chatIds ->
             if (chatIds.isEmpty()) flowOf(emptySet()) else chatRepository.allThreads().map { threads ->
                 threads.filter { it.id in chatIds }.map(ChatThread::mode).toSet()

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -248,114 +248,24 @@ class ChatViewModel(
      */
     fun observeVideo(videoId: String): Flow<GeneratedVideo?> = generatedVideoDao.observeById(videoId)
 
-    /** Guards against a second resume pass doubling up on a job already being polled. */
-    private val resumingVideoIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
-
     /**
-     * Resumed video jobs, by chat. These run outside [streamJobs] because they belong to no
-     * live turn, so deleting a conversation has to be able to find and stop them too.
-     *
-     * Concurrent rather than plain: entries are removed from job-completion handlers, which
-     * are not guaranteed to run on the dispatcher that registered them.
+     * Renders that outlive their turn — resumed on launch, cancelled when their chat is
+     * deleted. None of this is chat streaming, so none of it lives here.
      */
-    private val videoResumeJobs = java.util.concurrent.ConcurrentHashMap<String, MutableSet<Job>>()
-
-    private fun concurrentJobSet(): MutableSet<Job> =
-        java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap<Job, Boolean>())
+    private val videoRecovery by lazy {
+        VideoJobRecovery(
+            context = application,
+            store = generatedVideoStore,
+            engine = videoEngine,
+            settings = settingsRepository,
+            chatDao = chatDao,
+            messageDao = messageDao,
+            scope = viewModelScope,
+        )
+    }
 
     init {
-        viewModelScope.launch { resumeInterruptedVideos() }
-    }
-
-    /**
-     * Picks up video jobs that were still rendering when the process last died. The clip is
-     * already paid for and OpenRouter keeps rendering it regardless, so abandoning the job
-     * would silently cost the user money for nothing.
-     *
-     * A run killed before its assistant message was written has no card in the conversation,
-     * so one is inserted here — pointing at the job row, which the card then follows live.
-     */
-    private suspend fun resumeInterruptedVideos() {
-        val unfinished = runCatching { generatedVideoStore.unfinished() }.getOrNull().orEmpty()
-        if (unfinished.isEmpty()) return
-        val apiKey = settingsRepository.getApiKeyDirect()
-
-        unfinished.forEach { video ->
-            if (video.id in resumingVideoIds) return@forEach
-            resumingVideoIds.add(video.id)
-
-            if (apiKey.isBlank() || video.jobId == null) {
-                generatedVideoStore.markFailed(
-                    video, GeneratedVideo.STATUS_FAILED,
-                    "The video was interrupted and could not be resumed.",
-                )
-                return@forEach
-            }
-            ensureVideoMessage(video)
-            // LAZY, then registered, then started. Launching eagerly would leave a window —
-            // however brief, and however much the current dispatcher happens to close it —
-            // where the writer is running but cancelWorkForChat cannot see it, so deleting
-            // the conversation would race a job it has no way to cancel or join.
-            val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
-                KeepAliveService.acquire(getApplication(), "Finishing a video…")
-                try {
-                    videoEngine.resume(video, apiKey).collect { /* the row is the UI's source */ }
-                    notifyIfVideoReady(video.id)
-                } catch (_: Exception) {
-                    // The row already carries the failure; the card renders it on next open.
-                } finally {
-                    KeepAliveService.release(getApplication())
-                    resumingVideoIds.remove(video.id)
-                }
-            }
-            videoResumeJobs.getOrPut(video.chatId) { concurrentJobSet() }.add(job)
-            job.invokeOnCompletion {
-                videoResumeJobs[video.chatId]?.let { jobs ->
-                    jobs.remove(job)
-                    if (jobs.isEmpty()) videoResumeJobs.remove(video.chatId)
-                }
-            }
-            job.start()
-        }
-    }
-
-    /**
-     * Announces a finished clip only when one actually exists. The resume flow also ends
-     * *normally* when its row was deleted mid-render, so keying the notification off "the
-     * flow completed" would announce a video for a conversation the user just deleted — and
-     * tapping it would open nothing.
-     */
-    private suspend fun notifyIfVideoReady(videoId: String) {
-        val finished = runCatching { generatedVideoStore.byId(videoId) }.getOrNull() ?: return
-        if (!finished.isPlayable) return
-        ReplyNotifications.notifyReplyReady(
-            getApplication(), finished.chatId,
-            title = "Your video is ready",
-            text = "Tap to watch it in EchoFlow.",
-        )
-    }
-
-    /** Adds the card for a recovered job when the killed turn never got to persist one. */
-    private suspend fun ensureVideoMessage(video: GeneratedVideo) {
-        // The conversation can be deleted between reading the unfinished rows and getting
-        // here; inserting into it would fail the foreign key and take the resume pass with it.
-        if (chatDao.getThreadById(video.chatId) == null) return
-        val alreadyShown = messageDao.getMessagesForChatSync(video.chatId).any { message ->
-            ToolEventJson.segmentsFromJson(message.segmentsJson).any { it.video?.videoId == video.id }
-        }
-        if (alreadyShown) return
-        chatRepository.insertMessage(
-            ChatMessage(
-                id = UUID.randomUUID().toString(),
-                chatId = video.chatId,
-                role = "assistant",
-                content = "",
-                createdAt = System.currentTimeMillis(),
-                segmentsJson = ToolEventJson.segmentsToJson(
-                    listOf(PersistedSegment("video", video = VideoRef(video.id, video.filePath)))
-                ),
-            )
-        )
+        viewModelScope.launch { videoRecovery.resumeInterrupted() }
     }
 
     /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
@@ -628,7 +538,7 @@ class ChatViewModel(
      */
     private suspend fun cancelWorkForChat(chatId: String) {
         streamJobs.remove(chatId)?.cancelAndJoin()
-        videoResumeJobs.remove(chatId)?.forEach { it.cancelAndJoin() }
+        videoRecovery.cancelForChat(chatId)
     }
 
     fun renameThread(thread: ChatThread, newTitle: String) {
@@ -1291,7 +1201,18 @@ class ChatViewModel(
                     // mid-render, so announce a clip only once one actually exists.
                     segments.filterIsInstance<StreamSegment.Video>()
                         .lastOrNull { it.filePath != null }
-                        ?.let { notifyIfVideoReady(it.videoId) }
+                        ?.let { segment ->
+                            // "The flow completed" is not "there is a video": a run whose chat
+                            // was deleted mid-render also completes normally, with no file.
+                            val clip = runCatching { generatedVideoStore.byId(segment.videoId) }.getOrNull()
+                            if (clip?.isPlayable == true) {
+                                ReplyNotifications.notifyReplyReady(
+                                    getApplication(), chatId,
+                                    title = "Your video is ready",
+                                    text = "Tap to watch it in EchoFlow.",
+                                )
+                            }
+                        }
                 } else if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -103,7 +103,7 @@ class ChatViewModel(
      */
     fun switchMode(mode: AppMode) {
         if (mode == appMode.value) return
-        settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+        _currentChatThreadId.value?.let { settingsRepository.saveLastThreadId(appMode.value, it) }
         settingsRepository.saveAppMode(mode)
         _drawerSearchQuery.value = ""
         viewModelScope.launch {
@@ -344,7 +344,7 @@ class ChatViewModel(
         viewModelScope.launch {
             val thread = chatRepository.thread(chatId) ?: return@launch
             if (thread.mode != appMode.value) {
-                settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+                _currentChatThreadId.value?.let { settingsRepository.saveLastThreadId(appMode.value, it) }
                 settingsRepository.saveAppMode(thread.mode)
                 _drawerSearchQuery.value = ""
             }
@@ -480,7 +480,7 @@ class ChatViewModel(
                 _errorMessage.value = "That file is no longer available."
                 return@launch
             }
-            settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+            _currentChatThreadId.value?.let { settingsRepository.saveLastThreadId(appMode.value, it) }
             settingsRepository.saveAppMode(AppMode.Chat)
             _drawerSearchQuery.value = ""
             setMode(ChatMode.Normal)
@@ -541,8 +541,12 @@ class ChatViewModel(
 
     fun selectThread(chatId: String?) {
         _currentChatThreadId.value = chatId
-        // Parked so this mode reopens here after a round trip through the other one.
-        settingsRepository.saveLastThreadId(appMode.value, chatId)
+        // Parked so this mode reopens here after a round trip through the other one. A null
+        // means "blank composer" — from the new-conversation button, or from the hop into Chat
+        // that "Ask about this" makes — and must leave the remembered position alone. Writing
+        // it through would throw away wherever the user actually was. The blank thread earns
+        // its place in the memory once sendMessage gives it an identity.
+        chatId?.let { settingsRepository.saveLastThreadId(appMode.value, it) }
         clearPendingAttachment()
         clearError()
     }
@@ -977,6 +981,9 @@ class ChatViewModel(
                 isFirstMsgInChat = true
                 chatId = chatRepository.createThread(mode = appMode.value).id
                 _currentChatThreadId.value = chatId
+                // The blank thread is real now, so this mode returns here rather than to
+                // whatever came before it.
+                settingsRepository.saveLastThreadId(appMode.value, chatId)
             }
 
             if (streamJobs[chatId]?.isActive == true) return@launch

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -91,14 +91,51 @@ class ChatViewModel(
         chatDao, messageDao, browserSessionDao, browserStepDao, settingsRepository, webSearchService, viewModelScope
     )
 
-    val allThreads: StateFlow<List<ChatThread>> = chatRepository.allThreads()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = emptyList()
-        )
+    // ── App mode ─────────────────────────────────────────────────────────────────────────
 
-    // Drawer search: matches conversation titles and full message text.
+    /** Chat or Imagine. Lateral state, never a navigation destination — back never moves it. */
+    val appMode: StateFlow<AppMode> = settingsRepository.appMode
+
+    /**
+     * Switches surface, parking the current conversation so this mode returns to it later and
+     * restoring whatever the target mode had open. Switching is free: renders and streams keep
+     * running in the mode you left, and [renderingModes] is what says so.
+     */
+    fun switchMode(mode: AppMode) {
+        if (mode == appMode.value) return
+        settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+        settingsRepository.saveAppMode(mode)
+        _drawerSearchQuery.value = ""
+        viewModelScope.launch {
+            // Only restore a thread that still exists and still belongs to this mode.
+            val remembered = settingsRepository.getLastThreadIdDirect(mode)
+                ?.let { chatRepository.thread(it) }
+                ?.takeIf { it.mode == mode }
+            _currentChatThreadId.value = remembered?.id
+        }
+    }
+
+    /** This mode's conversations. The two histories never mix. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val allThreads: StateFlow<List<ChatThread>> = appMode
+        .flatMapLatest { chatRepository.threadsForMode(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * Modes with a render in flight, so the switch can show which one is still working. A
+     * clip takes minutes and is usually started in one mode and waited for in another;
+     * without this the split would simply hide the activity.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val renderingModes: StateFlow<Set<AppMode>> = generatedVideoDao.observeRenderingChatIds()
+        .flatMapLatest { chatIds ->
+            if (chatIds.isEmpty()) flowOf(emptySet()) else chatRepository.allThreads().map { threads ->
+                threads.filter { it.id in chatIds }.map(ChatThread::mode).toSet()
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
+    // Drawer search: matches conversation titles and full message text, scoped to the mode.
     private val _drawerSearchQuery = MutableStateFlow("")
     val drawerSearchQuery: StateFlow<String> = _drawerSearchQuery.asStateFlow()
 
@@ -122,6 +159,19 @@ class ChatViewModel(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = emptyList()
     )
+
+    /**
+     * How many conversations the *other* mode would have matched. A filtered list that hides
+     * a result the user knows exists is the one way this design can feel like data loss, so
+     * the drawer says where it went instead of staying silent.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val otherModeMatchCount: StateFlow<Int> = combine(appMode, _drawerSearchQuery) { mode, query ->
+        mode to query.trim()
+    }.flatMapLatest { (mode, query) ->
+        if (query.isBlank()) flowOf(0)
+        else chatRepository.searchMatchCount(if (mode == AppMode.Chat) AppMode.Imagine else AppMode.Chat, query)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
     private val _currentChatThreadId = MutableStateFlow<String?>(null)
     val currentChatThreadId: StateFlow<String?> = _currentChatThreadId.asStateFlow()
@@ -266,6 +316,32 @@ class ChatViewModel(
 
     init {
         viewModelScope.launch { videoRecovery.resumeInterrupted() }
+        viewModelScope.launch {
+            // Reopen where the user left off, but only if that conversation still exists and
+            // still belongs to the mode we are restoring into.
+            val mode = appMode.value
+            settingsRepository.getLastThreadIdDirect(mode)
+                ?.let { chatRepository.thread(it) }
+                ?.takeIf { it.mode == mode }
+                ?.let { _currentChatThreadId.value = it.id }
+        }
+    }
+
+    /**
+     * Opens a conversation from outside the UI — a notification tap — switching to whichever
+     * mode owns it first. Without the switch the thread would be selected while its own
+     * history was filtered out of view, which looks exactly like the app losing it.
+     */
+    fun openThreadFromNotification(chatId: String) {
+        viewModelScope.launch {
+            val thread = chatRepository.thread(chatId) ?: return@launch
+            if (thread.mode != appMode.value) {
+                settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+                settingsRepository.saveAppMode(thread.mode)
+                _drawerSearchQuery.value = ""
+            }
+            selectThread(thread.id)
+        }
     }
 
     /** The chat's current artifact (latest lineage), observed by the in-chat card and workspace. */
@@ -421,6 +497,8 @@ class ChatViewModel(
 
     fun selectThread(chatId: String?) {
         _currentChatThreadId.value = chatId
+        // Parked so this mode reopens here after a round trip through the other one.
+        settingsRepository.saveLastThreadId(appMode.value, chatId)
         clearPendingAttachment()
         clearError()
     }
@@ -853,7 +931,7 @@ class ChatViewModel(
 
             if (chatId == null) {
                 isFirstMsgInChat = true
-                chatId = chatRepository.createThread().id
+                chatId = chatRepository.createThread(mode = appMode.value).id
                 _currentChatThreadId.value = chatId
             }
 

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -455,6 +455,42 @@ class ChatViewModel(
     fun toggleArtifact() = toggleMode(ChatMode.Artifact)
     fun toggleImageGen() = toggleMode(ChatMode.ImageGen)
     fun toggleVideoGen() = toggleMode(ChatMode.VideoGen)
+
+    // ── Imagine ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Sends an Imagine turn. The media switch *is* the capability, so the surface sets the
+     * generation mode from what the user is making rather than asking them to arm it from a
+     * menu first — which is the entire reason image and video left Chat's "+" menu.
+     */
+    fun sendImagineMessage(prompt: String, media: ImagineMedia) {
+        setMode(if (media == ImagineMedia.Video) ChatMode.VideoGen else ChatMode.ImageGen)
+        sendMessage(prompt)
+    }
+
+    /**
+     * The bridge out of Imagine: opens a fresh Chat conversation with this piece of media
+     * attached. Without it, "what is in this picture?" is a dead end that ends in the user
+     * screenshotting their own app.
+     */
+    fun askAboutMediaInChat(filePath: String) {
+        viewModelScope.launch {
+            val file = File(filePath)
+            if (!file.exists()) {
+                _errorMessage.value = "That file is no longer available."
+                return@launch
+            }
+            settingsRepository.saveLastThreadId(appMode.value, _currentChatThreadId.value)
+            settingsRepository.saveAppMode(AppMode.Chat)
+            _drawerSearchQuery.value = ""
+            setMode(ChatMode.Normal)
+            selectThread(null)
+            setPendingAttachment(
+                Uri.fromFile(file),
+                if (file.extension.equals("mp4", ignoreCase = true)) "video/mp4" else "image/png",
+            )
+        }
+    }
     fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
     fun toggleWebSearchChip() = toggleMode(ChatMode.WebSearch)
     fun toggleDataAgent() = toggleMode(ChatMode.DataAgent)

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import com.echoflow.data.FusionPanel
 import com.echoflow.data.FusionPanelDao
 import com.echoflow.data.ImageModel
 import com.echoflow.data.ImageModelDao
+import com.echoflow.data.ImagineMedia
 import com.echoflow.data.DownloadState
 import com.echoflow.data.HuggingFaceModelSearch
 import com.echoflow.data.InferenceParams
@@ -129,6 +130,13 @@ class SettingsViewModel(
     val imageGenModelId: StateFlow<String> = repository.imageGenModel
     val imageModels: StateFlow<List<ImageModel>> = imageModelDao.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Imagine surface state
+    val imagineMedia: StateFlow<ImagineMedia> = repository.imagineMedia
+    val imageAspectRatio: StateFlow<String> = repository.imageAspectRatio
+
+    fun saveImagineMedia(media: ImagineMedia) = repository.saveImagineMedia(media)
+    fun saveImageAspectRatio(ratio: String) = repository.saveImageAspectRatio(ratio)
 
     // Video generation (OpenRouter only)
     val videoGenModelId: StateFlow<String> = repository.videoGenModel
@@ -459,6 +467,10 @@ class SettingsViewModel(
     fun saveVideoAspectRatio(ratio: String) = repository.saveVideoAspectRatio(ratio)
     fun saveVideoResolution(resolution: String) = repository.saveVideoResolution(resolution)
     fun saveVideoAudioEnabled(enabled: Boolean) = repository.saveVideoAudioEnabled(enabled)
+
+    /** Capabilities for any video model, so a picker row can show them before it is chosen. */
+    fun videoCapabilitiesFor(modelId: String): OpenRouterVideoModelInfo? =
+        _orVideoModels.value.firstOrNull { it.id == modelId }
 
     fun updateVideoModelQuery(query: String) {
         _videoModelQuery.value = query

--- a/app/src/main/java/com/echoflow/ui/components/AspectRatioPicker.kt
+++ b/app/src/main/java/com/echoflow/ui/components/AspectRatioPicker.kt
@@ -1,0 +1,180 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.VideoRequestPolicy
+import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberReducedMotion
+
+/** The box every ratio glyph is drawn to fit inside, so the row reads as one set. */
+private val GlyphBounds = 26.dp
+
+/**
+ * Framing, chosen from a small anchored popover rather than a full sheet — it is a two-second
+ * decision and a modal sheet would make it feel like a bigger one.
+ *
+ * Each option is drawn at its **true proportion**, and the outline springs to its new shape as
+ * the selection moves. That is the composer-scale echo of the card's stretch-to-aspect
+ * animation: the same idea in miniature, so the control and the result speak the same language.
+ *
+ * [supported] dims what the current model cannot do rather than hiding it, so the popover
+ * never rearranges itself between openings. A null or empty set means the model takes its
+ * framing from elsewhere and every option stays live.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun AspectRatioPopover(
+    expanded: Boolean,
+    selected: String,
+    supported: List<String>?,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+    unsupportedNote: String? = null,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(24.dp),
+    ) {
+        Column(Modifier.padding(horizontal = Spacing.m, vertical = Spacing.s).widthIn(max = 260.dp)) {
+            SectionLabel("Shape")
+            Spacer(Modifier.height(Spacing.s))
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                verticalArrangement = Arrangement.spacedBy(Spacing.s),
+            ) {
+                VideoRequestPolicy.ASPECT_RATIOS.forEach { ratio ->
+                    val enabled = supported.isNullOrEmpty() || ratio in supported
+                    AspectRatioOption(
+                        ratio = ratio,
+                        selected = ratio == selected,
+                        enabled = enabled,
+                        onClick = { onSelect(ratio); onDismiss() },
+                    )
+                }
+            }
+            if (unsupportedNote != null) {
+                Spacer(Modifier.height(Spacing.s))
+                Text(
+                    unsupportedNote,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AspectRatioOption(
+    ratio: String,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val reducedMotion = rememberReducedMotion()
+    // The glyph animates its own proportions, so the outline visibly re-shapes rather than
+    // one box switching off and another switching on.
+    val target = VideoRequestPolicy.aspectRatioValue(ratio)
+    val animatedAspect by animateFloatAsState(
+        targetValue = target,
+        animationSpec = if (reducedMotion) tween(0) else spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "ratio-glyph-$ratio",
+    )
+    val outline = when {
+        !enabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+        selected -> MaterialTheme.colorScheme.onPrimaryContainer
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(16.dp),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.semantics {
+            contentDescription = if (enabled) "$ratio aspect ratio" else "$ratio, not supported by this model"
+        },
+    ) {
+        Column(
+            Modifier.padding(horizontal = Spacing.m, vertical = Spacing.s).width(52.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(Modifier.size(GlyphBounds), contentAlignment = Alignment.Center) {
+                Box(
+                    Modifier.size(GlyphBounds).drawBehind {
+                        // Fit the true proportion inside a fixed box so portrait and landscape
+                        // options share a baseline instead of jumping around the row.
+                        val w: Float
+                        val h: Float
+                        if (animatedAspect >= 1f) {
+                            w = size.width
+                            h = size.width / animatedAspect
+                        } else {
+                            h = size.height
+                            w = size.height * animatedAspect
+                        }
+                        val stroke = 1.5.dp.toPx()
+                        drawRoundRect(
+                            color = outline,
+                            topLeft = Offset((size.width - w) / 2f, (size.height - h) / 2f),
+                            size = Size(w, h),
+                            cornerRadius = CornerRadius(3.dp.toPx(), 3.dp.toPx()),
+                            style = Stroke(width = stroke),
+                        )
+                    }
+                )
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                ratio,
+                style = MaterialTheme.typography.labelSmall,
+                color = if (enabled) {
+                    if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                },
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/components/BrowserComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/BrowserComponents.kt
@@ -22,11 +22,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -154,7 +154,7 @@ fun GlobalBrowserPill(
                 )
             }
             Spacer(Modifier.width(Spacing.xs))
-            Icon(Icons.Default.OpenInNew, "Open", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.inverseOnSurface)
+            Icon(Icons.AutoMirrored.Filled.OpenInNew, "Open", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.inverseOnSurface)
         }
     }
 }
@@ -256,7 +256,7 @@ fun BrowserSessionCard(
                     Text(session.lastOutput ?: "This step needs you.", style = MaterialTheme.typography.bodyMedium)
                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
                         Button(onClick = onOpen) {
-                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
+                            Icon(Icons.AutoMirrored.Filled.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
                         }
                         OutlinedButton(onClick = onCancel) { Text("Skip") }
                     }
@@ -316,7 +316,7 @@ fun BrowserSessionCard(
                 Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
                     if (session.hasLiveBrowser) {
                         Button(onClick = onOpen, modifier = Modifier.weight(1f)) {
-                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open browser")
+                            Icon(Icons.AutoMirrored.Filled.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open browser")
                         }
                     }
                     OutlinedButton(

--- a/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
@@ -37,8 +38,10 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.echoflow.data.AppMode
 import com.echoflow.data.ChatThread
 import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.rememberMorph
@@ -57,8 +60,11 @@ private val ButtonPressedShape = RoundedCornerShape(percent = 30)
 
 @Composable
 fun ChatDrawerContent(
+    mode: AppMode,
     allThreads: List<ChatThread>,
     currentThreadId: String?,
+    renderingChatIds: Set<String>,
+    otherModeMatchCount: Int,
     onThreadSelected: (String) -> Unit,
     onNewChatClicked: () -> Unit,
     onDeleteThread: (ChatThread) -> Unit,
@@ -68,6 +74,7 @@ fun ChatDrawerContent(
     searchQuery: String = "",
     onSearchQueryChange: ((String) -> Unit)? = null,
 ) {
+    val imagine = mode == AppMode.Imagine
     var threadToRename by remember { mutableStateOf<ChatThread?>(null) }
     var threadToDelete by remember { mutableStateOf<ChatThread?>(null) }
 
@@ -162,46 +169,63 @@ fun ChatDrawerContent(
                 )
             }
             Spacer(Modifier.width(Spacing.m))
-            Text("New conversation", style = MaterialTheme.typography.titleSmall)
+            Text(
+                if (imagine) "New creation" else "New conversation",
+                style = MaterialTheme.typography.titleSmall,
+            )
         }
 
         // Search across every conversation — titles and message text.
         if (onSearchQueryChange != null) {
             Spacer(Modifier.height(Spacing.m))
-            DrawerSearchField(query = searchQuery, onQueryChange = onSearchQueryChange)
+            DrawerSearchField(
+                query = searchQuery,
+                onQueryChange = onSearchQueryChange,
+                placeholder = if (imagine) "Search creations" else "Search conversations",
+            )
         }
 
         Spacer(Modifier.height(Spacing.l))
-        SectionLabel(if (searchQuery.isBlank()) "Recent" else "Results")
+        if (searchQuery.isNotBlank()) SectionLabel("Results")
 
-        if (searchQuery.isNotBlank() && allThreads.isEmpty()) {
-            Column(
-                Modifier.weight(1f).fillMaxWidth().padding(top = Spacing.xl),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Icon(
-                    Icons.Default.Search, null, Modifier.size(28.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        when {
+            searchQuery.isNotBlank() && allThreads.isEmpty() ->
+                DrawerEmptyState(
+                    icon = Icons.Default.Search,
+                    message = "Nothing here matches “$searchQuery”",
+                    modifier = Modifier.weight(1f),
                 )
-                Spacer(Modifier.height(Spacing.s))
-                Text(
-                    "No conversations match “$searchQuery”",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+            allThreads.isEmpty() ->
+                // Names where the other mode's history went. This is the one way the split can
+                // feel like data loss, and one sentence pre-empts the whole question.
+                DrawerEmptyState(
+                    icon = if (imagine) Icons.Default.AutoFixHigh else Icons.AutoMirrored.Filled.Chat,
+                    message = if (imagine) {
+                        "No creations yet.\nYour older image chats stayed in Chat."
+                    } else {
+                        "No conversations yet."
+                    },
+                    modifier = Modifier.weight(1f),
                 )
-            }
-        } else {
-            LazyColumn(Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-                items(allThreads, key = { it.id }) { thread ->
-                    ThreadPill(
-                        thread = thread,
-                        selected = thread.id == currentThreadId,
-                        onClick = { onThreadSelected(thread.id); onCloseDrawer?.invoke() },
-                        onRename = { threadToRename = thread },
-                        onDelete = { threadToDelete = thread },
-                    )
-                }
-            }
+            else -> DrawerThreadList(
+                threads = allThreads,
+                currentThreadId = currentThreadId,
+                renderingChatIds = renderingChatIds,
+                onThreadSelected = { onThreadSelected(it.id); onCloseDrawer?.invoke() },
+                onRename = { threadToRename = it },
+                onDelete = { threadToDelete = it },
+                grouped = searchQuery.isBlank(),
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        if (otherModeMatchCount > 0) {
+            Text(
+                "$otherModeMatchCount also in ${if (imagine) "Chat" else "Imagine"}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.m, top = Spacing.xs, bottom = Spacing.xs),
+            )
         }
 
         HorizontalDivider(Modifier.padding(vertical = Spacing.s), color = MaterialTheme.colorScheme.outlineVariant)
@@ -267,7 +291,7 @@ fun ChatDrawerContent(
  * grab that focus and pop the keyboard on every drawer swipe.
  */
 @Composable
-private fun DrawerSearchField(query: String, onQueryChange: (String) -> Unit) {
+private fun DrawerSearchField(query: String, onQueryChange: (String) -> Unit, placeholder: String) {
     var editing by remember { mutableStateOf(false) }
     var hadFocus by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
@@ -298,7 +322,7 @@ private fun DrawerSearchField(query: String, onQueryChange: (String) -> Unit) {
                         Box(contentAlignment = Alignment.CenterStart) {
                             if (query.isEmpty()) {
                                 Text(
-                                    "Search conversations",
+                                    placeholder,
                                     style = MaterialTheme.typography.bodyLarge,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -323,7 +347,7 @@ private fun DrawerSearchField(query: String, onQueryChange: (String) -> Unit) {
                 LaunchedEffect(Unit) { focusRequester.requestFocus() }
             } else {
                 Text(
-                    query.ifEmpty { "Search conversations" },
+                    query.ifEmpty { placeholder },
                     style = MaterialTheme.typography.bodyLarge,
                     color = if (query.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant
                     else MaterialTheme.colorScheme.onSurface,
@@ -371,44 +395,24 @@ private fun pressScale(
     )
 }
 
+/** Shared empty/no-results state for the drawer list. */
 @Composable
-private fun ThreadPill(
-    thread: ChatThread,
-    selected: Boolean,
-    onClick: () -> Unit,
-    onRename: () -> Unit,
-    onDelete: () -> Unit,
+private fun DrawerEmptyState(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    message: String,
+    modifier: Modifier = Modifier,
 ) {
-    Surface(
-        onClick = onClick,
-        shape = PillShape,
-        color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerLow,
-        modifier = Modifier.fillMaxWidth(),
+    Column(
+        modifier.fillMaxWidth().padding(top = Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Row(
-            Modifier.padding(start = Spacing.base, end = Spacing.xs).heightIn(min = 52.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                Icons.AutoMirrored.Filled.Chat, null, Modifier.size(20.dp),
-                tint = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.width(Spacing.m))
-            Text(
-                thread.title,
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodyLarge,
-                color = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f),
-            )
-            if (selected) {
-                IconButton(onClick = onRename, modifier = Modifier.size(36.dp)) {
-                    Icon(Icons.Default.Edit, "Rename", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer)
-                }
-                IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
-                    Icon(Icons.Default.DeleteOutline, "Delete", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.error)
-                }
-            }
-        }
+        Icon(icon, null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
@@ -67,10 +68,14 @@ fun ContextChipRow(
     val edgeFade = remember(scrollState) { { scrollState.canScrollForward to scrollState.canScrollBackward } }
     Row(
         modifier
+            // Offscreen FIRST: DstIn multiplies against the alpha of the layer beneath it, so
+            // the content has to already be in its own layer. With the order reversed the
+            // gradient has nothing to blend into and paints as a solid black bar.
+            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
             .drawWithContent {
                 drawContent()
                 val (forward, backward) = edgeFade()
-                val fade = 16.dp.toPx()
+                val fade = 20.dp.toPx()
                 // Fade only the edge that has content beyond it, so the row never looks
                 // clipped when it happens to fit.
                 if (backward) drawRect(
@@ -86,7 +91,6 @@ fun ContextChipRow(
                     blendMode = BlendMode.DstIn,
                 )
             }
-            .graphicsLayer { compositingStrategy = androidx.compose.ui.graphics.CompositingStrategy.Offscreen }
             .horizontalScroll(scrollState),
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
@@ -18,7 +18,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import com.echoflow.data.ImagineMedia
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -145,6 +154,72 @@ fun ModelPill(
                 Icons.Default.KeyboardArrowDown, null, Modifier.size(16.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+}
+
+/**
+ * Image or video, chosen inside the chip row.
+ *
+ * A **flat** connected pair, unlike the mode switch's floating tray. That difference is a
+ * rule, not an inconsistency: elevation belongs to chrome hovering over scrolling content,
+ * while controls resting inside a row stay flat — the same distinction that already separates
+ * the floating composer from an in-page text field.
+ */
+@Composable
+fun MediaToggle(
+    selected: ImagineMedia,
+    onSelect: (ImagineMedia) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val haptics = LocalHapticFeedback.current
+    Row(
+        modifier.selectableGroup(),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        ImagineMedia.entries.forEach { media ->
+            val isSelected = media == selected
+            val label = if (media == ImagineMedia.Video) "Video" else "Image"
+            // Outer corners round, inner corners tight, so the pair reads as one control.
+            val shape = when (media) {
+                ImagineMedia.Image -> RoundedCornerShape(
+                    topStartPercent = 50, bottomStartPercent = 50, topEndPercent = 20, bottomEndPercent = 20,
+                )
+                ImagineMedia.Video -> RoundedCornerShape(
+                    topStartPercent = 20, bottomStartPercent = 20, topEndPercent = 50, bottomEndPercent = 50,
+                )
+            }
+            Surface(
+                shape = shape,
+                color = if (isSelected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.surfaceContainerHighest,
+                modifier = Modifier
+                    .selectable(
+                        selected = isSelected,
+                        role = Role.RadioButton,
+                        onClick = {
+                            if (!isSelected) {
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                onSelect(media)
+                            }
+                        },
+                    )
+                    .semantics { contentDescription = "$label mode" },
+            ) {
+                Row(
+                    Modifier.padding(horizontal = Spacing.m, vertical = 7.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    val tint = if (isSelected) MaterialTheme.colorScheme.onPrimary
+                    else MaterialTheme.colorScheme.onSurfaceVariant
+                    Icon(
+                        if (media == ImagineMedia.Video) Icons.Default.Movie else Icons.Default.Image,
+                        null, Modifier.size(16.dp), tint = tint,
+                    )
+                    Spacer(Modifier.width(Spacing.xs))
+                    Text(label, style = MaterialTheme.typography.labelMedium, color = tint, maxLines = 1)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
@@ -1,0 +1,198 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The row directly above the composer: what this next message will be sent *with*.
+ *
+ * Scrolls horizontally rather than wrapping. Wrapping was pushing the composer up a line
+ * every time a couple of capabilities were on, which moves the send button out from under the
+ * thumb — the row growing is never worth the input moving.
+ */
+@Composable
+fun ContextChipRow(
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val edgeFade = remember(scrollState) { { scrollState.canScrollForward to scrollState.canScrollBackward } }
+    Row(
+        modifier
+            .drawWithContent {
+                drawContent()
+                val (forward, backward) = edgeFade()
+                val fade = 16.dp.toPx()
+                // Fade only the edge that has content beyond it, so the row never looks
+                // clipped when it happens to fit.
+                if (backward) drawRect(
+                    brush = Brush.horizontalGradient(listOf(Color.Transparent, Color.Black), 0f, fade),
+                    blendMode = BlendMode.DstIn,
+                )
+                if (forward) drawRect(
+                    brush = Brush.horizontalGradient(
+                        listOf(Color.Black, Color.Transparent),
+                        size.width - fade,
+                        size.width,
+                    ),
+                    blendMode = BlendMode.DstIn,
+                )
+            }
+            .graphicsLayer { compositingStrategy = androidx.compose.ui.graphics.CompositingStrategy.Offscreen }
+            .horizontalScroll(scrollState),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalAlignment = Alignment.CenterVertically,
+        content = content,
+    )
+}
+
+/**
+ * The model selector, at the leading edge of the chip row.
+ *
+ * It sits by the composer rather than in the top bar deliberately: in a multi-provider app the
+ * model is something you change mid-thought, and the bottom edge is where your thumb already
+ * is. It wears the provider's own mark so which brain is answering is readable without
+ * parsing the name.
+ */
+@Composable
+fun ModelPill(
+    modelId: String,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    supporting: String? = null,
+    leadingMark: (@Composable () -> Unit)? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.96f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "model-pill-press",
+    )
+    Surface(
+        onClick = onClick,
+        interactionSource = interaction,
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = modifier
+            .graphicsLayer { scaleX = scale; scaleY = scale }
+            .semantics { contentDescription = "Model: $label. Tap to change." },
+    ) {
+        Row(
+            Modifier.padding(start = 6.dp, end = Spacing.s, top = 5.dp, bottom = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingMark != null) leadingMark() else ProviderMark(modelId = modelId, size = 22.dp)
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.MiddleEllipsis,
+                modifier = Modifier.widthIn(max = 168.dp),
+            )
+            if (supporting != null) {
+                Spacer(Modifier.width(Spacing.xs))
+                Text(
+                    supporting,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+            Icon(
+                Icons.Default.KeyboardArrowDown, null, Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** A compact chip that opens a picker — ratio, resolution, or any other framing choice. */
+@Composable
+fun SettingChip(
+    icon: ImageVector?,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    active: Boolean = false,
+    description: String = label,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.96f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "setting-chip-press",
+    )
+    Surface(
+        onClick = onClick,
+        interactionSource = interaction,
+        shape = CircleShape,
+        color = if (active) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = modifier
+            .graphicsLayer { scaleX = scale; scaleY = scale }
+            .semantics { contentDescription = description },
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.m, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val tint = if (active) MaterialTheme.colorScheme.onPrimaryContainer
+            else MaterialTheme.colorScheme.onSurfaceVariant
+            if (icon != null) {
+                Icon(icon, null, Modifier.size(16.dp), tint = tint)
+                Spacer(Modifier.width(Spacing.xs))
+            }
+            Text(
+                label,
+                style = MaterialTheme.typography.labelMedium,
+                color = if (active) MaterialTheme.colorScheme.onPrimaryContainer
+                else MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ContextChips.kt
@@ -112,7 +112,6 @@ fun ModelPill(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    supporting: String? = null,
     leadingMark: (@Composable () -> Unit)? = null,
 ) {
     val interaction = remember { MutableInteractionSource() }
@@ -145,15 +144,6 @@ fun ModelPill(
                 overflow = TextOverflow.MiddleEllipsis,
                 modifier = Modifier.widthIn(max = 168.dp),
             )
-            if (supporting != null) {
-                Spacer(Modifier.width(Spacing.xs))
-                Text(
-                    supporting,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                )
-            }
             Icon(
                 Icons.Default.KeyboardArrowDown, null, Modifier.size(16.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
+++ b/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
@@ -1,0 +1,189 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.AutoFixHigh
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.AppMode
+import com.echoflow.data.ChatThread
+import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberReducedMotion
+import java.util.Calendar
+
+private val PillShape = RoundedCornerShape(28.dp)
+
+/**
+ * One mode's conversations, grouped by when they were last touched.
+ *
+ * The grouping costs nothing and is the difference between a list and something that looks
+ * looked-after — a flat run of thirty titles gives the eye nowhere to land.
+ */
+@Composable
+fun DrawerThreadList(
+    threads: List<ChatThread>,
+    currentThreadId: String?,
+    renderingChatIds: Set<String>,
+    onThreadSelected: (ChatThread) -> Unit,
+    onRename: (ChatThread) -> Unit,
+    onDelete: (ChatThread) -> Unit,
+    grouped: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val reducedMotion = rememberReducedMotion()
+    val sections = remember(threads, grouped) {
+        if (grouped) ThreadRecency.group(threads) else listOf(null to threads)
+    }
+    LazyColumn(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        sections.forEach { (label, sectionThreads) ->
+            if (label != null) {
+                item(key = "section-$label") {
+                    Box(Modifier.padding(top = Spacing.s, bottom = Spacing.xs)) { SectionLabel(label) }
+                }
+            }
+            items(sectionThreads, key = { it.id }) { thread ->
+                ThreadPill(
+                    thread = thread,
+                    selected = thread.id == currentThreadId,
+                    rendering = thread.id in renderingChatIds,
+                    reducedMotion = reducedMotion,
+                    onClick = { onThreadSelected(thread) },
+                    onRename = { onRename(thread) },
+                    onDelete = { onDelete(thread) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThreadPill(
+    thread: ChatThread,
+    selected: Boolean,
+    rendering: Boolean,
+    reducedMotion: Boolean,
+    onClick: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
+    else MaterialTheme.colorScheme.onSurface
+    val mutedColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
+    else MaterialTheme.colorScheme.onSurfaceVariant
+    val description = buildString {
+        append(thread.title)
+        if (rendering) append(", video rendering")
+    }
+    Surface(
+        onClick = onClick,
+        shape = PillShape,
+        color = if (selected) MaterialTheme.colorScheme.secondaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = description },
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.xs).heightIn(min = 52.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                if (thread.mode == AppMode.Imagine) Icons.Default.AutoFixHigh else Icons.AutoMirrored.Filled.Chat,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = mutedColor,
+            )
+            Spacer(Modifier.width(Spacing.m))
+            Text(
+                thread.title,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor,
+                modifier = Modifier.weight(1f),
+            )
+            // Same 6dp breathing dot as the mode switch: one vocabulary for "still working",
+            // so a single glance always means the same thing wherever it appears.
+            if (rendering) {
+                Spacer(Modifier.width(Spacing.s))
+                RenderingPulse(color = MaterialTheme.colorScheme.primary, reducedMotion = reducedMotion)
+                Spacer(Modifier.width(Spacing.xs))
+            }
+            if (selected) {
+                IconButton(onClick = onRename, modifier = Modifier.size(36.dp)) {
+                    Icon(Icons.Default.Edit, "Rename", Modifier.size(18.dp), tint = contentColor)
+                }
+                IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                    Icon(Icons.Default.DeleteOutline, "Delete", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Buckets conversations by last activity. Pure and calendar-based rather than arithmetic on
+ * millisecond spans: "yesterday" means the previous calendar day, not 24-to-48 hours ago, and
+ * a conversation touched at 00:30 should not be filed under yesterday at 00:45.
+ */
+internal object ThreadRecency {
+    const val TODAY = "Today"
+    const val YESTERDAY = "Yesterday"
+    const val THIS_WEEK = "Previous 7 days"
+    const val EARLIER = "Older"
+
+    fun group(
+        threads: List<ChatThread>,
+        now: Long = System.currentTimeMillis(),
+    ): List<Pair<String, List<ChatThread>>> {
+        val order = listOf(TODAY, YESTERDAY, THIS_WEEK, EARLIER)
+        return threads.groupBy { bucketOf(it.updatedAt, now) }
+            .toList()
+            .sortedBy { (label, _) -> order.indexOf(label) }
+    }
+
+    fun bucketOf(timestamp: Long, now: Long): String {
+        val startOfToday = startOfDay(now)
+        return when {
+            timestamp >= startOfToday -> TODAY
+            timestamp >= startOfToday - DAY_MS -> YESTERDAY
+            timestamp >= startOfToday - 6 * DAY_MS -> THIS_WEEK
+            else -> EARLIER
+        }
+    }
+
+    private fun startOfDay(now: Long): Long = Calendar.getInstance().apply {
+        timeInMillis = now
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+
+    private const val DAY_MS = 24L * 60 * 60 * 1000
+}

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -18,13 +18,13 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.automirrored.filled.CompareArrows
+import androidx.compose.material.icons.automirrored.filled.Assignment
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
-import androidx.compose.material.icons.filled.Assignment
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.CompareArrows
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.Hub
@@ -275,7 +275,7 @@ fun SubagentCard(
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Row(Modifier.padding(Spacing.m)) {
-                                Icon(Icons.Default.Assignment, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                                Icon(Icons.AutoMirrored.Filled.Assignment, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
                                 Spacer(Modifier.width(Spacing.s))
                                 Column {
                                     Text("Task brief", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -507,7 +507,7 @@ private fun FusionDeliberation(analysis: FusionAnalysis) {
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Row(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.CompareArrows, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                    Icon(Icons.AutoMirrored.Filled.CompareArrows, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
                     Spacer(Modifier.width(Spacing.s))
                     Text("How the panel compared", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
                     Icon(Icons.Default.KeyboardArrowDown, if (open) "Collapse" else "Expand", Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -521,7 +521,7 @@ private fun FusionDeliberation(analysis: FusionAnalysis) {
                         }
                     }
                     if (analysis.contradictions.isNotEmpty()) {
-                        FusionSection("Disagreements", Icons.Default.CompareArrows, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer) {
+                        FusionSection("Disagreements", Icons.AutoMirrored.Filled.CompareArrows, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer) {
                             Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
                                 analysis.contradictions.forEach { c ->
                                     Column {

--- a/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ImageGenComponents.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -99,10 +100,10 @@ import kotlin.math.hypot
 /** The compact side of the placeholder square while the model is still painting. */
 private val PlaceholderSize = 216.dp
 
-/** The widest the settled image may render inside the reply. */
-private val SettledMaxWidth = 340.dp
+/** The widest a settled image renders inside a chat reply. Imagine overrides this. */
+internal val ChatMediaWidth = 340.dp
 
-/** The tallest the settled image may render; taller aspects are capped and center-cropped. */
+/** The tallest a settled image renders; taller aspects are capped and center-cropped. */
 private val SettledMaxHeight = 420.dp
 
 /**
@@ -125,6 +126,8 @@ fun GeneratedImageSegment(
     previousImagePath: String?,
     animate: Boolean,
     onCopy: (() -> Unit)? = null,
+    maxWidth: Dp = ChatMediaWidth,
+    actions: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -144,7 +147,7 @@ fun GeneratedImageSegment(
     // The display footprint: true aspect at bubble width, capped so height never exceeds
     // SettledMaxHeight (the stretch targets exactly what the settled image will occupy,
     // so the reveal ends with zero snap or reflow).
-    val minAspect = SettledMaxWidth.value / SettledMaxHeight.value
+    val minAspect = maxWidth.value / SettledMaxHeight.value
     val displayAspect = (rawAspect ?: 1f).coerceAtLeast(minAspect)
 
     var settled by rememberSaveable(filePath) { mutableStateOf(!animate && filePath != null) }
@@ -170,7 +173,7 @@ fun GeneratedImageSegment(
 
     // Both dimensions of the card interpolate together from the placeholder square to the
     // settled footprint, driven by the single stretch value.
-    val morphMaxWidth = (PlaceholderSize.value + (SettledMaxWidth.value - PlaceholderSize.value) * stretch.value).dp
+    val morphMaxWidth = (PlaceholderSize.value + (maxWidth.value - PlaceholderSize.value) * stretch.value).dp
     val morphAspect = 1f + (displayAspect - 1f) * stretch.value
 
     // Persisted history starts settled with the aspect still decoding for a few ms — hold the
@@ -270,6 +273,7 @@ fun GeneratedImageSegment(
                         }
                     },
                     onShare = { filePath?.let { scope.launch { shareGeneratedImage(context, it) } } },
+                    extra = actions,
                 )
             }
         }
@@ -286,6 +290,7 @@ internal fun GeneratedImageActions(
     onDownload: () -> Unit,
     onShare: () -> Unit,
     modifier: Modifier = Modifier,
+    extra: (@Composable () -> Unit)? = null,
 ) {
     Row(
         modifier = modifier,
@@ -308,6 +313,7 @@ internal fun GeneratedImageActions(
             modifier = Modifier.size(48.dp),
             colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         ) { Icon(Icons.Default.Share, "Share", Modifier.size(20.dp)) }
+        extra?.invoke()
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/components/ModeSwitch.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ModeSwitch.kt
@@ -1,0 +1,266 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.AutoFixHigh
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.AppMode
+import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberReducedMotion
+import kotlin.math.abs
+
+/** 48dp so every segment clears the accessibility touch minimum without an expansion hack. */
+private val TrayHeight = 48.dp
+private val TrayPadding = 4.dp
+private val MaxTrayWidth = 220.dp
+
+/** How far the thumb stretches along its direction of travel at the midpoint of a switch. */
+private const val TravelStretch = 0.08f
+
+/** The app's one "still working" rhythm — the dot field's cycle, reused so they read as one idea. */
+private const val PulseCycleMs = 3000
+
+/**
+ * The app's top-level surface switch: Chat or Imagine.
+ *
+ * Built as a **floating tray with a raised thumb** rather than a flat connected pair, so it
+ * wears the same material recipe as the composer at the other edge of the screen —
+ * `surfaceContainerHigh`, 3dp tonal, 8dp shadow. The two pills bookend the content between
+ * them, and the screen reads as one composition instead of chrome plus a control.
+ *
+ * That construction is also where the recessed look comes from: the tray casts a soft shadow
+ * *down* onto scrolling content while the thumb casts a tight one *into* the tray, so the
+ * unselected side reads as carved out. Deliberately no true inner shadow — those need custom
+ * drawing, they vanish in dark themes where shadows barely register, and they are foreign to
+ * Material's lighting model. Here the tonal contrast carries the depth on its own when
+ * shadows cannot.
+ *
+ * [renderingModes] marks a surface that still has a clip rendering, so switching away from a
+ * long job never hides it.
+ */
+@Composable
+fun ModeSwitch(
+    selected: AppMode,
+    onSelect: (AppMode) -> Unit,
+    renderingModes: Set<AppMode>,
+    modifier: Modifier = Modifier,
+) {
+    val haptics = LocalHapticFeedback.current
+    val reducedMotion = rememberReducedMotion()
+    val interactions = remember { AppMode.entries.associateWith { MutableInteractionSource() } }
+    val anyPressed = interactions.values.map { it.collectIsPressedAsState().value }.any { it }
+
+    // One value drives both the thumb's position and its mid-flight stretch.
+    val travel by animateFloatAsState(
+        targetValue = if (selected == AppMode.Chat) 0f else 1f,
+        animationSpec = if (reducedMotion) tween(0) else spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "mode-thumb-travel",
+    )
+    val pressScale by animateFloatAsState(
+        targetValue = if (anyPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "mode-thumb-press",
+    )
+
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 3.dp,
+        shadowElevation = 8.dp,
+        modifier = modifier.height(TrayHeight),
+    ) {
+        BoxWithConstraints(Modifier.padding(TrayPadding)) {
+            val segmentWidth = maxWidth / 2
+
+            // Peaks at the midpoint of travel and is exactly 1 at either rest position, so the
+            // thumb elongates as it crosses and settles round — the squash-and-stretch that
+            // makes the switch feel like an object rather than a highlight moving.
+            val stretch = 1f + TravelStretch * (1f - abs(travel - 0.5f) * 2f)
+
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primary,
+                shadowElevation = if (anyPressed) 0.dp else 2.dp,
+                modifier = Modifier
+                    .width(segmentWidth)
+                    .fillMaxHeight()
+                    .offset(x = segmentWidth * travel)
+                    .graphicsLayer {
+                        scaleX = stretch * pressScale
+                        scaleY = pressScale
+                    },
+            ) {}
+
+            Row(Modifier.fillMaxHeight().selectableGroup()) {
+                AppMode.entries.forEach { mode ->
+                    ModeSegment(
+                        mode = mode,
+                        selected = mode == selected,
+                        rendering = mode in renderingModes,
+                        interactionSource = interactions.getValue(mode),
+                        reducedMotion = reducedMotion,
+                        onClick = {
+                            if (mode != selected) {
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                onSelect(mode)
+                            }
+                        },
+                        modifier = Modifier.width(segmentWidth).fillMaxHeight(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModeSegment(
+    mode: AppMode,
+    selected: Boolean,
+    rendering: Boolean,
+    interactionSource: MutableInteractionSource,
+    reducedMotion: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Content colour crossfades as the thumb passes underneath; the label itself never moves,
+    // so text stays rock-steady through the switch.
+    val contentColor by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.onPrimary
+        else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(durationMillis = if (reducedMotion) 0 else 220),
+        label = "mode-segment-content",
+    )
+    val label = mode.label
+    val description = buildString {
+        append(label)
+        append(" mode")
+        if (rendering) append(", video rendering")
+    }
+
+    Row(
+        modifier
+            .selectable(
+                selected = selected,
+                interactionSource = interactionSource,
+                indication = null, // the thumb IS the selection affordance; a ripple would fight it
+                role = Role.Tab,
+                onClick = onClick,
+            )
+            .semantics { contentDescription = description },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(mode.icon, contentDescription = null, Modifier.size(18.dp), tint = contentColor)
+        Spacer(Modifier.width(6.dp))
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        // Inline rather than corner-anchored: a badge pinned to a corner that is actively
+        // stretching would jitter through every switch.
+        if (rendering) {
+            Spacer(Modifier.width(Spacing.xs))
+            RenderingPulse(color = contentColor, reducedMotion = reducedMotion)
+        }
+    }
+}
+
+/**
+ * The app's single "still working" mark — a 6dp dot breathing on the dot field's own rhythm.
+ * Used here and on drawer rows and nowhere else, so one glance always means one thing.
+ */
+@Composable
+internal fun RenderingPulse(color: androidx.compose.ui.graphics.Color, reducedMotion: Boolean) {
+    val alpha = if (reducedMotion) {
+        1f
+    } else {
+        val transition = rememberInfiniteTransition(label = "rendering-pulse")
+        transition.animateFloat(
+            initialValue = 0.45f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = PulseCycleMs / 2),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "rendering-pulse-alpha",
+        ).value
+    }
+    Box(
+        Modifier
+            .size(6.dp)
+            .drawBehind {
+                drawCircle(color = color, alpha = alpha, center = Offset(size.width / 2f, size.height / 2f))
+            }
+    )
+}
+
+private val AppMode.label: String
+    get() = when (this) {
+        AppMode.Chat -> "Chat"
+        AppMode.Imagine -> "Imagine"
+    }
+
+/**
+ * Imagine gets the wand rather than a sparkle: `AutoAwesome` is already spoken for by Artifacts
+ * and Echo Labs, and a top-level surface deserves a glyph it does not share.
+ */
+private val AppMode.icon: ImageVector
+    get() = when (this) {
+        AppMode.Chat -> Icons.AutoMirrored.Filled.Chat
+        AppMode.Imagine -> Icons.Default.AutoFixHigh
+    }

--- a/app/src/main/java/com/echoflow/ui/components/ProviderIdentity.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ProviderIdentity.kt
@@ -1,0 +1,162 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoFixHigh
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.RoundedPolygon
+import com.echoflow.data.CustomProviderConfig
+import com.echoflow.ui.theme.RoundedPolygonShape
+
+/**
+ * Who runs a model, expressed as a shape and a tonal colour pair.
+ *
+ * In a multi-provider app, provenance *is* information — it is the privacy story, the cost
+ * story and the latency story at once — so every model needs to be identifiable at a glance.
+ * Real vendor logos are a trademark minefield, but the app already owns a better answer:
+ * [MaterialShapes]. A stable shape per provider is legally clean, instantly scannable, and is
+ * literally the design language the rest of the app is built from.
+ *
+ * Colour comes from **theme roles** rather than brand hex values, so identity survives dynamic
+ * colour and all six accents intact. Shape carries most of the distinction; the colour role
+ * adds a second axis without ever fighting the user's palette.
+ */
+enum class ProviderIdentity(
+    val label: String,
+    val shape: RoundedPolygon,
+    private val tone: Tone,
+) {
+    OpenAi("OpenAI", MaterialShapes.Cookie6Sided, Tone.Secondary),
+    Anthropic("Anthropic", MaterialShapes.Sunny, Tone.Primary),
+    Google("Google", MaterialShapes.Clover4Leaf, Tone.Tertiary),
+    Meta("Meta", MaterialShapes.Oval, Tone.Secondary),
+    Mistral("Mistral", MaterialShapes.Pentagon, Tone.Tertiary),
+    DeepSeek("DeepSeek", MaterialShapes.Gem, Tone.Primary),
+    Qwen("Qwen", MaterialShapes.Puffy, Tone.Secondary),
+    XAi("xAI", MaterialShapes.Diamond, Tone.Primary),
+    Kling("Kling", MaterialShapes.Flower, Tone.Tertiary),
+    ByteDance("ByteDance", MaterialShapes.Burst, Tone.Secondary),
+    OnDevice("On device", MaterialShapes.Cookie9Sided, Tone.Tertiary),
+    Other("Cloud", MaterialShapes.Circle, Tone.Secondary);
+
+    private enum class Tone { Primary, Secondary, Tertiary }
+
+    val container: Color
+        @Composable get() = when (tone) {
+            Tone.Primary -> MaterialTheme.colorScheme.primaryContainer
+            Tone.Secondary -> MaterialTheme.colorScheme.secondaryContainer
+            Tone.Tertiary -> MaterialTheme.colorScheme.tertiaryContainer
+        }
+
+    val onContainer: Color
+        @Composable get() = when (tone) {
+            Tone.Primary -> MaterialTheme.colorScheme.onPrimaryContainer
+            Tone.Secondary -> MaterialTheme.colorScheme.onSecondaryContainer
+            Tone.Tertiary -> MaterialTheme.colorScheme.onTertiaryContainer
+        }
+
+    companion object {
+        /**
+         * Reads the provider out of a model id. Handles both OpenRouter's `vendor/model` form
+         * and the app's own `openai:`-style prefixes for direct-API models; falls back to
+         * matching the vendor name anywhere in the id, which covers ids that route a vendor's
+         * model through someone else's infrastructure.
+         */
+        fun of(modelId: String): ProviderIdentity {
+            val id = modelId.lowercase()
+            return when {
+                id.startsWith("local/") -> OnDevice
+                id.startsWith(CustomProviderConfig.PREFIX_OPENAI) || id.contains("openai") || id.contains("gpt-") -> OpenAi
+                id.startsWith(CustomProviderConfig.PREFIX_CLAUDE) || id.contains("anthropic") || id.contains("claude") -> Anthropic
+                id.startsWith(CustomProviderConfig.PREFIX_GEMINI) || id.contains("google") || id.contains("gemini") || id.contains("gemma") || id.contains("veo") -> Google
+                id.startsWith(CustomProviderConfig.PREFIX_XAI) || id.contains("x-ai") || id.contains("grok") -> XAi
+                id.contains("meta-llama") || id.contains("llama") -> Meta
+                id.contains("mistral") || id.contains("magistral") -> Mistral
+                id.contains("deepseek") -> DeepSeek
+                id.contains("qwen") || id.contains("alibaba") || id.contains("wan-") -> Qwen
+                id.contains("kwaivgi") || id.contains("kling") -> Kling
+                id.contains("bytedance") || id.contains("seedance") -> ByteDance
+                else -> Other
+            }
+        }
+    }
+}
+
+/**
+ * The provider monogram. Used in the composer pill, picker rows and Imagine cards from one
+ * definition, so the same model wears the same mark everywhere it appears.
+ */
+@Composable
+fun ProviderMark(
+    modelId: String,
+    size: Dp = 24.dp,
+    selected: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    val identity = remember(modelId) { ProviderIdentity.of(modelId) }
+    val container = if (selected) MaterialTheme.colorScheme.primary else identity.container
+    val content = if (selected) MaterialTheme.colorScheme.onPrimary else identity.onContainer
+    Box(
+        modifier
+            .size(size)
+            .clip(RoundedPolygonShape(identity.shape))
+            .background(container),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = identity.glyph,
+            contentDescription = null,
+            modifier = Modifier.size(size * 0.46f),
+            tint = content,
+        )
+    }
+}
+
+/**
+ * A tiny glyph inside the shape. Deliberately generic — the *shape* is what identifies the
+ * provider; the glyph only says what kind of thing it is, so nothing here can be mistaken for
+ * a vendor's actual logo.
+ */
+private val ProviderIdentity.glyph: ImageVector
+    get() = when (this) {
+        ProviderIdentity.OnDevice -> Icons.Default.PhoneAndroid
+        ProviderIdentity.Kling, ProviderIdentity.ByteDance -> Icons.Default.Movie
+        else -> Icons.Default.Cloud
+    }
+
+/** The mark for a generative surface that has no single provider yet (empty Imagine states). */
+@Composable
+fun ImagineMark(size: Dp = 24.dp, modifier: Modifier = Modifier) {
+    Box(
+        modifier
+            .size(size)
+            .clip(RoundedPolygonShape(MaterialShapes.Flower))
+            .background(MaterialTheme.colorScheme.tertiaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Default.AutoFixHigh, null,
+            Modifier.size(size * 0.46f),
+            tint = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/VideoGenComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -46,6 +47,7 @@ import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -56,6 +58,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -81,6 +84,7 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -102,11 +106,11 @@ import java.io.File
 /** The compact side of the placeholder square while the clip is still rendering. */
 private val PlaceholderSize = 216.dp
 
-/** The widest a settled clip may render inside the reply. */
-private val SettledMaxWidth = 340.dp
+/** The widest a settled clip renders inside a chat reply. Imagine overrides this. */
+internal val ChatVideoWidth = 340.dp
 
-/** The tallest a settled clip may render; taller aspects are capped. */
-private val SettledMaxHeight = 420.dp
+/** The tallest a settled clip renders; taller aspects are capped. */
+private val SettledMaxHeight = 560.dp
 
 /** The clip's real dimensions and opening frame, read once from the file. */
 private data class VideoPoster(val aspect: Float, val frame: ImageBitmap?)
@@ -136,6 +140,9 @@ fun GeneratedVideoSegment(
     animate: Boolean,
     errorMessage: String? = null,
     onCopy: (() -> Unit)? = null,
+    maxWidth: Dp = ChatVideoWidth,
+    actions: (@Composable () -> Unit)? = null,
+    onRetry: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -146,7 +153,7 @@ fun GeneratedVideoSegment(
     if (status == GeneratedVideo.STATUS_FAILED || status == GeneratedVideo.STATUS_CANCELLED ||
         status == GeneratedVideo.STATUS_EXPIRED
     ) {
-        VideoFailureCard(status, errorMessage, modifier)
+        VideoFailureCard(status, errorMessage, onRetry, maxWidth, modifier)
         return
     }
 
@@ -157,7 +164,7 @@ fun GeneratedVideoSegment(
         value = filePath?.let { path -> withContext(Dispatchers.IO) { readVideoPoster(path, requestedAspect) } }
     }
 
-    val minAspect = SettledMaxWidth.value / SettledMaxHeight.value
+    val minAspect = maxWidth.value / SettledMaxHeight.value
     val displayAspect = (poster?.aspect ?: requestedAspect).coerceAtLeast(minAspect)
 
     var settled by rememberSaveable(filePath) { mutableStateOf(!animate && filePath != null) }
@@ -180,7 +187,7 @@ fun GeneratedVideoSegment(
     )
     val scanColor = MaterialTheme.colorScheme.primary
 
-    val morphMaxWidth = (PlaceholderSize.value + (SettledMaxWidth.value - PlaceholderSize.value) * stretch.value).dp
+    val morphMaxWidth = (PlaceholderSize.value + (maxWidth.value - PlaceholderSize.value) * stretch.value).dp
     val morphAspect = 1f + (displayAspect - 1f) * stretch.value
 
     // Persisted history starts settled with the poster still decoding for a few ms — hold the
@@ -302,6 +309,7 @@ fun GeneratedVideoSegment(
                         }
                     },
                     onShare = { filePath?.let { scope.launch { shareGeneratedVideo(context, it) } } },
+                    extra = actions,
                 )
             }
         }
@@ -319,6 +327,7 @@ internal fun GeneratedVideoActions(
     onDownload: () -> Unit,
     onShare: () -> Unit,
     modifier: Modifier = Modifier,
+    extra: (@Composable () -> Unit)? = null,
 ) {
     Row(modifier, horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
         onCopy?.let { copy ->
@@ -343,6 +352,7 @@ internal fun GeneratedVideoActions(
             modifier = Modifier.size(48.dp),
             colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         ) { Icon(Icons.Default.Share, "Share", Modifier.size(20.dp)) }
+        extra?.invoke()
     }
 }
 
@@ -438,11 +448,17 @@ fun GeneratedVideoViewer(filePath: String, onDismiss: () -> Unit) {
 }
 
 @Composable
-private fun VideoFailureCard(status: String, errorMessage: String?, modifier: Modifier = Modifier) {
+private fun VideoFailureCard(
+    status: String,
+    errorMessage: String?,
+    onRetry: (() -> Unit)?,
+    maxWidth: Dp,
+    modifier: Modifier = Modifier,
+) {
     Surface(
         shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.errorContainer,
-        modifier = modifier.fillMaxWidth().widthIn(max = SettledMaxWidth),
+        modifier = modifier.fillMaxWidth().widthIn(max = maxWidth),
     ) {
         Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
             Icon(Icons.Default.ErrorOutline, null, tint = MaterialTheme.colorScheme.onErrorContainer)
@@ -464,6 +480,16 @@ private fun VideoFailureCard(status: String, errorMessage: String?, modifier: Mo
                         color = MaterialTheme.colorScheme.onErrorContainer,
                         textAlign = TextAlign.Start,
                     )
+                }
+                // A failed render used to be a dead end, which is a poor way to end a wait
+                // the user paid for in both money and minutes.
+                if (onRetry != null) {
+                    Spacer(Modifier.height(Spacing.xs))
+                    TextButton(onClick = onRetry, contentPadding = PaddingValues(0.dp)) {
+                        Icon(Icons.Default.Refresh, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onErrorContainer)
+                        Spacer(Modifier.width(Spacing.xs))
+                        Text("Try again", color = MaterialTheme.colorScheme.onErrorContainer)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/BrowserWorkspaceScreen.kt
@@ -36,13 +36,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -233,7 +233,7 @@ private fun BrowserViewport(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                 ),
             ) {
-                Icon(Icons.Default.OpenInNew, "Open in external browser", Modifier.size(20.dp))
+                Icon(Icons.AutoMirrored.Filled.OpenInNew, "Open in external browser", Modifier.size(20.dp))
             }
         }
     }
@@ -332,7 +332,7 @@ private fun OpeningState(domain: String, busy: Boolean, phase: String?) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
-            Icon(Icons.Default.OpenInNew, null, Modifier.size(40.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Icon(Icons.AutoMirrored.Filled.OpenInNew, null, Modifier.size(40.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             Text("Live view isn't available", style = MaterialTheme.typography.titleMedium)
         }
     }
@@ -526,7 +526,7 @@ private fun BrowserPauseBar(
                     Text(session.lastOutput ?: "This step needs you.", color = MaterialTheme.colorScheme.onTertiaryContainer)
                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
                         Button(onClick = onOpenExternal) {
-                            Icon(Icons.Default.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
+                            Icon(Icons.AutoMirrored.Filled.OpenInNew, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Open live browser")
                         }
                         OutlinedButton(onClick = onCancel) { Text("Skip") }
                     }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -86,6 +86,8 @@ import com.echoflow.ui.components.AgentDeployingCard
 import com.echoflow.ui.components.BrandMark
 import com.echoflow.ui.components.ArtifactCard
 import com.echoflow.ui.components.CapabilityChip
+import com.echoflow.ui.components.ContextChipRow
+import com.echoflow.ui.components.ModelPill
 import com.echoflow.ui.components.DataResultCard
 import com.echoflow.ui.components.FusionCard
 import com.echoflow.ui.components.EffortPill
@@ -147,6 +149,9 @@ internal fun InputToolbar(
     onToggleImageGen: () -> Unit,
     videoGenActive: Boolean,
     onToggleVideoGen: () -> Unit,
+    modelId: String,
+    modelLabel: String,
+    onOpenModelPicker: () -> Unit,
     browserSession: com.echoflow.data.BrowserSession?,
     browserSteps: List<com.echoflow.data.BrowserStep>,
     onBrowserOpen: () -> Unit,
@@ -231,65 +236,61 @@ internal fun InputToolbar(
             }
         }
 
-        // Active capability chips — always show what's on so behaviour is never hidden.
-        AnimatedVisibility(visible = webSearchChipOn || deepResearchActive || dataAgentActive || echoAdviserActive || echoFusionActive || echoAgentActive || browserFlowActive || artifactActive || imageGenActive || videoGenActive) {
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-                verticalArrangement = Arrangement.spacedBy(Spacing.s),
-                modifier = Modifier.padding(start = Spacing.s, bottom = Spacing.s),
-            ) {
-                if (webSearchChipOn) {
-                    CapabilityChip(Icons.Default.TravelExplore, "Web search", onRemove = onToggleWebSearch)
-                }
-                if (browserFlowActive) {
-                    CapabilityChip(Icons.Default.Language, "Browser Flow", onRemove = onToggleBrowserFlow)
-                }
-                if (artifactActive) {
-                    CapabilityChip(Icons.Default.AutoAwesome, "Artifact", onRemove = onToggleArtifact)
-                }
-                if (imageGenActive) {
-                    CapabilityChip(Icons.Default.Brush, "Create image", onRemove = onToggleImageGen)
-                }
-                if (videoGenActive) {
-                    CapabilityChip(Icons.Default.Movie, "Create video", onRemove = onToggleVideoGen)
-                }
-                if (echoAdviserActive) {
-                    CapabilityChip(
-                        Icons.Default.Psychology,
-                        advisorChipLabel?.let { "Adviser · $it" } ?: "Echo Adviser",
-                        onRemove = onToggleEchoAdviser,
-                    )
-                }
-                if (echoFusionActive) {
-                    CapabilityChip(
-                        Icons.Default.AccountTree,
-                        fusionChipLabel?.let { "Fusion · $it" } ?: "Echo Fusion",
-                        onRemove = onToggleEchoFusion,
-                    )
-                }
-                if (echoAgentActive) {
-                    CapabilityChip(
-                        Icons.Default.Hub,
-                        agentChipLabel?.let { "Echo Agent · $it" } ?: "Echo Agents",
-                        onRemove = onToggleEchoAgent,
-                    )
-                }
-                if (deepResearchActive) {
-                    CapabilityChip(
-                        Icons.Default.Science,
-                        researchEngineLabel?.takeIf { it.isNotBlank() && it != "Choose engine" }?.let { "Research · $it" } ?: "Deep Research",
-                        onRemove = onToggleDeepResearch,
-                    )
-                    // Exa Agent's depth/cost dial lives here, not in the engine list.
-                    if (showEffortPill) EffortPill(effort = exaEffort, onSelect = onSelectEffort)
-                }
-                if (dataAgentActive) {
-                    CapabilityChip(
-                        Icons.Default.Science,
-                        dataAgentLabel.takeIf { it.isNotBlank() && it != "Choose agent" }?.let { "Data Agent · $it" } ?: "Data Agent",
-                        onRemove = onToggleDataAgent,
-                    )
-                }
+        // What this next message will be sent with: the model first, then whatever
+        // capabilities are on. Always visible — the model is never implicit.
+        ContextChipRow(Modifier.padding(start = Spacing.s, bottom = Spacing.s)) {
+            ModelPill(modelId = modelId, label = modelLabel, onClick = onOpenModelPicker)
+            if (webSearchChipOn) {
+                CapabilityChip(Icons.Default.TravelExplore, "Web search", onRemove = onToggleWebSearch)
+            }
+            if (browserFlowActive) {
+                CapabilityChip(Icons.Default.Language, "Browser Flow", onRemove = onToggleBrowserFlow)
+            }
+            if (artifactActive) {
+                CapabilityChip(Icons.Default.AutoAwesome, "Artifact", onRemove = onToggleArtifact)
+            }
+            if (imageGenActive) {
+                CapabilityChip(Icons.Default.Brush, "Create image", onRemove = onToggleImageGen)
+            }
+            if (videoGenActive) {
+                CapabilityChip(Icons.Default.Movie, "Create video", onRemove = onToggleVideoGen)
+            }
+            if (echoAdviserActive) {
+                CapabilityChip(
+                    Icons.Default.Psychology,
+                    advisorChipLabel?.let { "Adviser · $it" } ?: "Echo Adviser",
+                    onRemove = onToggleEchoAdviser,
+                )
+            }
+            if (echoFusionActive) {
+                CapabilityChip(
+                    Icons.Default.AccountTree,
+                    fusionChipLabel?.let { "Fusion · $it" } ?: "Echo Fusion",
+                    onRemove = onToggleEchoFusion,
+                )
+            }
+            if (echoAgentActive) {
+                CapabilityChip(
+                    Icons.Default.Hub,
+                    agentChipLabel?.let { "Echo Agent · $it" } ?: "Echo Agents",
+                    onRemove = onToggleEchoAgent,
+                )
+            }
+            if (deepResearchActive) {
+                CapabilityChip(
+                    Icons.Default.Science,
+                    researchEngineLabel?.takeIf { it.isNotBlank() && it != "Choose engine" }?.let { "Research · $it" } ?: "Deep Research",
+                    onRemove = onToggleDeepResearch,
+                )
+                // Exa Agent's depth/cost dial lives here, not in the engine list.
+                if (showEffortPill) EffortPill(effort = exaEffort, onSelect = onSelectEffort)
+            }
+            if (dataAgentActive) {
+                CapabilityChip(
+                    Icons.Default.Science,
+                    dataAgentLabel.takeIf { it.isNotBlank() && it != "Choose agent" }?.let { "Data Agent · $it" } ?: "Data Agent",
+                    onRemove = onToggleDataAgent,
+                )
             }
         }
 

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -145,10 +145,6 @@ internal fun InputToolbar(
     onToggleBrowserFlow: () -> Unit,
     artifactActive: Boolean,
     onToggleArtifact: () -> Unit,
-    imageGenActive: Boolean,
-    onToggleImageGen: () -> Unit,
-    videoGenActive: Boolean,
-    onToggleVideoGen: () -> Unit,
     modelId: String,
     modelLabel: String,
     onOpenModelPicker: () -> Unit,
@@ -249,12 +245,6 @@ internal fun InputToolbar(
             if (artifactActive) {
                 CapabilityChip(Icons.Default.AutoAwesome, "Artifact", onRemove = onToggleArtifact)
             }
-            if (imageGenActive) {
-                CapabilityChip(Icons.Default.Brush, "Create image", onRemove = onToggleImageGen)
-            }
-            if (videoGenActive) {
-                CapabilityChip(Icons.Default.Movie, "Create video", onRemove = onToggleVideoGen)
-            }
             if (echoAdviserActive) {
                 CapabilityChip(
                     Icons.Default.Psychology,
@@ -343,10 +333,6 @@ internal fun InputToolbar(
                         browserFlowOn = browserFlowActive,
                         browserFlowAvailable = browserFlowAvailable,
                         artifactOn = artifactActive,
-                        imageGenOn = imageGenActive,
-                        onToggleImageGen = { plusMenuOpen = false; onToggleImageGen() },
-                        videoGenOn = videoGenActive,
-                        onToggleVideoGen = { plusMenuOpen = false; onToggleVideoGen() },
                         onImage = { plusMenuOpen = false; onAttach() },
                         onFiles = { plusMenuOpen = false; onAttachPdf() },
                         onToggleWebSearch = { plusMenuOpen = false; onToggleWebSearch() },
@@ -371,8 +357,6 @@ internal fun InputToolbar(
                                 dataAgentActive -> "Describe the data to extract…"
                                 deepResearchActive -> "Research a topic…"
                                 artifactActive -> "Describe an artifact to build…"
-                                imageGenActive -> "Describe an image — or a change…"
-                                videoGenActive -> "Describe a video…"
                                 else -> "Ask anything…"
                             }
                         )
@@ -425,10 +409,6 @@ internal fun PlusMenu(
     browserFlowOn: Boolean,
     browserFlowAvailable: Boolean,
     artifactOn: Boolean,
-    imageGenOn: Boolean,
-    onToggleImageGen: () -> Unit,
-    videoGenOn: Boolean,
-    onToggleVideoGen: () -> Unit,
     onImage: () -> Unit,
     onFiles: () -> Unit,
     onToggleWebSearch: () -> Unit,
@@ -441,21 +421,30 @@ internal fun PlusMenu(
     onToggleArtifact: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        // Image is offered for cloud models and vision-capable on-device (.litertlm) bundles.
-        if (showImage) {
-            DropdownMenuItem(
-                text = { Text("Image") },
-                leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
-                onClick = onImage,
-            )
+        // Attachments first, and labelled: they add context to this message, while everything
+        // below changes how the model works. Mixing the two in one flat list was the menu's
+        // real problem, not its length.
+        if (showImage || showFiles) {
+            MenuSectionLabel("Attach")
+            // Image is offered for cloud models and vision-capable on-device bundles.
+            if (showImage) {
+                DropdownMenuItem(
+                    text = { Text("Image") },
+                    leadingIcon = { Icon(Icons.Outlined.AddPhotoAlternate, null) },
+                    onClick = onImage,
+                )
+            }
+            if (showFiles) {
+                DropdownMenuItem(
+                    text = { Text("Files") },
+                    leadingIcon = { Icon(Icons.Default.PictureAsPdf, null) },
+                    onClick = onFiles,
+                )
+            }
+            HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
         }
-        if (showFiles) {
-            DropdownMenuItem(
-                text = { Text("Files") },
-                leadingIcon = { Icon(Icons.Default.PictureAsPdf, null) },
-                onClick = onFiles,
-            )
-        }
+
+        MenuSectionLabel("Capabilities")
         DropdownMenuItem(
             text = { Text("Web search") },
             leadingIcon = { Icon(Icons.Default.TravelExplore, null) },
@@ -474,20 +463,6 @@ internal fun PlusMenu(
             leadingIcon = { Icon(Icons.Default.AutoAwesome, null) },
             trailingIcon = { if (artifactOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
             onClick = onToggleArtifact,
-        )
-        // Create image — generate and conversationally edit images (OpenRouter image models).
-        DropdownMenuItem(
-            text = { Text("Create image") },
-            leadingIcon = { Icon(Icons.Default.Brush, null) },
-            trailingIcon = { if (imageGenOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
-            onClick = onToggleImageGen,
-        )
-        // Create video — render a short clip through OpenRouter's async video models.
-        DropdownMenuItem(
-            text = { Text("Create video") },
-            leadingIcon = { Icon(Icons.Default.Movie, null) },
-            trailingIcon = { if (videoGenOn) Icon(Icons.Default.Check, "On", tint = MaterialTheme.colorScheme.primary) },
-            onClick = onToggleVideoGen,
         )
         // Data Agent only appears once it's enabled in Settings and a Firecrawl key exists.
         if (dataAgentAvailable) {
@@ -511,6 +486,7 @@ internal fun PlusMenu(
         // profile/panel is missing, sending surfaces a "set it up" message.
         if (echoAdviserAvailable || echoFusionAvailable || echoAgentAvailable) {
             HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
+            MenuSectionLabel("Echo Labs")
         }
         if (echoAdviserAvailable) {
             DropdownMenuItem(
@@ -640,4 +616,15 @@ internal fun ShapedIconButton(
             ),
         contentAlignment = Alignment.Center,
     ) { content() }
+}
+
+/** A quiet header inside the "+" menu, so its two halves read as different kinds of choice. */
+@Composable
+private fun MenuSectionLabel(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = Spacing.m, top = Spacing.s, bottom = Spacing.xs),
+    )
 }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -77,6 +77,7 @@ import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
 import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
+import com.echoflow.data.AppMode
 import com.echoflow.data.GeneratedVideo
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
@@ -87,6 +88,7 @@ import com.echoflow.ui.components.AgentDeployingCard
 import com.echoflow.ui.components.BrandMark
 import com.echoflow.ui.components.ArtifactCard
 import com.echoflow.ui.components.CapabilityChip
+import com.echoflow.ui.components.ModeSwitch
 import com.echoflow.ui.components.DataResultCard
 import com.echoflow.ui.components.FusionCard
 import com.echoflow.ui.components.EffortPill
@@ -338,8 +340,23 @@ internal fun StreamingAssistantBubble(
     }
 }
 
+/**
+ * The floating top bar: place on the left, **identity** in the middle, action on the right.
+ *
+ * The centre slot belongs to the most permanent thing on screen, which is which surface you
+ * are on — so the mode switch lives here and the model selector moved down to the composer,
+ * where it sits with the other controls you change mid-thought.
+ */
 @Composable
-internal fun ChatTopBar(modelName: String, researchMode: Boolean, onMenu: () -> Unit, onModel: () -> Unit, onNewChat: () -> Unit, modifier: Modifier = Modifier) {
+internal fun ChatTopBar(
+    mode: AppMode,
+    onSelectMode: (AppMode) -> Unit,
+    renderingModes: Set<AppMode>,
+    onMenu: () -> Unit,
+    onNewChat: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val newLabel = if (mode == AppMode.Imagine) "New creation" else "New conversation"
     CenterAlignedTopAppBar(
         modifier = modifier,
         navigationIcon = {
@@ -351,29 +368,11 @@ internal fun ChatTopBar(modelName: String, researchMode: Boolean, onMenu: () -> 
             ) { Icon(Icons.Default.Menu, "Open conversations", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
         },
         title = {
-            // Model selector as a Material 3 Expressive split button — both halves open the picker.
-            // In Deep Research mode it selects the research engine instead of the chat model.
-            SplitButtonLayout(
-                leadingButton = {
-                    SplitButtonDefaults.LeadingButton(onClick = onModel) {
-                        if (researchMode) {
-                            Icon(Icons.Default.Science, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
-                            Spacer(Modifier.width(Spacing.xs))
-                        }
-                        Text(
-                            modelName,
-                            style = MaterialTheme.typography.titleSmall,
-                            maxLines = 1, overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.widthIn(max = 150.dp),
-                        )
-                    }
-                },
-                trailingButton = {
-                    // TrailingButton is a toggle in M3; we just use its tap to open the picker.
-                    SplitButtonDefaults.TrailingButton(checked = false, onCheckedChange = { onModel() }) {
-                        Icon(Icons.Default.KeyboardArrowDown, "Choose model", Modifier.size(20.dp))
-                    }
-                },
+            ModeSwitch(
+                selected = mode,
+                onSelect = onSelectMode,
+                renderingModes = renderingModes,
+                modifier = Modifier.widthIn(max = 220.dp),
             )
         },
         actions = {
@@ -383,7 +382,7 @@ internal fun ChatTopBar(modelName: String, researchMode: Boolean, onMenu: () -> 
                 restShape = MaterialShapes.Cookie7Sided, pressedShape = MaterialShapes.Sunny,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 pulseOnClick = true,
-            ) { Icon(Icons.Default.Add, "New conversation", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer) }
+            ) { Icon(Icons.Default.Add, newLabel, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onTertiaryContainer) }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent),
     )

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -1,111 +1,46 @@
-
-@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 
 package com.echoflow.ui.screens
 
-import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.content.MediaType
-import androidx.compose.foundation.content.ReceiveContentListener
-import androidx.compose.foundation.content.TransferableContent
-import androidx.compose.foundation.content.consume
-import androidx.compose.foundation.content.contentReceiver
-import androidx.compose.foundation.content.hasMediaType
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.outlined.AddPhotoAlternate
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.Dp
-import androidx.graphics.shapes.RoundedPolygon
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import com.echoflow.data.AdvisorProfile
-import com.echoflow.data.AgentProfile
-import com.echoflow.data.ChatMessage
-import com.echoflow.data.CustomProviderCapabilities
-import com.echoflow.data.DataAgentCatalog
-import com.echoflow.data.DeepResearchCatalog
-import com.echoflow.data.DeepResearchModel
-import com.echoflow.data.DrEngine
-import com.echoflow.data.FusionPanel
-import com.echoflow.data.ResearchRun
-import com.echoflow.data.ToolEventJson
+import com.echoflow.data.AppMode
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
-import com.echoflow.ui.StreamSegment
-import com.echoflow.ui.components.AdvisorCard
-import com.echoflow.ui.components.AgentDeployingCard
-import com.echoflow.ui.components.BrandMark
-import com.echoflow.ui.components.ArtifactCard
-import com.echoflow.ui.components.CapabilityChip
-import com.echoflow.ui.components.DataResultCard
-import com.echoflow.ui.components.FusionCard
-import com.echoflow.ui.components.EffortPill
-import com.echoflow.ui.components.MarkdownText
-import com.echoflow.ui.components.ReportCard
-import com.echoflow.ui.components.ResearchProgressCard
-import com.echoflow.ui.components.RichMarkdown
-import com.echoflow.ui.components.SearchActivityCard
-import com.echoflow.ui.components.SectionLabel
-import com.echoflow.ui.components.SubagentCard
-import com.echoflow.ui.theme.BrandShapes
-import com.echoflow.ui.theme.MorphPolygonShape
-import com.echoflow.ui.theme.Spacing
-import com.echoflow.ui.theme.rememberMorph
-import com.echoflow.ui.theme.rememberMorphProgress
-import kotlinx.coroutines.launch
 
-/** Single built-in model. Everything else the user adds in Settings. */
-private val DEFAULT_MODEL = "google/gemini-2.0-flash" to "Gemini 2.0 Flash"
-
+/**
+ * The app's main surface, and the seam between its two modes.
+ *
+ * Deliberately thin. It owns only what both modes share — the scaffold, the floating top bar
+ * and the error banner — and hands the body to whichever surface is active. The top bar sits
+ * *outside* the crossfade on purpose: chrome that persists across a mode change should
+ * transform in place, never fade out and back in, or switching reads as navigating somewhere
+ * else rather than refocusing where you are.
+ */
 @Composable
 fun ChatScreen(
     chatViewModel: ChatViewModel,
@@ -113,358 +48,60 @@ fun ChatScreen(
     onMenuClicked: () -> Unit,
     onSettingsClicked: () -> Unit,
 ) {
-    val clipboard = LocalClipboardManager.current
-
-    val messages by chatViewModel.currentMessages.collectAsState()
-    val isStreaming by chatViewModel.isStreaming.collectAsState()
-    val activeSegments by chatViewModel.activeSegments.collectAsState()
-    val statusNote by chatViewModel.statusNote.collectAsState()
-    val progressLoading by chatViewModel.apiProgressLoading.collectAsState()
-    val localModelLoading by chatViewModel.localModelLoading.collectAsState()
-    val anyLocalStreamActive by chatViewModel.anyLocalStreamActive.collectAsState()
+    val mode by chatViewModel.appMode.collectAsState()
+    val renderingModes by chatViewModel.renderingModes.collectAsState()
     val errorMessage by chatViewModel.errorMessage.collectAsState()
 
-    val pendingUri by chatViewModel.pendingAttachmentUri.collectAsState()
-    val pendingMime by chatViewModel.pendingAttachmentMimeType.collectAsState()
-    val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
-    val selectedModelID by settingsViewModel.selectedModel.collectAsState()
-    val customProviderConfig by settingsViewModel.customProviderConfig.collectAsState()
-    val customModelsList by settingsViewModel.customModels.collectAsState()
-    val customProviderModels by settingsViewModel.customProviderModels.collectAsState()
-    val localModelsList by settingsViewModel.localModels.collectAsState()
-    val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
-    val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
-
-    val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
-    val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
-    val dataAgentActive by chatViewModel.dataAgentActive.collectAsState()
-    val researchRun by chatViewModel.currentResearchRun.collectAsState()
-    val drModelId by settingsViewModel.deepResearchModelId.collectAsState()
-    val drModels by settingsViewModel.deepResearchModels.collectAsState()
-    val exaKey by settingsViewModel.exaApiKey.collectAsState()
-    val parallelKey by settingsViewModel.parallelApiKey.collectAsState()
-    val firecrawlKey by settingsViewModel.firecrawlApiKey.collectAsState()
-    val exaEffort by settingsViewModel.deepResearchExaEffort.collectAsState()
-    val dataAgentEnabled by settingsViewModel.dataAgentEnabled.collectAsState()
-    val dataAgentEngineId by settingsViewModel.dataAgentEngine.collectAsState()
-
-    val echoAdviserActive by chatViewModel.echoAdviserActive.collectAsState()
-    val echoFusionActive by chatViewModel.echoFusionActive.collectAsState()
-    val advisorProfiles by settingsViewModel.advisorProfiles.collectAsState()
-    val fusionPanels by settingsViewModel.fusionPanels.collectAsState()
-    val echoAdviserProfileId by settingsViewModel.echoAdviserProfileId.collectAsState()
-    val echoFusionPanelId by settingsViewModel.echoFusionPanelId.collectAsState()
-    val activeAdvisor = advisorProfiles.firstOrNull { it.id == echoAdviserProfileId }
-    val activePanel = fusionPanels.firstOrNull { it.id == echoFusionPanelId }
-
-    val echoAgentActive by chatViewModel.echoAgentActive.collectAsState()
-    val agentProfiles by settingsViewModel.agentProfiles.collectAsState()
-    val echoAgentProfileId by settingsViewModel.echoAgentProfileId.collectAsState()
-    val activeAgent = agentProfiles.firstOrNull { it.id == echoAgentProfileId }
-
-    // Echo Labs master switches gate which experimental modes appear in the "+" menu.
-    val echoAdviserEnabled by settingsViewModel.echoAdviserEnabled.collectAsState()
-    val echoFusionEnabled by settingsViewModel.echoFusionEnabled.collectAsState()
-    val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
-
-    val artifactActive by chatViewModel.artifactActive.collectAsState()
-    val imageGenActive by chatViewModel.imageGenActive.collectAsState()
-    val imageGenModelId by settingsViewModel.imageGenModelId.collectAsState()
-    val imageModels by settingsViewModel.imageModels.collectAsState()
-    // "Create image" swaps the model picker to the OpenRouter image models.
-    val imageModelEntries = remember(imageModels) {
-        val default = com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
-        listOf(default) + imageModels.filter { it.id != default.first }.map { it.id to it.name }
-    }
-    val imageModelLabel = imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
-    // "Create video" swaps the model picker to OpenRouter video models. Cloud only — there is
-    // no on-device route — so the local section of the picker stays empty.
-    val videoGenActive by chatViewModel.videoGenActive.collectAsState()
-    val videoGenModelId by settingsViewModel.videoGenModelId.collectAsState()
-    val videoModels by settingsViewModel.videoModels.collectAsState()
-    val videoModelEntries = remember(videoModels) {
-        val default = com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID to
-            com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
-        listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
-    }
-    val videoModelLabel = videoModelEntries.firstOrNull { it.first == videoGenModelId }?.second ?: videoGenModelId
-
-    val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
-    val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
-    val browserSession by chatViewModel.currentBrowserSession.collectAsState()
-    val browserSteps by chatViewModel.currentBrowserSteps.collectAsState()
-    val browserStartConflict by chatViewModel.browserStartConflict.collectAsState()
-    // The owning chat is "captured" while a session is live — every message drives the browser.
-    val browserCaptured = browserSession != null
-    val browserBusy = browserSession?.let {
-        it.status == com.echoflow.data.BrowserSession.STATUS_RUNNING ||
-            it.status == com.echoflow.data.BrowserSession.STATUS_STARTING ||
-            it.status == com.echoflow.data.BrowserSession.STATUS_RESOLVING
-    } == true
-
-    var textInput by remember { mutableStateOf("") }
-    var showModelMenu by remember { mutableStateOf(false) }
-    val appMode by chatViewModel.appMode.collectAsState()
-    val renderingModes by chatViewModel.renderingModes.collectAsState()
-
-
-    val drEngineLabel = remember(drModelId, drModels) {
-        DeepResearchCatalog.providerEngineById(drModelId)?.name
-            ?: drModels.firstOrNull { it.id == drModelId }?.name
-            ?: if (drModelId.isBlank()) "Choose engine" else drModelId
-    }
-    val dataAgentLabel = remember(dataAgentEngineId) {
-        DataAgentCatalog.byId(dataAgentEngineId)?.name ?: "Choose agent"
-    }
-    val dataAgentAvailable = dataAgentEnabled && firecrawlKey.isNotBlank()
-
-    // Image attachments work for cloud models and for on-device .litertlm bundles (which
-    // support vision); .task models are text-only, so the Image option is hidden for them.
-    val imageAttachAllowed = remember(selectedModelID, localModelsList, customProviderConfig) {
-        when {
-            selectedModelID.startsWith("local/") ->
-                localModelsList.firstOrNull { it.id == selectedModelID }
-                    ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) -> customProviderConfig.ollamaImagesEnabled
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) -> customProviderConfig.openAiCompatibleImagesEnabled
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS) ->
-                CustomProviderCapabilities.cerebrasSupportsImages(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS))
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_XAI) ->
-                CustomProviderCapabilities.xAiSupportsImages(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_XAI))
-            else -> true
-        }
-    }
-    val imageAttachAvailable = imageAttachAllowed && !deepResearchActive && !dataAgentActive
-    val selectedModelIsOpenRouter = remember(selectedModelID) {
-        !selectedModelID.startsWith("local/") && !selectedModelID.startsWith("custom/")
-    }
-    val selectedModelIsDirectCloudPdfCapable = remember(selectedModelID) {
-        selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) ||
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CLAUDE) ||
-            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_GEMINI) ||
-            (
-                selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS) &&
-                    CustomProviderCapabilities.cerebrasSupportsPdfs(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS))
-                )
-    }
-    val selectedModelIsCustomPdfCapable = remember(selectedModelID, customProviderConfig) {
-        selectedModelIsDirectCloudPdfCapable ||
-            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) && customProviderConfig.ollamaPdfsEnabled) ||
-            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) && customProviderConfig.openAiCompatiblePdfsEnabled)
-    }
-    val deepResearchUsesOpenRouter = remember(deepResearchActive, drModelId) {
-        deepResearchActive && drModelId.isNotBlank() && !DeepResearchCatalog.isProviderEngine(drModelId)
-    }
-    val pdfAttachAllowed = remember(
-        selectedModelIsOpenRouter,
-        deepResearchActive,
-        deepResearchUsesOpenRouter,
-        dataAgentActive,
-        echoAdviserActive,
-        echoFusionActive,
-        echoAgentActive,
-        selectedModelIsCustomPdfCapable,
-    ) {
-        when {
-            dataAgentActive -> false
-            deepResearchActive -> deepResearchUsesOpenRouter
-            echoFusionActive -> true
-            echoAdviserActive -> selectedModelIsOpenRouter
-            echoAgentActive -> selectedModelIsOpenRouter
-            else -> selectedModelIsOpenRouter || selectedModelIsCustomPdfCapable
-        }
-    }
-    LaunchedEffect(pendingUri, pendingMime, imageAttachAvailable, pdfAttachAllowed) {
-        if (pendingUri != null) {
-            val pendingIsPdf = pendingMime.equals("application/pdf", ignoreCase = true)
-            if ((pendingIsPdf && !pdfAttachAllowed) || (!pendingIsPdf && !imageAttachAvailable)) {
-                chatViewModel.clearPendingAttachment()
-            }
-        }
-    }
-
-    val activeModelList = remember(customModelsList, customProviderModels) {
-        val list = mutableListOf(DEFAULT_MODEL)
-        customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
-        customProviderModels.filter { !it.isLocalLike }.forEach { model ->
-            if (list.none { it.first == model.id }) list.add(model.id to "${model.group}: ${model.name}")
-        }
-        list
-    }
-    val openRouterOnlyModelList = remember(customModelsList) {
-        val list = mutableListOf(DEFAULT_MODEL)
-        customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
-        list
-    }
-    val localModelEntries = remember(localModelsList, localModelsEnabled, customProviderModels) {
-        val entries = mutableListOf<Pair<String, String>>()
-        if (localModelsEnabled) entries.addAll(localModelsList.map { it.id to it.name })
-        customProviderModels.filter { it.isLocalLike }.forEach { model ->
-            entries.add(model.id to "${model.group}: ${model.name}")
-        }
-        entries
-    }
-    val modelShortName = activeModelList.firstOrNull { it.first == selectedModelID }?.second
-        ?: customModelsList.firstOrNull { it.id == selectedModelID }?.name
-        ?: customProviderModels.firstOrNull { it.id == selectedModelID }?.let { "${it.group}: ${it.name}" }
-        ?: localModelsList.firstOrNull { it.id == selectedModelID }?.name
-        ?: selectedModelID
-
-    // The pill shows — and the picker changes — whichever selector the active capability
-    // actually uses. One derivation feeds both, so they can never disagree about what a tap
-    // is going to open.
-    val contextModelId = when {
-        videoGenActive -> videoGenModelId
-        imageGenActive -> imageGenModelId
-        echoFusionActive -> activePanel?.models?.firstOrNull().orEmpty()
-        dataAgentActive -> dataAgentEngineId
-        deepResearchActive -> drModelId
-        else -> selectedModelID
-    }
-    val contextModelLabel = when {
-        videoGenActive -> videoModelLabel
-        imageGenActive -> imageModelLabel
-        echoFusionActive -> activePanel?.name ?: "Choose panel"
-        echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
-        echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
-        dataAgentActive -> dataAgentLabel
-        deepResearchActive -> drEngineLabel
-        else -> modelShortName
-    }
-    val localSendBlocked = selectedModelID.startsWith("local/") && anyLocalStreamActive && !isStreaming
-
-    val imagePicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia(),
-        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri) },
-    )
-    val pdfPicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument(),
-        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri, "application/pdf") },
-    )
-
-    // Measure the floating input's height so the message list always pads exactly enough to clear
-    // it — including when the keyboard pushes the input up (its measured height grows with the inset).
-    val density = LocalDensity.current
-    var inputHeightPx by remember { mutableStateOf(0) }
-    val messageBottomInset = if (inputHeightPx > 0) with(density) { inputHeightPx.toDp() } else 96.dp
-    // Top inset so the chat scrolls behind the floating top bar without hiding the first message.
+    // Top inset so content scrolls behind the floating bar without hiding its first item.
     val topBarInset = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 64.dp
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
-        // Everything (top bar + input) floats; the chat fills behind it. Insets handled per-element.
+        // Everything floats; each surface fills behind it. Insets are handled per element.
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) { padding ->
         Box(Modifier.fillMaxSize().padding(padding)) {
-            if (messages.isEmpty() && !isStreaming && !progressLoading) {
-                EmptyState { textInput = it }
-            } else {
-                // key() gives each conversation a fresh MessagesPane (own scroll state), so switching
-                // opens at the bottom with no inherited-offset jump. bottomInset keeps the last
-                // message clear of the floating input.
-                key(currentThreadId) {
-                    MessagesPane(
-                        messages = messages,
-                        isStreaming = isStreaming,
-                        segments = activeSegments,
-                        statusNote = statusNote,
-                        progressLoading = progressLoading,
-                        modelLoading = localModelLoading,
-                        researchRun = researchRun,
-                        onCancelResearch = { chatViewModel.cancelResearch() },
-                        topInset = topBarInset,
-                        bottomInset = messageBottomInset,
-                        onCopy = { clipboard.setText(AnnotatedString(it)) },
-                        onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
-                        observeVideo = chatViewModel::observeVideo,
+            val spatial = MaterialTheme.motionScheme.defaultSpatialSpec<IntOffset>()
+            val effects = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
+            AnimatedContent(
+                targetState = mode,
+                transitionSpec = {
+                    // Fade-through with a slight lean in the direction of the switch: enough to
+                    // say which way you moved, far too little to read as a page transition.
+                    val forward = targetState == AppMode.Imagine
+                    val shift = { full: Int -> if (forward) full / 24 else -full / 24 }
+                    (slideInHorizontally(spatial, shift) + fadeIn(effects)) togetherWith
+                        (slideOutHorizontally(spatial) { -shift(it) } + fadeOut(effects))
+                },
+                label = "appMode",
+            ) { current ->
+                when (current) {
+                    AppMode.Chat -> ChatSurface(
+                        chatViewModel = chatViewModel,
+                        settingsViewModel = settingsViewModel,
+                        onSettingsClicked = onSettingsClicked,
+                        topBarInset = topBarInset,
+                    )
+                    AppMode.Imagine -> ImagineSurface(
+                        chatViewModel = chatViewModel,
+                        settingsViewModel = settingsViewModel,
+                        onSettingsClicked = onSettingsClicked,
+                        topBarInset = topBarInset,
                     )
                 }
             }
 
-            // Floating, transparent top bar (chat scrolls behind it).
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
-                mode = appMode,
+                mode = mode,
                 onSelectMode = chatViewModel::switchMode,
                 renderingModes = renderingModes,
                 onMenu = onMenuClicked,
                 onNewChat = { chatViewModel.startNewChat() },
             )
 
-            // Floating input toolbar over the bottom of the chat.
-            InputToolbar(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .onSizeChanged { inputHeightPx = it.height },
-                text = textInput,
-                onText = { textInput = it },
-                pendingUri = pendingUri?.toString(),
-                pendingMime = pendingMime,
-                pendingName = pendingName,
-                onClearAttachment = { chatViewModel.clearPendingAttachment() },
-                onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
-                onAttachPdf = { pdfPicker.launch(arrayOf("application/pdf")) },
-                onReceiveImage = { uri -> chatViewModel.setPendingPastedImage(uri) },
-                imageAttachEnabled = imageAttachAvailable,
-                pdfAttachEnabled = pdfAttachAllowed,
-                isStreaming = isStreaming,
-                deepResearchActive = deepResearchActive,
-                webSearchChipOn = webSearchChipOn,
-                dataAgentActive = dataAgentActive,
-                dataAgentAvailable = dataAgentAvailable,
-                echoAdviserActive = echoAdviserActive,
-                echoFusionActive = echoFusionActive,
-                echoAgentActive = echoAgentActive,
-                advisorChipLabel = activeAdvisor?.name,
-                fusionChipLabel = activePanel?.name,
-                agentChipLabel = activeAgent?.name,
-                onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
-                onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
-                onToggleDataAgent = { chatViewModel.toggleDataAgent() },
-                onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
-                onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
-                onToggleEchoAgent = { chatViewModel.toggleEchoAgent() },
-                echoAdviserAvailable = echoAdviserEnabled,
-                echoFusionAvailable = echoFusionEnabled,
-                echoAgentAvailable = echoAgentEnabled,
-                browserFlowActive = browserFlowActive,
-                browserFlowAvailable = browserFlowAvailable,
-                onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
-                artifactActive = artifactActive,
-                onToggleArtifact = { chatViewModel.toggleArtifact() },
-                imageGenActive = imageGenActive,
-                onToggleImageGen = { chatViewModel.toggleImageGen() },
-                videoGenActive = videoGenActive,
-                onToggleVideoGen = { chatViewModel.toggleVideoGen() },
-                modelId = contextModelId,
-                modelLabel = contextModelLabel,
-                onOpenModelPicker = { showModelMenu = true },
-                browserSession = browserSession,
-                browserSteps = browserSteps,
-                onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },
-                onBrowserFinish = { browserSession?.let { chatViewModel.browserFinish(it.id) } },
-                onBrowserStop = { browserSession?.let { chatViewModel.browserStop(it.id) } },
-                onBrowserPick = { url -> browserSession?.let { chatViewModel.browserResolveCandidate(it.id, url) } },
-                onBrowserConfirmDomain = { browserSession?.let { chatViewModel.browserConfirmDomain(it.id) } },
-                onBrowserConfirmSend = { browserSession?.let { chatViewModel.browserConfirmSend(it.id) } },
-                onBrowserCancel = { browserSession?.let { chatViewModel.browserCancelPending(it.id) } },
-                researchInProgress = researchRun != null,
-                researchEngineLabel = drEngineLabel,
-                dataAgentLabel = dataAgentLabel,
-                showEffortPill = deepResearchActive && drModelId == "exa-agent",
-                exaEffort = exaEffort,
-                onSelectEffort = { settingsViewModel.saveDeepResearchExaEffort(it) },
-                blockedReason = when {
-                    browserBusy -> "Browser is working — please wait…"
-                    researchRun != null -> "A run is in progress — see the card above"
-                    localSendBlocked -> "On-device model is busy in another chat"
-                    else -> null
-                },
-                onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
-                onStop = { chatViewModel.stopStreaming() },
-            )
-
-            // Error banner floats just below the top bar.
+            // Errors belong to the app, not to a surface: a failure raised in one mode should
+            // still be readable if the user has already switched away from it.
             AnimatedVisibility(
                 visible = errorMessage != null,
                 modifier = Modifier.align(Alignment.TopCenter).padding(top = topBarInset),
@@ -473,130 +110,6 @@ fun ChatScreen(
             ) {
                 errorMessage?.let { ErrorBanner(it) { chatViewModel.clearError() } }
             }
-
-            // One live browser session app-wide: starting a second is blocked with a choice.
-            browserStartConflict?.let { conflict ->
-                AlertDialog(
-                    onDismissRequest = { chatViewModel.dismissBrowserConflict() },
-                    title = { Text("A browser session is already active") },
-                    text = {
-                        Text(
-                            "Browser Flow is running in \"${conflict.activeSession.goal.take(40)}\". " +
-                                "Finish it before starting another, or return to it.",
-                        )
-                    },
-                    confirmButton = {
-                        TextButton(onClick = { chatViewModel.browserReturnToActive() }) { Text("Return to browser") }
-                    },
-                    dismissButton = {
-                        Row {
-                            TextButton(
-                                onClick = {
-                                    textInput = ""
-                                    chatViewModel.browserFinishActiveThenStart()
-                                },
-                                enabled = conflict.pendingPrompt.isNotEmpty(),
-                            ) { Text("Finish & start new") }
-                            TextButton(onClick = { chatViewModel.dismissBrowserConflict() }) { Text("Cancel") }
-                        }
-                    },
-                )
-            }
-        }
-    }
-
-    if (showModelMenu) {
-        if (videoGenActive) {
-            ModelPickerSheet(
-                models = videoModelEntries,
-                localModels = emptyList(),
-                selectedId = videoGenModelId,
-                onSelect = { settingsViewModel.saveVideoGenModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (imageGenActive) {
-            ModelPickerSheet(
-                models = imageModelEntries,
-                localModels = emptyList(),
-                selectedId = imageGenModelId,
-                onSelect = { settingsViewModel.saveImageGenModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (echoFusionActive) {
-            FusionPickerSheet(
-                panels = fusionPanels,
-                selectedId = echoFusionPanelId,
-                onSelect = { settingsViewModel.saveEchoFusionPanel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (echoAdviserActive) {
-            AdvisorPickerSheet(
-                models = openRouterOnlyModelList,
-                selectedModelId = selectedModelID,
-                profiles = advisorProfiles,
-                selectedProfileId = echoAdviserProfileId,
-                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
-                onSelectProfile = { settingsViewModel.saveEchoAdviserProfile(it) },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (echoAgentActive) {
-            AgentPickerSheet(
-                models = openRouterOnlyModelList,
-                selectedModelId = selectedModelID,
-                profiles = agentProfiles,
-                selectedProfileId = echoAgentProfileId,
-                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
-                onSelectProfile = { settingsViewModel.saveEchoAgentProfile(it) },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (dataAgentActive) {
-            val dataEngines = remember(firecrawlKey) {
-                if (firecrawlKey.isNotBlank()) DataAgentCatalog.engines else emptyList()
-            }
-            DeepResearchModelSheet(
-                title = "Data Agent engine",
-                subtitle = "Firecrawl agents that extract data from the web",
-                providerEngines = dataEngines,
-                agentModels = emptyList(),
-                showAgentSection = false,
-                selectedId = dataAgentEngineId,
-                onSelect = { settingsViewModel.saveDataAgentEngine(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (deepResearchActive) {
-            val availableProviderEngines = remember(exaKey, parallelKey, firecrawlKey) {
-                DeepResearchCatalog.providerEngines.filter { eng ->
-                    when (eng.provider) {
-                        "exa" -> exaKey.isNotBlank()
-                        "parallel" -> parallelKey.isNotBlank()
-                        "firecrawl" -> firecrawlKey.isNotBlank()
-                        else -> false
-                    }
-                }
-            }
-            DeepResearchModelSheet(
-                providerEngines = availableProviderEngines,
-                agentModels = drModels,
-                selectedId = drModelId,
-                onSelect = { settingsViewModel.saveDeepResearchModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else {
-            ModelPickerSheet(
-                models = activeModelList,
-                localModels = localModelEntries,
-                selectedId = selectedModelID,
-                onSelect = { settingsViewModel.saveSelectedModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -204,6 +204,9 @@ fun ChatScreen(
 
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
+    val appMode by chatViewModel.appMode.collectAsState()
+    val renderingModes by chatViewModel.renderingModes.collectAsState()
+
 
     val drEngineLabel = remember(drModelId, drModels) {
         DeepResearchCatalog.providerEngineById(drModelId)?.name
@@ -306,6 +309,28 @@ fun ChatScreen(
         ?: customProviderModels.firstOrNull { it.id == selectedModelID }?.let { "${it.group}: ${it.name}" }
         ?: localModelsList.firstOrNull { it.id == selectedModelID }?.name
         ?: selectedModelID
+
+    // The pill shows — and the picker changes — whichever selector the active capability
+    // actually uses. One derivation feeds both, so they can never disagree about what a tap
+    // is going to open.
+    val contextModelId = when {
+        videoGenActive -> videoGenModelId
+        imageGenActive -> imageGenModelId
+        echoFusionActive -> activePanel?.models?.firstOrNull().orEmpty()
+        dataAgentActive -> dataAgentEngineId
+        deepResearchActive -> drModelId
+        else -> selectedModelID
+    }
+    val contextModelLabel = when {
+        videoGenActive -> videoModelLabel
+        imageGenActive -> imageModelLabel
+        echoFusionActive -> activePanel?.name ?: "Choose panel"
+        echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
+        echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
+        dataAgentActive -> dataAgentLabel
+        deepResearchActive -> drEngineLabel
+        else -> modelShortName
+    }
     val localSendBlocked = selectedModelID.startsWith("local/") && anyLocalStreamActive && !isStreaming
 
     val imagePicker = rememberLauncherForActivityResult(
@@ -359,19 +384,10 @@ fun ChatScreen(
             // Floating, transparent top bar (chat scrolls behind it).
             ChatTopBar(
                 modifier = Modifier.align(Alignment.TopCenter),
-                modelName = when {
-                    videoGenActive -> videoModelLabel
-                    imageGenActive -> imageModelLabel
-                    echoFusionActive -> activePanel?.name ?: "Choose panel"
-                    echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
-                    echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
-                    dataAgentActive -> dataAgentLabel
-                    deepResearchActive -> drEngineLabel
-                    else -> modelShortName
-                },
-                researchMode = deepResearchActive || dataAgentActive,
+                mode = appMode,
+                onSelectMode = chatViewModel::switchMode,
+                renderingModes = renderingModes,
                 onMenu = onMenuClicked,
-                onModel = { showModelMenu = true },
                 onNewChat = { chatViewModel.startNewChat() },
             )
 
@@ -420,6 +436,9 @@ fun ChatScreen(
                 onToggleImageGen = { chatViewModel.toggleImageGen() },
                 videoGenActive = videoGenActive,
                 onToggleVideoGen = { chatViewModel.toggleVideoGen() },
+                modelId = contextModelId,
+                modelLabel = contextModelLabel,
+                onOpenModelPicker = { showModelMenu = true },
                 browserSession = browserSession,
                 browserSteps = browserSteps,
                 onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -1,0 +1,578 @@
+
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.screens
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.content.MediaType
+import androidx.compose.foundation.content.ReceiveContentListener
+import androidx.compose.foundation.content.TransferableContent
+import androidx.compose.foundation.content.consume
+import androidx.compose.foundation.content.contentReceiver
+import androidx.compose.foundation.content.hasMediaType
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.AddPhotoAlternate
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.echoflow.data.AdvisorProfile
+import com.echoflow.data.AgentProfile
+import com.echoflow.data.ChatMessage
+import com.echoflow.data.CustomProviderCapabilities
+import com.echoflow.data.DataAgentCatalog
+import com.echoflow.data.DeepResearchCatalog
+import com.echoflow.data.DeepResearchModel
+import com.echoflow.data.DrEngine
+import com.echoflow.data.FusionPanel
+import com.echoflow.data.ResearchRun
+import com.echoflow.data.ToolEventJson
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.SettingsViewModel
+import com.echoflow.ui.StreamSegment
+import com.echoflow.ui.components.AdvisorCard
+import com.echoflow.ui.components.AgentDeployingCard
+import com.echoflow.ui.components.BrandMark
+import com.echoflow.ui.components.ArtifactCard
+import com.echoflow.ui.components.CapabilityChip
+import com.echoflow.ui.components.DataResultCard
+import com.echoflow.ui.components.FusionCard
+import com.echoflow.ui.components.EffortPill
+import com.echoflow.ui.components.MarkdownText
+import com.echoflow.ui.components.ReportCard
+import com.echoflow.ui.components.ResearchProgressCard
+import com.echoflow.ui.components.RichMarkdown
+import com.echoflow.ui.components.SearchActivityCard
+import com.echoflow.ui.components.SectionLabel
+import com.echoflow.ui.components.SubagentCard
+import com.echoflow.ui.theme.BrandShapes
+import com.echoflow.ui.theme.MorphPolygonShape
+import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberMorph
+import com.echoflow.ui.theme.rememberMorphProgress
+import kotlinx.coroutines.launch
+
+/** Single built-in model. Everything else the user adds in Settings. */
+private val DEFAULT_MODEL = "google/gemini-2.0-flash" to "Gemini 2.0 Flash"
+
+/**
+ * The Chat surface: turn-taking conversation and every capability that makes an answer
+ * better — search, research, artifacts, the browser, the Echo modes.
+ *
+ * Renders its own body and composer inside the router's Box. The top bar is not here: it is
+ * chrome shared with Imagine and must not fade when the surfaces cross-fade.
+ */
+@Composable
+internal fun ChatSurface(
+    chatViewModel: ChatViewModel,
+    settingsViewModel: SettingsViewModel,
+    onSettingsClicked: () -> Unit,
+    topBarInset: Dp,
+) {
+    val clipboard = LocalClipboardManager.current
+
+    val messages by chatViewModel.currentMessages.collectAsState()
+    val isStreaming by chatViewModel.isStreaming.collectAsState()
+    val activeSegments by chatViewModel.activeSegments.collectAsState()
+    val statusNote by chatViewModel.statusNote.collectAsState()
+    val progressLoading by chatViewModel.apiProgressLoading.collectAsState()
+    val localModelLoading by chatViewModel.localModelLoading.collectAsState()
+    val anyLocalStreamActive by chatViewModel.anyLocalStreamActive.collectAsState()
+
+    val pendingUri by chatViewModel.pendingAttachmentUri.collectAsState()
+    val pendingMime by chatViewModel.pendingAttachmentMimeType.collectAsState()
+    val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
+    val selectedModelID by settingsViewModel.selectedModel.collectAsState()
+    val customProviderConfig by settingsViewModel.customProviderConfig.collectAsState()
+    val customModelsList by settingsViewModel.customModels.collectAsState()
+    val customProviderModels by settingsViewModel.customProviderModels.collectAsState()
+    val localModelsList by settingsViewModel.localModels.collectAsState()
+    val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
+    val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
+
+    val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
+    val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
+    val dataAgentActive by chatViewModel.dataAgentActive.collectAsState()
+    val researchRun by chatViewModel.currentResearchRun.collectAsState()
+    val drModelId by settingsViewModel.deepResearchModelId.collectAsState()
+    val drModels by settingsViewModel.deepResearchModels.collectAsState()
+    val exaKey by settingsViewModel.exaApiKey.collectAsState()
+    val parallelKey by settingsViewModel.parallelApiKey.collectAsState()
+    val firecrawlKey by settingsViewModel.firecrawlApiKey.collectAsState()
+    val exaEffort by settingsViewModel.deepResearchExaEffort.collectAsState()
+    val dataAgentEnabled by settingsViewModel.dataAgentEnabled.collectAsState()
+    val dataAgentEngineId by settingsViewModel.dataAgentEngine.collectAsState()
+
+    val echoAdviserActive by chatViewModel.echoAdviserActive.collectAsState()
+    val echoFusionActive by chatViewModel.echoFusionActive.collectAsState()
+    val advisorProfiles by settingsViewModel.advisorProfiles.collectAsState()
+    val fusionPanels by settingsViewModel.fusionPanels.collectAsState()
+    val echoAdviserProfileId by settingsViewModel.echoAdviserProfileId.collectAsState()
+    val echoFusionPanelId by settingsViewModel.echoFusionPanelId.collectAsState()
+    val activeAdvisor = advisorProfiles.firstOrNull { it.id == echoAdviserProfileId }
+    val activePanel = fusionPanels.firstOrNull { it.id == echoFusionPanelId }
+
+    val echoAgentActive by chatViewModel.echoAgentActive.collectAsState()
+    val agentProfiles by settingsViewModel.agentProfiles.collectAsState()
+    val echoAgentProfileId by settingsViewModel.echoAgentProfileId.collectAsState()
+    val activeAgent = agentProfiles.firstOrNull { it.id == echoAgentProfileId }
+
+    // Echo Labs master switches gate which experimental modes appear in the "+" menu.
+    val echoAdviserEnabled by settingsViewModel.echoAdviserEnabled.collectAsState()
+    val echoFusionEnabled by settingsViewModel.echoFusionEnabled.collectAsState()
+    val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
+
+    val artifactActive by chatViewModel.artifactActive.collectAsState()
+    val imageGenActive by chatViewModel.imageGenActive.collectAsState()
+    val imageGenModelId by settingsViewModel.imageGenModelId.collectAsState()
+    val imageModels by settingsViewModel.imageModels.collectAsState()
+    // "Create image" swaps the model picker to the OpenRouter image models.
+    val imageModelEntries = remember(imageModels) {
+        val default = com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
+        listOf(default) + imageModels.filter { it.id != default.first }.map { it.id to it.name }
+    }
+    val imageModelLabel = imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
+    // "Create video" swaps the model picker to OpenRouter video models. Cloud only — there is
+    // no on-device route — so the local section of the picker stays empty.
+    val videoGenActive by chatViewModel.videoGenActive.collectAsState()
+    val videoGenModelId by settingsViewModel.videoGenModelId.collectAsState()
+    val videoModels by settingsViewModel.videoModels.collectAsState()
+    val videoModelEntries = remember(videoModels) {
+        val default = com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID to
+            com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
+        listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
+    }
+    val videoModelLabel = videoModelEntries.firstOrNull { it.first == videoGenModelId }?.second ?: videoGenModelId
+
+    val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
+    val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
+    val browserSession by chatViewModel.currentBrowserSession.collectAsState()
+    val browserSteps by chatViewModel.currentBrowserSteps.collectAsState()
+    val browserStartConflict by chatViewModel.browserStartConflict.collectAsState()
+    // The owning chat is "captured" while a session is live — every message drives the browser.
+    val browserCaptured = browserSession != null
+    val browserBusy = browserSession?.let {
+        it.status == com.echoflow.data.BrowserSession.STATUS_RUNNING ||
+            it.status == com.echoflow.data.BrowserSession.STATUS_STARTING ||
+            it.status == com.echoflow.data.BrowserSession.STATUS_RESOLVING
+    } == true
+
+    var textInput by remember { mutableStateOf("") }
+    var showModelMenu by remember { mutableStateOf(false) }
+
+    val drEngineLabel = remember(drModelId, drModels) {
+        DeepResearchCatalog.providerEngineById(drModelId)?.name
+            ?: drModels.firstOrNull { it.id == drModelId }?.name
+            ?: if (drModelId.isBlank()) "Choose engine" else drModelId
+    }
+    val dataAgentLabel = remember(dataAgentEngineId) {
+        DataAgentCatalog.byId(dataAgentEngineId)?.name ?: "Choose agent"
+    }
+    val dataAgentAvailable = dataAgentEnabled && firecrawlKey.isNotBlank()
+
+    // Image attachments work for cloud models and for on-device .litertlm bundles (which
+    // support vision); .task models are text-only, so the Image option is hidden for them.
+    val imageAttachAllowed = remember(selectedModelID, localModelsList, customProviderConfig) {
+        when {
+            selectedModelID.startsWith("local/") ->
+                localModelsList.firstOrNull { it.id == selectedModelID }
+                    ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) -> customProviderConfig.ollamaImagesEnabled
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) -> customProviderConfig.openAiCompatibleImagesEnabled
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS) ->
+                CustomProviderCapabilities.cerebrasSupportsImages(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS))
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_XAI) ->
+                CustomProviderCapabilities.xAiSupportsImages(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_XAI))
+            else -> true
+        }
+    }
+    val imageAttachAvailable = imageAttachAllowed && !deepResearchActive && !dataAgentActive
+    val selectedModelIsOpenRouter = remember(selectedModelID) {
+        !selectedModelID.startsWith("local/") && !selectedModelID.startsWith("custom/")
+    }
+    val selectedModelIsDirectCloudPdfCapable = remember(selectedModelID) {
+        selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) ||
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CLAUDE) ||
+            selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_GEMINI) ||
+            (
+                selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS) &&
+                    CustomProviderCapabilities.cerebrasSupportsPdfs(selectedModelID.removePrefix(com.echoflow.data.CustomProviderConfig.PREFIX_CEREBRAS))
+                )
+    }
+    val selectedModelIsCustomPdfCapable = remember(selectedModelID, customProviderConfig) {
+        selectedModelIsDirectCloudPdfCapable ||
+            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OLLAMA) && customProviderConfig.ollamaPdfsEnabled) ||
+            (selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI_COMPATIBLE) && customProviderConfig.openAiCompatiblePdfsEnabled)
+    }
+    val deepResearchUsesOpenRouter = remember(deepResearchActive, drModelId) {
+        deepResearchActive && drModelId.isNotBlank() && !DeepResearchCatalog.isProviderEngine(drModelId)
+    }
+    val pdfAttachAllowed = remember(
+        selectedModelIsOpenRouter,
+        deepResearchActive,
+        deepResearchUsesOpenRouter,
+        dataAgentActive,
+        echoAdviserActive,
+        echoFusionActive,
+        echoAgentActive,
+        selectedModelIsCustomPdfCapable,
+    ) {
+        when {
+            dataAgentActive -> false
+            deepResearchActive -> deepResearchUsesOpenRouter
+            echoFusionActive -> true
+            echoAdviserActive -> selectedModelIsOpenRouter
+            echoAgentActive -> selectedModelIsOpenRouter
+            else -> selectedModelIsOpenRouter || selectedModelIsCustomPdfCapable
+        }
+    }
+    LaunchedEffect(pendingUri, pendingMime, imageAttachAvailable, pdfAttachAllowed) {
+        if (pendingUri != null) {
+            val pendingIsPdf = pendingMime.equals("application/pdf", ignoreCase = true)
+            if ((pendingIsPdf && !pdfAttachAllowed) || (!pendingIsPdf && !imageAttachAvailable)) {
+                chatViewModel.clearPendingAttachment()
+            }
+        }
+    }
+
+    val activeModelList = remember(customModelsList, customProviderModels) {
+        val list = mutableListOf(DEFAULT_MODEL)
+        customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
+        customProviderModels.filter { !it.isLocalLike }.forEach { model ->
+            if (list.none { it.first == model.id }) list.add(model.id to "${model.group}: ${model.name}")
+        }
+        list
+    }
+    val openRouterOnlyModelList = remember(customModelsList) {
+        val list = mutableListOf(DEFAULT_MODEL)
+        customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
+        list
+    }
+    val localModelEntries = remember(localModelsList, localModelsEnabled, customProviderModels) {
+        val entries = mutableListOf<Pair<String, String>>()
+        if (localModelsEnabled) entries.addAll(localModelsList.map { it.id to it.name })
+        customProviderModels.filter { it.isLocalLike }.forEach { model ->
+            entries.add(model.id to "${model.group}: ${model.name}")
+        }
+        entries
+    }
+    val modelShortName = activeModelList.firstOrNull { it.first == selectedModelID }?.second
+        ?: customModelsList.firstOrNull { it.id == selectedModelID }?.name
+        ?: customProviderModels.firstOrNull { it.id == selectedModelID }?.let { "${it.group}: ${it.name}" }
+        ?: localModelsList.firstOrNull { it.id == selectedModelID }?.name
+        ?: selectedModelID
+
+    // The pill shows — and the picker changes — whichever selector the active capability
+    // actually uses. One derivation feeds both, so they can never disagree about what a tap
+    // is going to open.
+    val contextModelId = when {
+        videoGenActive -> videoGenModelId
+        imageGenActive -> imageGenModelId
+        echoFusionActive -> activePanel?.models?.firstOrNull().orEmpty()
+        dataAgentActive -> dataAgentEngineId
+        deepResearchActive -> drModelId
+        else -> selectedModelID
+    }
+    val contextModelLabel = when {
+        videoGenActive -> videoModelLabel
+        imageGenActive -> imageModelLabel
+        echoFusionActive -> activePanel?.name ?: "Choose panel"
+        echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
+        echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
+        dataAgentActive -> dataAgentLabel
+        deepResearchActive -> drEngineLabel
+        else -> modelShortName
+    }
+    val localSendBlocked = selectedModelID.startsWith("local/") && anyLocalStreamActive && !isStreaming
+
+    val imagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri) },
+    )
+    val pdfPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri, "application/pdf") },
+    )
+
+    // Measure the floating input's height so the message list always pads exactly enough to clear
+    // it — including when the keyboard pushes the input up (its measured height grows with the inset).
+    val density = LocalDensity.current
+    var inputHeightPx by remember { mutableStateOf(0) }
+    val messageBottomInset = if (inputHeightPx > 0) with(density) { inputHeightPx.toDp() } else 96.dp
+    Box(Modifier.fillMaxSize()) {
+        if (messages.isEmpty() && !isStreaming && !progressLoading) {
+            EmptyState { textInput = it }
+        } else {
+            // key() gives each conversation a fresh MessagesPane (own scroll state), so switching
+            // opens at the bottom with no inherited-offset jump. bottomInset keeps the last
+            // message clear of the floating input.
+            key(currentThreadId) {
+                MessagesPane(
+                    messages = messages,
+                    isStreaming = isStreaming,
+                    segments = activeSegments,
+                    statusNote = statusNote,
+                    progressLoading = progressLoading,
+                    modelLoading = localModelLoading,
+                    researchRun = researchRun,
+                    onCancelResearch = { chatViewModel.cancelResearch() },
+                    topInset = topBarInset,
+                    bottomInset = messageBottomInset,
+                    onCopy = { clipboard.setText(AnnotatedString(it)) },
+                    onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
+                    observeVideo = chatViewModel::observeVideo,
+                )
+            }
+        }
+
+
+        // Floating input toolbar over the bottom of the chat.
+        InputToolbar(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged { inputHeightPx = it.height },
+            text = textInput,
+            onText = { textInput = it },
+            pendingUri = pendingUri?.toString(),
+            pendingMime = pendingMime,
+            pendingName = pendingName,
+            onClearAttachment = { chatViewModel.clearPendingAttachment() },
+            onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
+            onAttachPdf = { pdfPicker.launch(arrayOf("application/pdf")) },
+            onReceiveImage = { uri -> chatViewModel.setPendingPastedImage(uri) },
+            imageAttachEnabled = imageAttachAvailable,
+            pdfAttachEnabled = pdfAttachAllowed,
+            isStreaming = isStreaming,
+            deepResearchActive = deepResearchActive,
+            webSearchChipOn = webSearchChipOn,
+            dataAgentActive = dataAgentActive,
+            dataAgentAvailable = dataAgentAvailable,
+            echoAdviserActive = echoAdviserActive,
+            echoFusionActive = echoFusionActive,
+            echoAgentActive = echoAgentActive,
+            advisorChipLabel = activeAdvisor?.name,
+            fusionChipLabel = activePanel?.name,
+            agentChipLabel = activeAgent?.name,
+            onToggleDeepResearch = { chatViewModel.toggleDeepResearch() },
+            onToggleWebSearch = { chatViewModel.toggleWebSearchChip() },
+            onToggleDataAgent = { chatViewModel.toggleDataAgent() },
+            onToggleEchoAdviser = { chatViewModel.toggleEchoAdviser() },
+            onToggleEchoFusion = { chatViewModel.toggleEchoFusion() },
+            onToggleEchoAgent = { chatViewModel.toggleEchoAgent() },
+            echoAdviserAvailable = echoAdviserEnabled,
+            echoFusionAvailable = echoFusionEnabled,
+            echoAgentAvailable = echoAgentEnabled,
+            browserFlowActive = browserFlowActive,
+            browserFlowAvailable = browserFlowAvailable,
+            onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
+            artifactActive = artifactActive,
+            onToggleArtifact = { chatViewModel.toggleArtifact() },
+            imageGenActive = imageGenActive,
+            onToggleImageGen = { chatViewModel.toggleImageGen() },
+            videoGenActive = videoGenActive,
+            onToggleVideoGen = { chatViewModel.toggleVideoGen() },
+            modelId = contextModelId,
+            modelLabel = contextModelLabel,
+            onOpenModelPicker = { showModelMenu = true },
+            browserSession = browserSession,
+            browserSteps = browserSteps,
+            onBrowserOpen = { browserSession?.let { chatViewModel.openBrowserWorkspace(it.chatId) } },
+            onBrowserFinish = { browserSession?.let { chatViewModel.browserFinish(it.id) } },
+            onBrowserStop = { browserSession?.let { chatViewModel.browserStop(it.id) } },
+            onBrowserPick = { url -> browserSession?.let { chatViewModel.browserResolveCandidate(it.id, url) } },
+            onBrowserConfirmDomain = { browserSession?.let { chatViewModel.browserConfirmDomain(it.id) } },
+            onBrowserConfirmSend = { browserSession?.let { chatViewModel.browserConfirmSend(it.id) } },
+            onBrowserCancel = { browserSession?.let { chatViewModel.browserCancelPending(it.id) } },
+            researchInProgress = researchRun != null,
+            researchEngineLabel = drEngineLabel,
+            dataAgentLabel = dataAgentLabel,
+            showEffortPill = deepResearchActive && drModelId == "exa-agent",
+            exaEffort = exaEffort,
+            onSelectEffort = { settingsViewModel.saveDeepResearchExaEffort(it) },
+            blockedReason = when {
+                browserBusy -> "Browser is working — please wait…"
+                researchRun != null -> "A run is in progress — see the card above"
+                localSendBlocked -> "On-device model is busy in another chat"
+                else -> null
+            },
+            onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
+            onStop = { chatViewModel.stopStreaming() },
+        )
+
+
+        // One live browser session app-wide: starting a second is blocked with a choice.
+        browserStartConflict?.let { conflict ->
+            AlertDialog(
+                onDismissRequest = { chatViewModel.dismissBrowserConflict() },
+                title = { Text("A browser session is already active") },
+                text = {
+                    Text(
+                        "Browser Flow is running in \"${conflict.activeSession.goal.take(40)}\". " +
+                            "Finish it before starting another, or return to it.",
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = { chatViewModel.browserReturnToActive() }) { Text("Return to browser") }
+                },
+                dismissButton = {
+                    Row {
+                        TextButton(
+                            onClick = {
+                                textInput = ""
+                                chatViewModel.browserFinishActiveThenStart()
+                            },
+                            enabled = conflict.pendingPrompt.isNotEmpty(),
+                        ) { Text("Finish & start new") }
+                        TextButton(onClick = { chatViewModel.dismissBrowserConflict() }) { Text("Cancel") }
+                    }
+                },
+            )
+    }
+}
+
+    if (showModelMenu) {
+        if (videoGenActive) {
+            ModelPickerSheet(
+                models = videoModelEntries,
+                localModels = emptyList(),
+                selectedId = videoGenModelId,
+                onSelect = { settingsViewModel.saveVideoGenModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (imageGenActive) {
+            ModelPickerSheet(
+                models = imageModelEntries,
+                localModels = emptyList(),
+                selectedId = imageGenModelId,
+                onSelect = { settingsViewModel.saveImageGenModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoFusionActive) {
+            FusionPickerSheet(
+                panels = fusionPanels,
+                selectedId = echoFusionPanelId,
+                onSelect = { settingsViewModel.saveEchoFusionPanel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoAdviserActive) {
+            AdvisorPickerSheet(
+                models = openRouterOnlyModelList,
+                selectedModelId = selectedModelID,
+                profiles = advisorProfiles,
+                selectedProfileId = echoAdviserProfileId,
+                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
+                onSelectProfile = { settingsViewModel.saveEchoAdviserProfile(it) },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (echoAgentActive) {
+            AgentPickerSheet(
+                models = openRouterOnlyModelList,
+                selectedModelId = selectedModelID,
+                profiles = agentProfiles,
+                selectedProfileId = echoAgentProfileId,
+                onSelectModel = { settingsViewModel.saveSelectedModel(it) },
+                onSelectProfile = { settingsViewModel.saveEchoAgentProfile(it) },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (dataAgentActive) {
+            val dataEngines = remember(firecrawlKey) {
+                if (firecrawlKey.isNotBlank()) DataAgentCatalog.engines else emptyList()
+            }
+            DeepResearchModelSheet(
+                title = "Data Agent engine",
+                subtitle = "Firecrawl agents that extract data from the web",
+                providerEngines = dataEngines,
+                agentModels = emptyList(),
+                showAgentSection = false,
+                selectedId = dataAgentEngineId,
+                onSelect = { settingsViewModel.saveDataAgentEngine(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else if (deepResearchActive) {
+            val availableProviderEngines = remember(exaKey, parallelKey, firecrawlKey) {
+                DeepResearchCatalog.providerEngines.filter { eng ->
+                    when (eng.provider) {
+                        "exa" -> exaKey.isNotBlank()
+                        "parallel" -> parallelKey.isNotBlank()
+                        "firecrawl" -> firecrawlKey.isNotBlank()
+                        else -> false
+                    }
+                }
+            }
+            DeepResearchModelSheet(
+                providerEngines = availableProviderEngines,
+                agentModels = drModels,
+                selectedId = drModelId,
+                onSelect = { settingsViewModel.saveDeepResearchModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        } else {
+            ModelPickerSheet(
+                models = activeModelList,
+                localModels = localModelEntries,
+                selectedId = selectedModelID,
+                onSelect = { settingsViewModel.saveSelectedModel(it); showModelMenu = false },
+                onManage = { showModelMenu = false; onSettingsClicked() },
+                onDismiss = { showModelMenu = false },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -174,26 +174,6 @@ internal fun ChatSurface(
     val echoAgentEnabled by settingsViewModel.echoAgentEnabled.collectAsState()
 
     val artifactActive by chatViewModel.artifactActive.collectAsState()
-    val imageGenActive by chatViewModel.imageGenActive.collectAsState()
-    val imageGenModelId by settingsViewModel.imageGenModelId.collectAsState()
-    val imageModels by settingsViewModel.imageModels.collectAsState()
-    // "Create image" swaps the model picker to the OpenRouter image models.
-    val imageModelEntries = remember(imageModels) {
-        val default = com.echoflow.data.SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
-        listOf(default) + imageModels.filter { it.id != default.first }.map { it.id to it.name }
-    }
-    val imageModelLabel = imageModelEntries.firstOrNull { it.first == imageGenModelId }?.second ?: imageGenModelId
-    // "Create video" swaps the model picker to OpenRouter video models. Cloud only — there is
-    // no on-device route — so the local section of the picker stays empty.
-    val videoGenActive by chatViewModel.videoGenActive.collectAsState()
-    val videoGenModelId by settingsViewModel.videoGenModelId.collectAsState()
-    val videoModels by settingsViewModel.videoModels.collectAsState()
-    val videoModelEntries = remember(videoModels) {
-        val default = com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID to
-            com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
-        listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
-    }
-    val videoModelLabel = videoModelEntries.firstOrNull { it.first == videoGenModelId }?.second ?: videoGenModelId
 
     val browserFlowActive by chatViewModel.browserFlowActive.collectAsState()
     val browserFlowAvailable by chatViewModel.browserFlowAvailable.collectAsState()
@@ -317,16 +297,12 @@ internal fun ChatSurface(
     // actually uses. One derivation feeds both, so they can never disagree about what a tap
     // is going to open.
     val contextModelId = when {
-        videoGenActive -> videoGenModelId
-        imageGenActive -> imageGenModelId
         echoFusionActive -> activePanel?.models?.firstOrNull().orEmpty()
         dataAgentActive -> dataAgentEngineId
         deepResearchActive -> drModelId
         else -> selectedModelID
     }
     val contextModelLabel = when {
-        videoGenActive -> videoModelLabel
-        imageGenActive -> imageModelLabel
         echoFusionActive -> activePanel?.name ?: "Choose panel"
         echoAdviserActive -> activeAdvisor?.let { "$modelShortName · ${it.name}" } ?: "Pick an advisor"
         echoAgentActive -> activeAgent?.let { "$modelShortName · ${it.name}" } ?: "Pick an Echo Agent"
@@ -418,10 +394,6 @@ internal fun ChatSurface(
             onToggleBrowserFlow = { chatViewModel.toggleBrowserFlow() },
             artifactActive = artifactActive,
             onToggleArtifact = { chatViewModel.toggleArtifact() },
-            imageGenActive = imageGenActive,
-            onToggleImageGen = { chatViewModel.toggleImageGen() },
-            videoGenActive = videoGenActive,
-            onToggleVideoGen = { chatViewModel.toggleVideoGen() },
             modelId = contextModelId,
             modelLabel = contextModelLabel,
             onOpenModelPicker = { showModelMenu = true },
@@ -482,25 +454,7 @@ internal fun ChatSurface(
 }
 
     if (showModelMenu) {
-        if (videoGenActive) {
-            ModelPickerSheet(
-                models = videoModelEntries,
-                localModels = emptyList(),
-                selectedId = videoGenModelId,
-                onSelect = { settingsViewModel.saveVideoGenModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (imageGenActive) {
-            ModelPickerSheet(
-                models = imageModelEntries,
-                localModels = emptyList(),
-                selectedId = imageGenModelId,
-                onSelect = { settingsViewModel.saveImageGenModel(it); showModelMenu = false },
-                onManage = { showModelMenu = false; onSettingsClicked() },
-                onDismiss = { showModelMenu = false },
-            )
-        } else if (echoFusionActive) {
+        if (echoFusionActive) {
             FusionPickerSheet(
                 panels = fusionPanels,
                 selectedId = echoFusionPanelId,

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
@@ -1,0 +1,351 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.ChatMessage
+import com.echoflow.data.GeneratedVideo
+import com.echoflow.data.ImagineMedia
+import com.echoflow.data.PersistedSegment
+import com.echoflow.data.ToolEventJson
+import com.echoflow.data.VideoRequestPolicy
+import com.echoflow.ui.StreamSegment
+import com.echoflow.ui.components.GeneratedImageSegment
+import com.echoflow.ui.components.GeneratedVideoSegment
+import com.echoflow.ui.components.ImagineMark
+import com.echoflow.ui.theme.Spacing
+import kotlinx.coroutines.flow.Flow
+
+/** Imagine's content column. Wider than a chat bubble — here the media is the subject. */
+internal val ImagineMediaWidth = 480.dp
+
+/**
+ * The contact sheet: every generation in this session, newest at the bottom.
+ *
+ * Structurally the same timeline as Chat, so the streaming and persistence spine is shared,
+ * but with the conversation furniture stripped out. There is no assistant header and no user
+ * bubble — the prompt becomes the caption under its own result, because in a creative tool the
+ * thing you made should never be the smaller half of the screen.
+ */
+@Composable
+internal fun ImagineCanvas(
+    messages: List<ChatMessage>,
+    isStreaming: Boolean,
+    segments: List<StreamSegment>,
+    progressLoading: Boolean,
+    topInset: Dp,
+    bottomInset: Dp,
+    observeVideo: (String) -> Flow<GeneratedVideo?>,
+    onAskAbout: (String) -> Unit,
+    onRetry: (String) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    var autoFollow by remember { mutableStateOf(true) }
+    val atBottom by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf true
+            last.index >= info.totalItemsCount - 1 && (last.offset + last.size) <= info.viewportEndOffset + 8
+        }
+    }
+    LaunchedEffect(atBottom, listState.isScrollInProgress) {
+        if (listState.isScrollInProgress) autoFollow = atBottom
+    }
+    LaunchedEffect(messages.size, progressLoading) {
+        if (autoFollow) {
+            val index = listState.layoutInfo.totalItemsCount - 1
+            if (index >= 0) runCatching { listState.scrollToItem(index, Int.MAX_VALUE) }
+        }
+    }
+    LaunchedEffect(autoFollow, isStreaming, progressLoading) {
+        if (autoFollow && (isStreaming || progressLoading)) {
+            while (true) {
+                withFrameNanos { it }
+                if (!listState.isScrollInProgress) {
+                    val index = listState.layoutInfo.totalItemsCount - 1
+                    if (index >= 0) runCatching { listState.scrollToItem(index, Int.MAX_VALUE) }
+                }
+            }
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        contentPadding = PaddingValues(
+            start = Spacing.base, end = Spacing.base,
+            top = topInset, bottom = bottomInset,
+        ),
+    ) {
+        items(messages, key = { it.id }) { message ->
+            ImagineResult(
+                message = message,
+                observeVideo = observeVideo,
+                onAskAbout = onAskAbout,
+                onRetry = onRetry,
+            )
+        }
+        if (segments.isNotEmpty()) {
+            item(key = "streaming") {
+                LiveImagineResult(segments)
+            }
+        }
+    }
+}
+
+/** One finished generation: media first, its prompt as the caption beneath. */
+@Composable
+private fun ImagineResult(
+    message: ChatMessage,
+    observeVideo: (String) -> Flow<GeneratedVideo?>,
+    onAskAbout: (String) -> Unit,
+    onRetry: (String) -> Unit,
+) {
+    if (message.role == "user") return // the prompt shows as its result's caption instead
+
+    val persisted = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
+    Column(
+        Modifier.fillMaxWidth().widthIn(max = ImagineMediaWidth),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        persisted.forEach { segment ->
+            when (segment.type) {
+                "image" -> segment.image?.let { ref ->
+                    GeneratedImageSegment(
+                        filePath = ref.filePath,
+                        pattern = "ripple",
+                        previousImagePath = null,
+                        animate = false,
+                        maxWidth = ImagineMediaWidth,
+                        actions = { AskAboutButton { onAskAbout(ref.filePath) } },
+                    )
+                }
+                "video" -> segment.video?.let { ref ->
+                    val live by remember(ref.videoId) { observeVideo(ref.videoId) }.collectAsState(initial = null)
+                    val filePath = live?.filePath ?: ref.filePath
+                    GeneratedVideoSegment(
+                        videoId = ref.videoId,
+                        filePath = filePath,
+                        pattern = "ripple",
+                        aspectRatio = live?.aspectRatio ?: VideoRequestPolicy.DEFAULT_ASPECT_RATIO,
+                        status = live?.status ?: if (filePath != null) {
+                            GeneratedVideo.STATUS_COMPLETED
+                        } else {
+                            GeneratedVideo.STATUS_IN_PROGRESS
+                        },
+                        animate = ref.filePath == null,
+                        errorMessage = live?.error,
+                        maxWidth = ImagineMediaWidth,
+                        actions = filePath?.let { path -> { AskAboutButton { onAskAbout(path) } } },
+                        onRetry = live?.prompt?.let { prompt -> { onRetry(prompt) } },
+                    )
+                }
+                else -> Unit
+            }
+        }
+        promptCaptionOf(persisted, message)?.let { caption ->
+            Spacer(Modifier.height(Spacing.s))
+            PromptCaption(caption)
+        }
+    }
+}
+
+/** The in-flight generation, rendered with the full choreography. */
+@Composable
+private fun LiveImagineResult(segments: List<StreamSegment>) {
+    Column(
+        Modifier.fillMaxWidth().widthIn(max = ImagineMediaWidth),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        segments.forEach { segment ->
+            when (segment) {
+                is StreamSegment.Image -> GeneratedImageSegment(
+                    filePath = segment.filePath,
+                    pattern = segment.pattern,
+                    previousImagePath = segment.previousImagePath,
+                    animate = true,
+                    maxWidth = ImagineMediaWidth,
+                )
+                is StreamSegment.Video -> GeneratedVideoSegment(
+                    videoId = segment.videoId,
+                    filePath = segment.filePath,
+                    pattern = segment.pattern,
+                    aspectRatio = segment.aspectRatio,
+                    status = segment.status,
+                    animate = true,
+                    errorMessage = segment.error,
+                    maxWidth = ImagineMediaWidth,
+                )
+                is StreamSegment.Text -> {
+                    if (segment.text.isNotBlank()) {
+                        Spacer(Modifier.height(Spacing.s))
+                        PromptCaption(segment.text)
+                    }
+                }
+                else -> Unit
+            }
+        }
+    }
+}
+
+/** Expands on tap: one line keeps the sheet scannable, the full text is a tap away. */
+@Composable
+private fun PromptCaption(text: String) {
+    var expanded by remember(text) { mutableStateOf(false) }
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = if (expanded) Int.MAX_VALUE else 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.xs)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { expanded = !expanded },
+    )
+}
+
+@Composable
+private fun AskAboutButton(onClick: () -> Unit) {
+    FilledTonalIconButton(
+        onClick = onClick,
+        modifier = Modifier.size(48.dp),
+        colors = IconButtonDefaults.filledTonalIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+    ) {
+        Icon(Icons.AutoMirrored.Filled.Chat, "Ask about this in Chat", Modifier.size(20.dp))
+    }
+}
+
+/**
+ * Imagine's opening screen. The dot field does decorative duty here — the same texture that
+ * marks a generation in progress, at rest, so the surface introduces its own language before
+ * anything has been made.
+ */
+@Composable
+internal fun ImagineEmptyState(
+    media: ImagineMedia,
+    topInset: Dp,
+    bottomInset: Dp,
+    onPrompt: (String) -> Unit,
+) {
+    val starters = remember(media) {
+        if (media == ImagineMedia.Video) {
+            listOf(
+                "A paper boat drifting down a rain-filled gutter",
+                "Slow dolly through a greenhouse at sunrise",
+                "Neon signs reflecting in a wet street",
+            )
+        } else {
+            listOf(
+                "A lighthouse in a storm, painted in gouache",
+                "An isometric cutaway of a tiny bookshop",
+                "Portrait of an astronaut made of stained glass",
+            )
+        }
+    }
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(top = topInset, bottom = bottomInset)
+            .padding(horizontal = Spacing.xl),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        ImagineMark(size = 72.dp)
+        Spacer(Modifier.height(Spacing.l))
+        Text(
+            "Describe it. Watch it appear.",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            // Answers the only question this split can raise, before it is asked.
+            "Your older image chats stayed in Chat.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(Spacing.xl))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.s, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            starters.forEach { prompt ->
+                Surface(
+                    onClick = { onPrompt(prompt) },
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ) {
+                    Text(
+                        prompt,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The caption for a result: the assistant's own sentence if it wrote one, otherwise nothing —
+ * the user's prompt is already the message directly above in the source data, and repeating it
+ * under every image would double the reading for no gain.
+ */
+private fun promptCaptionOf(persisted: List<PersistedSegment>, message: ChatMessage): String? =
+    persisted.firstOrNull { it.type == "text" }?.text?.takeIf { it.isNotBlank() }
+        ?: message.content.takeIf { it.isNotBlank() }
+

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
@@ -2,7 +2,11 @@
 
 package com.echoflow.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,7 +14,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -42,6 +49,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -55,7 +66,8 @@ import com.echoflow.data.VideoRequestPolicy
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.GeneratedImageSegment
 import com.echoflow.ui.components.GeneratedVideoSegment
-import com.echoflow.ui.components.ImagineMark
+import com.echoflow.ui.components.DotFieldCanvas
+import com.echoflow.ui.components.SectionLabel
 import com.echoflow.ui.theme.Spacing
 import kotlinx.coroutines.flow.Flow
 
@@ -267,76 +279,169 @@ private fun AskAboutButton(onClick: () -> Unit) {
 }
 
 /**
- * Imagine's opening screen. The dot field does decorative duty here — the same texture that
- * marks a generation in progress, at rest, so the surface introduces its own language before
- * anything has been made.
+ * One way in: a prompt worth stealing, the shape it wants, and a tone to wear. Tapping sets
+ * the ratio as well as the text — which is how the shape control introduces itself, since
+ * almost nobody opens that chip unprompted.
+ */
+private data class ImagineStarter(val prompt: String, val ratio: String, val tone: Int)
+
+/**
+ * Imagine's opening screen.
+ *
+ * The hero is a **live dot field** — the exact texture that marks a generation in progress,
+ * running at rest. It costs nothing (the canvas already exists) and it means the surface
+ * teaches its own language before anything is made: the second time the user sees those dots,
+ * they already read as "something is happening".
+ *
+ * Starters are shaped tiles rather than sentences in grey pills, each drawn at the ratio it
+ * would produce, so the first thing on screen is a row of pictures-to-be.
  */
 @Composable
 internal fun ImagineEmptyState(
     media: ImagineMedia,
     topInset: Dp,
     bottomInset: Dp,
-    onPrompt: (String) -> Unit,
+    onStarter: (String, String) -> Unit,
 ) {
+    val video = media == ImagineMedia.Video
+    // Alternates per entry, exactly as a real generation does: never quite the same room twice.
+    val pattern = remember(media) { listOf("ripple", "rain").random() }
     val starters = remember(media) {
-        if (media == ImagineMedia.Video) {
+        if (video) {
             listOf(
-                "A paper boat drifting down a rain-filled gutter",
-                "Slow dolly through a greenhouse at sunrise",
-                "Neon signs reflecting in a wet street",
+                ImagineStarter("A paper boat running a rain-filled gutter", "16:9", 0),
+                ImagineStarter("Neon bleeding into a wet street", "9:16", 1),
+                ImagineStarter("Slow dolly through a greenhouse at sunrise", "21:9", 2),
             )
         } else {
             listOf(
-                "A lighthouse in a storm, painted in gouache",
-                "An isometric cutaway of a tiny bookshop",
-                "Portrait of an astronaut made of stained glass",
+                ImagineStarter("A lighthouse mid-storm, painted in gouache", "16:9", 0),
+                ImagineStarter("An astronaut rendered in stained glass", "9:16", 1),
+                ImagineStarter("Isometric cutaway of a tiny bookshop", "1:1", 2),
             )
         }
     }
+
     Column(
         Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(top = topInset, bottom = bottomInset)
-            .padding(horizontal = Spacing.xl),
+            .padding(horizontal = Spacing.base),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        ImagineMark(size = 72.dp)
-        Spacer(Modifier.height(Spacing.l))
-        Text(
-            "Describe it. Watch it appear.",
-            style = MaterialTheme.typography.headlineSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(Spacing.s))
-        Text(
-            // Answers the only question this split can raise, before it is asked.
-            "Your older image chats stayed in Chat.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(Spacing.xl))
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(Spacing.s, Alignment.CenterHorizontally),
-            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        // Type sits *inside* the texture over a scrim — an editorial cover, not an icon with a
+        // caption underneath it.
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 10f)
+                .clip(RoundedCornerShape(32.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         ) {
-            starters.forEach { prompt ->
-                Surface(
-                    onClick = { onPrompt(prompt) },
-                    shape = MaterialTheme.shapes.large,
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                ) {
-                    Text(
-                        prompt,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+            DotFieldCanvas(
+                pattern = pattern,
+                revealFraction = { 0f },
+                modifier = Modifier.matchParentSize(),
+            )
+            Box(
+                Modifier.matchParentSize().background(
+                    Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        0.45f to MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.75f),
+                        1f to MaterialTheme.colorScheme.surfaceContainerHigh,
                     )
-                }
+                )
+            )
+            Column(
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = Spacing.l, end = Spacing.l, bottom = Spacing.l),
+            ) {
+                Text(
+                    "Make something.",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    if (video) "Describe a clip. The model decides how long it runs."
+                    else "Describe an image, then talk it into shape.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
+
+        Spacer(Modifier.height(Spacing.xl))
+        SectionLabel("Start from")
+        Spacer(Modifier.height(Spacing.m))
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.m),
+        ) {
+            starters.forEach { starter ->
+                StarterTile(starter) { onStarter(starter.prompt, starter.ratio) }
+            }
+        }
+    }
+}
+
+/** Every tile is this tall; width follows the ratio. A contact sheet, not a ragged stack. */
+private val StarterTileHeight = 132.dp
+
+/** A prompt shown as the shape it would produce, rather than a sentence in a grey pill. */
+@Composable
+private fun StarterTile(starter: ImagineStarter, onClick: () -> Unit) {
+    val container = when (starter.tone) {
+        0 -> MaterialTheme.colorScheme.primaryContainer
+        1 -> MaterialTheme.colorScheme.tertiaryContainer
+        else -> MaterialTheme.colorScheme.secondaryContainer
+    }
+    // Uniform height, width derived from the ratio — the way a strip of frames actually
+    // reads. Sizing by width instead would let a 9:16 tile tower over a 16:9 one and leave
+    // every caption sitting at a different height.
+    val ratio = VideoRequestPolicy.aspectRatioValue(starter.ratio)
+    val tileWidth = (StarterTileHeight.value * ratio).dp.coerceIn(96.dp, 228.dp)
+
+    Column(
+        Modifier
+            .width(tileWidth)
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick)
+            .padding(bottom = Spacing.xs),
+    ) {
+        Box(
+            Modifier
+                .width(tileWidth)
+                .height(StarterTileHeight)
+                .clip(RoundedCornerShape(16.dp))
+                .background(
+                    Brush.linearGradient(
+                        listOf(container, MaterialTheme.colorScheme.surfaceContainerHighest),
+                    )
+                ),
+            contentAlignment = Alignment.BottomEnd,
+        ) {
+            Text(
+                starter.ratio,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(Spacing.s),
+            )
+        }
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            starter.prompt,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            // Fixed at two lines so the row keeps a straight baseline whatever the prompts say.
+            minLines = 2,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
@@ -2,11 +2,13 @@
 
 package com.echoflow.ui.screens
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,10 +16,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -50,9 +50,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -66,9 +64,8 @@ import com.echoflow.data.VideoRequestPolicy
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.GeneratedImageSegment
 import com.echoflow.ui.components.GeneratedVideoSegment
-import com.echoflow.ui.components.DotFieldCanvas
-import com.echoflow.ui.components.SectionLabel
 import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberReducedMotion
 import kotlinx.coroutines.flow.Flow
 
 /** Imagine's content column. Wider than a chat bubble — here the media is the subject. */
@@ -278,172 +275,6 @@ private fun AskAboutButton(onClick: () -> Unit) {
     }
 }
 
-/**
- * One way in: a prompt worth stealing, the shape it wants, and a tone to wear. Tapping sets
- * the ratio as well as the text — which is how the shape control introduces itself, since
- * almost nobody opens that chip unprompted.
- */
-private data class ImagineStarter(val prompt: String, val ratio: String, val tone: Int)
-
-/**
- * Imagine's opening screen.
- *
- * The hero is a **live dot field** — the exact texture that marks a generation in progress,
- * running at rest. It costs nothing (the canvas already exists) and it means the surface
- * teaches its own language before anything is made: the second time the user sees those dots,
- * they already read as "something is happening".
- *
- * Starters are shaped tiles rather than sentences in grey pills, each drawn at the ratio it
- * would produce, so the first thing on screen is a row of pictures-to-be.
- */
-@Composable
-internal fun ImagineEmptyState(
-    media: ImagineMedia,
-    topInset: Dp,
-    bottomInset: Dp,
-    onStarter: (String, String) -> Unit,
-) {
-    val video = media == ImagineMedia.Video
-    // Alternates per entry, exactly as a real generation does: never quite the same room twice.
-    val pattern = remember(media) { listOf("ripple", "rain").random() }
-    val starters = remember(media) {
-        if (video) {
-            listOf(
-                ImagineStarter("A paper boat running a rain-filled gutter", "16:9", 0),
-                ImagineStarter("Neon bleeding into a wet street", "9:16", 1),
-                ImagineStarter("Slow dolly through a greenhouse at sunrise", "21:9", 2),
-            )
-        } else {
-            listOf(
-                ImagineStarter("A lighthouse mid-storm, painted in gouache", "16:9", 0),
-                ImagineStarter("An astronaut rendered in stained glass", "9:16", 1),
-                ImagineStarter("Isometric cutaway of a tiny bookshop", "1:1", 2),
-            )
-        }
-    }
-
-    Column(
-        Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(top = topInset, bottom = bottomInset)
-            .padding(horizontal = Spacing.base),
-        verticalArrangement = Arrangement.Center,
-    ) {
-        // Type sits *inside* the texture over a scrim — an editorial cover, not an icon with a
-        // caption underneath it.
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .aspectRatio(16f / 10f)
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-        ) {
-            DotFieldCanvas(
-                pattern = pattern,
-                revealFraction = { 0f },
-                modifier = Modifier.matchParentSize(),
-            )
-            Box(
-                Modifier.matchParentSize().background(
-                    Brush.verticalGradient(
-                        0f to Color.Transparent,
-                        0.45f to MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.75f),
-                        1f to MaterialTheme.colorScheme.surfaceContainerHigh,
-                    )
-                )
-            )
-            Column(
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(start = Spacing.l, end = Spacing.l, bottom = Spacing.l),
-            ) {
-                Text(
-                    "Make something.",
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Spacer(Modifier.height(2.dp))
-                Text(
-                    if (video) "Describe a clip. The model decides how long it runs."
-                    else "Describe an image, then talk it into shape.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        Spacer(Modifier.height(Spacing.xl))
-        SectionLabel("Start from")
-        Spacer(Modifier.height(Spacing.m))
-        Row(
-            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.m),
-        ) {
-            starters.forEach { starter ->
-                StarterTile(starter) { onStarter(starter.prompt, starter.ratio) }
-            }
-        }
-    }
-}
-
-/** Every tile is this tall; width follows the ratio. A contact sheet, not a ragged stack. */
-private val StarterTileHeight = 132.dp
-
-/** A prompt shown as the shape it would produce, rather than a sentence in a grey pill. */
-@Composable
-private fun StarterTile(starter: ImagineStarter, onClick: () -> Unit) {
-    val container = when (starter.tone) {
-        0 -> MaterialTheme.colorScheme.primaryContainer
-        1 -> MaterialTheme.colorScheme.tertiaryContainer
-        else -> MaterialTheme.colorScheme.secondaryContainer
-    }
-    // Uniform height, width derived from the ratio — the way a strip of frames actually
-    // reads. Sizing by width instead would let a 9:16 tile tower over a 16:9 one and leave
-    // every caption sitting at a different height.
-    val ratio = VideoRequestPolicy.aspectRatioValue(starter.ratio)
-    val tileWidth = (StarterTileHeight.value * ratio).dp.coerceIn(96.dp, 228.dp)
-
-    Column(
-        Modifier
-            .width(tileWidth)
-            .clip(RoundedCornerShape(20.dp))
-            .clickable(onClick = onClick)
-            .padding(bottom = Spacing.xs),
-    ) {
-        Box(
-            Modifier
-                .width(tileWidth)
-                .height(StarterTileHeight)
-                .clip(RoundedCornerShape(16.dp))
-                .background(
-                    Brush.linearGradient(
-                        listOf(container, MaterialTheme.colorScheme.surfaceContainerHighest),
-                    )
-                ),
-            contentAlignment = Alignment.BottomEnd,
-        ) {
-            Text(
-                starter.ratio,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(Spacing.s),
-            )
-        }
-        Spacer(Modifier.height(Spacing.s))
-        Text(
-            starter.prompt,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            // Fixed at two lines so the row keeps a straight baseline whatever the prompts say.
-            minLines = 2,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = Spacing.xs),
-        )
-    }
-}
 
 /**
  * The caption for a result: the assistant's own sentence if it wrote one, otherwise nothing —
@@ -453,4 +284,115 @@ private fun StarterTile(starter: ImagineStarter, onClick: () -> Unit) {
 private fun promptCaptionOf(persisted: List<PersistedSegment>, message: ChatMessage): String? =
     persisted.firstOrNull { it.type == "text" }?.text?.takeIf { it.isNotBlank() }
         ?: message.content.takeIf { it.isNotBlank() }
+
+/** The frame's long side; both dimensions derive from the live ratio inside this bound. */
+private val EmptyFrameBounds = 288.dp
+
+/**
+ * Imagine's opening screen: an empty frame.
+ *
+ * No mascot, no feature tour, no marketing copy — the one image every creative tool in
+ * history shares is the blank canvas, so the blank canvas is the whole screen. It earns its
+ * keep twice over:
+ *
+ *  - The frame is drawn at the ratio currently selected in the composer and re-proportions
+ *    on a spring when that changes, so the empty state is a live preview of the shape you
+ *    are about to make — and the shape control teaches itself.
+ *  - The dots inside are the generation texture at rest. The app's story then reads in
+ *    order: still dots, dancing dots, picture.
+ */
+@Composable
+internal fun ImagineEmptyState(
+    media: ImagineMedia,
+    aspectRatio: String,
+    topInset: Dp,
+    bottomInset: Dp,
+    onPrompt: (String) -> Unit,
+) {
+    val reducedMotion = rememberReducedMotion()
+    val aspect by animateFloatAsState(
+        targetValue = VideoRequestPolicy.aspectRatioValue(aspectRatio),
+        animationSpec = if (reducedMotion) tween(0) else spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "empty-frame-aspect",
+    )
+    // Fit the live ratio inside a square bound. Width and height are both continuous
+    // functions of the animated value, so the frame morphs through 1:1 without a jump.
+    val frameWidth = if (aspect >= 1f) EmptyFrameBounds else EmptyFrameBounds * aspect
+    val frameHeight = if (aspect >= 1f) EmptyFrameBounds / aspect else EmptyFrameBounds
+
+    val example = if (media == ImagineMedia.Video) {
+        "Slow dolly through a greenhouse at sunrise"
+    } else {
+        "A lighthouse mid-storm, painted in gouache"
+    }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(top = topInset, bottom = bottomInset)
+            .padding(horizontal = Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            Modifier
+                .width(frameWidth)
+                .height(frameHeight)
+                .clip(RoundedCornerShape(24.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            RestingDots(Modifier.matchParentSize())
+            // The frame IS the ratio — naming it links this shape to the chip that changes it.
+            Text(
+                aspectRatio,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.m),
+            )
+        }
+        Spacer(Modifier.height(Spacing.xl))
+        Text(
+            "It begins with a sentence.",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(Spacing.s))
+        Text(
+            "Try “$example”",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onPrompt(example) },
+        )
+    }
+}
+
+/**
+ * The generation texture at rest: a sparse, motionless grid of dots. Deliberately static —
+ * this screen's only movement is the frame answering the ratio control.
+ */
+@Composable
+private fun RestingDots(modifier: Modifier = Modifier) {
+    val color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.16f)
+    Canvas(modifier) {
+        val cell = 20.dp.toPx()
+        val radius = 1.6.dp.toPx()
+        val cols = (size.width / cell).toInt()
+        val rows = (size.height / cell).toInt()
+        val originX = (size.width - cols * cell) / 2f + cell / 2f
+        val originY = (size.height - rows * cell) / 2f + cell / 2f
+        for (row in 0 until rows) {
+            for (col in 0 until cols) {
+                drawCircle(color, radius, Offset(originX + col * cell, originY + row * cell))
+            }
+        }
+    }
+}
 

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineCanvas.kt
@@ -285,114 +285,58 @@ private fun promptCaptionOf(persisted: List<PersistedSegment>, message: ChatMess
     persisted.firstOrNull { it.type == "text" }?.text?.takeIf { it.isNotBlank() }
         ?: message.content.takeIf { it.isNotBlank() }
 
-/** The frame's long side; both dimensions derive from the live ratio inside this bound. */
-private val EmptyFrameBounds = 288.dp
-
 /**
- * Imagine's opening screen: an empty frame.
+ * Imagine's opening screen: a canvas that is already alive.
  *
- * No mascot, no feature tour, no marketing copy — the one image every creative tool in
- * history shares is the blank canvas, so the blank canvas is the whole screen. It earns its
- * keep twice over:
- *
- *  - The frame is drawn at the ratio currently selected in the composer and re-proportions
- *    on a spring when that changes, so the empty state is a live preview of the shape you
- *    are about to make — and the shape control teaches itself.
- *  - The dots inside are the generation texture at rest. The app's story then reads in
- *    order: still dots, dancing dots, picture.
+ * The field fills the surface edge to edge and answers a finger, so the very first gesture a
+ * user makes here gets a reply. Type sits inside it rather than on top of it — one line, and
+ * an example that fills the composer when tapped. Nothing else: the screen's job is to make
+ * the next action obvious, and the next action is to type.
  */
 @Composable
 internal fun ImagineEmptyState(
     media: ImagineMedia,
-    aspectRatio: String,
     topInset: Dp,
     bottomInset: Dp,
     onPrompt: (String) -> Unit,
 ) {
-    val reducedMotion = rememberReducedMotion()
-    val aspect by animateFloatAsState(
-        targetValue = VideoRequestPolicy.aspectRatioValue(aspectRatio),
-        animationSpec = if (reducedMotion) tween(0) else spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMediumLow,
-        ),
-        label = "empty-frame-aspect",
-    )
-    // Fit the live ratio inside a square bound. Width and height are both continuous
-    // functions of the animated value, so the frame morphs through 1:1 without a jump.
-    val frameWidth = if (aspect >= 1f) EmptyFrameBounds else EmptyFrameBounds * aspect
-    val frameHeight = if (aspect >= 1f) EmptyFrameBounds / aspect else EmptyFrameBounds
-
-    val example = if (media == ImagineMedia.Video) {
+    val video = media == ImagineMedia.Video
+    val example = if (video) {
         "Slow dolly through a greenhouse at sunrise"
     } else {
         "A lighthouse mid-storm, painted in gouache"
     }
 
-    Column(
-        Modifier
-            .fillMaxSize()
-            .padding(top = topInset, bottom = bottomInset)
-            .padding(horizontal = Spacing.xl),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Box(
+    Box(Modifier.fillMaxSize()) {
+        ImagineField(Modifier.fillMaxSize())
+
+        Column(
             Modifier
-                .width(frameWidth)
-                .height(frameHeight)
-                .clip(RoundedCornerShape(24.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                .fillMaxSize()
+                .padding(top = topInset, bottom = bottomInset)
+                .padding(horizontal = Spacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            RestingDots(Modifier.matchParentSize())
-            // The frame IS the ratio — naming it links this shape to the chip that changes it.
             Text(
-                aspectRatio,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
-                modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.m),
+                if (video) "Picture it moving." else "Picture something.",
+                style = MaterialTheme.typography.displaySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(Spacing.m))
+            // Low-contrast and quiet: the field is the thing being looked at, and this is a
+            // way in for anyone who would rather start from something than from nothing.
+            Text(
+                "Try “$example”",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onPrompt(example) }
+                    .padding(horizontal = Spacing.m, vertical = Spacing.s),
             )
         }
-        Spacer(Modifier.height(Spacing.xl))
-        Text(
-            "It begins with a sentence.",
-            style = MaterialTheme.typography.headlineSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(Spacing.s))
-        Text(
-            "Try “$example”",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) { onPrompt(example) },
-        )
     }
 }
-
-/**
- * The generation texture at rest: a sparse, motionless grid of dots. Deliberately static —
- * this screen's only movement is the frame answering the ratio control.
- */
-@Composable
-private fun RestingDots(modifier: Modifier = Modifier) {
-    val color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.16f)
-    Canvas(modifier) {
-        val cell = 20.dp.toPx()
-        val radius = 1.6.dp.toPx()
-        val cols = (size.width / cell).toInt()
-        val rows = (size.height / cell).toInt()
-        val originX = (size.width - cols * cell) / 2f + cell / 2f
-        val originY = (size.height - rows * cell) / 2f + cell / 2f
-        for (row in 0 until rows) {
-            for (col in 0 until cols) {
-                drawCircle(color, radius, Offset(originX + col * cell, originY + row * cell))
-            }
-        }
-    }
-}
-

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineComposer.kt
@@ -83,7 +83,6 @@ internal fun ImagineComposer(
     ratioNote: String?,
     modelId: String,
     modelLabel: String,
-    costHint: String?,
     onOpenModelPicker: () -> Unit,
     audioSupported: Boolean,
     audioEnabled: Boolean,
@@ -168,12 +167,10 @@ internal fun ImagineComposer(
                     unsupportedNote = ratioNote,
                 )
             }
-            ModelPill(
-                modelId = modelId,
-                label = modelLabel,
-                supporting = costHint,
-                onClick = onOpenModelPicker,
-            )
+            // Name only. Cost, capabilities and resolutions belong in the picker, where you
+            // are actually comparing models — beside the prompt they are noise you have
+            // already decided about.
+            ModelPill(modelId = modelId, label = modelLabel, onClick = onOpenModelPicker)
             if (media == ImagineMedia.Video && audioSupported) {
                 SettingChip(
                     icon = Icons.Default.GraphicEq,

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineComposer.kt
@@ -1,0 +1,255 @@
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.content.MediaType
+import androidx.compose.foundation.content.ReceiveContentListener
+import androidx.compose.foundation.content.TransferableContent
+import androidx.compose.foundation.content.consume
+import androidx.compose.foundation.content.contentReceiver
+import androidx.compose.foundation.content.hasMediaType
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AspectRatio
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.echoflow.data.ImagineMedia
+import com.echoflow.ui.components.AspectRatioPopover
+import com.echoflow.ui.components.ContextChipRow
+import com.echoflow.ui.components.MediaToggle
+import com.echoflow.ui.components.ModelPill
+import com.echoflow.ui.components.SettingChip
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * Imagine's prompt bar.
+ *
+ * Same floating-pill material as Chat's composer, but the row above it carries creation
+ * controls instead of capability chips: what to make, how it is framed, which model, and
+ * whether it has sound. Framing is promoted here from Settings on purpose — in a creative
+ * tool the shape of the thing you are making is a per-prompt decision, not a preference.
+ */
+@Composable
+internal fun ImagineComposer(
+    text: String,
+    onText: (String) -> Unit,
+    media: ImagineMedia,
+    onSelectMedia: (ImagineMedia) -> Unit,
+    aspectRatio: String,
+    supportedRatios: List<String>?,
+    onSelectRatio: (String) -> Unit,
+    ratioNote: String?,
+    modelId: String,
+    modelLabel: String,
+    costHint: String?,
+    onOpenModelPicker: () -> Unit,
+    audioSupported: Boolean,
+    audioEnabled: Boolean,
+    onToggleAudio: () -> Unit,
+    pendingUri: String?,
+    pendingName: String?,
+    onClearAttachment: () -> Unit,
+    onAttach: () -> Unit,
+    onReceiveImage: (Uri) -> Unit,
+    isBusy: Boolean,
+    blockedReason: String?,
+    onSend: () -> Unit,
+    onStop: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var ratioMenuOpen by remember { mutableStateOf(false) }
+    val imageReceiver = remember(onReceiveImage) {
+        object : ReceiveContentListener {
+            override fun onReceive(transferableContent: TransferableContent): TransferableContent? {
+                if (!transferableContent.hasMediaType(MediaType.Image)) return transferableContent
+                return transferableContent.consume { item ->
+                    item.uri?.let { onReceiveImage(it); true } == true
+                }
+            }
+        }
+    }
+
+    Column(
+        modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
+            .padding(horizontal = Spacing.base, vertical = Spacing.m),
+    ) {
+        // The reference image: an edit source for images, a first frame for video.
+        AnimatedVisibility(visible = pendingUri != null) {
+            pendingUri?.let { uri ->
+                Surface(
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    modifier = Modifier.padding(bottom = Spacing.s),
+                ) {
+                    Row(Modifier.padding(Spacing.s), verticalAlignment = Alignment.CenterVertically) {
+                        AsyncImage(
+                            uri, null,
+                            Modifier.size(40.dp).clip(MaterialTheme.shapes.medium),
+                            contentScale = ContentScale.Crop,
+                        )
+                        Spacer(Modifier.width(Spacing.m))
+                        Text(
+                            pendingName ?: if (media == ImagineMedia.Video) "First frame" else "Reference",
+                            maxLines = 1, overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = onClearAttachment, modifier = Modifier.size(28.dp)) {
+                            Icon(
+                                Icons.Default.Close, "Remove", Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        ContextChipRow(Modifier.padding(start = Spacing.s, bottom = Spacing.s)) {
+            MediaToggle(selected = media, onSelect = onSelectMedia)
+            Box {
+                SettingChip(
+                    icon = Icons.Default.AspectRatio,
+                    label = aspectRatio,
+                    onClick = { ratioMenuOpen = true },
+                    description = "Shape: $aspectRatio. Tap to change.",
+                )
+                AspectRatioPopover(
+                    expanded = ratioMenuOpen,
+                    selected = aspectRatio,
+                    supported = supportedRatios,
+                    onSelect = onSelectRatio,
+                    onDismiss = { ratioMenuOpen = false },
+                    unsupportedNote = ratioNote,
+                )
+            }
+            ModelPill(
+                modelId = modelId,
+                label = modelLabel,
+                supporting = costHint,
+                onClick = onOpenModelPicker,
+            )
+            if (media == ImagineMedia.Video && audioSupported) {
+                SettingChip(
+                    icon = Icons.Default.GraphicEq,
+                    label = if (audioEnabled) "Audio on" else "Audio off",
+                    onClick = onToggleAudio,
+                    active = audioEnabled,
+                    description = if (audioEnabled) "Audio on. Tap to turn off." else "Audio off. Tap to turn on.",
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = blockedReason != null) {
+            Text(
+                blockedReason.orEmpty(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.base, bottom = Spacing.s),
+            )
+        }
+
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 3.dp,
+            shadowElevation = 8.dp,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.s), verticalAlignment = Alignment.CenterVertically) {
+                // Imagine's "+" is one thing, so it is a button rather than a menu.
+                ShapedIconButton(
+                    onClick = onAttach,
+                    enabled = true,
+                    size = 44.dp,
+                    restShape = MaterialShapes.Cookie6Sided,
+                    pressedShape = MaterialShapes.Flower,
+                    container = MaterialTheme.colorScheme.tertiaryContainer,
+                    pulseOnClick = true,
+                ) {
+                    Icon(
+                        if (media == ImagineMedia.Video) Icons.Default.Movie else Icons.Default.Image,
+                        if (media == ImagineMedia.Video) "Add a first frame" else "Add a reference image",
+                        Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+
+                TextField(
+                    value = text,
+                    onValueChange = onText,
+                    placeholder = {
+                        Text(
+                            if (media == ImagineMedia.Video) "Describe your video…"
+                            else "Describe what you want to see…"
+                        )
+                    },
+                    maxLines = 6,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
+                    ),
+                    textStyle = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier
+                        .weight(1f)
+                        .contentReceiver(imageReceiver)
+                        .testTag("imagine_input_field"),
+                )
+
+                val canSend = text.trim().isNotEmpty() && !isBusy && blockedReason == null
+                SendButton(enabled = canSend, isStreaming = isBusy, research = false, onStop = onStop) {
+                    if (canSend) onSend()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineField.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineField.kt
@@ -1,0 +1,172 @@
+package com.echoflow.ui.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import com.echoflow.ui.theme.rememberReducedMotion
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.hypot
+import kotlin.math.min
+import kotlin.math.sin
+
+private val CellSize = 22.dp
+
+/** How far a touch reaches. Wide enough to read as a field being disturbed, not a cursor. */
+private val TouchRadius = 84.dp
+
+/** Peak displacement directly under the finger. */
+private val TouchPush = 26.dp
+
+/** Dots dim toward the top and bottom so the field never fights the bar or the composer. */
+private val EdgeFade = 96.dp
+
+private const val RestAlpha = 0.13f
+private const val PeakAlpha = 0.72f
+
+/**
+ * The living field: Imagine's blank canvas.
+ *
+ * Every empty state is a still arrangement of things — a mark, a headline, a few pills — and a
+ * still arrangement is exactly what a creative surface should not be. This one is built from
+ * the app's own material, the generation dots, and it is **alive and touchable**: a slow
+ * current drifts through it constantly, and a finger pushes it apart, leaving a glowing wake
+ * that springs shut behind you.
+ *
+ * That states the whole pitch of the surface without a word of copy. A blank page that moves
+ * when you touch it is obviously somewhere you *do* something, not somewhere you read about
+ * doing something. And because it is the same texture that will dance while a real generation
+ * runs, the first thing anyone learns here is the app's own visual language.
+ *
+ * Position, size, brightness and colour are all continuous functions of one displacement
+ * value, so no channel can pop or drift out of step with another.
+ */
+@Composable
+internal fun ImagineField(modifier: Modifier = Modifier) {
+    val reducedMotion = rememberReducedMotion()
+    var timeMs by remember { mutableLongStateOf(0L) }
+    var touch by remember { mutableStateOf<Offset?>(null) }
+
+    // The wake opens under the finger and springs shut on release rather than snapping off,
+    // so lifting away feels like letting go of something.
+    val reach = remember { Animatable(0f) }
+
+    if (!reducedMotion) {
+        LaunchedEffect(Unit) {
+            while (true) {
+                withFrameNanos { nanos -> timeMs = nanos / 1_000_000 }
+            }
+        }
+    }
+    LaunchedEffect(touch != null) {
+        reach.animateTo(
+            targetValue = if (touch != null) 1f else 0f,
+            animationSpec = spring(
+                dampingRatio = if (touch != null) Spring.DampingRatioNoBouncy else Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessLow,
+            ),
+        )
+    }
+
+    val restColor = MaterialTheme.colorScheme.primary
+    val crestColor = lerp(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+        0.45f,
+    )
+
+    Canvas(
+        modifier.pointerInput(reducedMotion) {
+            if (reducedMotion) return@pointerInput
+            // Tracked by hand rather than via a drag detector: the field must answer the
+            // instant a finger lands, not once the touch has travelled far enough to count
+            // as a drag.
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                touch = down.position
+                while (true) {
+                    val change = awaitPointerEvent().changes.firstOrNull() ?: break
+                    if (!change.pressed) break
+                    touch = change.position
+                }
+                touch = null
+            }
+        }
+    ) {
+        // Read inside the draw block so the field redraws every frame without recomposing.
+        val t = timeMs / 1000f
+        val reachNow = reach.value
+        val touchNow = touch
+
+        val cell = CellSize.toPx()
+        val cols = (size.width / cell).toInt() + 1
+        val rows = (size.height / cell).toInt() + 1
+        val originX = (size.width - (cols - 1) * cell) / 2f
+        val originY = (size.height - (rows - 1) * cell) / 2f
+        val restRadius = 1.7.dp.toPx()
+        val radius = TouchRadius.toPx()
+        val push = TouchPush.toPx()
+        val fadeBand = EdgeFade.toPx()
+
+        for (row in 0 until rows) {
+            for (col in 0 until cols) {
+                val homeX = originX + col * cell
+                val homeY = originY + row * cell
+
+                // Two sine layers at different scales and speeds, each axis driven by the
+                // *other* axis's coordinate. Cheap, but that cross-coupling is what turns a
+                // pulsing grid into something reading as a current, with no repeat to spot.
+                var x = homeX
+                var y = homeY
+                if (!reducedMotion) {
+                    x += sin(homeY / 150f + t * 0.42f) * 5.5f + sin(homeY / 61f - t * 0.27f) * 2.2f
+                    y += cos(homeX / 168f + t * 0.33f) * 5.5f + cos(homeX / 74f - t * 0.23f) * 2.2f
+                }
+
+                if (touchNow != null && reachNow > 0.001f) {
+                    val dx = x - touchNow.x
+                    val dy = y - touchNow.y
+                    val distance = hypot(dx, dy).coerceAtLeast(0.001f)
+                    // Gaussian falloff: the disturbance has no edge to notice, it simply
+                    // stops mattering. A linear radius would draw a visible circle.
+                    val amount = exp(-(distance * distance) / (2f * radius * radius)) * push * reachNow
+                    x += dx / distance * amount
+                    y += dy / distance * amount
+                }
+
+                val displaced = hypot(x - homeX, y - homeY)
+                val energy = (displaced / push).coerceIn(0f, 1f)
+                // Smoothstep, so the wake has a soft shoulder rather than a hard bright ring.
+                val eased = energy * energy * (3f - 2f * energy)
+
+                val edge = (min(y, size.height - y) / fadeBand).coerceIn(0f, 1f)
+                val alpha = (RestAlpha + (PeakAlpha - RestAlpha) * eased) * edge
+                if (alpha <= 0.004f) continue
+
+                drawCircle(
+                    color = lerp(restColor, crestColor, eased),
+                    radius = restRadius * (1f + 1.25f * eased),
+                    center = Offset(x, y),
+                    alpha = alpha,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ImaginePickerSheet.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImaginePickerSheet.kt
@@ -1,0 +1,234 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.ImagineMedia
+import com.echoflow.data.OpenRouterVideoModelInfo
+import com.echoflow.ui.components.MediaToggle
+import com.echoflow.ui.components.ProviderIdentity
+import com.echoflow.ui.components.ProviderMark
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * Imagine's model picker: **cards**, not rows.
+ *
+ * In Chat a model is a specification and you compare numbers. In Imagine the model *is* the
+ * aesthetic — choosing Veo over Kling over Seedance is a creative decision, closer to picking
+ * film stock than picking a spec — so a list of ids is the wrong genre entirely.
+ *
+ * The media switch lives inside the sheet and mirrors the composer's, so "Video, then Kling"
+ * is one gesture rather than a mode change followed by a second trip.
+ */
+@Composable
+internal fun ImagineModelPickerSheet(
+    media: ImagineMedia,
+    onSelectMedia: (ImagineMedia) -> Unit,
+    models: List<Pair<String, String>>,
+    selectedId: String,
+    capabilitiesFor: (String) -> OpenRouterVideoModelInfo?,
+    resolution: String,
+    audioEnabled: Boolean,
+    onSelect: (String) -> Unit,
+    onManage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxHeight(0.9f),
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = Spacing.base).navigationBarsPadding()) {
+            Row(
+                Modifier.fillMaxWidth().padding(bottom = Spacing.base),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Choose a look",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        "The model sets the style as much as the prompt does",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                TextButton(onClick = onManage) {
+                    Icon(Icons.Default.Tune, null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(Spacing.s))
+                    Text("Manage")
+                }
+            }
+
+            MediaToggle(selected = media, onSelect = onSelectMedia)
+            Spacer(Modifier.height(Spacing.base))
+
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(minSize = 150.dp),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.m),
+                verticalArrangement = Arrangement.spacedBy(Spacing.m),
+                contentPadding = PaddingValues(bottom = Spacing.xl),
+            ) {
+                items(models, key = { it.first }) { (id, name) ->
+                    ImagineModelCard(
+                        modelId = id,
+                        name = name,
+                        selected = id == selectedId,
+                        capabilities = if (media == ImagineMedia.Video) capabilitiesFor(id) else null,
+                        resolution = resolution,
+                        audioEnabled = audioEnabled,
+                        onClick = { onSelect(id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImagineModelCard(
+    modelId: String,
+    name: String,
+    selected: Boolean,
+    capabilities: OpenRouterVideoModelInfo?,
+    resolution: String,
+    audioEnabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val identity = remember(modelId) { ProviderIdentity.of(modelId) }
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(20.dp),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column {
+            // A tonal band in the provider's own colour stands in for a sample frame: it makes
+            // the grid scannable by vendor at a glance, and it degrades honestly — an empty
+            // rectangle would promise a preview the app cannot yet show.
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(identity.container, MaterialTheme.colorScheme.surfaceContainerHighest),
+                        )
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                ProviderMark(modelId = modelId, size = 40.dp)
+                if (selected) {
+                    Icon(
+                        Icons.Default.CheckCircle, "Selected",
+                        Modifier.align(Alignment.TopEnd).padding(Spacing.s).size(20.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            Column(Modifier.padding(Spacing.m)) {
+                Text(
+                    name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                capabilities?.priceHint(resolution, audioEnabled)?.let { hint ->
+                    Text(
+                        hint,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                }
+                if (capabilities != null) {
+                    Spacer(Modifier.height(Spacing.xs))
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        capabilities.resolutions.take(3).forEach { CapabilityTag(it, selected) }
+                        if (capabilities.supportsAudio) CapabilityTag("Audio", selected, Icons.Default.GraphicEq)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CapabilityTag(
+    label: String,
+    selected: Boolean,
+    icon: androidx.compose.ui.graphics.vector.ImageVector? = null,
+) {
+    Surface(
+        shape = CircleShape,
+        color = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+        else MaterialTheme.colorScheme.surfaceContainerHighest,
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.s, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val tint = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+            else MaterialTheme.colorScheme.onSurfaceVariant
+            if (icon != null) {
+                Icon(icon, null, Modifier.size(11.dp), tint = tint)
+                Spacer(Modifier.width(2.dp))
+            }
+            Text(label, style = MaterialTheme.typography.labelSmall, color = tint)
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
@@ -1,0 +1,185 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.ImagineMedia
+import com.echoflow.data.SettingsRepository
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.SettingsViewModel
+
+/**
+ * The Imagine surface: describe something, watch it appear, refine it.
+ *
+ * Structurally a timeline like Chat — which keeps the entire streaming, segment and
+ * persistence spine intact — but presented as a contact sheet rather than a conversation. The
+ * media is the subject, the prompt is its caption, and the controls that shape it live in the
+ * composer instead of a settings page.
+ */
+@Composable
+internal fun ImagineSurface(
+    chatViewModel: ChatViewModel,
+    settingsViewModel: SettingsViewModel,
+    onSettingsClicked: () -> Unit,
+    topBarInset: Dp,
+) {
+    val messages by chatViewModel.currentMessages.collectAsState()
+    val isStreaming by chatViewModel.isStreaming.collectAsState()
+    val activeSegments by chatViewModel.activeSegments.collectAsState()
+    val progressLoading by chatViewModel.apiProgressLoading.collectAsState()
+    val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
+    val pendingUri by chatViewModel.pendingAttachmentUri.collectAsState()
+    val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
+
+    val media by settingsViewModel.imagineMedia.collectAsState()
+    val imageModels by settingsViewModel.imageModels.collectAsState()
+    val videoModels by settingsViewModel.videoModels.collectAsState()
+    val imageModelId by settingsViewModel.imageGenModelId.collectAsState()
+    val videoModelId by settingsViewModel.videoGenModelId.collectAsState()
+    val imageRatio by settingsViewModel.imageAspectRatio.collectAsState()
+    val videoRatio by settingsViewModel.videoAspectRatio.collectAsState()
+    val videoResolution by settingsViewModel.videoResolution.collectAsState()
+    val audioEnabled by settingsViewModel.videoAudioEnabled.collectAsState()
+    val videoCapabilities by settingsViewModel.selectedVideoModelCapabilities.collectAsState()
+
+    var textInput by remember { mutableStateOf("") }
+    var showModelPicker by remember { mutableStateOf(false) }
+
+    // Capabilities drive the ratio chip and the cost hint, so load them as the surface opens
+    // rather than waiting for the user to go looking for the picker.
+    LaunchedEffect(Unit) { settingsViewModel.loadVideoModelDirectory() }
+
+    val isVideo = media == ImagineMedia.Video
+    val modelEntries = remember(media, imageModels, videoModels) {
+        val default = if (isVideo) {
+            SettingsRepository.DEFAULT_VIDEO_MODEL_ID to SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
+        } else {
+            SettingsRepository.DEFAULT_IMAGE_MODEL_ID to "Gemini 2.5 Flash Image"
+        }
+        val added = if (isVideo) videoModels.map { it.id to it.name } else imageModels.map { it.id to it.name }
+        listOf(default) + added.filter { it.first != default.first }
+    }
+    val modelId = if (isVideo) videoModelId else imageModelId
+    val modelLabel = modelEntries.firstOrNull { it.first == modelId }?.second ?: modelId
+    val ratio = if (isVideo) videoRatio else imageRatio
+
+    // Video framing is a hard contract with the provider; image framing is an instruction in
+    // the prompt, so every ratio stays available there.
+    val supportedRatios = if (isVideo) videoCapabilities?.aspectRatios else null
+    val ratioNote = if (isVideo && !videoCapabilities?.aspectRatios.isNullOrEmpty()) {
+        "$modelLabel supports " + videoCapabilities!!.aspectRatios.joinToString(", ")
+    } else {
+        null
+    }
+    val costHint = if (isVideo) videoCapabilities?.priceHint(videoResolution, audioEnabled) else null
+
+    val imagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+        onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri) },
+    )
+
+    val density = LocalDensity.current
+    var composerHeightPx by remember { mutableStateOf(0) }
+    val bottomInset = if (composerHeightPx > 0) with(density) { composerHeightPx.toDp() } else 120.dp
+
+    Box(Modifier.fillMaxSize()) {
+        if (messages.isEmpty() && !isStreaming && !progressLoading) {
+            ImagineEmptyState(
+                media = media,
+                topInset = topBarInset,
+                bottomInset = bottomInset,
+                onPrompt = { textInput = it },
+            )
+        } else {
+            key(currentThreadId) {
+                ImagineCanvas(
+                    messages = messages,
+                    isStreaming = isStreaming,
+                    segments = activeSegments,
+                    progressLoading = progressLoading,
+                    topInset = topBarInset,
+                    bottomInset = bottomInset,
+                    observeVideo = chatViewModel::observeVideo,
+                    onAskAbout = chatViewModel::askAboutMediaInChat,
+                    onRetry = { textInput = it },
+                )
+            }
+        }
+
+        ImagineComposer(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged { composerHeightPx = it.height },
+            text = textInput,
+            onText = { textInput = it },
+            media = media,
+            onSelectMedia = settingsViewModel::saveImagineMedia,
+            aspectRatio = ratio,
+            supportedRatios = supportedRatios,
+            onSelectRatio = {
+                if (isVideo) settingsViewModel.saveVideoAspectRatio(it) else settingsViewModel.saveImageAspectRatio(it)
+            },
+            ratioNote = ratioNote,
+            modelId = modelId,
+            modelLabel = modelLabel,
+            costHint = costHint,
+            onOpenModelPicker = { showModelPicker = true },
+            audioSupported = videoCapabilities?.supportsAudio == true,
+            audioEnabled = audioEnabled,
+            onToggleAudio = { settingsViewModel.saveVideoAudioEnabled(!audioEnabled) },
+            pendingUri = pendingUri?.toString(),
+            pendingName = pendingName,
+            onClearAttachment = { chatViewModel.clearPendingAttachment() },
+            onAttach = {
+                imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            },
+            onReceiveImage = { uri -> chatViewModel.setPendingPastedImage(uri) },
+            isBusy = isStreaming || progressLoading,
+            blockedReason = null,
+            onSend = {
+                val prompt = textInput
+                textInput = ""
+                chatViewModel.sendImagineMessage(prompt, media)
+            },
+            onStop = { chatViewModel.stopStreaming() },
+        )
+    }
+
+    if (showModelPicker) {
+        ImagineModelPickerSheet(
+            media = media,
+            onSelectMedia = settingsViewModel::saveImagineMedia,
+            models = modelEntries,
+            selectedId = modelId,
+            capabilitiesFor = settingsViewModel::videoCapabilitiesFor,
+            resolution = videoResolution,
+            audioEnabled = audioEnabled,
+            onSelect = {
+                if (isVideo) settingsViewModel.saveVideoGenModel(it) else settingsViewModel.saveImageGenModel(it)
+                showModelPicker = false
+            },
+            onManage = { showModelPicker = false; onSettingsClicked() },
+            onDismiss = { showModelPicker = false },
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
@@ -65,8 +65,8 @@ internal fun ImagineSurface(
     var textInput by remember { mutableStateOf("") }
     var showModelPicker by remember { mutableStateOf(false) }
 
-    // Capabilities drive the ratio chip and the cost hint, so load them as the surface opens
-    // rather than waiting for the user to go looking for the picker.
+    // Capabilities drive the ratio chip and the picker's cards, so load them as the surface
+    // opens rather than waiting for the user to go looking for the picker.
     LaunchedEffect(Unit) { settingsViewModel.loadVideoModelDirectory() }
 
     val isVideo = media == ImagineMedia.Video
@@ -91,8 +91,6 @@ internal fun ImagineSurface(
     } else {
         null
     }
-    val costHint = if (isVideo) videoCapabilities?.priceHint(videoResolution, audioEnabled) else null
-
     val imagePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri) },
@@ -142,7 +140,6 @@ internal fun ImagineSurface(
             ratioNote = ratioNote,
             modelId = modelId,
             modelLabel = modelLabel,
-            costHint = costHint,
             onOpenModelPicker = { showModelPicker = true },
             audioSupported = videoCapabilities?.supportsAudio == true,
             audioEnabled = audioEnabled,

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
@@ -104,7 +104,6 @@ internal fun ImagineSurface(
         if (messages.isEmpty() && !isStreaming && !progressLoading) {
             ImagineEmptyState(
                 media = media,
-                aspectRatio = ratio,
                 topInset = topBarInset,
                 bottomInset = bottomInset,
                 onPrompt = { textInput = it },

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
@@ -106,7 +106,13 @@ internal fun ImagineSurface(
                 media = media,
                 topInset = topBarInset,
                 bottomInset = bottomInset,
-                onPrompt = { textInput = it },
+                onStarter = { prompt, ratio ->
+                    textInput = prompt
+                    // The starter carries its own shape, so picking one also demonstrates
+                    // that the ratio chip exists and does something.
+                    if (isVideo) settingsViewModel.saveVideoAspectRatio(ratio)
+                    else settingsViewModel.saveImageAspectRatio(ratio)
+                },
             )
         } else {
             key(currentThreadId) {

--- a/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt
@@ -104,15 +104,10 @@ internal fun ImagineSurface(
         if (messages.isEmpty() && !isStreaming && !progressLoading) {
             ImagineEmptyState(
                 media = media,
+                aspectRatio = ratio,
                 topInset = topBarInset,
                 bottomInset = bottomInset,
-                onStarter = { prompt, ratio ->
-                    textInput = prompt
-                    // The starter carries its own shape, so picking one also demonstrates
-                    // that the ratio chip exists and does something.
-                    if (isVideo) settingsViewModel.saveVideoAspectRatio(ratio)
-                    else settingsViewModel.saveImageAspectRatio(ratio)
-                },
+                onPrompt = { textInput = it },
             )
         } else {
             key(currentThreadId) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
@@ -47,19 +47,8 @@ import com.echoflow.ui.components.groupedItemShape
 import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
 
-/**
- * Image generation settings. Cloud only — OpenRouter image models, with the same directory
- * search the chat model picker uses.
- */
 @Composable
-internal fun ImageGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
-    SettingsPageScaffold(title = "Image generation", subtitle = "Create & edit images in chat", onBack = onBack) {
-        OpenRouterImageEngineSection(viewModel)
-    }
-}
-
-@Composable
-private fun OpenRouterImageEngineSection(viewModel: SettingsViewModel) {
+internal fun ImageGenSection(viewModel: SettingsViewModel) {
     val imageModels by viewModel.imageModels.collectAsState()
     val selectedId by viewModel.imageGenModelId.collectAsState()
     val orQuery by viewModel.orModelQuery.collectAsState()

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsImagine.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsImagine.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.echoflow.data.ImagineMedia
+import com.echoflow.ui.SettingsViewModel
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * One settings page for the Imagine surface, split the same way the surface itself is: a media
+ * selector on top, then everything that applies to what you are making.
+ *
+ * The selector is bound to the *same* preference the composer's media toggle writes, so the
+ * two never disagree about what you are currently making — and opening Settings from Imagine
+ * lands on the half you were already using.
+ */
+@Composable
+internal fun ImaginePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val media by viewModel.imagineMedia.collectAsState()
+
+    SettingsPageScaffold(title = "Imagine", subtitle = "Create images & video in chat", onBack = onBack) {
+        ConnectedToggleRow(
+            options = listOf(
+                ImagineMedia.Image.storageKey to "Image",
+                ImagineMedia.Video.storageKey to "Video",
+            ),
+            selected = media.storageKey,
+            onSelect = { viewModel.saveImagineMedia(ImagineMedia.fromStorage(it)) },
+            icons = listOf(Icons.Default.Image, Icons.Default.Movie),
+        )
+        Spacer(Modifier.height(Spacing.xl))
+
+        val effects = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
+        AnimatedContent(
+            targetState = media,
+            transitionSpec = { fadeIn(effects) togetherWith fadeOut(effects) },
+            label = "imagineSections",
+        ) { current ->
+            when (current) {
+                ImagineMedia.Image -> ImageGenSection(viewModel)
+                ImagineMedia.Video -> VideoGenSection(viewModel)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Check
@@ -147,8 +148,7 @@ internal const val PageCloudModels = "cloud_models"
 internal const val PageWebSearch = "web_search"
 internal const val PageLocalModels = "local_models"
 internal const val PageDeepResearch = "deep_research"
-internal const val PageImageGen = "image_gen"
-internal const val PageVideoGen = "video_gen"
+internal const val PageImagine = "imagine"
 internal const val PageDataAgent = "data_agent"
 internal const val PageBrowserFlow = "browser_flow"
 internal const val PageEchoLabs = "echo_labs"
@@ -215,8 +215,7 @@ fun SettingsScreen(
             PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
             PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
-            PageImageGen -> ImageGenPage(viewModel, onBack = { page = PageHome })
-            PageVideoGen -> VideoGenPage(viewModel, onBack = { page = PageHome })
+            PageImagine -> ImaginePage(viewModel, onBack = { page = PageHome })
             PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = { page = PageHome })
             PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageEchoLabs })
             PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageEchoLabs })
@@ -303,15 +302,13 @@ internal fun SettingsHomePage(
         else imageGenModelId
     val videoGenModelId by viewModel.videoGenModelId.collectAsState()
     val videoModelsHome by viewModel.videoModels.collectAsState()
-    val videoAspectRatioHome by viewModel.videoAspectRatio.collectAsState()
-    val videoResolutionHome by viewModel.videoResolution.collectAsState()
     val videoModelName = videoModelsHome.firstOrNull { it.id == videoGenModelId }?.name
         ?: if (videoGenModelId == com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_ID) {
             com.echoflow.data.SettingsRepository.DEFAULT_VIDEO_MODEL_NAME
         } else {
             videoGenModelId
         }
-    val videoGenSubtitle = "$videoModelName · $videoAspectRatioHome · $videoResolutionHome"
+    val imagineSubtitle = "$imageGenSubtitle · $videoModelName"
     val deepResearchSubtitle = when {
         deepResearchModelId.isBlank() -> "No engine selected"
         else -> DeepResearchCatalog.providerEngineById(deepResearchModelId)?.name
@@ -361,7 +358,7 @@ internal fun SettingsHomePage(
                 subtitle = "$themeLabel theme · $accentLabel accent",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 0, count = 8,
+                index = 0, count = 7,
                 onClick = { onOpen(PageAppearance) },
             )
             SettingsNavRow(
@@ -371,7 +368,7 @@ internal fun SettingsHomePage(
                 subtitle = cloudSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 1, count = 8,
+                index = 1, count = 7,
                 onClick = { onOpen(PageCloudModels) },
             )
             SettingsNavRow(
@@ -381,7 +378,7 @@ internal fun SettingsHomePage(
                 subtitle = localSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 2, count = 8,
+                index = 2, count = 7,
                 onClick = { onOpen(PageLocalModels) },
             )
             SettingsNavRow(
@@ -391,7 +388,7 @@ internal fun SettingsHomePage(
                 subtitle = searchSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 3, count = 8,
+                index = 3, count = 7,
                 onClick = { onOpen(PageWebSearch) },
             )
             SettingsNavRow(
@@ -401,28 +398,18 @@ internal fun SettingsHomePage(
                 subtitle = deepResearchSubtitle,
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 4, count = 8,
+                index = 4, count = 7,
                 onClick = { onOpen(PageDeepResearch) },
             )
             SettingsNavRow(
-                icon = Icons.Default.Brush,
+                icon = Icons.Default.AutoFixHigh,
                 polygon = MaterialShapes.Flower,
-                title = "Image generation",
-                subtitle = imageGenSubtitle,
+                title = "Imagine",
+                subtitle = imagineSubtitle,
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
-                index = 5, count = 8,
-                onClick = { onOpen(PageImageGen) },
-            )
-            SettingsNavRow(
-                icon = Icons.Default.Movie,
-                polygon = MaterialShapes.Cookie6Sided,
-                title = "Video generation",
-                subtitle = videoGenSubtitle,
-                container = MaterialTheme.colorScheme.secondaryContainer,
-                onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
-                index = 6, count = 8,
-                onClick = { onOpen(PageVideoGen) },
+                index = 5, count = 7,
+                onClick = { onOpen(PageImagine) },
             )
             SettingsNavRow(
                 icon = Icons.Default.AutoAwesome,
@@ -431,7 +418,7 @@ internal fun SettingsHomePage(
                 subtitle = echoLabsSubtitle,
                 container = MaterialTheme.colorScheme.tertiaryContainer,
                 onContainer = MaterialTheme.colorScheme.onTertiaryContainer,
-                index = 7, count = 8,
+                index = 6, count = 7,
                 onClick = { onOpen(PageEchoLabs) },
             )
         }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsVideoGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsVideoGen.kt
@@ -80,7 +80,7 @@ import com.echoflow.ui.theme.Spacing
  * as choices that silently fail.
  */
 @Composable
-internal fun VideoGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+internal fun VideoGenSection(viewModel: SettingsViewModel) {
     val videoModels by viewModel.videoModels.collectAsState()
     val selectedId by viewModel.videoGenModelId.collectAsState()
     val aspectRatio by viewModel.videoAspectRatio.collectAsState()
@@ -105,7 +105,7 @@ internal fun VideoGenPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
         listOf(default) + videoModels.filter { it.id != default.first }.map { it.id to it.name }
     }
 
-    SettingsPageScaffold(title = "Video generation", subtitle = "Create short clips in chat", onBack = onBack) {
+    Column {
         PageSection("How it works", null)
         Text(
             "Turn on “Create video” from the + menu in chat, then describe a clip. Generation " +

--- a/app/src/main/java/com/echoflow/ui/theme/Motion.kt
+++ b/app/src/main/java/com/echoflow/ui/theme/Motion.kt
@@ -1,0 +1,33 @@
+package com.echoflow.ui.theme
+
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * True when the user has turned animations off system-wide (Developer options → animator
+ * duration scale, or the accessibility "remove animations" toggle, which sets the same value).
+ *
+ * EchoFlow leans hard on motion — dot fields, scanline reveals, shape morphs — and all of it
+ * is decoration over information. Honouring this flag lets the signature degrade to stillness
+ * rather than being ignored: reveals become crossfades, springs become snaps, looping
+ * animations render at their resting frame.
+ *
+ * Read once per composition rather than observed: the platform restarts activities when the
+ * developer setting changes, and polling a global setting every frame would cost more than the
+ * animations it disables.
+ */
+@Composable
+fun rememberReducedMotion(): Boolean {
+    val context = LocalContext.current
+    return remember(context) {
+        runCatching {
+            Settings.Global.getFloat(
+                context.contentResolver,
+                Settings.Global.ANIMATOR_DURATION_SCALE,
+                1f,
+            ) == 0f
+        }.getOrDefault(false)
+    }
+}

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,7 +56,7 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version seventeen without data loss`() {
+    fun `production database upgrades version one through version eighteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
 
         // v13 tables exist and are queryable after the chained migration.
@@ -74,6 +74,15 @@ class DatabaseUpgradeTest {
         database.openHelper.readableDatabase.query(
             "SELECT jobId, pollingUrl, status, filePath FROM generated_videos LIMIT 0"
         ).use { /* v16 job columns are queryable */ }
+
+        // v18: the mode split grandfathers every existing conversation into Chat. This is the
+        // whole safety story of the two-sidebar design — nothing is reclassified by content.
+        database.openHelper.readableDatabase.query(
+            "SELECT kind FROM chat_threads WHERE id = 'thread-1'"
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("chat", cursor.getString(0))
+        }
 
         database.openHelper.readableDatabase.query(
             "SELECT content, reasoning, localAttachmentUri, localAttachmentName " +

--- a/app/src/test/java/com/echoflow/data/ThreadModeScopingTest.kt
+++ b/app/src/test/java/com/echoflow/data/ThreadModeScopingTest.kt
@@ -1,0 +1,98 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The two histories. Everything here protects the same promise: a conversation belongs to the
+ * mode that made it, forever, and nothing reclassifies by content.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ThreadModeScopingTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var database: AppDatabase
+    private lateinit var repository: ChatRepository
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        repository = ChatRepository(
+            chatDao = database.chatDao(),
+            messageDao = database.messageDao(),
+            localModelDao = database.localModelDao(),
+            researchRunDao = database.researchRunDao(),
+            deepResearchModelDao = database.deepResearchModelDao(),
+            advisorProfileDao = database.advisorProfileDao(),
+            fusionPanelDao = database.fusionPanelDao(),
+            agentProfileDao = database.agentProfileDao(),
+            browserSessionDao = database.browserSessionDao(),
+            browserStepDao = database.browserStepDao(),
+            artifactDao = database.artifactDao(),
+            artifactVersionDao = database.artifactVersionDao(),
+        )
+    }
+
+    @After
+    fun tearDown() = database.close()
+
+    @Test fun `a thread is stamped with the mode that created it`() = runBlocking {
+        assertEquals(AppMode.Chat, repository.createThread(AppMode.Chat).mode)
+        assertEquals(AppMode.Imagine, repository.createThread(AppMode.Imagine).mode)
+    }
+
+    @Test fun `each mode sees only its own conversations`() = runBlocking {
+        repository.createThread(AppMode.Chat, title = "a question")
+        repository.createThread(AppMode.Chat, title = "another question")
+        repository.createThread(AppMode.Imagine, title = "a lighthouse")
+
+        assertEquals(
+            listOf("another question", "a question"),
+            repository.threadsForMode(AppMode.Chat).first().map { it.title },
+        )
+        assertEquals(
+            listOf("a lighthouse"),
+            repository.threadsForMode(AppMode.Imagine).first().map { it.title },
+        )
+    }
+
+    @Test fun `a thread written before the split reads as Chat`() = runBlocking {
+        // The column default is the entire grandfather rule. An older row — inserted without
+        // a kind, exactly as every pre-v18 conversation was — must land in Chat, images and
+        // all, rather than being sorted by what it happens to contain.
+        database.openHelper.writableDatabase.execSQL(
+            "INSERT INTO chat_threads (id, title, createdAt, updatedAt) VALUES ('old', 'Old chat', 1, 1)"
+        )
+
+        val restored = repository.thread("old")!!
+        assertEquals(AppMode.Chat, restored.mode)
+        assertEquals(listOf("Old chat"), repository.threadsForMode(AppMode.Chat).first().map { it.title })
+        assertEquals(emptyList<String>(), repository.threadsForMode(AppMode.Imagine).first().map { it.title })
+    }
+
+    @Test fun `a scoped search can report what the other mode is holding`() = runBlocking {
+        repository.createThread(AppMode.Chat, title = "sunset over water")
+        repository.createThread(AppMode.Imagine, title = "sunset painting")
+        repository.createThread(AppMode.Imagine, title = "sunset timelapse")
+
+        // What the drawer's "also N in Imagine" line is counting: results that exist but are
+        // filtered out of the list the user is looking at.
+        assertEquals(2, repository.searchMatchCount(AppMode.Imagine, "sunset").first())
+        assertEquals(1, repository.searchMatchCount(AppMode.Chat, "sunset").first())
+        assertEquals(0, repository.searchMatchCount(AppMode.Imagine, "lighthouse").first())
+    }
+
+    @Test fun `default titles follow the mode`() = runBlocking {
+        assertEquals("New Conversation", repository.createThread(AppMode.Chat).title)
+        assertEquals("New Creation", repository.createThread(AppMode.Imagine).title)
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/components/ModeSwitchTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/ModeSwitchTest.kt
@@ -1,0 +1,98 @@
+package com.echoflow.ui.components
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import com.echoflow.data.AppMode
+import com.echoflow.data.ImagineMedia
+import com.echoflow.ui.theme.EchoFlowTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class ModeSwitchTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun bothSurfacesAreAlwaysReachableAndLabelled() {
+        // Imagine is a brand-new concept, so it must never hide behind an unfamiliar glyph:
+        // both segments carry a label at all times, whichever one is active.
+        var picked: AppMode? = null
+        composeRule.setContent {
+            EchoFlowTheme {
+                ModeSwitch(
+                    selected = AppMode.Chat,
+                    onSelect = { picked = it },
+                    renderingModes = emptySet(),
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Chat mode").assertHasClickAction()
+        composeRule.onNodeWithContentDescription("Imagine mode").assertHasClickAction().performClick()
+        assertEquals(AppMode.Imagine, picked)
+    }
+
+    @Test
+    fun tappingTheActiveSurfaceDoesNothing() {
+        // One control, one meaning: re-selecting where you already are must not fire, or every
+        // stray tap on the bar would re-park and restore the current conversation.
+        var picked: AppMode? = null
+        composeRule.setContent {
+            EchoFlowTheme {
+                ModeSwitch(
+                    selected = AppMode.Imagine,
+                    onSelect = { picked = it },
+                    renderingModes = emptySet(),
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Imagine mode").performClick()
+        assertNull(picked)
+    }
+
+    @Test
+    fun aRenderInTheOtherSurfaceIsAnnounced() {
+        // The split's one real risk is hiding work. A clip rendering in Imagine has to be
+        // visible — and legible to TalkBack — while the user is over in Chat.
+        composeRule.setContent {
+            EchoFlowTheme {
+                ModeSwitch(
+                    selected = AppMode.Chat,
+                    onSelect = {},
+                    renderingModes = setOf(AppMode.Imagine),
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Imagine mode, video rendering").assertHasClickAction()
+        composeRule.onNodeWithContentDescription("Chat mode").assertHasClickAction()
+    }
+
+    @Test
+    fun theMediaToggleSelectsWhatImagineIsMaking() {
+        var picked: ImagineMedia? = null
+        composeRule.setContent {
+            EchoFlowTheme {
+                MediaToggle(selected = ImagineMedia.Image, onSelect = { picked = it })
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Video mode").performClick()
+        assertEquals(ImagineMedia.Video, picked)
+
+        // Same rule as the mode switch: selecting the current option is a no-op.
+        picked = null
+        composeRule.onNodeWithContentDescription("Image mode").performClick()
+        assertNull(picked)
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/components/ThreadRecencyTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/ThreadRecencyTest.kt
@@ -1,0 +1,59 @@
+package com.echoflow.ui.components
+
+import com.echoflow.data.ChatThread
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Calendar
+
+/**
+ * Recency buckets are calendar-based, not span-based. "Yesterday" has to mean the previous
+ * calendar day — a conversation touched at 23:50 must not still read as "today" at 00:10 the
+ * next morning just because 24 hours have not elapsed.
+ */
+class ThreadRecencyTest {
+
+    private fun at(year: Int, month: Int, day: Int, hour: Int = 12, minute: Int = 0): Long =
+        Calendar.getInstance().apply {
+            clear()
+            set(year, month, day, hour, minute)
+        }.timeInMillis
+
+    private val now = at(2026, Calendar.JULY, 27, hour = 10)
+
+    @Test fun `earlier the same day is today, however early`() {
+        assertEquals(ThreadRecency.TODAY, ThreadRecency.bucketOf(at(2026, Calendar.JULY, 27, 0, 5), now))
+        assertEquals(ThreadRecency.TODAY, ThreadRecency.bucketOf(now, now))
+    }
+
+    @Test fun `last night is yesterday even though it is under 24 hours ago`() {
+        val lastNight = at(2026, Calendar.JULY, 26, hour = 23, minute = 50)
+        assertEquals(ThreadRecency.YESTERDAY, ThreadRecency.bucketOf(lastNight, now))
+    }
+
+    @Test fun `the rest of the week, then everything older`() {
+        assertEquals(ThreadRecency.THIS_WEEK, ThreadRecency.bucketOf(at(2026, Calendar.JULY, 23), now))
+        assertEquals(ThreadRecency.EARLIER, ThreadRecency.bucketOf(at(2026, Calendar.JULY, 1), now))
+        assertEquals(ThreadRecency.EARLIER, ThreadRecency.bucketOf(at(2025, Calendar.DECEMBER, 25), now))
+    }
+
+    @Test fun `sections come back newest-first and skip buckets with nothing in them`() {
+        val threads = listOf(
+            thread("old", at(2026, Calendar.JANUARY, 2)),
+            thread("today", at(2026, Calendar.JULY, 27, 9)),
+            thread("week", at(2026, Calendar.JULY, 24)),
+        )
+
+        val grouped = ThreadRecency.group(threads, now)
+
+        assertEquals(listOf(ThreadRecency.TODAY, ThreadRecency.THIS_WEEK, ThreadRecency.EARLIER), grouped.map { it.first })
+        assertEquals(listOf("today"), grouped[0].second.map { it.id })
+        assertEquals(listOf("week"), grouped[1].second.map { it.id })
+    }
+
+    @Test fun `an empty list produces no sections rather than four empty ones`() {
+        assertEquals(emptyList<Pair<String, List<ChatThread>>>(), ThreadRecency.group(emptyList(), now))
+    }
+
+    private fun thread(id: String, updatedAt: Long) =
+        ChatThread(id = id, title = id, createdAt = updatedAt, updatedAt = updatedAt)
+}

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,124 @@
+# Chat and Imagine
+
+EchoFlow has two top-level surfaces. They are not two feature sets — they are two *shapes* of
+interaction, which is why they get separate composers, result presentation and history rather
+than sharing one screen with a menu toggle.
+
+**Chat** is turn-taking. You ask, the model answers, the answer is prose you read and move
+past. Every chat capability — search, research, browser, artifacts, the Echo modes — is a
+variation on "make the answer better".
+
+**Imagine** is a creative loop. Prompt, render, judge, refine. The output is an artifact you
+keep, with settings that persist across turns and a result that wants to be big.
+
+Switching is lateral, never navigation: system back does not move between them.
+
+## History is grandfathered, never rewritten
+
+`ChatThread.kind` is stamped once at creation from the active mode and is immutable
+afterwards. The v18 migration defaults it to `'chat'`, and **that default is the whole safety
+story**: every conversation that predates the split becomes a Chat thread, including ones full
+of generated images.
+
+Nothing inspects a thread's content to classify it. A thread with forty messages and three
+images was a conversation, and reclassifying it would feel to its owner like losing it.
+
+The drawer filters by the active mode. Two details keep a filtered list from reading as a lost
+one:
+
+- The Imagine empty state says outright that older image chats stayed in Chat.
+- A scoped search reports how many results the *other* mode holds.
+
+Each mode also remembers its own open conversation, so a round trip returns you where you
+were rather than somewhere else.
+
+## Nothing hides work
+
+A clip renders for minutes and is routinely started in one mode and waited for from the other.
+`renderingChatIds` reads non-terminal rows straight from `generated_videos` — the only source
+that covers live turns, resumed jobs and process death alike — and drives a 6dp breathing dot
+on the mode switch and on drawer rows. One vocabulary for "still working", used nowhere else,
+so one glance always means one thing.
+
+Notification taps switch modes before selecting, since a thread selected while its own history
+is filtered out of view looks exactly like the app losing it.
+
+## The top bar
+
+```
+[☰]        ⟨ 💬 Chat │ ✦ Imagine ⟩        [+]
+```
+
+Place, **identity**, action. The centre slot belongs to the most permanent thing on screen, so
+the mode switch takes it and the model selector moved down to the composer's chip row — in a
+multi-provider app the model is something you change mid-thought, and the bottom edge is where
+your thumb already is.
+
+The switch is a **floating tray with a raised thumb**, wearing the composer's own material
+recipe (`surfaceContainerHigh`, 3dp tonal, 8dp shadow) so the two pills bookend the screen.
+That construction also produces the recessed look: the tray shadows *down* onto content while
+the thumb shadows *into* the tray, making the unselected side read as carved out. There is
+deliberately no true inner shadow — it would need custom drawing, vanish in dark themes where
+shadows barely register, and be foreign to Material's lighting model. Tonal contrast carries
+the depth when shadows cannot.
+
+The thumb travels on a spring and stretches at the midpoint of the journey, which is what makes
+selection feel like an object moving rather than a highlight jumping. Labels never move; only
+their colour crossfades underneath.
+
+### One rule for toggles
+
+Floating chrome toggles (the mode switch) wear the tray. In-page toggles (the media switch, the
+Settings selector) stay flat. Same distinction that separates the floating composer from an
+in-page text field: elevation belongs to chrome that hovers over scrolling content.
+
+## Imagine
+
+Image and video are **one surface with a media switch**, not two modes. They share a prompt, a
+framing, a result to keep and a refine loop; how long it takes, whether it can be edited and
+whether it has audio are settings, not separate features.
+
+The media switch *is* the capability — choosing Video and pressing send is the whole gesture,
+which is why both left Chat's "+" menu.
+
+Framing is promoted out of Settings into a chip beside the prompt, because in a creative tool
+the shape of the thing you are making is a per-prompt decision. Each option is drawn at its
+true proportion and springs to its new shape as the selection moves — the composer-scale echo
+of the card's stretch-to-aspect animation.
+
+Video framing is a hard contract (an out-of-set ratio is a 400 from OpenRouter), so unsupported
+options are disabled with the reason. Image framing is an instruction in the prompt, so every
+ratio stays available.
+
+Results are a contact sheet, not a conversation: no assistant header, no user bubble, media at
+480dp rather than a 340dp chat bubble, prompt as the caption. The generating → stretch → reveal
+choreography is unchanged, just given a larger stage.
+
+Two dead ends have exits: **Ask about this** opens a Chat conversation with the media attached,
+and a failed render offers a retry.
+
+## Provider identity
+
+Provenance is information — the privacy story, the cost story and the latency story at once —
+so every model needs to be identifiable at a glance. Real vendor logos are a trademark
+minefield, so each provider gets a stable `MaterialShapes` polygon plus a **theme colour role**
+(not a brand hex, so identity survives dynamic colour and all six accents). Shape carries the
+distinction; the colour role adds a second axis without fighting the user's palette.
+
+The same mark appears in the composer pill, picker rows and Imagine cards from one definition.
+
+## Files
+
+| Concern | File |
+| --- | --- |
+| Mode + media enums | `data/AppMode.kt`, `data/ImagineMedia.kt` |
+| Thread ownership | `data/Models.kt` (`ChatThread.kind`), `data/ChatRepository.kt` |
+| Mode state, scoping, bridges | `ui/ChatViewModel.kt` |
+| Mode switch | `ui/components/ModeSwitch.kt` |
+| Model pill, media toggle, chip row | `ui/components/ContextChips.kt` |
+| Provider marks | `ui/components/ProviderIdentity.kt` |
+| Ratio popover | `ui/components/AspectRatioPicker.kt` |
+| Drawer list + recency | `ui/components/DrawerThreadList.kt` |
+| Router / surfaces | `ui/screens/ChatScreen.kt`, `ChatSurface.kt`, `ImagineSurface.kt` |
+| Imagine canvas + composer + picker | `ui/screens/ImagineCanvas.kt`, `ImagineComposer.kt`, `ImaginePickerSheet.kt` |
+| Merged settings | `ui/screens/SettingsImagine.kt` |


### PR DESCRIPTION
Splits the app into two top-level surfaces. Verified running on a Pixel emulator — screenshots below.

## Why two surfaces

They aren't two feature sets, they're two *shapes* of interaction. **Chat** is turn-taking: you ask, the model answers, the answer is prose you move past, and every capability (search, research, browser, artifacts, Echo) is a variation on "make the answer better". **Imagine** is a creative loop: prompt, render, judge, refine, with settings that persist across turns and a result that wants to be big.

That's why they get separate composers, result presentation and history rather than a menu toggle.

## History is grandfathered, never rewritten

`ChatThread.kind` is stamped once at creation and immutable after. The v18 migration defaults it to `'chat'`, and **that default is the entire safety story**: every existing conversation becomes a Chat thread, images and all. Nothing inspects content to classify — a thread with forty messages and three images was a conversation, and reclassifying it would feel like losing it.

Two details stop a filtered list reading as a lost one: the Imagine empty state says outright that older image chats stayed in Chat, and a scoped search reports how many results the *other* mode holds. Each mode also remembers its own open conversation.

## Nothing hides work

A clip renders for minutes and is usually started in one mode and waited for from the other. `renderingChatIds` reads non-terminal rows straight from the database — the only source covering live turns, resumed jobs and process death alike — and drives a 6dp breathing dot on the switch and on drawer rows. One vocabulary for "still working", used nowhere else. Notification taps switch modes before selecting.

## The top bar

Place, **identity**, action. The centre slot goes to the most permanent thing on screen, so the model selector moved down to the chip row — in a multi-provider app the model is something you change mid-thought, and the bottom edge is where your thumb is.

The switch is a floating tray with a raised thumb wearing the composer's material recipe, so the two pills bookend the screen. That construction is what produces the recessed look you asked for: the tray shadows *down* onto content, the thumb shadows *into* the tray. No true inner shadow — it needs custom drawing, vanishes in dark themes, and is foreign to Material's lighting model; tonal contrast carries the depth instead. The thumb travels on a spring and stretches mid-journey; labels never move, only their colour crossfades underneath.

**One rule for toggles:** floating chrome wears the tray, in-page controls stay flat.

## Imagine

One surface with a media switch, not two modes. The switch *is* the capability — choose Video, press send — which is why both left Chat's "+" menu.

Framing is promoted out of Settings into a chip beside the prompt, and each option is drawn at its **true proportion**, springing to shape as selection moves. That's the composer-scale echo of the card's stretch-to-aspect animation, so control and result finally speak the same language. Video ratios disable what the model can't do (a 400 otherwise); image ratios stay open since they're a prompt instruction.

Results are a contact sheet: no assistant header, no user bubble, media at 480dp instead of 340dp, prompt as caption. **The generating → stretch → reveal choreography and the ratio animation are untouched**, just given a larger stage.

Two dead ends got exits: "Ask about this" opens a Chat conversation with the media attached, and a failed render offers a retry.

## Also

- **Provider identity** — a stable MaterialShape + theme colour role per vendor, so provenance is readable at a glance without shipping anyone's trademark, and it survives dynamic colour.
- **"+" menu sectioned** into Attach / Capabilities / Echo Labs. Length was never the problem; it mixed things that add context to *this message* with things that change how the model works.
- **Settings merged** — one Imagine page bound to the same media preference the composer writes, so the hub returns to seven rows.
- **Drawer** groups by recency (calendar-based, so "yesterday" means the previous day).
- Reduced-motion support, RTL icon fixes, haptics on selection, TalkBack descriptions throughout.

## Refactors this needed

`ChatViewModel` shed 110 lines to `VideoJobRecovery` (durable-job bookkeeping was never chat streaming). `ChatScreen` split into a thin router plus two surfaces — the router keeps the top bar *outside* the crossfade, because chrome that persists across a mode change must transform in place or switching reads as navigating away. The drawer's thread list moved to its own file, and both call sites went to named arguments.

## Verification

`testDebugUnitTest`, `lintDebug`, `assembleDebug` all clean. New tests cover thread-mode scoping (including a raw pre-v18 row reading as Chat), the v18 migration, recency bucketing, and both selection controls.

Ran on a Pixel 10 Pro emulator: Chat, Imagine, the drawer, mode persistence across restart, and the ratio popover all confirmed working. That run **found a real bug** — the chip row's edge fade painted as a solid black bar, because `graphicsLayer` sat after `drawWithContent` and `DstIn` had no layer to blend into. Fixed in `d16f562`.

Not exercised: actually generating an image or video (needs a live API key).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate Chat and Imagine surfaces with persistent, mode-specific conversation histories.
  * Added image and video creation workflows with model selection, aspect-ratio controls, media switching, conversational editing, and progress visibility.
  * Added retry controls for failed video generations and recovery of interrupted renders.
  * Improved conversation search, recency grouping, rendering indicators, and “Ask about this” media actions.
  * Added an Imagine section to Settings.

* **Bug Fixes**
  * Notifications now open conversations in the correct mode.
  * Existing conversations are preserved during the database upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes distinct Chat and Imagine interaction surfaces while preserving mode-specific history and durable generation state.
- I like the product direction: separating conversational turn-taking from the creative prompt-render-refine loop gives each workflow an appropriate composer, history, and result presentation.
- Existing threads remain classified as Chat through the v18 migration, while newly created threads carry an immutable mode.
- Mode-aware navigation, notifications, search, settings, rendering indicators, and per-surface conversation restoration support the split.
- The previous remembered-position issue is addressed by preventing a blank “Ask about this” composer from persisting `null`; this could be implemented even more robustly with a focused regression test covering the complete Imagine-to-Chat transition and return path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Coordinates mode switching, per-mode thread restoration, notification routing, and media handoff without retaining the previously reported null-persistence defect. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Adds the v18 migration that assigns existing threads to Chat. |
| app/src/main/java/com/echoflow/data/Daos.kt | Scopes thread queries and search by surface while retaining cross-mode result counts. |
| app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt | Routes between the new Chat and Imagine surfaces while keeping shared chrome outside the transition. |
| app/src/main/java/com/echoflow/ui/screens/ImagineSurface.kt | Introduces the dedicated creative workflow and connects generated media to the Chat handoff. |
| app/src/main/java/com/echoflow/data/VideoJobRecovery.kt | Extracts durable video-job recovery from the chat view model while preserving database-backed recovery behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Chat[Chat surface] -->|Switch mode; save Chat position| Imagine[Imagine surface]
    Imagine -->|Switch mode; save Imagine position| Chat
    Imagine -->|Ask about this; attach media| Blank[Blank Chat composer]
    Blank -->|Send message| MediaChat[New Chat thread]
    Notification[Notification tap] -->|Resolve thread kind| Chat
    Notification -->|Resolve thread kind| Imagine
```
</details>

<sub>Reviews (6): Last reviewed commit: ["feat(imagine): the blank canvas is alive..."](https://github.com/adityavardhansharma/echoflow/commit/73a8eccfdc9eb120b0d2d62087fba90e4c5858f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47771711)</sub>

<!-- /greptile_comment -->