### PR TITLE
fix(chat): stop Imagine gen mode from sticking into Chat

### DIFF
--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -103,10 +103,23 @@ class ChatViewModel(
      */
     fun switchMode(mode: AppMode) {
         if (mode == appMode.value) return
+        if (mode == AppMode.Chat) clearImagineArmedModes()
         parkCurrentPosition()
         settingsRepository.saveAppMode(mode)
         _drawerSearchQuery.value = ""
         restorePosition(mode)
+    }
+
+    /**
+     * Image/video gen is armed by Imagine for a single send. If that sticky [ChatMode]
+     * survives a surface switch, every later Chat message generates media instead of
+     * answering — which is exactly what happens when a long video render tempts the user
+     * into Chat while the last Imagine mode is still live.
+     */
+    private fun clearImagineArmedModes() {
+        if (_chatMode.value is ChatMode.ImageGen || _chatMode.value is ChatMode.VideoGen) {
+            setMode(ChatMode.Normal)
+        }
     }
 
     /**
@@ -400,6 +413,7 @@ class ChatViewModel(
         viewModelScope.launch {
             val thread = chatRepository.thread(chatId) ?: return@launch
             if (thread.mode != appMode.value) {
+                if (thread.mode == AppMode.Chat) clearImagineArmedModes()
                 parkCurrentPosition()
                 settingsRepository.saveAppMode(thread.mode)
                 _drawerSearchQuery.value = ""
@@ -518,6 +532,9 @@ class ChatViewModel(
      * Sends an Imagine turn. The media switch *is* the capability, so the surface sets the
      * generation mode from what the user is making rather than asking them to arm it from a
      * menu first — which is the entire reason image and video left Chat's "+" menu.
+     *
+     * The mode is one-shot: [sendMessage] consumes it before launching so a later Chat send
+     * cannot inherit ImageGen/VideoGen after the user switches surfaces mid-render.
      */
     fun sendImagineMessage(prompt: String, media: ImagineMedia) {
         setMode(if (media == ImagineMedia.Video) ChatMode.VideoGen else ChatMode.ImageGen)
@@ -824,12 +841,17 @@ class ChatViewModel(
             if (streamJobs[chatId]?.isActive == true) return
         }
 
+        // Capture and consume image/video gen before the coroutine starts. These modes are
+        // armed per send by [sendImagineMessage]; leaving them sticky makes Chat generate
+        // media for every later question after the user switches away mid-render.
+        val imageGenMode = _chatMode.value is ChatMode.ImageGen
+        val videoGenMode = _chatMode.value is ChatMode.VideoGen
+        if (imageGenMode || videoGenMode) clearImagineArmedModes()
+
         viewModelScope.launch {
             clearPendingAttachment()
             clearError()
 
-            val imageGenMode = _chatMode.value is ChatMode.ImageGen
-            val videoGenMode = _chatMode.value is ChatMode.VideoGen
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
             val customProviderConfig = settingsRepository.getCustomProviderConfigDirect()


### PR DESCRIPTION
## Summary

- **Bug:** After generating an image/video in Imagine, `ChatMode.ImageGen` / `VideoGen` stayed armed forever. Switching to Chat mid-render (especially while video is still rendering) made every chat question generate media instead of answering.
- **Fix:** Treat image/video gen as a one-shot mode — capture it at send time, then clear it immediately (same pattern as Deep Research / Browser Flow).
- **Defense:** Also clear any leftover Imagine-armed mode when entering Chat via the mode switch or a notification tap.

## Test plan

- [ ] In Imagine, generate an image, then convert it to video
- [ ] While video is still rendering, switch to Chat
- [ ] Ask a normal text question with a chat model — expect a text reply, not image/video generation
- [ ] Ask a second chat question — still text
- [ ] Switch back to Imagine, generate another image — still works
- [ ] Switch Chat ↔ Imagine without sending — Chat still answers in text

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a focused product-quality fix that makes Imagine generation modes one-shot and prevents them from leaking into Chat.
- Captures the image/video generation mode at send time and clears the shared mode before asynchronous generation begins.
- Defensively clears stale generation modes when switching or navigating into Chat.
- The product direction is strong: Chat and Imagine now maintain clearer behavioral boundaries during long-running renders.
- The implementation could be strengthened with ViewModel tests covering mid-render surface switches, notification navigation, and repeated sends.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and cleanly prevents Imagine generation state from leaking into subsequent Chat messages.

Media intent is captured before asynchronous work begins, while the shared mode is reset synchronously and additionally cleared on the current Chat-entry paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Captures media-generation intent per send and clears stale ImageGen/VideoGen state on consumption and Chat entry; no actionable defect found. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Imagine send] --> B[Capture ImageGen or VideoGen]
    B --> C[Reset shared ChatMode to Normal]
    C --> D[Launch captured media generation]
    D --> E[Switch or navigate to Chat]
    E --> F[Normal text send]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): stop Imagine gen mode from st..."](https://github.com/adityavardhansharma/echoflow/commit/3c5968a1d3796fef072734220556340afe2cf6b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47987004)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->