### PR TITLE
Add AGENTS.md for Cursor Cloud Android development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+EchoFlow is a **single-module Android app** (Kotlin + Jetpack Compose). There is no backend, Docker stack, or npm/pip dependency tree.
+
+### Prerequisites (VM image)
+
+- **JDK 21** (OpenJDK 21 is preinstalled)
+- **Android SDK** at `/home/ubuntu/Android/Sdk` (platform `android-37.0`, build-tools `36.0.0`, platform-tools)
+- `local.properties` with `sdk.dir=/home/ubuntu/Android/Sdk` (gitignored; created by the update script if missing)
+
+### Common commands
+
+See [README.md](README.md) for product context. Standard Gradle tasks:
+
+| Task | Command |
+|------|---------|
+| Build debug APK | `./gradlew :app:assembleDebug` |
+| Unit tests (no device) | `./gradlew :app:testDebugUnitTest` |
+| Lint | `./gradlew :app:lintDebug` |
+| Instrumented tests (device/emulator) | `./gradlew :app:connectedDebugAndroidTest` |
+
+`./gradlew` must be executable (`chmod +x ./gradlew`).
+
+### Emulator / on-device run caveats
+
+- Release and default debug APKs package **arm64-v8a only** (on-device AI native libs). They install on physical arm64 phones, not on x86_64 emulators.
+- Cloud VMs are typically **x86_64 without `/dev/kvm`**, so the Android Emulator cannot run arm64 system images here. Use **Robolectric unit tests** for UI/logic validation in cloud agents.
+- To run the full app interactively: use an **arm64 Android device** or an **arm64 host with KVM**, then `./gradlew :app:installDebug`.
+
+### Secrets
+
+No API keys are required to build or run tests. Runtime keys are configured in-app via Settings. Optional `.env` is supported by the Secrets Gradle Plugin (see `.env.example`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,19 @@
 
 EchoFlow is a **single-module Android app** (Kotlin + Jetpack Compose). There is no backend, Docker stack, or npm/pip dependency tree.
 
-### Prerequisites (VM image)
+### Prerequisites
 
-- **JDK 21** (OpenJDK 21 is preinstalled)
-- **Android SDK** at `/home/ubuntu/Android/Sdk` (platform `android-37.0`, build-tools `36.0.0`, platform-tools)
-- `local.properties` with `sdk.dir=/home/ubuntu/Android/Sdk` (gitignored; created by the update script if missing)
+- **JDK 21** (CI uses Temurin 21; match the major version locally)
+- **Android SDK** via `ANDROID_HOME` / `ANDROID_SDK_ROOT` (common default: `~/Android/Sdk`)
+- `local.properties` with `sdk.dir=<your SDK path>` (gitignored; created by the update script when missing)
+
+SDK packages are **not pinned to a single machine path or patch release**. Read `compileSdk` in `app/build.gradle.kts` (currently `37`) and install the matching platform with `sdkmanager`, picking the **package id** from `sdkmanager --list` (for example `platforms;android-36` on API 36 hosts). Do not assume the on-disk folder name (such as `platforms/android-37.0`) is the install command — API 37+ may only publish dotted package ids, and patch releases differ across machines. Also install `platform-tools` and a compatible `build-tools` package; Gradle/AGP will report anything still missing on the first build.
+
+```bash
+# List candidates, then install the one that matches compileSdk on this host:
+sdkmanager --list | rg "platforms;android-<compileSdk>"
+sdkmanager "platform-tools" "build-tools;36.0.0" "<platform-package-from-list>"
+```
 
 ### Common commands
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for developing EchoFlow (Android/Kotlin/Gradle).

Includes:
- Android SDK setup via `ANDROID_HOME` (not a fixed VM path)
- Deriving SDK platform packages from `compileSdk` + `sdkmanager --list` (avoids hardcoding `android-37.0` or invalid `platforms;android-37`)
- Common Gradle commands (build, test, lint)
- Emulator/device caveats (arm64-only APK, no KVM on cloud x86 VMs)
- Secrets/build notes

The VM update script ensures `gradlew` is executable and creates `local.properties` from `ANDROID_HOME` or `~/Android/Sdk` when missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4b65a51-4f26-43e3-9565-77b4fd794ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4b65a51-4f26-43e3-9565-77b4fd794ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Cursor Cloud guidance for configuring and developing the Android project.
- What works well: it avoids coupling setup to a fixed SDK path and directs agents to inspect the installed SDK package catalog.
- What can be better implemented: the SDK-discovery example should assign or extract `compileSdk` and interpolate that value into the search command, rather than presenting an inert placeholder.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the SDK-discovery command reliably substitutes the repository's compile SDK value.

Copying the documented command searches for the literal text `<compileSdk>`, returns no platform candidates, and leaves cloud agents unable to install the platform required by the Android build.

**Files Needing Attention:** AGENTS.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds useful cloud-development guidance, but the literal `<compileSdk>` search placeholder prevents the documented SDK platform discovery command from working. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix AGENTS.md SDK platform guidance for ..."](https://github.com/adityavardhansharma/echoflow/commit/af05b0272d8cdb7e3e4651c6e046719d20970728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48045224)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for Cursor Cloud environments, including setup prerequisites, Android SDK configuration, Gradle commands, emulator limitations, native library considerations, and secrets management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->