### PR TITLE
Add prompt long-press edit with reply version history

### DIFF
--- a/app/schemas/com.echoflow.data.AppDatabase/19.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/19.json
@@ -1,0 +1,1198 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "0f41b730ba233d11e958e702bc4ff2e1",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `kind` TEXT NOT NULL DEFAULT 'chat', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'chat'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, `replyVersionsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyVersionsJson",
+            "columnName": "replyVersionsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0f41b730ba233d11e958e702bc4ff2e1')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ImageModel::class, GeneratedImage::class,
         VideoModel::class, GeneratedVideo::class
     ],
-    version = 18, // v18: conversations belong to a mode (chat | imagine)
+    version = 19, // v19: assistant reply version history on prompt edits
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -352,6 +352,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        internal val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN replyVersionsJson TEXT")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -377,6 +383,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_15_16,
                     MIGRATION_16_17,
                     MIGRATION_17_18,
+                    MIGRATION_18_19,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -63,6 +63,7 @@ class ChatRepository(
     }
 
     suspend fun insertMessage(message: ChatMessage) = messageDao.insertMessage(message)
+    suspend fun deleteMessage(messageId: String) = messageDao.deleteMessageById(messageId)
     suspend fun history(chatId: String): List<ChatMessage> = messageDao.getMessagesForChatSync(chatId)
     suspend fun thread(chatId: String): ChatThread? = chatDao.getThreadById(chatId)
 }

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -64,6 +64,8 @@ class ChatRepository(
 
     suspend fun insertMessage(message: ChatMessage) = messageDao.insertMessage(message)
     suspend fun deleteMessage(messageId: String) = messageDao.deleteMessageById(messageId)
+    suspend fun applyEditedUserTurn(updatedUser: ChatMessage, assistantMessageId: String?) =
+        messageDao.applyEditedUserTurn(updatedUser, assistantMessageId)
     suspend fun history(chatId: String): List<ChatMessage> = messageDao.getMessagesForChatSync(chatId)
     suspend fun thread(chatId: String): ChatThread? = chatDao.getThreadById(chatId)
 }

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -247,6 +247,15 @@ data class PersistedSegment(
     val video: VideoRef? = null // present when type == "video"
 )
 
+/** One archived assistant answer for a user turn, stored before a prompt edit regenerates the reply. */
+data class ReplyVersion(
+    val content: String,
+    val reasoning: String? = null,
+    val toolEventsJson: String? = null,
+    val citationsJson: String? = null,
+    val segmentsJson: String? = null,
+)
+
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */
 object ToolEventJson {
     private val moshi: Moshi = Moshi.Builder()
@@ -282,4 +291,41 @@ object ToolEventJson {
 
     fun segmentsFromJson(json: String?): List<PersistedSegment> =
         json?.let { runCatching { segmentsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+
+    private val replyVersionsAdapter: JsonAdapter<List<ReplyVersion>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, ReplyVersion::class.java)
+    )
+
+    fun replyVersionsToJson(versions: List<ReplyVersion>): String? =
+        if (versions.isEmpty()) null else replyVersionsAdapter.toJson(versions)
+
+    fun replyVersionsFromJson(json: String?): List<ReplyVersion> =
+        json?.let { runCatching { replyVersionsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+}
+
+/** Helpers for browsing archived assistant answers on a [ChatMessage]. */
+object ReplyVersioning {
+    fun archivedVersions(message: ChatMessage): List<ReplyVersion> =
+        ToolEventJson.replyVersionsFromJson(message.replyVersionsJson)
+
+    fun totalVersions(message: ChatMessage): Int = archivedVersions(message).size + 1
+
+    /** Returns the message fields to render for [versionIndex] (0 = oldest, last = newest). */
+    fun displayMessage(message: ChatMessage, versionIndex: Int): ChatMessage {
+        val archived = archivedVersions(message)
+        val latestIndex = archived.size
+        val clamped = versionIndex.coerceIn(0, latestIndex)
+        if (clamped >= latestIndex) return message
+        val version = archived[clamped]
+        return message.copy(
+            content = version.content,
+            reasoning = version.reasoning,
+            toolEventsJson = version.toolEventsJson,
+            citationsJson = version.citationsJson,
+            segmentsJson = version.segmentsJson,
+        )
+    }
+
+    fun copyText(message: ChatMessage, versionIndex: Int): String =
+        displayMessage(message, versionIndex).content
 }

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -326,6 +326,21 @@ object ReplyVersioning {
         )
     }
 
-    fun copyText(message: ChatMessage, versionIndex: Int): String =
-        displayMessage(message, versionIndex).content
+    fun copyText(message: ChatMessage, versionIndex: Int): String {
+        val displayed = displayMessage(message, versionIndex)
+        return copyTextFromSegments(displayed.segmentsJson).ifBlank { displayed.content }
+    }
+
+    /** Flattens visible answer text from a persisted segment timeline for clipboard copy. */
+    fun copyTextFromSegments(segmentsJson: String?): String {
+        val segments = ToolEventJson.segmentsFromJson(segmentsJson)
+        if (segments.isEmpty()) return ""
+        return segments.mapNotNull { segment ->
+            when (segment.type) {
+                "text", "report", "data" -> segment.text
+                "reasoning" -> segment.text?.let { text -> "Reasoning:\n$text" }
+                else -> null
+            }
+        }.filter { !it.isNullOrBlank() }.joinToString("\n\n")
+    }
 }

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -50,6 +50,15 @@ interface MessageDao {
     @Query("DELETE FROM chat_messages WHERE id = :messageId")
     suspend fun deleteMessageById(messageId: String)
 
+    /** Atomically persists an edited user turn and removes the assistant reply it replaces. */
+    @Transaction
+    suspend fun applyEditedUserTurn(updatedUser: ChatMessage, assistantMessageId: String?) {
+        insertMessage(updatedUser)
+        if (assistantMessageId != null) {
+            deleteMessageById(assistantMessageId)
+        }
+    }
+
     @Query("DELETE FROM chat_messages WHERE chatId = :chatId")
     suspend fun deleteMessagesForChat(chatId: String)
 

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -47,6 +47,9 @@ interface MessageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMessage(message: ChatMessage)
 
+    @Query("DELETE FROM chat_messages WHERE id = :messageId")
+    suspend fun deleteMessageById(messageId: String)
+
     @Query("DELETE FROM chat_messages WHERE chatId = :chatId")
     suspend fun deleteMessagesForChat(chatId: String)
 

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -50,7 +50,9 @@ data class ChatMessage(
     val localAttachmentName: String? = null,
     val toolEventsJson: String? = null, // JSON List<ToolEvent>: web searches the model ran for this answer
     val citationsJson: String? = null, // JSON List<Citation>: deduped sources backing this answer
-    val segmentsJson: String? = null // JSON List<PersistedSegment>: ordered reply timeline (reasoning/search/text interleaved)
+    val segmentsJson: String? = null, // JSON List<PersistedSegment>: ordered reply timeline (reasoning/search/text interleaved)
+    /** JSON List<ReplyVersion>: prior assistant answers for this turn, kept when the user edits their prompt. */
+    val replyVersionsJson: String? = null,
 )
 
 @Entity(tableName = "custom_models")

--- a/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
+++ b/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
@@ -21,7 +21,7 @@ internal object AssistantMessagePersistence {
                 (it is StreamSegment.Image && it.filePath != null) ||
                 it is StreamSegment.Video
         }
-        if (content.isEmpty() && !hasDurableCard && !stopped) return null
+        if (content.isEmpty() && !hasDurableCard && !stopped && interrupted.isNullOrBlank()) return null
         val reasoning = normalized.filterIsInstance<StreamSegment.Reasoning>()
             .joinToString("\n\n") { it.text }.trim().ifBlank { null }
         val events = normalized.mapIndexedNotNull { index, segment ->
@@ -35,6 +35,18 @@ internal object AssistantMessagePersistence {
         }
         val finalContent = interrupted?.let { "$content\n\n*[Connection lost: $it]*" } ?: content
         return AssistantMessageDraft(finalContent, reasoning, events, citations, persisted)
+    }
+
+    /** Persists a failure stub so edit-turn version history is not orphaned in Room. */
+    fun interruptedOnlyDraft(message: String): AssistantMessageDraft {
+        val text = message.trim()
+        return AssistantMessageDraft(
+            content = text,
+            reasoning = null,
+            toolEvents = emptyList(),
+            citations = emptyList(),
+            segments = listOf(PersistedSegment(type = "text", text = text)),
+        )
     }
 
     private fun persistedSegment(segment: StreamSegment): PersistedSegment? = when (segment) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -160,6 +160,37 @@ class ChatViewModel(
     private fun openThread(chatId: String?) {
         navigation.navigated()
         _currentChatThreadId.value = chatId
+        _replyVersionIndex.value = emptyMap()
+    }
+
+    /** User message being edited in the composer; cleared once the edit is sent or cancelled. */
+    private val _editingUserMessageId = MutableStateFlow<String?>(null)
+    val editingUserMessageId: StateFlow<String?> = _editingUserMessageId.asStateFlow()
+
+    /** Per-assistant-message reply version index. Absent entries default to the latest version. */
+    private val _replyVersionIndex = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val replyVersionIndex: StateFlow<Map<String, Int>> = _replyVersionIndex.asStateFlow()
+
+    fun beginEditUserMessage(messageId: String): String? {
+        val messages = currentMessages.value
+        val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
+        if (lastUser.id != messageId) return null
+        _editingUserMessageId.value = messageId
+        return lastUser.content
+    }
+
+    fun cancelEditMessage() {
+        _editingUserMessageId.value = null
+    }
+
+    fun selectReplyVersion(messageId: String, index: Int) {
+        _replyVersionIndex.value = _replyVersionIndex.value + (messageId to index.coerceAtLeast(0))
+    }
+
+    fun replyVersionIndexFor(messageId: String, totalVersions: Int): Int {
+        val stored = _replyVersionIndex.value[messageId]
+        val latest = (totalVersions - 1).coerceAtLeast(0)
+        return stored?.coerceIn(0, latest) ?: latest
     }
 
     /** Records where this mode is being left — including "on a blank composer". */
@@ -808,6 +839,8 @@ class ChatViewModel(
 
     fun sendMessage(content: String) {
         val prompt = content.trim()
+        val editingUserId: String? = _editingUserMessageId.value
+        _editingUserMessageId.value = null
         val attachmentUri = _pendingAttachmentUri.value?.toString()
         val attachmentMime = _pendingAttachmentMimeType.value
         val attachmentName = _pendingAttachmentName.value
@@ -851,6 +884,13 @@ class ChatViewModel(
         viewModelScope.launch {
             clearPendingAttachment()
             clearError()
+
+            var preservedReplyVersionsJson: String? = null
+            if (editingUserId != null) {
+                val prepared = prepareEditTurn(editingUserId, prompt)
+                if (prepared == null) return@launch
+                preservedReplyVersionsJson = prepared
+            }
 
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
@@ -1088,35 +1128,39 @@ class ChatViewModel(
             if (streamJobs[chatId]?.isActive == true) return@launch
             coroutineContext[Job]?.let { streamJobs[chatId] = it }
 
-            // Insert User Message
-            val userMsg = ChatMessage(
-                id = UUID.randomUUID().toString(),
-                chatId = chatId,
-                role = "user",
-                content = prompt,
-                createdAt = System.currentTimeMillis(),
-                localAttachmentUri = attachmentUri,
-                localAttachmentMimeType = attachmentMime,
-                localAttachmentName = attachmentName
-            )
-            chatRepository.insertMessage(userMsg)
+            if (editingUserId == null) {
+                // Insert User Message
+                val userMsg = ChatMessage(
+                    id = UUID.randomUUID().toString(),
+                    chatId = chatId,
+                    role = "user",
+                    content = prompt,
+                    createdAt = System.currentTimeMillis(),
+                    localAttachmentUri = attachmentUri,
+                    localAttachmentMimeType = attachmentMime,
+                    localAttachmentName = attachmentName
+                )
+                chatRepository.insertMessage(userMsg)
 
-            // Update Thread Timestamp
-            chatRepository.touchThread(chatId)
+                // Update Thread Timestamp
+                chatRepository.touchThread(chatId)
 
-            // Trigger background Title generation. Local chats use the word fallback:
-            // no API key may exist, and the on-device engine is single-flight.
-            if (isFirstMsgInChat) {
-                if (isLocal || customProviderActive) {
-                    val words = prompt.split("\\s+".toRegex())
-                    val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
-                    chatRepository.renameThread(chatId, fallbackTitle)
-                } else {
-                    launch {
-                        val generatedTitle = openRouterService.generateTitle(apiKey, selectedModel, prompt)
-                        chatRepository.renameThread(chatId!!, generatedTitle)
+                // Trigger background Title generation. Local chats use the word fallback:
+                // no API key may exist, and the on-device engine is single-flight.
+                if (isFirstMsgInChat) {
+                    if (isLocal || customProviderActive) {
+                        val words = prompt.split("\\s+".toRegex())
+                        val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
+                        chatRepository.renameThread(chatId, fallbackTitle)
+                    } else {
+                        launch {
+                            val generatedTitle = openRouterService.generateTitle(apiKey, selectedModel, prompt)
+                            chatRepository.renameThread(chatId!!, generatedTitle)
+                        }
                     }
                 }
+            } else {
+                chatRepository.touchThread(chatId)
             }
 
             // Load updated dialog history
@@ -1426,7 +1470,7 @@ class ChatViewModel(
                 if (videoGenMode && segments.any { it is StreamSegment.Video && !it.generating }) {
                     delay(2600)
                 }
-                persistAssistantMessage(chatId, segments, interrupted = null)
+                persistAssistantMessage(chatId, segments, interrupted = null, replyVersionsJson = preservedReplyVersionsJson)
                 if (videoGenMode) {
                     // The video flow also completes normally when its row was deleted
                     // mid-render, so announce a clip only once one actually exists.
@@ -1455,13 +1499,13 @@ class ChatViewModel(
                 // User tapped Stop — keep whatever streamed so far and surface no error banner.
                 // The persist runs under NonCancellable so it isn't skipped by the cancellation.
                 withContext(NonCancellable) {
-                    persistAssistantMessage(chatId, segments, interrupted = null, stopped = true)
+                    persistAssistantMessage(chatId, segments, interrupted = null, stopped = true, replyVersionsJson = preservedReplyVersionsJson)
                 }
                 throw e
             } catch (e: Exception) {
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."
-                persistAssistantMessage(chatId, segments, interrupted = e.message)
+                persistAssistantMessage(chatId, segments, interrupted = e.message, replyVersionsJson = preservedReplyVersionsJson)
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,
@@ -1729,11 +1773,52 @@ class ChatViewModel(
         currentResearchRun.value?.let { DeepResearchForegroundService.cancel(getApplication(), it.id) }
     }
 
+    private suspend fun prepareEditTurn(userMessageId: String, newContent: String): String? {
+        val chatId = _currentChatThreadId.value ?: return null
+        val messages = chatRepository.history(chatId)
+        val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
+        if (lastUser.id != userMessageId) {
+            _errorMessage.value = "Only your most recent message can be edited."
+            return null
+        }
+        if (newContent.isBlank()) {
+            _errorMessage.value = "Edited message cannot be empty."
+            return null
+        }
+        if (_chatMode.value !is ChatMode.Normal && _chatMode.value !is ChatMode.WebSearch) {
+            _errorMessage.value = "Finish the active mode before editing a message."
+            return null
+        }
+
+        val userIndex = messages.indexOfFirst { it.id == userMessageId }
+        val assistant = messages.getOrNull(userIndex + 1)?.takeIf { it.role == "assistant" }
+        var preservedVersionsJson = assistant?.replyVersionsJson
+
+        if (assistant != null) {
+            val archived = ToolEventJson.replyVersionsFromJson(assistant.replyVersionsJson).toMutableList()
+            archived += ReplyVersion(
+                content = assistant.content,
+                reasoning = assistant.reasoning,
+                toolEventsJson = assistant.toolEventsJson,
+                citationsJson = assistant.citationsJson,
+                segmentsJson = assistant.segmentsJson,
+            )
+            preservedVersionsJson = ToolEventJson.replyVersionsToJson(archived)
+            chatRepository.deleteMessage(assistant.id)
+        }
+
+        chatRepository.insertMessage(
+            lastUser.copy(content = newContent, createdAt = System.currentTimeMillis())
+        )
+        return preservedVersionsJson
+    }
+
     private suspend fun persistAssistantMessage(
         chatId: String,
         segments: List<StreamSegment>,
         interrupted: String?,
         stopped: Boolean = false,
+        replyVersionsJson: String? = null,
     ) {
         val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped) ?: return
         messageDao.insertMessage(
@@ -1747,6 +1832,7 @@ class ChatViewModel(
                 toolEventsJson = ToolEventJson.toolEventsToJson(draft.toolEvents),
                 citationsJson = ToolEventJson.citationsToJson(draft.citations),
                 segmentsJson = ToolEventJson.segmentsToJson(draft.segments),
+                replyVersionsJson = replyVersionsJson,
             )
         )
         chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = System.currentTimeMillis())) }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -171,6 +171,21 @@ class ChatViewModel(
     private val _replyVersionIndex = MutableStateFlow<Map<String, Int>>(emptyMap())
     val replyVersionIndex: StateFlow<Map<String, Int>> = _replyVersionIndex.asStateFlow()
 
+    /** One-shot signal to reload composer text after a failed edit regeneration. */
+    private val _editTurnRestore = MutableStateFlow<EditTurnRestore?>(null)
+    val editTurnRestore: StateFlow<EditTurnRestore?> = _editTurnRestore.asStateFlow()
+
+    data class EditTurnRestore(val userMessageId: String, val prompt: String)
+
+    fun consumeEditTurnRestore() {
+        _editTurnRestore.value = null
+    }
+
+    private fun restoreEditTurn(userMessageId: String, prompt: String) {
+        _editingUserMessageId.value = userMessageId
+        _editTurnRestore.value = EditTurnRestore(userMessageId, prompt)
+    }
+
     fun beginEditUserMessage(messageId: String): String? {
         val messages = currentMessages.value
         val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
@@ -891,7 +906,7 @@ class ChatViewModel(
             clearError()
 
             if (editingUserId != null) {
-                validateEditTurn(editingUserId, prompt)?.let { message ->
+                validateEditTurn(editingUserId, prompt, hasAttachment = attachmentUri != null)?.let { message ->
                     _errorMessage.value = message
                     return@launch
                 }
@@ -1166,6 +1181,15 @@ class ChatViewModel(
                     }
                 }
             } else {
+                setStreamState(
+                    chatId,
+                    ActiveStreamState(
+                        segments = emptyList(),
+                        statusNote = null,
+                        progressLoading = true,
+                        isLocal = isLocal,
+                    ),
+                )
                 preservedReplyVersionsJson = withContext(NonCancellable) {
                     commitEditTurn(
                         userMessageId = editingUserId,
@@ -1175,11 +1199,11 @@ class ChatViewModel(
                         attachmentName = attachmentName,
                     )
                 } ?: run {
+                    setStreamState(chatId, null)
                     _errorMessage.value = "Could not edit message."
                     return@launch
                 }
                 chatRepository.touchThread(chatId)
-                _editingUserMessageId.value = null
             }
             clearPendingAttachment()
 
@@ -1491,6 +1515,9 @@ class ChatViewModel(
                     delay(2600)
                 }
                 persistAssistantMessage(chatId, segments, interrupted = null, replyVersionsJson = preservedReplyVersionsJson)
+                if (editingUserId != null) {
+                    _editingUserMessageId.value = null
+                }
                 if (videoGenMode) {
                     // The video flow also completes normally when its row was deleted
                     // mid-render, so announce a clip only once one actually exists.
@@ -1526,6 +1553,9 @@ class ChatViewModel(
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."
                 persistAssistantMessage(chatId, segments, interrupted = e.message, replyVersionsJson = preservedReplyVersionsJson)
+                if (editingUserId != null) {
+                    restoreEditTurn(editingUserId, prompt)
+                }
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,
@@ -1793,14 +1823,18 @@ class ChatViewModel(
         currentResearchRun.value?.let { DeepResearchForegroundService.cancel(getApplication(), it.id) }
     }
 
-    private suspend fun validateEditTurn(userMessageId: String, newContent: String): String? {
+    private suspend fun validateEditTurn(
+        userMessageId: String,
+        newContent: String,
+        hasAttachment: Boolean,
+    ): String? {
         val chatId = _currentChatThreadId.value ?: return "No conversation open."
         val messages = chatRepository.history(chatId)
         val lastUser = messages.lastOrNull { it.role == "user" } ?: return "No message to edit."
         if (lastUser.id != userMessageId) {
             return "Only your most recent message can be edited."
         }
-        if (newContent.isBlank()) {
+        if (newContent.isBlank() && !hasAttachment) {
             return "Edited message cannot be empty."
         }
         if (_chatMode.value !is ChatMode.Normal && _chatMode.value !is ChatMode.WebSearch) {
@@ -1835,6 +1869,7 @@ class ChatViewModel(
                 segmentsJson = assistant.segmentsJson,
             )
             preservedVersionsJson = ToolEventJson.replyVersionsToJson(archived)
+            _replyVersionIndex.value = _replyVersionIndex.value - assistant.id
         }
 
         chatRepository.applyEditedUserTurn(
@@ -1857,7 +1892,14 @@ class ChatViewModel(
         stopped: Boolean = false,
         replyVersionsJson: String? = null,
     ) {
-        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped) ?: return
+        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped)
+            ?: if (replyVersionsJson != null) {
+                AssistantMessagePersistence.interruptedOnlyDraft(
+                    interrupted ?: "Something went wrong generating a reply.",
+                )
+            } else {
+                null
+            } ?: return
         messageDao.insertMessage(
             ChatMessage(
                 id = UUID.randomUUID().toString(),

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1166,13 +1166,18 @@ class ChatViewModel(
                     }
                 }
             } else {
-                preservedReplyVersionsJson = commitEditTurn(
-                    userMessageId = editingUserId,
-                    newContent = prompt,
-                    attachmentUri = attachmentUri,
-                    attachmentMime = attachmentMime,
-                    attachmentName = attachmentName,
-                ) ?: return@launch
+                preservedReplyVersionsJson = withContext(NonCancellable) {
+                    commitEditTurn(
+                        userMessageId = editingUserId,
+                        newContent = prompt,
+                        attachmentUri = attachmentUri,
+                        attachmentMime = attachmentMime,
+                        attachmentName = attachmentName,
+                    )
+                } ?: run {
+                    _errorMessage.value = "Could not edit message."
+                    return@launch
+                }
                 chatRepository.touchThread(chatId)
                 _editingUserMessageId.value = null
             }
@@ -1830,17 +1835,17 @@ class ChatViewModel(
                 segmentsJson = assistant.segmentsJson,
             )
             preservedVersionsJson = ToolEventJson.replyVersionsToJson(archived)
-            chatRepository.deleteMessage(assistant.id)
         }
 
-        chatRepository.insertMessage(
-            editedUserMessageForEditTurn(
+        chatRepository.applyEditedUserTurn(
+            updatedUser = editedUserMessageForEditTurn(
                 lastUser = lastUser,
                 newContent = newContent,
                 attachmentUri = attachmentUri,
                 attachmentMime = attachmentMime,
                 attachmentName = attachmentName,
-            )
+            ),
+            assistantMessageId = assistant?.id,
         )
         return preservedVersionsJson
     }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -176,11 +176,18 @@ class ChatViewModel(
         val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
         if (lastUser.id != messageId) return null
         _editingUserMessageId.value = messageId
+        val uri = lastUser.localAttachmentUri?.let(Uri::parse)
+        if (uri != null) {
+            setPendingAttachment(uri, lastUser.localAttachmentMimeType, lastUser.localAttachmentName)
+        } else {
+            clearPendingAttachment()
+        }
         return lastUser.content
     }
 
     fun cancelEditMessage() {
         _editingUserMessageId.value = null
+        clearPendingAttachment()
     }
 
     fun selectReplyVersion(messageId: String, index: Int) {
@@ -840,7 +847,6 @@ class ChatViewModel(
     fun sendMessage(content: String) {
         val prompt = content.trim()
         val editingUserId: String? = _editingUserMessageId.value
-        _editingUserMessageId.value = null
         val attachmentUri = _pendingAttachmentUri.value?.toString()
         val attachmentMime = _pendingAttachmentMimeType.value
         val attachmentName = _pendingAttachmentName.value
@@ -882,14 +888,13 @@ class ChatViewModel(
         if (imageGenMode || videoGenMode) clearImagineArmedModes()
 
         viewModelScope.launch {
-            clearPendingAttachment()
             clearError()
 
-            var preservedReplyVersionsJson: String? = null
             if (editingUserId != null) {
-                val prepared = prepareEditTurn(editingUserId, prompt)
-                if (prepared == null) return@launch
-                preservedReplyVersionsJson = prepared
+                validateEditTurn(editingUserId, prompt)?.let { message ->
+                    _errorMessage.value = message
+                    return@launch
+                }
             }
 
             val apiKey = settingsRepository.getApiKeyDirect()
@@ -1128,6 +1133,7 @@ class ChatViewModel(
             if (streamJobs[chatId]?.isActive == true) return@launch
             coroutineContext[Job]?.let { streamJobs[chatId] = it }
 
+            var preservedReplyVersionsJson: String? = null
             if (editingUserId == null) {
                 // Insert User Message
                 val userMsg = ChatMessage(
@@ -1160,8 +1166,17 @@ class ChatViewModel(
                     }
                 }
             } else {
+                preservedReplyVersionsJson = commitEditTurn(
+                    userMessageId = editingUserId,
+                    newContent = prompt,
+                    attachmentUri = attachmentUri,
+                    attachmentMime = attachmentMime,
+                    attachmentName = attachmentName,
+                ) ?: return@launch
                 chatRepository.touchThread(chatId)
+                _editingUserMessageId.value = null
             }
+            clearPendingAttachment()
 
             // Load updated dialog history
             val fullHistory = chatRepository.history(chatId)
@@ -1773,22 +1788,33 @@ class ChatViewModel(
         currentResearchRun.value?.let { DeepResearchForegroundService.cancel(getApplication(), it.id) }
     }
 
-    private suspend fun prepareEditTurn(userMessageId: String, newContent: String): String? {
+    private suspend fun validateEditTurn(userMessageId: String, newContent: String): String? {
+        val chatId = _currentChatThreadId.value ?: return "No conversation open."
+        val messages = chatRepository.history(chatId)
+        val lastUser = messages.lastOrNull { it.role == "user" } ?: return "No message to edit."
+        if (lastUser.id != userMessageId) {
+            return "Only your most recent message can be edited."
+        }
+        if (newContent.isBlank()) {
+            return "Edited message cannot be empty."
+        }
+        if (_chatMode.value !is ChatMode.Normal && _chatMode.value !is ChatMode.WebSearch) {
+            return "Finish the active mode before editing a message."
+        }
+        return null
+    }
+
+    private suspend fun commitEditTurn(
+        userMessageId: String,
+        newContent: String,
+        attachmentUri: String?,
+        attachmentMime: String?,
+        attachmentName: String?,
+    ): String? {
         val chatId = _currentChatThreadId.value ?: return null
         val messages = chatRepository.history(chatId)
         val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
-        if (lastUser.id != userMessageId) {
-            _errorMessage.value = "Only your most recent message can be edited."
-            return null
-        }
-        if (newContent.isBlank()) {
-            _errorMessage.value = "Edited message cannot be empty."
-            return null
-        }
-        if (_chatMode.value !is ChatMode.Normal && _chatMode.value !is ChatMode.WebSearch) {
-            _errorMessage.value = "Finish the active mode before editing a message."
-            return null
-        }
+        if (lastUser.id != userMessageId) return null
 
         val userIndex = messages.indexOfFirst { it.id == userMessageId }
         val assistant = messages.getOrNull(userIndex + 1)?.takeIf { it.role == "assistant" }
@@ -1808,7 +1834,13 @@ class ChatViewModel(
         }
 
         chatRepository.insertMessage(
-            lastUser.copy(content = newContent, createdAt = System.currentTimeMillis())
+            editedUserMessageForEditTurn(
+                lastUser = lastUser,
+                newContent = newContent,
+                attachmentUri = attachmentUri,
+                attachmentMime = attachmentMime,
+                attachmentName = attachmentName,
+            )
         )
         return preservedVersionsJson
     }
@@ -2010,3 +2042,17 @@ class ChatViewModel(
         }
     }
 }
+
+internal fun editedUserMessageForEditTurn(
+    lastUser: ChatMessage,
+    newContent: String,
+    attachmentUri: String?,
+    attachmentMime: String?,
+    attachmentName: String?,
+): ChatMessage = lastUser.copy(
+    content = newContent,
+    createdAt = System.currentTimeMillis(),
+    localAttachmentUri = attachmentUri,
+    localAttachmentMimeType = attachmentMime,
+    localAttachmentName = attachmentName,
+)

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessageActions.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessageActions.kt
@@ -1,0 +1,228 @@
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.echoflow.ui.theme.Spacing
+
+@Composable
+internal fun UserMessageBubble(
+    content: String,
+    canEdit: Boolean,
+    onCopy: () -> Unit,
+    onEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+    attachment: @Composable (() -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    var menuOpen by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        ColumnContent(
+            content = content,
+            attachment = attachment,
+            onLongClick = { menuOpen = true },
+        )
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text("Copy") },
+                leadingIcon = { Icon(Icons.Default.ContentCopy, null) },
+                onClick = {
+                    copyPrompt(context, content)
+                    onCopy()
+                    menuOpen = false
+                },
+            )
+            if (canEdit) {
+                DropdownMenuItem(
+                    text = { Text("Edit") },
+                    leadingIcon = { Icon(Icons.Default.Edit, null) },
+                    onClick = {
+                        menuOpen = false
+                        onEdit()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnContent(
+    content: String,
+    attachment: @Composable (() -> Unit)?,
+    onLongClick: () -> Unit,
+) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        Column(
+            horizontalAlignment = Alignment.End,
+            modifier = Modifier.widthIn(max = 320.dp),
+        ) {
+            attachment?.invoke()
+            Surface(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp))
+                    .combinedClickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {},
+                        onLongClick = onLongClick,
+                    ),
+                shape = RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp),
+                color = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Text(
+                    content,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(horizontal = 18.dp, vertical = Spacing.m),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ReplyVersionBar(
+    currentIndex: Int,
+    totalVersions: Int,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onCopy: () -> Unit,
+    showCopy: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (totalVersions <= 1 && !showCopy) return
+    Row(
+        modifier = modifier.padding(top = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        if (totalVersions > 1) {
+            Surface(
+                onClick = onPrevious,
+                enabled = currentIndex > 0,
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(
+                    alpha = if (currentIndex > 0) 1f else 0.5f,
+                ),
+                modifier = Modifier.size(28.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                        "Previous answer",
+                        Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Text(
+                "${currentIndex + 1}/$totalVersions",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Surface(
+                onClick = onNext,
+                enabled = currentIndex < totalVersions - 1,
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(
+                    alpha = if (currentIndex < totalVersions - 1) 1f else 0.5f,
+                ),
+                modifier = Modifier.size(28.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        "Next answer",
+                        Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.width(Spacing.xs))
+        }
+        if (showCopy) {
+            FilledTonalIconButton(
+                onClick = onCopy,
+                modifier = Modifier.size(32.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+            ) {
+                Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+internal fun AnimatedReplyContent(
+    targetIndex: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable (Int) -> Unit,
+) {
+    AnimatedContent(
+        targetState = targetIndex,
+        modifier = modifier,
+        transitionSpec = { fadeIn() togetherWith fadeOut() },
+        label = "reply-version",
+    ) { index ->
+        content(index)
+    }
+}
+
+private fun copyPrompt(context: Context, prompt: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+    clipboard.setPrimaryClip(ClipData.newPlainText("Message", prompt))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -79,6 +79,7 @@ import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
 import com.echoflow.data.AppMode
 import com.echoflow.data.GeneratedVideo
+import com.echoflow.data.ReplyVersioning
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
@@ -130,6 +131,11 @@ internal fun MessagesPane(
     onCopy: (String) -> Unit,
     onArtifactOpen: () -> Unit = {},
     observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
+    lastUserMessageId: String? = null,
+    onEditUserMessage: (String) -> Unit = {},
+    replyVersionIndexFor: (String, Int) -> Int = { _, total -> (total - 1).coerceAtLeast(0) },
+    onReplyVersionChange: (String, Int) -> Unit = { _, _ -> },
+    canEditMessages: Boolean = true,
 ) {
     val listState = rememberLazyListState()
     var autoFollow by remember { mutableStateOf(true) }
@@ -169,9 +175,17 @@ internal fun MessagesPane(
         items(messages, key = { it.id }) { msg ->
             MessageBubble(
                 msg,
-                onCopy = { onCopy(msg.content) },
+                onCopy = { text -> onCopy(text) },
                 onArtifactOpen = onArtifactOpen,
                 observeVideo = observeVideo,
+                canEditUserMessage = canEditMessages && msg.role == "user" && msg.id == lastUserMessageId,
+                onEditUserMessage = onEditUserMessage,
+                replyVersionIndex = if (msg.role == "assistant") {
+                    replyVersionIndexFor(msg.id, ReplyVersioning.totalVersions(msg))
+                } else {
+                    0
+                },
+                onReplyVersionChange = onReplyVersionChange,
             )
         }
         researchRun?.let { run ->
@@ -414,13 +428,22 @@ internal fun MessageBubble(
     streaming: Boolean = false,
     onArtifactOpen: () -> Unit = {},
     observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
-    onCopy: () -> Unit,
+    onCopy: (String) -> Unit,
+    canEditUserMessage: Boolean = false,
+    onEditUserMessage: (String) -> Unit = {},
+    replyVersionIndex: Int = 0,
+    onReplyVersionChange: (String, Int) -> Unit = { _, _ -> },
 ) {
     val isUser = message.role == "user"
     if (isUser) {
-        Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            Column(horizontalAlignment = Alignment.End, modifier = Modifier.widthIn(max = 320.dp)) {
-                message.localAttachmentUri?.let { uri ->
+        UserMessageBubble(
+            content = message.content,
+            canEdit = canEditUserMessage,
+            onCopy = { onCopy(message.content) },
+            onEdit = { onEditUserMessage(message.id) },
+            modifier = modifier,
+            attachment = message.localAttachmentUri?.let { uri ->
+                {
                     MessageAttachmentPreview(
                         uri = uri,
                         mimeType = message.localAttachmentMimeType,
@@ -428,16 +451,11 @@ internal fun MessageBubble(
                         modifier = Modifier.padding(bottom = Spacing.s),
                     )
                 }
-                Surface(
-                    shape = RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp),
-                    color = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ) {
-                    Text(message.content, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(horizontal = 18.dp, vertical = Spacing.m))
-                }
-            }
-        }
+            },
+        )
     } else {
+        val totalVersions = ReplyVersioning.totalVersions(message)
+        val displayMessage = ReplyVersioning.displayMessage(message, replyVersionIndex)
         // ChatGPT / Claude style: no bubble, full content width.
         Column(modifier.fillMaxWidth()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -447,37 +465,87 @@ internal fun MessageBubble(
             }
             Spacer(Modifier.height(Spacing.s))
 
-            // Finished replies render their persisted timeline in arrival order, so
-            // reason → search → reason → search → answer keeps exactly the layout it
-            // streamed with instead of merging all reasoning into one block.
-            val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
-            // Generated media carries its own copy/save/share row, so the bubble's own copy
-            // button is suppressed when a clip or image is the reply's last word.
-            val lastGeneratedMediaIndex = persistedSegments.indexOfLast { segment ->
-                (segment.type == "image" && segment.image != null) ||
-                    (segment.type == "video" && segment.video != null)
-            }
-
-            message.localAttachmentUri?.let { uri ->
-                MessageAttachmentPreview(
-                    uri = uri,
-                    mimeType = message.localAttachmentMimeType,
-                    name = message.localAttachmentName,
-                    modifier = Modifier.padding(bottom = Spacing.s),
+            AnimatedReplyContent(targetIndex = replyVersionIndex) { versionIndex ->
+                AssistantReplyBody(
+                    message = ReplyVersioning.displayMessage(message, versionIndex),
+                    messageId = message.id,
+                    streaming = streaming,
+                    onArtifactOpen = onArtifactOpen,
+                    observeVideo = observeVideo,
+                    onCopy = onCopy,
                 )
             }
 
-            when {
+            if (!streaming) {
+                val copyText = ReplyVersioning.copyText(message, replyVersionIndex)
+                ReplyVersionBar(
+                    currentIndex = replyVersionIndex,
+                    totalVersions = totalVersions,
+                    onPrevious = {
+                        onReplyVersionChange(message.id, (replyVersionIndex - 1).coerceAtLeast(0))
+                    },
+                    onNext = {
+                        onReplyVersionChange(
+                            message.id,
+                            (replyVersionIndex + 1).coerceAtMost(totalVersions - 1),
+                        )
+                    },
+                    onCopy = {
+                        onCopy(copyText)
+                    },
+                    showCopy = {
+                        val segments = ToolEventJson.segmentsFromJson(displayMessage.segmentsJson)
+                        val lastGeneratedMediaIndex = segments.indexOfLast { segment ->
+                            (segment.type == "image" && segment.image != null) ||
+                                (segment.type == "video" && segment.video != null)
+                        }
+                        lastGeneratedMediaIndex == -1
+                    }(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistantReplyBody(
+    message: ChatMessage,
+    messageId: String,
+    streaming: Boolean,
+    onArtifactOpen: () -> Unit,
+    observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
+    onCopy: (String) -> Unit,
+) {
+    val persistedSegments = remember(messageId, message.segmentsJson) {
+        ToolEventJson.segmentsFromJson(message.segmentsJson)
+    }
+    val lastGeneratedMediaIndex = persistedSegments.indexOfLast { segment ->
+        (segment.type == "image" && segment.image != null) ||
+            (segment.type == "video" && segment.video != null)
+    }
+
+    message.localAttachmentUri?.let { uri ->
+        MessageAttachmentPreview(
+            uri = uri,
+            mimeType = message.localAttachmentMimeType,
+            name = message.localAttachmentName,
+            modifier = Modifier.padding(bottom = Spacing.s),
+        )
+    }
+
+    when {
                 streaming -> {
                     // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
                     if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
                 }
                 persistedSegments.isNotEmpty() -> {
-                    val planSteps = remember(message.id) {
+                    val planSteps = remember(messageId, message.segmentsJson) {
                         persistedSegments.firstOrNull { it.type == "plan" }?.text
                             ?.split("\n")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
                     }
-                    val reportCitations = remember(message.id) { ToolEventJson.citationsFromJson(message.citationsJson) }
+                    val reportCitations = remember(messageId, message.citationsJson) {
+                        ToolEventJson.citationsFromJson(message.citationsJson)
+                    }
                     persistedSegments.forEachIndexed { index, segment ->
                         when (segment.type) {
                             "reasoning" -> {
@@ -545,7 +613,9 @@ internal fun MessageBubble(
                                         pattern = "ripple",
                                         previousImagePath = null,
                                         animate = false,
-                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
+                                        onCopy = if (index == lastGeneratedMediaIndex) {
+                                            { onCopy(message.content) }
+                                        } else null,
                                     )
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
@@ -572,7 +642,9 @@ internal fun MessageBubble(
                                         // lands in front of the user — that one gets the reveal.
                                         animate = ref.filePath == null,
                                         errorMessage = live?.error,
-                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
+                                        onCopy = if (index == lastGeneratedMediaIndex) {
+                                            { onCopy(message.content) }
+                                        } else null,
                                     )
                                     if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                                 }
@@ -588,7 +660,7 @@ internal fun MessageBubble(
                                     report = segment.text.orEmpty(),
                                     citations = reportCitations,
                                     planSteps = planSteps,
-                                    onCopy = onCopy,
+                                    onCopy = { onCopy(segment.text.orEmpty()) },
                                 )
                                 if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                             }
@@ -596,7 +668,7 @@ internal fun MessageBubble(
                                 DataResultCard(
                                     json = segment.text.orEmpty(),
                                     citations = reportCitations,
-                                    onCopy = onCopy,
+                                    onCopy = { onCopy(segment.text.orEmpty()) },
                                 )
                                 if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
                             }
@@ -614,7 +686,9 @@ internal fun MessageBubble(
                         ReasoningSection(reasoning = reasoningText, active = false)
                         Spacer(Modifier.height(Spacing.s))
                     }
-                    val toolEvents = remember(message.id) { ToolEventJson.toolEventsFromJson(message.toolEventsJson) }
+                    val toolEvents = remember(messageId, message.toolEventsJson) {
+                        ToolEventJson.toolEventsFromJson(message.toolEventsJson)
+                    }
                     toolEvents.forEach { event ->
                         SearchActivityCard(query = event.query, sources = event.sources, active = false)
                         Spacer(Modifier.height(Spacing.s))
@@ -622,17 +696,6 @@ internal fun MessageBubble(
                     RichMarkdown(message.content, Modifier.fillMaxWidth())
                 }
             }
-
-            if (!streaming && lastGeneratedMediaIndex == -1) {
-                Spacer(Modifier.height(Spacing.xs))
-                FilledTonalIconButton(
-                    onClick = onCopy,
-                    modifier = Modifier.size(32.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp)) }
-            }
-        }
-    }
 }
 
 /**

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -140,6 +140,10 @@ internal fun ChatSurface(
     val localModelsList by settingsViewModel.localModels.collectAsState()
     val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
     val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
+    val editingUserMessageId by chatViewModel.editingUserMessageId.collectAsState()
+    val replyVersionIndices by chatViewModel.replyVersionIndex.collectAsState()
+
+    val lastUserMessageId = remember(messages) { messages.lastOrNull { it.role == "user" }?.id }
 
     val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
     val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
@@ -348,15 +352,52 @@ internal fun ChatSurface(
                     onCopy = { clipboard.setText(AnnotatedString(it)) },
                     onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
                     observeVideo = chatViewModel::observeVideo,
+                    lastUserMessageId = lastUserMessageId,
+                    onEditUserMessage = { id ->
+                        chatViewModel.beginEditUserMessage(id)?.let { textInput = it }
+                    },
+                    replyVersionIndexFor = { messageId, total ->
+                        replyVersionIndices[messageId]?.coerceIn(0, (total - 1).coerceAtLeast(0))
+                            ?: (total - 1).coerceAtLeast(0)
+                    },
+                    onReplyVersionChange = chatViewModel::selectReplyVersion,
+                    canEditMessages = !isStreaming && editingUserMessageId == null,
                 )
             }
         }
 
 
         // Floating input toolbar over the bottom of the chat.
+        Column(Modifier.align(Alignment.BottomCenter)) {
+            if (editingUserMessageId != null) {
+                Surface(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                ) {
+                    Row(
+                        Modifier.padding(horizontal = Spacing.base, vertical = Spacing.s),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "Editing message",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = {
+                            chatViewModel.cancelEditMessage()
+                            textInput = ""
+                        }) {
+                            Text("Cancel")
+                        }
+                    }
+                }
+            }
         InputToolbar(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
                 .onSizeChanged { inputHeightPx = it.height },
             text = textInput,
             onText = { textInput = it },
@@ -421,6 +462,7 @@ internal fun ChatSurface(
             onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
             onStop = { chatViewModel.stopStreaming() },
         )
+        }
 
 
         // One live browser session app-wide: starting a second is blocked with a choice.

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -142,6 +142,7 @@ internal fun ChatSurface(
     val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
     val editingUserMessageId by chatViewModel.editingUserMessageId.collectAsState()
     val replyVersionIndices by chatViewModel.replyVersionIndex.collectAsState()
+    val editTurnRestore by chatViewModel.editTurnRestore.collectAsState()
 
     val lastUserMessageId = remember(messages) { messages.lastOrNull { it.role == "user" }?.id }
 
@@ -194,6 +195,14 @@ internal fun ChatSurface(
 
     var textInput by remember { mutableStateOf("") }
     var showModelMenu by remember { mutableStateOf(false) }
+
+    LaunchedEffect(editTurnRestore) {
+        editTurnRestore?.let { restore ->
+            textInput = restore.prompt
+            chatViewModel.beginEditUserMessage(restore.userMessageId)
+            chatViewModel.consumeEditTurnRestore()
+        }
+    }
 
     val drEngineLabel = remember(drModelId, drModels) {
         DeepResearchCatalog.providerEngineById(drModelId)?.name

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,7 +56,7 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version eighteen without data loss`() {
+    fun `production database upgrades version one through version nineteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
 
         // v13 tables exist and are queryable after the chained migration.
@@ -82,6 +82,14 @@ class DatabaseUpgradeTest {
         ).use { cursor ->
             cursor.moveToFirst()
             assertEquals("chat", cursor.getString(0))
+        }
+
+        // v19: reply version history for prompt edits.
+        database.openHelper.readableDatabase.query(
+            "SELECT replyVersionsJson FROM chat_messages WHERE id = 'message-1'"
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(null, cursor.getString(0))
         }
 
         database.openHelper.readableDatabase.query(

--- a/app/src/test/java/com/echoflow/data/ReplyVersioningTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersioningTest.kt
@@ -39,4 +39,17 @@ class ReplyVersioningTest {
         assertEquals("older", shown.content)
         assertEquals("latest", ReplyVersioning.displayMessage(message, 1).content)
     }
+
+    @Test
+    fun `copyText prefers segment timeline over empty content field`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "",
+            createdAt = 1L,
+            segmentsJson = """[{"type":"text","text":"Visible answer body"}]""",
+        )
+        assertEquals("Visible answer body", ReplyVersioning.copyText(message, 0))
+    }
 }

--- a/app/src/test/java/com/echoflow/data/ReplyVersioningTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersioningTest.kt
@@ -1,0 +1,42 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReplyVersioningTest {
+    @Test
+    fun `totalVersions counts archived plus current`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "latest",
+            createdAt = 1L,
+            replyVersionsJson = ToolEventJson.replyVersionsToJson(
+                listOf(
+                    ReplyVersion(content = "first"),
+                    ReplyVersion(content = "second"),
+                ),
+            ),
+        )
+        assertEquals(3, ReplyVersioning.totalVersions(message))
+    }
+
+    @Test
+    fun `displayMessage returns archived snapshot for earlier index`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "latest",
+            createdAt = 1L,
+            segmentsJson = """[{"type":"text","text":"latest"}]""",
+            replyVersionsJson = ToolEventJson.replyVersionsToJson(
+                listOf(ReplyVersion(content = "older", segmentsJson = """[{"type":"text","text":"older"}]""")),
+            ),
+        )
+        val shown = ReplyVersioning.displayMessage(message, 0)
+        assertEquals("older", shown.content)
+        assertEquals("latest", ReplyVersioning.displayMessage(message, 1).content)
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
+++ b/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
@@ -79,6 +79,18 @@ class AssistantMessagePersistenceTest {
         assertNull(segment.video?.filePath)
     }
 
+    @Test fun `keeps interrupted empty response so edit history is not orphaned`() {
+        val draft = AssistantMessagePersistence.draft(emptyList(), "network error", stopped = false)!!
+        assertTrue(draft.content.contains("network error"))
+        assertEquals("text", draft.segments.last().type)
+    }
+
+    @Test fun `interruptedOnlyDraft writes a minimal persisted stub`() {
+        val draft = AssistantMessagePersistence.interruptedOnlyDraft("Reply failed.")
+        assertEquals("Reply failed.", draft.content)
+        assertEquals("Reply failed.", draft.segments.single().text)
+    }
+
     @Test fun `normalizes reasoning only answer and appends interruption`() {
         val draft = AssistantMessagePersistence.draft(
             listOf(StreamSegment.Reasoning("work\nAnswer: result")), "timeout", stopped = false,

--- a/app/src/test/java/com/echoflow/ui/EditTurnSupportTest.kt
+++ b/app/src/test/java/com/echoflow/ui/EditTurnSupportTest.kt
@@ -1,0 +1,48 @@
+package com.echoflow.ui
+
+import com.echoflow.data.ChatMessage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EditTurnSupportTest {
+    private val baseUser = ChatMessage(
+        id = "u1",
+        chatId = "c1",
+        role = "user",
+        content = "old prompt",
+        createdAt = 100L,
+        localAttachmentUri = "content://old",
+        localAttachmentMimeType = "image/png",
+        localAttachmentName = "old.png",
+    )
+
+    @Test
+    fun `edited user message uses composer attachment state`() {
+        val edited = editedUserMessageForEditTurn(
+            lastUser = baseUser,
+            newContent = "new prompt",
+            attachmentUri = "content://new",
+            attachmentMime = "image/jpeg",
+            attachmentName = "new.jpg",
+        )
+        assertEquals("new prompt", edited.content)
+        assertEquals("content://new", edited.localAttachmentUri)
+        assertEquals("image/jpeg", edited.localAttachmentMimeType)
+        assertEquals("new.jpg", edited.localAttachmentName)
+    }
+
+    @Test
+    fun `edited user message clears attachment when composer has none`() {
+        val edited = editedUserMessageForEditTurn(
+            lastUser = baseUser,
+            newContent = "new prompt",
+            attachmentUri = null,
+            attachmentMime = null,
+            attachmentName = null,
+        )
+        assertNull(edited.localAttachmentUri)
+        assertNull(edited.localAttachmentMimeType)
+        assertNull(edited.localAttachmentName)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds long-press actions on user messages and reply version browsing after prompt edits.

- **Long-press user message** → Copy or Edit (Edit only on the most recent user message)
- **Edit flow** → Loads the prompt into the composer, archives the previous assistant answer, removes it from the thread, and regenerates with the normal thinking/reasoning/web-search streaming UI
- **Reply versions** → When an answer has been regenerated, a subtle `1/N` pager with left/right arrows appears below the reply alongside the copy button
- **Persistence** → Prior answers are stored in `replyVersionsJson` (Room v19); reopening a thread always shows the latest version, while version browsing persists within a session
- **Design** → Uses Material 3 expressive surfaces, tonal icon buttons, and fade transitions between versions

## Greptile review fixes

- **Validation failure deletes history** — Edit DB mutations run only after all send validation passes
- **Edited attachment state diverges** — Edit begin syncs attachment into composer; commit persists composer attachment state
- **Edit commit can lose history** — User update + assistant deletion run in a single Room `@Transaction` under `NonCancellable`
- **Post-commit stream failure orphans versions** — Interrupted/empty edit failures now persist a stub assistant row with `replyVersionsJson` intact
- **Edit state lost on failure** — Composer text and edit banner restore after regeneration errors
- **Copy on versioned replies** — Copy uses segment timeline text, not just the flat `content` field
- **Attachment-only edits** — Allowed when the composer has a pending attachment

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (all unit tests pass)
- [x] `ReplyVersioningTest` — version indexing, display, and segment copy
- [x] `EditTurnSupportTest` — attachment state on edit commit
- [x] `AssistantMessagePersistenceTest` — interrupted empty responses and failure stubs
- [x] `DatabaseUpgradeTest` — v1→v19 migration without data loss
- [ ] Manual: edit with missing API key — prior answer remains intact
- [ ] Manual: edit regeneration failure — composer reopens in edit mode with prompt restored

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3d01511-9e14-4703-81cf-d748c1701794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3d01511-9e14-4703-81cf-d748c1701794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

I like the product direction of making prompt iteration feel native while retaining prior answers.
- Adds long-press Copy/Edit actions for the latest user prompt and restores edited prompts into the composer.
- Archives assistant answers in Room-backed reply-version history and adds an in-session reply pager.
- Adds transactional edited-turn persistence, failure stubs, attachment synchronization, migration coverage, and focused versioning tests.
- The edit lifecycle would be better implemented as one guarded state transition covering commit, stream setup, persistence, cancellation, and restoration.

<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because pre-stream edit failures can still lose the prior reply history, and stopping regeneration leaves the composer in a stale edit session.

The transactional database mutation fixes cancellation within the user-update/assistant-delete pair, but the destructive commit still precedes unguarded setup operations, while the cancellation branch persists the replacement without completing or restoring edit state.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/ChatViewModel.kt

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Implements edit validation, transactional commit orchestration, streaming regeneration, failure persistence, and UI edit state, but pre-stream exceptions can still orphan history and stopping leaves stale edit state. |
| app/src/main/java/com/echoflow/data/Daos.kt | Adds an appropriate Room transaction that atomically updates the edited user row and removes the replaced assistant. |
| app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt | Adds a minimal interruption draft so empty failed regenerations can retain archived reply versions. |
| app/src/main/java/com/echoflow/data/ChatStreamModels.kt | Adds reply-version serialization, display selection, and segment-aware clipboard text. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Adds version selection and pager rendering for persisted assistant timelines. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Advances Room to version 19 with a nullable replyVersionsJson migration. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant UI as Chat UI
    participant VM as ChatViewModel
    participant DB as Room
    participant M as Model stream
    U->>UI: Long-press latest prompt
    UI->>VM: Begin edit
    U->>VM: Send edited prompt
    VM->>DB: Transactionally update user and delete old reply
    DB-->>VM: Archived reply versions retained
    VM->>M: Regenerate answer
    alt Completed
        M-->>VM: Reply segments
        VM->>DB: Persist replacement with versions
        VM->>UI: Finish edit
    else Failed or stopped
        VM->>DB: Persist interruption or partial reply
        VM->>UI: Restore or finalize edit state
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/src/main/java/com/echoflow/ui/ChatViewModel.kt`, line 1545-1551 ([link](https://github.com/adityavardhansharma/echoflow/blob/b758bbdf1283d03b906137ec2f9e07cf5cc82f74/app/src/main/java/com/echoflow/ui/ChatViewModel.kt#L1545-L1551)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stopped regeneration leaves edit active**

   When the user stops a regenerated response, this branch persists the partial replacement but neither clears nor restores `_editingUserMessageId`. The next send is therefore treated as another edit of the already-committed turn and can fail with “Could not edit message” because its prior assistant row was removed by the first commit.

   **Context Used:** always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Harden edit regeneration failures and ve..."](https://github.com/adityavardhansharma/echoflow/commit/b758bbdf1283d03b906137ec2f9e07cf5cc82f74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48158690)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->