### PR TITLE
feat(chat): long-press edit prompt with reply version history

### DIFF
--- a/app/schemas/com.echoflow.data.AppDatabase/19.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/19.json
@@ -1,0 +1,1198 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "0f41b730ba233d11e958e702bc4ff2e1",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `kind` TEXT NOT NULL DEFAULT 'chat', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'chat'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, `replyVersionsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyVersionsJson",
+            "columnName": "replyVersionsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2723b954ea7793f1efd29b274f9ca885')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -16,7 +16,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ImageModel::class, GeneratedImage::class,
         VideoModel::class, GeneratedVideo::class
     ],
-    version = 18, // v18: conversations belong to a mode (chat | imagine)
+    version = 19, // v19: assistant reply version history for prompt edits
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -352,6 +352,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /** Prompt-edit reply history: older assistant answers live as JSON on the latest row. */
+        internal val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN replyVersionsJson TEXT")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -377,6 +384,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_15_16,
                     MIGRATION_16_17,
                     MIGRATION_17_18,
+                    MIGRATION_18_19,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -63,6 +63,8 @@ class ChatRepository(
     }
 
     suspend fun insertMessage(message: ChatMessage) = messageDao.insertMessage(message)
+    suspend fun replaceUserTurn(updatedUser: ChatMessage, oldAssistantId: String?) =
+        messageDao.replaceUserTurn(updatedUser, oldAssistantId)
     suspend fun history(chatId: String): List<ChatMessage> = messageDao.getMessagesForChatSync(chatId)
     suspend fun thread(chatId: String): ChatThread? = chatDao.getThreadById(chatId)
 }

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -354,4 +354,8 @@ object ReplyVersions {
         citationsJson = message.citationsJson,
         segmentsJson = message.segmentsJson,
     )
+
+    /** Append the current answer to its existing history before replacing the row. */
+    fun archiveCurrent(message: ChatMessage): String? =
+        ToolEventJson.replyVersionsToJson(archived(message) + snapshot(message))
 }

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -247,6 +247,15 @@ data class PersistedSegment(
     val video: VideoRef? = null // present when type == "video"
 )
 
+/** One archived assistant answer kept when a prompt is edited and the reply is regenerated. */
+data class ReplyVersion(
+    val content: String,
+    val reasoning: String? = null,
+    val toolEventsJson: String? = null,
+    val citationsJson: String? = null,
+    val segmentsJson: String? = null,
+)
+
 /** Shared Moshi adapters for the ChatMessage.toolEventsJson / citationsJson columns. */
 object ToolEventJson {
     private val moshi: Moshi = Moshi.Builder()
@@ -263,6 +272,10 @@ object ToolEventJson {
 
     private val segmentsAdapter: JsonAdapter<List<PersistedSegment>> = moshi.adapter(
         Types.newParameterizedType(List::class.java, PersistedSegment::class.java)
+    )
+
+    private val replyVersionsAdapter: JsonAdapter<List<ReplyVersion>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, ReplyVersion::class.java)
     )
 
     fun toolEventsToJson(events: List<ToolEvent>): String? =
@@ -282,4 +295,63 @@ object ToolEventJson {
 
     fun segmentsFromJson(json: String?): List<PersistedSegment> =
         json?.let { runCatching { segmentsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+
+    fun replyVersionsToJson(versions: List<ReplyVersion>): String? =
+        if (versions.isEmpty()) null else replyVersionsAdapter.toJson(versions)
+
+    fun replyVersionsFromJson(json: String?): List<ReplyVersion> =
+        json?.let { runCatching { replyVersionsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+}
+
+/**
+ * Browse archived + current assistant answers on a [ChatMessage].
+ * Index 0 is the oldest archived reply; the last index is the live row (latest).
+ */
+object ReplyVersions {
+    fun archived(message: ChatMessage): List<ReplyVersion> =
+        ToolEventJson.replyVersionsFromJson(message.replyVersionsJson)
+
+    fun count(message: ChatMessage): Int = archived(message).size + 1
+
+    fun display(message: ChatMessage, index: Int): ChatMessage {
+        val prior = archived(message)
+        val latest = prior.size
+        val i = index.coerceIn(0, latest)
+        if (i >= latest) return message
+        val snap = prior[i]
+        return message.copy(
+            content = snap.content,
+            reasoning = snap.reasoning,
+            toolEventsJson = snap.toolEventsJson,
+            citationsJson = snap.citationsJson,
+            segmentsJson = snap.segmentsJson,
+        )
+    }
+
+    fun copyText(message: ChatMessage, index: Int): String {
+        val shown = display(message, index)
+        val fromSegments = textFromSegments(shown.segmentsJson)
+        return fromSegments.ifBlank { shown.content }
+    }
+
+    fun textFromSegments(segmentsJson: String?): String {
+        val segments = ToolEventJson.segmentsFromJson(segmentsJson)
+        if (segments.isEmpty()) return ""
+        return segments.mapNotNull { segment ->
+            when (segment.type) {
+                "text", "report", "data" -> segment.text
+                "reasoning" -> segment.text?.let { "Reasoning:\n$it" }
+                else -> null
+            }
+        }.filter { !it.isNullOrBlank() }.joinToString("\n\n")
+    }
+
+    /** Snapshot the live assistant row into a [ReplyVersion] (for archiving on edit). */
+    fun snapshot(message: ChatMessage): ReplyVersion = ReplyVersion(
+        content = message.content,
+        reasoning = message.reasoning,
+        toolEventsJson = message.toolEventsJson,
+        citationsJson = message.citationsJson,
+        segmentsJson = message.segmentsJson,
+    )
 }

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -47,6 +47,19 @@ interface MessageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMessage(message: ChatMessage)
 
+    @Query("DELETE FROM chat_messages WHERE id = :messageId")
+    suspend fun deleteMessageById(messageId: String)
+
+    /**
+     * Prompt edit: write the updated user row and drop the assistant answer it replaces
+     * in one transaction so a crash never leaves a half-edited turn.
+     */
+    @Transaction
+    suspend fun replaceUserTurn(updatedUser: ChatMessage, oldAssistantId: String?) {
+        insertMessage(updatedUser)
+        if (oldAssistantId != null) deleteMessageById(oldAssistantId)
+    }
+
     @Query("DELETE FROM chat_messages WHERE chatId = :chatId")
     suspend fun deleteMessagesForChat(chatId: String)
 

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -50,7 +50,13 @@ data class ChatMessage(
     val localAttachmentName: String? = null,
     val toolEventsJson: String? = null, // JSON List<ToolEvent>: web searches the model ran for this answer
     val citationsJson: String? = null, // JSON List<Citation>: deduped sources backing this answer
-    val segmentsJson: String? = null // JSON List<PersistedSegment>: ordered reply timeline (reasoning/search/text interleaved)
+    val segmentsJson: String? = null, // JSON List<PersistedSegment>: ordered reply timeline (reasoning/search/text interleaved)
+    /**
+     * Prior assistant answers for this turn, oldest first. Filled when the user edits their
+     * last prompt and regenerates — the row itself always holds the latest reply; this column
+     * keeps the history so the 1/2 pager can switch between them.
+     */
+    val replyVersionsJson: String? = null,
 )
 
 @Entity(tableName = "custom_models")

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -57,7 +57,24 @@ data class ChatMessage(
      * keeps the history so the 1/2 pager can switch between them.
      */
     val replyVersionsJson: String? = null,
-)
+) {
+    /**
+     * Rewrites a user prompt without moving its turn in the transcript. [createdAt] is the
+     * stable ordering key: keeping it means a failed regeneration can restore the original
+     * assistant row verbatim and it will still sort after the prompt it answers.
+     */
+    fun withEditedPrompt(
+        content: String,
+        attachmentUri: String?,
+        attachmentMimeType: String?,
+        attachmentName: String?,
+    ): ChatMessage = copy(
+        content = content,
+        localAttachmentUri = attachmentUri,
+        localAttachmentMimeType = attachmentMimeType,
+        localAttachmentName = attachmentName,
+    )
+}
 
 @Entity(tableName = "custom_models")
 data class CustomModel(

--- a/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
+++ b/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
@@ -37,18 +37,6 @@ internal object AssistantMessagePersistence {
         return AssistantMessageDraft(finalContent, reasoning, events, citations, persisted)
     }
 
-    /** Fallback draft so an edit-turn failure still re-attaches archived reply versions. */
-    fun failureStub(message: String): AssistantMessageDraft {
-        val text = message.trim().ifBlank { "Something went wrong generating a reply." }
-        return AssistantMessageDraft(
-            content = text,
-            reasoning = null,
-            toolEvents = emptyList(),
-            citations = emptyList(),
-            segments = listOf(PersistedSegment(type = "text", text = text)),
-        )
-    }
-
     private fun persistedSegment(segment: StreamSegment): PersistedSegment? = when (segment) {
         is StreamSegment.Reasoning -> segment.text.trim().takeIf(String::isNotEmpty)?.let { PersistedSegment("reasoning", text = it) }
         is StreamSegment.Search -> PersistedSegment("search", query = segment.query, sources = segment.sources)

--- a/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
+++ b/app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt
@@ -21,7 +21,7 @@ internal object AssistantMessagePersistence {
                 (it is StreamSegment.Image && it.filePath != null) ||
                 it is StreamSegment.Video
         }
-        if (content.isEmpty() && !hasDurableCard && !stopped) return null
+        if (content.isEmpty() && !hasDurableCard && !stopped && interrupted.isNullOrBlank()) return null
         val reasoning = normalized.filterIsInstance<StreamSegment.Reasoning>()
             .joinToString("\n\n") { it.text }.trim().ifBlank { null }
         val events = normalized.mapIndexedNotNull { index, segment ->
@@ -35,6 +35,18 @@ internal object AssistantMessagePersistence {
         }
         val finalContent = interrupted?.let { "$content\n\n*[Connection lost: $it]*" } ?: content
         return AssistantMessageDraft(finalContent, reasoning, events, citations, persisted)
+    }
+
+    /** Fallback draft so an edit-turn failure still re-attaches archived reply versions. */
+    fun failureStub(message: String): AssistantMessageDraft {
+        val text = message.trim().ifBlank { "Something went wrong generating a reply." }
+        return AssistantMessageDraft(
+            content = text,
+            reasoning = null,
+            toolEvents = emptyList(),
+            citations = emptyList(),
+            segments = listOf(PersistedSegment(type = "text", text = text)),
+        )
     }
 
     private fun persistedSegment(segment: StreamSegment): PersistedSegment? = when (segment) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1152,6 +1152,9 @@ class ChatViewModel(
 
             // Carried into the new assistant row so prior answers survive regeneration.
             var archivedReplyVersionsJson: String? = null
+            // If an edited generation fails, restore this exact row instead of persisting the
+            // failed attempt as another browsable answer version.
+            var replacedAssistant: ChatMessage? = null
 
             if (editingUserId == null) {
                 // Insert User Message
@@ -1210,6 +1213,7 @@ class ChatViewModel(
                     return@launch
                 }
                 archivedReplyVersionsJson = editResult.archivedVersionsJson
+                replacedAssistant = editResult.replacedAssistant
                 chatRepository.touchThread(chatId)
             }
 
@@ -1520,6 +1524,16 @@ class ChatViewModel(
                 if (videoGenMode && segments.any { it is StreamSegment.Video && !it.generating }) {
                     delay(2600)
                 }
+                if (
+                    editingUserId != null &&
+                    AssistantMessagePersistence.draft(
+                        segments = segments,
+                        interrupted = null,
+                        stopped = false,
+                    ) == null
+                ) {
+                    throw IllegalStateException("The model returned no response. Try again.")
+                }
                 persistAssistantMessage(
                     chatId, segments, interrupted = null,
                     replyVersionsJson = archivedReplyVersionsJson,
@@ -1563,13 +1577,22 @@ class ChatViewModel(
             } catch (e: Exception) {
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."
-                persistAssistantMessage(
-                    chatId, segments, interrupted = e.message,
-                    replyVersionsJson = archivedReplyVersionsJson,
-                )
                 if (editingUserId != null) {
-                    // Keep edit mode so the user can fix the prompt and try again.
+                    // A transport/provider failure is not an answer version. Put the replaced
+                    // answer back exactly as it was and keep edit mode ready for a retry.
+                    withContext(NonCancellable) {
+                        val assistantToRestore = replacedAssistant
+                        if (assistantToRestore != null) {
+                            chatRepository.insertMessage(assistantToRestore)
+                        }
+                    }
                     _editingUserMessageId.value = editingUserId
+                } else {
+                    persistAssistantMessage(
+                        chatId,
+                        segments,
+                        interrupted = e.message,
+                    )
                 }
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
@@ -1856,7 +1879,10 @@ class ChatViewModel(
         return null
     }
 
-    private data class EditTurnResult(val archivedVersionsJson: String?)
+    private data class EditTurnResult(
+        val archivedVersionsJson: String?,
+        val replacedAssistant: ChatMessage?,
+    )
 
     /**
      * Updates the last user prompt, archives the previous assistant answer, and removes that
@@ -1880,9 +1906,7 @@ class ChatViewModel(
 
         var archivedJson = assistant?.replyVersionsJson
         if (assistant != null) {
-            val prior = ReplyVersions.archived(assistant).toMutableList()
-            prior += ReplyVersions.snapshot(assistant)
-            archivedJson = ToolEventJson.replyVersionsToJson(prior)
+            archivedJson = ReplyVersions.archiveCurrent(assistant)
             _replyVersionPick.value = _replyVersionPick.value - assistant.id
         }
 
@@ -1896,7 +1920,10 @@ class ChatViewModel(
             ),
             oldAssistantId = assistant?.id,
         )
-        return EditTurnResult(archivedJson)
+        return EditTurnResult(
+            archivedVersionsJson = archivedJson,
+            replacedAssistant = assistant,
+        )
     }
 
     private suspend fun persistAssistantMessage(
@@ -1906,14 +1933,7 @@ class ChatViewModel(
         stopped: Boolean = false,
         replyVersionsJson: String? = null,
     ) {
-        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped)
-            ?: if (replyVersionsJson != null) {
-                AssistantMessagePersistence.failureStub(
-                    interrupted ?: "Something went wrong generating a reply.",
-                )
-            } else {
-                null
-            } ?: return
+        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped) ?: return
         messageDao.insertMessage(
             ChatMessage(
                 id = UUID.randomUUID().toString(),

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1911,12 +1911,11 @@ class ChatViewModel(
         }
 
         chatRepository.replaceUserTurn(
-            updatedUser = lastUser.copy(
+            updatedUser = lastUser.withEditedPrompt(
                 content = newContent,
-                createdAt = System.currentTimeMillis(),
-                localAttachmentUri = attachmentUri,
-                localAttachmentMimeType = attachmentMime,
-                localAttachmentName = attachmentName,
+                attachmentUri = attachmentUri,
+                attachmentMimeType = attachmentMime,
+                attachmentName = attachmentName,
             ),
             oldAssistantId = assistant?.id,
         )

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -163,6 +163,7 @@ class ChatViewModel(
         // Version pick is session-only; reopening always lands on the latest answer.
         _replyVersionPick.value = emptyMap()
         _editingUserMessageId.value = null
+        clearPendingAttachment()
     }
 
     // ── Prompt edit + reply versions ──────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -160,6 +160,53 @@ class ChatViewModel(
     private fun openThread(chatId: String?) {
         navigation.navigated()
         _currentChatThreadId.value = chatId
+        // Version pick is session-only; reopening always lands on the latest answer.
+        _replyVersionPick.value = emptyMap()
+        _editingUserMessageId.value = null
+    }
+
+    // ── Prompt edit + reply versions ──────────────────────────────────────────────
+
+    /** User message currently loaded into the composer for edit; null when not editing. */
+    private val _editingUserMessageId = MutableStateFlow<String?>(null)
+    val editingUserMessageId: StateFlow<String?> = _editingUserMessageId.asStateFlow()
+
+    /**
+     * Which archived answer is shown for each assistant message id. Missing keys mean
+     * "show latest" so close/reopen always prefers the newest reply.
+     */
+    private val _replyVersionPick = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val replyVersionPick: StateFlow<Map<String, Int>> = _replyVersionPick.asStateFlow()
+
+    /**
+     * Start editing [messageId] if it is the last user prompt. Returns the text to put in
+     * the composer, or null when edit is not allowed.
+     */
+    fun beginEditUserMessage(messageId: String): String? {
+        val lastUser = currentMessages.value.lastOrNull { it.role == "user" } ?: return null
+        if (lastUser.id != messageId) return null
+        _editingUserMessageId.value = messageId
+        val uri = lastUser.localAttachmentUri?.let(Uri::parse)
+        if (uri != null) {
+            setPendingAttachment(uri, lastUser.localAttachmentMimeType, lastUser.localAttachmentName)
+        } else {
+            clearPendingAttachment()
+        }
+        return lastUser.content
+    }
+
+    fun cancelEditMessage() {
+        _editingUserMessageId.value = null
+        clearPendingAttachment()
+    }
+
+    fun selectReplyVersion(messageId: String, index: Int) {
+        _replyVersionPick.value = _replyVersionPick.value + (messageId to index.coerceAtLeast(0))
+    }
+
+    fun replyVersionIndex(messageId: String, total: Int): Int {
+        val latest = (total - 1).coerceAtLeast(0)
+        return _replyVersionPick.value[messageId]?.coerceIn(0, latest) ?: latest
     }
 
     /** Records where this mode is being left — including "on a blank composer". */
@@ -808,33 +855,38 @@ class ChatViewModel(
 
     fun sendMessage(content: String) {
         val prompt = content.trim()
+        val editingUserId = _editingUserMessageId.value
         val attachmentUri = _pendingAttachmentUri.value?.toString()
         val attachmentMime = _pendingAttachmentMimeType.value
         val attachmentName = _pendingAttachmentName.value
 
         if (prompt.isEmpty() && attachmentUri == null) return
 
-        // Deep Research and Data Agent are different pipelines (foreground service +
-        // provider/agent orchestration), so they short-circuit the normal streaming send.
-        if (_chatMode.value is ChatMode.DeepResearch && prompt.isNotEmpty()) {
-            startDeepResearch(prompt, attachmentUri, attachmentMime, attachmentName)
-            return
-        }
-        if (_chatMode.value is ChatMode.DataAgent && prompt.isNotEmpty()) {
-            startDataAgent(prompt)
-            return
-        }
-        // Browser Flow: the owning chat is captured — every message drives the same live browser.
-        val activeBrowser = currentBrowserSession.value
-        if (activeBrowser != null && prompt.isNotEmpty()) {
-            clearPendingAttachment()
-            browserAgent.sendCommand(activeBrowser.chatId, prompt)
-            return
-        }
-        // Igniter: the "+ → Browser Flow" chip starts a new session, then turns itself off.
-        if (_chatMode.value is ChatMode.BrowserFlow && prompt.isNotEmpty()) {
-            startBrowserSession(prompt)
-            return
+        // Prompt edit always uses the normal chat stream path (archive old answer, stream new).
+        // Special modes would fork into a different pipeline and lose the version chain.
+        if (editingUserId == null) {
+            // Deep Research and Data Agent are different pipelines (foreground service +
+            // provider/agent orchestration), so they short-circuit the normal streaming send.
+            if (_chatMode.value is ChatMode.DeepResearch && prompt.isNotEmpty()) {
+                startDeepResearch(prompt, attachmentUri, attachmentMime, attachmentName)
+                return
+            }
+            if (_chatMode.value is ChatMode.DataAgent && prompt.isNotEmpty()) {
+                startDataAgent(prompt)
+                return
+            }
+            // Browser Flow: the owning chat is captured — every message drives the same live browser.
+            val activeBrowser = currentBrowserSession.value
+            if (activeBrowser != null && prompt.isNotEmpty()) {
+                clearPendingAttachment()
+                browserAgent.sendCommand(activeBrowser.chatId, prompt)
+                return
+            }
+            // Igniter: the "+ → Browser Flow" chip starts a new session, then turns itself off.
+            if (_chatMode.value is ChatMode.BrowserFlow && prompt.isNotEmpty()) {
+                startBrowserSession(prompt)
+                return
+            }
         }
 
         _currentChatThreadId.value?.let { chatId ->
@@ -844,13 +896,22 @@ class ChatViewModel(
         // Capture and consume image/video gen before the coroutine starts. These modes are
         // armed per send by [sendImagineMessage]; leaving them sticky makes Chat generate
         // media for every later question after the user switches away mid-render.
-        val imageGenMode = _chatMode.value is ChatMode.ImageGen
-        val videoGenMode = _chatMode.value is ChatMode.VideoGen
+        // Edit-turn never generates media — it re-asks as a normal chat reply.
+        val imageGenMode = editingUserId == null && _chatMode.value is ChatMode.ImageGen
+        val videoGenMode = editingUserId == null && _chatMode.value is ChatMode.VideoGen
         if (imageGenMode || videoGenMode) clearImagineArmedModes()
 
         viewModelScope.launch {
-            clearPendingAttachment()
             clearError()
+
+            if (editingUserId != null) {
+                validateEditTurn(editingUserId, prompt, hasAttachment = attachmentUri != null)?.let { reason ->
+                    _errorMessage.value = reason
+                    return@launch
+                }
+            }
+
+            clearPendingAttachment()
 
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
@@ -1088,35 +1149,67 @@ class ChatViewModel(
             if (streamJobs[chatId]?.isActive == true) return@launch
             coroutineContext[Job]?.let { streamJobs[chatId] = it }
 
-            // Insert User Message
-            val userMsg = ChatMessage(
-                id = UUID.randomUUID().toString(),
-                chatId = chatId,
-                role = "user",
-                content = prompt,
-                createdAt = System.currentTimeMillis(),
-                localAttachmentUri = attachmentUri,
-                localAttachmentMimeType = attachmentMime,
-                localAttachmentName = attachmentName
-            )
-            chatRepository.insertMessage(userMsg)
+            // Carried into the new assistant row so prior answers survive regeneration.
+            var archivedReplyVersionsJson: String? = null
 
-            // Update Thread Timestamp
-            chatRepository.touchThread(chatId)
+            if (editingUserId == null) {
+                // Insert User Message
+                val userMsg = ChatMessage(
+                    id = UUID.randomUUID().toString(),
+                    chatId = chatId,
+                    role = "user",
+                    content = prompt,
+                    createdAt = System.currentTimeMillis(),
+                    localAttachmentUri = attachmentUri,
+                    localAttachmentMimeType = attachmentMime,
+                    localAttachmentName = attachmentName
+                )
+                chatRepository.insertMessage(userMsg)
 
-            // Trigger background Title generation. Local chats use the word fallback:
-            // no API key may exist, and the on-device engine is single-flight.
-            if (isFirstMsgInChat) {
-                if (isLocal || customProviderActive) {
-                    val words = prompt.split("\\s+".toRegex())
-                    val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
-                    chatRepository.renameThread(chatId, fallbackTitle)
-                } else {
-                    launch {
-                        val generatedTitle = openRouterService.generateTitle(apiKey, selectedModel, prompt)
-                        chatRepository.renameThread(chatId!!, generatedTitle)
+                // Update Thread Timestamp
+                chatRepository.touchThread(chatId)
+
+                // Trigger background Title generation. Local chats use the word fallback:
+                // no API key may exist, and the on-device engine is single-flight.
+                if (isFirstMsgInChat) {
+                    if (isLocal || customProviderActive) {
+                        val words = prompt.split("\\s+".toRegex())
+                        val fallbackTitle = words.take(4).joinToString(" ") + if (words.size > 4) "..." else ""
+                        chatRepository.renameThread(chatId, fallbackTitle)
+                    } else {
+                        launch {
+                            val generatedTitle = openRouterService.generateTitle(apiKey, selectedModel, prompt)
+                            chatRepository.renameThread(chatId!!, generatedTitle)
+                        }
                     }
                 }
+            } else {
+                // Show thinking immediately while we drop the old answer and start the stream.
+                setStreamState(
+                    chatId,
+                    ActiveStreamState(
+                        segments = emptyList(),
+                        statusNote = null,
+                        progressLoading = true,
+                        isLocal = isLocal,
+                    ),
+                )
+                val editResult = withContext(NonCancellable) {
+                    commitEditTurn(
+                        userMessageId = editingUserId,
+                        newContent = prompt,
+                        attachmentUri = attachmentUri,
+                        attachmentMime = attachmentMime,
+                        attachmentName = attachmentName,
+                    )
+                }
+                if (editResult == null) {
+                    setStreamState(chatId, null)
+                    _errorMessage.value = "Could not edit message."
+                    return@launch
+                }
+                archivedReplyVersionsJson = editResult.archivedVersionsJson
+                chatRepository.touchThread(chatId)
             }
 
             // Load updated dialog history
@@ -1426,7 +1519,11 @@ class ChatViewModel(
                 if (videoGenMode && segments.any { it is StreamSegment.Video && !it.generating }) {
                     delay(2600)
                 }
-                persistAssistantMessage(chatId, segments, interrupted = null)
+                persistAssistantMessage(
+                    chatId, segments, interrupted = null,
+                    replyVersionsJson = archivedReplyVersionsJson,
+                )
+                if (editingUserId != null) _editingUserMessageId.value = null
                 if (videoGenMode) {
                     // The video flow also completes normally when its row was deleted
                     // mid-render, so announce a clip only once one actually exists.
@@ -1455,13 +1552,24 @@ class ChatViewModel(
                 // User tapped Stop — keep whatever streamed so far and surface no error banner.
                 // The persist runs under NonCancellable so it isn't skipped by the cancellation.
                 withContext(NonCancellable) {
-                    persistAssistantMessage(chatId, segments, interrupted = null, stopped = true)
+                    persistAssistantMessage(
+                        chatId, segments, interrupted = null, stopped = true,
+                        replyVersionsJson = archivedReplyVersionsJson,
+                    )
                 }
+                if (editingUserId != null) _editingUserMessageId.value = null
                 throw e
             } catch (e: Exception) {
                 e.printStackTrace()
                 _errorMessage.value = e.message ?: "An unexpected error occurred during chat."
-                persistAssistantMessage(chatId, segments, interrupted = e.message)
+                persistAssistantMessage(
+                    chatId, segments, interrupted = e.message,
+                    replyVersionsJson = archivedReplyVersionsJson,
+                )
+                if (editingUserId != null) {
+                    // Keep edit mode so the user can fix the prompt and try again.
+                    _editingUserMessageId.value = editingUserId
+                }
                 if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(
                         getApplication(), chatId,
@@ -1729,13 +1837,82 @@ class ChatViewModel(
         currentResearchRun.value?.let { DeepResearchForegroundService.cancel(getApplication(), it.id) }
     }
 
+    private suspend fun validateEditTurn(
+        userMessageId: String,
+        newContent: String,
+        hasAttachment: Boolean,
+    ): String? {
+        val chatId = _currentChatThreadId.value ?: return "No conversation open."
+        val messages = chatRepository.history(chatId)
+        val lastUser = messages.lastOrNull { it.role == "user" } ?: return "No message to edit."
+        if (lastUser.id != userMessageId) return "Only your most recent message can be edited."
+        if (newContent.isBlank() && !hasAttachment) return "Edited message cannot be empty."
+        // Keep edit on the normal answer path so version history stays coherent.
+        val mode = _chatMode.value
+        if (mode !is ChatMode.Normal && mode !is ChatMode.WebSearch) {
+            return "Turn off the active mode before editing a message."
+        }
+        return null
+    }
+
+    private data class EditTurnResult(val archivedVersionsJson: String?)
+
+    /**
+     * Updates the last user prompt, archives the previous assistant answer, and removes that
+     * answer from the transcript so streaming can replace it. Returns null on validation failure.
+     * [EditTurnResult.archivedVersionsJson] may be null when there was no assistant yet.
+     */
+    private suspend fun commitEditTurn(
+        userMessageId: String,
+        newContent: String,
+        attachmentUri: String?,
+        attachmentMime: String?,
+        attachmentName: String?,
+    ): EditTurnResult? {
+        val chatId = _currentChatThreadId.value ?: return null
+        val messages = chatRepository.history(chatId)
+        val lastUser = messages.lastOrNull { it.role == "user" } ?: return null
+        if (lastUser.id != userMessageId) return null
+
+        val userIndex = messages.indexOfFirst { it.id == userMessageId }
+        val assistant = messages.getOrNull(userIndex + 1)?.takeIf { it.role == "assistant" }
+
+        var archivedJson = assistant?.replyVersionsJson
+        if (assistant != null) {
+            val prior = ReplyVersions.archived(assistant).toMutableList()
+            prior += ReplyVersions.snapshot(assistant)
+            archivedJson = ToolEventJson.replyVersionsToJson(prior)
+            _replyVersionPick.value = _replyVersionPick.value - assistant.id
+        }
+
+        chatRepository.replaceUserTurn(
+            updatedUser = lastUser.copy(
+                content = newContent,
+                createdAt = System.currentTimeMillis(),
+                localAttachmentUri = attachmentUri,
+                localAttachmentMimeType = attachmentMime,
+                localAttachmentName = attachmentName,
+            ),
+            oldAssistantId = assistant?.id,
+        )
+        return EditTurnResult(archivedJson)
+    }
+
     private suspend fun persistAssistantMessage(
         chatId: String,
         segments: List<StreamSegment>,
         interrupted: String?,
         stopped: Boolean = false,
+        replyVersionsJson: String? = null,
     ) {
-        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped) ?: return
+        val draft = AssistantMessagePersistence.draft(segments, interrupted, stopped)
+            ?: if (replyVersionsJson != null) {
+                AssistantMessagePersistence.failureStub(
+                    interrupted ?: "Something went wrong generating a reply.",
+                )
+            } else {
+                null
+            } ?: return
         messageDao.insertMessage(
             ChatMessage(
                 id = UUID.randomUUID().toString(),
@@ -1747,6 +1924,7 @@ class ChatViewModel(
                 toolEventsJson = ToolEventJson.toolEventsToJson(draft.toolEvents),
                 citationsJson = ToolEventJson.citationsToJson(draft.citations),
                 segmentsJson = ToolEventJson.segmentsToJson(draft.segments),
+                replyVersionsJson = replyVersionsJson,
             )
         )
         chatDao.getThreadById(chatId)?.let { chatDao.updateThread(it.copy(updatedAt = System.currentTimeMillis())) }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -524,7 +524,12 @@ private fun AssistantAnswerBody(
         (segment.type == "image" && segment.image != null) ||
             (segment.type == "video" && segment.video != null)
     }
-    val copyAction: () -> Unit = { onCopy(ReplyVersions.copyText(message, ReplyVersions.count(message) - 1)) }
+    // [message] is already the selected snapshot. Reading its body directly keeps embedded
+    // report/data copy actions aligned with the version currently on screen.
+    val copyAction: () -> Unit = {
+        val timelineText = ReplyVersions.textFromSegments(message.segmentsJson)
+        onCopy(timelineText.ifBlank { message.content })
+    }
 
     message.localAttachmentUri?.let { uri ->
         MessageAttachmentPreview(

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -79,6 +79,7 @@ import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
 import com.echoflow.data.AppMode
 import com.echoflow.data.GeneratedVideo
+import com.echoflow.data.ReplyVersions
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.SettingsViewModel
@@ -130,6 +131,11 @@ internal fun MessagesPane(
     onCopy: (String) -> Unit,
     onArtifactOpen: () -> Unit = {},
     observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
+    lastUserMessageId: String? = null,
+    onEditUserMessage: (String) -> Unit = {},
+    replyVersionIndexFor: (messageId: String, total: Int) -> Int = { _, total -> (total - 1).coerceAtLeast(0) },
+    onReplyVersionChange: (messageId: String, index: Int) -> Unit = { _, _ -> },
+    canEditMessages: Boolean = true,
 ) {
     val listState = rememberLazyListState()
     var autoFollow by remember { mutableStateOf(true) }
@@ -167,11 +173,20 @@ internal fun MessagesPane(
         contentPadding = PaddingValues(start = Spacing.base, end = Spacing.base, top = topInset, bottom = bottomInset),
     ) {
         items(messages, key = { it.id }) { msg ->
+            val versionTotal = if (msg.role == "assistant") ReplyVersions.count(msg) else 1
             MessageBubble(
                 msg,
-                onCopy = { onCopy(msg.content) },
+                onCopy = { text -> onCopy(text) },
                 onArtifactOpen = onArtifactOpen,
                 observeVideo = observeVideo,
+                canEditUserMessage = canEditMessages && msg.role == "user" && msg.id == lastUserMessageId,
+                onEditUserMessage = onEditUserMessage,
+                replyVersionIndex = if (msg.role == "assistant") {
+                    replyVersionIndexFor(msg.id, versionTotal)
+                } else {
+                    0
+                },
+                onReplyVersionChange = onReplyVersionChange,
             )
         }
         researchRun?.let { run ->
@@ -414,13 +429,22 @@ internal fun MessageBubble(
     streaming: Boolean = false,
     onArtifactOpen: () -> Unit = {},
     observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
-    onCopy: () -> Unit,
+    onCopy: (String) -> Unit,
+    canEditUserMessage: Boolean = false,
+    onEditUserMessage: (String) -> Unit = {},
+    replyVersionIndex: Int = 0,
+    onReplyVersionChange: (String, Int) -> Unit = { _, _ -> },
 ) {
     val isUser = message.role == "user"
     if (isUser) {
-        Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            Column(horizontalAlignment = Alignment.End, modifier = Modifier.widthIn(max = 320.dp)) {
-                message.localAttachmentUri?.let { uri ->
+        UserPromptBubble(
+            content = message.content,
+            canEdit = canEditUserMessage,
+            onCopy = { onCopy(message.content) },
+            onEdit = { onEditUserMessage(message.id) },
+            modifier = modifier,
+            attachment = message.localAttachmentUri?.let { uri ->
+                {
                     MessageAttachmentPreview(
                         uri = uri,
                         mimeType = message.localAttachmentMimeType,
@@ -428,16 +452,11 @@ internal fun MessageBubble(
                         modifier = Modifier.padding(bottom = Spacing.s),
                     )
                 }
-                Surface(
-                    shape = RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp),
-                    color = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ) {
-                    Text(message.content, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(horizontal = 18.dp, vertical = Spacing.m))
-                }
-            }
-        }
+            },
+        )
     } else {
+        val versionCount = ReplyVersions.count(message)
+        val displayMessage = ReplyVersions.display(message, replyVersionIndex)
         // ChatGPT / Claude style: no bubble, full content width.
         Column(modifier.fillMaxWidth()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -447,190 +466,232 @@ internal fun MessageBubble(
             }
             Spacer(Modifier.height(Spacing.s))
 
-            // Finished replies render their persisted timeline in arrival order, so
-            // reason → search → reason → search → answer keeps exactly the layout it
-            // streamed with instead of merging all reasoning into one block.
-            val persistedSegments = remember(message.id) { ToolEventJson.segmentsFromJson(message.segmentsJson) }
-            // Generated media carries its own copy/save/share row, so the bubble's own copy
-            // button is suppressed when a clip or image is the reply's last word.
-            val lastGeneratedMediaIndex = persistedSegments.indexOfLast { segment ->
-                (segment.type == "image" && segment.image != null) ||
-                    (segment.type == "video" && segment.video != null)
-            }
-
-            message.localAttachmentUri?.let { uri ->
-                MessageAttachmentPreview(
-                    uri = uri,
-                    mimeType = message.localAttachmentMimeType,
-                    name = message.localAttachmentName,
-                    modifier = Modifier.padding(bottom = Spacing.s),
+            AnimatedAnswerVersion(versionIndex = replyVersionIndex) { versionIndex ->
+                AssistantAnswerBody(
+                    message = ReplyVersions.display(message, versionIndex),
+                    messageKey = "${message.id}-$versionIndex",
+                    streaming = streaming,
+                    onArtifactOpen = onArtifactOpen,
+                    observeVideo = observeVideo,
+                    onCopy = onCopy,
                 )
             }
 
-            when {
-                streaming -> {
-                    // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
-                    if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
+            if (!streaming) {
+                val segments = ToolEventJson.segmentsFromJson(displayMessage.segmentsJson)
+                val lastGeneratedMediaIndex = segments.indexOfLast { segment ->
+                    (segment.type == "image" && segment.image != null) ||
+                        (segment.type == "video" && segment.video != null)
                 }
-                persistedSegments.isNotEmpty() -> {
-                    val planSteps = remember(message.id) {
-                        persistedSegments.firstOrNull { it.type == "plan" }?.text
-                            ?.split("\n")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+                AnswerActionBar(
+                    versionIndex = replyVersionIndex,
+                    versionCount = versionCount,
+                    onPreviousVersion = {
+                        onReplyVersionChange(message.id, (replyVersionIndex - 1).coerceAtLeast(0))
+                    },
+                    onNextVersion = {
+                        onReplyVersionChange(
+                            message.id,
+                            (replyVersionIndex + 1).coerceAtMost(versionCount - 1),
+                        )
+                    },
+                    onCopy = { onCopy(ReplyVersions.copyText(message, replyVersionIndex)) },
+                    showCopy = lastGeneratedMediaIndex == -1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistantAnswerBody(
+    message: ChatMessage,
+    messageKey: String,
+    streaming: Boolean,
+    onArtifactOpen: () -> Unit,
+    observeVideo: (String) -> Flow<GeneratedVideo?> = { flowOf(null) },
+    onCopy: (String) -> Unit,
+) {
+    // Finished replies render their persisted timeline in arrival order, so
+    // reason → search → reason → search → answer keeps exactly the layout it
+    // streamed with instead of merging all reasoning into one block.
+    val persistedSegments = remember(messageKey, message.segmentsJson) {
+        ToolEventJson.segmentsFromJson(message.segmentsJson)
+    }
+    // Generated media carries its own copy/save/share row, so the bubble's own copy
+    // button is suppressed when a clip or image is the reply's last word.
+    val lastGeneratedMediaIndex = persistedSegments.indexOfLast { segment ->
+        (segment.type == "image" && segment.image != null) ||
+            (segment.type == "video" && segment.video != null)
+    }
+    val copyAction: () -> Unit = { onCopy(ReplyVersions.copyText(message, ReplyVersions.count(message) - 1)) }
+
+    message.localAttachmentUri?.let { uri ->
+        MessageAttachmentPreview(
+            uri = uri,
+            mimeType = message.localAttachmentMimeType,
+            name = message.localAttachmentName,
+            modifier = Modifier.padding(bottom = Spacing.s),
+        )
+    }
+
+    when {
+        streaming -> {
+            // Live markdown, revealed at a smooth steady cadence (decoupled from bursty chunks).
+            if (message.content.isNotBlank()) SmoothStreamingText(message.content, Modifier.fillMaxWidth())
+        }
+        persistedSegments.isNotEmpty() -> {
+            val planSteps = remember(messageKey) {
+                persistedSegments.firstOrNull { it.type == "plan" }?.text
+                    ?.split("\n")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+            }
+            val reportCitations = remember(messageKey, message.citationsJson) {
+                ToolEventJson.citationsFromJson(message.citationsJson)
+            }
+            persistedSegments.forEachIndexed { index, segment ->
+                when (segment.type) {
+                    "reasoning" -> {
+                        ReasoningSection(reasoning = segment.text.orEmpty(), active = false)
+                        Spacer(Modifier.height(Spacing.s))
                     }
-                    val reportCitations = remember(message.id) { ToolEventJson.citationsFromJson(message.citationsJson) }
-                    persistedSegments.forEachIndexed { index, segment ->
-                        when (segment.type) {
-                            "reasoning" -> {
-                                ReasoningSection(reasoning = segment.text.orEmpty(), active = false)
-                                Spacer(Modifier.height(Spacing.s))
-                            }
-                            "search" -> {
-                                SearchActivityCard(query = segment.query.orEmpty(), sources = segment.sources.orEmpty(), active = false)
-                                Spacer(Modifier.height(Spacing.s))
-                            }
-                            "advisor" -> {
-                                segment.advisor?.let { a ->
-                                    AdvisorCard(
-                                        advisorName = a.advisorName,
-                                        advisorModel = a.advisorModel,
-                                        prompt = a.prompt,
-                                        advice = a.advice,
-                                        active = false,
-                                    )
-                                    Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "fusion" -> {
-                                segment.fusion?.let { f ->
-                                    FusionCard(
-                                        panelName = f.panelName,
-                                        models = f.models,
-                                        analysis = f,
-                                        active = false,
-                                    )
-                                    Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "subagent" -> {
-                                segment.subagent?.let { s ->
-                                    SubagentCard(
-                                        taskName = s.taskName,
-                                        taskDescription = s.taskDescription,
-                                        workerModel = s.workerModel,
-                                        outcome = s.outcome,
-                                        error = s.error,
-                                        active = false,
-                                    )
-                                    Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "artifact" -> {
-                                segment.artifact?.let { a ->
-                                    ArtifactCard(
-                                        title = a.title,
-                                        artifactType = a.type,
-                                        version = a.version,
-                                        building = false,
-                                        charCount = 0,
-                                        truncated = false,
-                                        onOpen = onArtifactOpen,
-                                    )
-                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "image" -> {
-                                segment.image?.let { ref ->
-                                    com.echoflow.ui.components.GeneratedImageSegment(
-                                        filePath = ref.filePath,
-                                        pattern = "ripple",
-                                        previousImagePath = null,
-                                        animate = false,
-                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
-                                    )
-                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "video" -> {
-                                segment.video?.let { ref ->
-                                    // The row, not the segment, is the truth: a clip can still be
-                                    // rendering when its message is written (or finish while the
-                                    // app is dead), so the card follows the job live.
-                                    val live by remember(ref.videoId) { observeVideo(ref.videoId) }
-                                        .collectAsState(initial = null)
-                                    com.echoflow.ui.components.GeneratedVideoSegment(
-                                        videoId = ref.videoId,
-                                        filePath = live?.filePath ?: ref.filePath,
-                                        pattern = "ripple",
-                                        aspectRatio = live?.aspectRatio
-                                            ?: com.echoflow.data.VideoRequestPolicy.DEFAULT_ASPECT_RATIO,
-                                        status = live?.status ?: if (ref.filePath != null) {
-                                            GeneratedVideo.STATUS_COMPLETED
-                                        } else {
-                                            GeneratedVideo.STATUS_IN_PROGRESS
-                                        },
-                                        // A message written before the file existed means the clip
-                                        // lands in front of the user — that one gets the reveal.
-                                        animate = ref.filePath == null,
-                                        errorMessage = live?.error,
-                                        onCopy = onCopy.takeIf { index == lastGeneratedMediaIndex },
-                                    )
-                                    if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                                }
-                            }
-                            "stopped" -> {
-                                StoppedNotice()
-                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                            }
-                            // The plan is rendered as a disclosure inside the report card.
-                            "plan" -> Unit
-                            "report" -> {
-                                ReportCard(
-                                    report = segment.text.orEmpty(),
-                                    citations = reportCitations,
-                                    planSteps = planSteps,
-                                    onCopy = onCopy,
-                                )
-                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                            }
-                            "data" -> {
-                                DataResultCard(
-                                    json = segment.text.orEmpty(),
-                                    citations = reportCitations,
-                                    onCopy = onCopy,
-                                )
-                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                            }
-                            else -> {
-                                RichMarkdown(segment.text.orEmpty(), Modifier.fillMaxWidth())
-                                if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
-                            }
+                    "search" -> {
+                        SearchActivityCard(query = segment.query.orEmpty(), sources = segment.sources.orEmpty(), active = false)
+                        Spacer(Modifier.height(Spacing.s))
+                    }
+                    "advisor" -> {
+                        segment.advisor?.let { a ->
+                            AdvisorCard(
+                                advisorName = a.advisorName,
+                                advisorModel = a.advisorModel,
+                                prompt = a.prompt,
+                                advice = a.advice,
+                                active = false,
+                            )
+                            Spacer(Modifier.height(Spacing.s))
                         }
                     }
-                }
-                else -> {
-                    // Legacy messages saved before the timeline column existed.
-                    val reasoningText = message.reasoning
-                    if (!reasoningText.isNullOrBlank()) {
-                        ReasoningSection(reasoning = reasoningText, active = false)
-                        Spacer(Modifier.height(Spacing.s))
+                    "fusion" -> {
+                        segment.fusion?.let { f ->
+                            FusionCard(
+                                panelName = f.panelName,
+                                models = f.models,
+                                analysis = f,
+                                active = false,
+                            )
+                            Spacer(Modifier.height(Spacing.s))
+                        }
                     }
-                    val toolEvents = remember(message.id) { ToolEventJson.toolEventsFromJson(message.toolEventsJson) }
-                    toolEvents.forEach { event ->
-                        SearchActivityCard(query = event.query, sources = event.sources, active = false)
-                        Spacer(Modifier.height(Spacing.s))
+                    "subagent" -> {
+                        segment.subagent?.let { s ->
+                            SubagentCard(
+                                taskName = s.taskName,
+                                taskDescription = s.taskDescription,
+                                workerModel = s.workerModel,
+                                outcome = s.outcome,
+                                error = s.error,
+                                active = false,
+                            )
+                            Spacer(Modifier.height(Spacing.s))
+                        }
                     }
-                    RichMarkdown(message.content, Modifier.fillMaxWidth())
+                    "artifact" -> {
+                        segment.artifact?.let { a ->
+                            ArtifactCard(
+                                title = a.title,
+                                artifactType = a.type,
+                                version = a.version,
+                                building = false,
+                                charCount = 0,
+                                truncated = false,
+                                onOpen = onArtifactOpen,
+                            )
+                            if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                        }
+                    }
+                    "image" -> {
+                        segment.image?.let { ref ->
+                            com.echoflow.ui.components.GeneratedImageSegment(
+                                filePath = ref.filePath,
+                                pattern = "ripple",
+                                previousImagePath = null,
+                                animate = false,
+                                onCopy = copyAction.takeIf { index == lastGeneratedMediaIndex },
+                            )
+                            if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                        }
+                    }
+                    "video" -> {
+                        segment.video?.let { ref ->
+                            // The row, not the segment, is the truth: a clip can still be
+                            // rendering when its message is written (or finish while the
+                            // app is dead), so the card follows the job live.
+                            val live by remember(ref.videoId) { observeVideo(ref.videoId) }
+                                .collectAsState(initial = null)
+                            com.echoflow.ui.components.GeneratedVideoSegment(
+                                videoId = ref.videoId,
+                                filePath = live?.filePath ?: ref.filePath,
+                                pattern = "ripple",
+                                aspectRatio = live?.aspectRatio
+                                    ?: com.echoflow.data.VideoRequestPolicy.DEFAULT_ASPECT_RATIO,
+                                status = live?.status ?: if (ref.filePath != null) {
+                                    GeneratedVideo.STATUS_COMPLETED
+                                } else {
+                                    GeneratedVideo.STATUS_IN_PROGRESS
+                                },
+                                // A message written before the file existed means the clip
+                                // lands in front of the user — that one gets the reveal.
+                                animate = ref.filePath == null,
+                                errorMessage = live?.error,
+                                onCopy = copyAction.takeIf { index == lastGeneratedMediaIndex },
+                            )
+                            if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                        }
+                    }
+                    "stopped" -> {
+                        StoppedNotice()
+                        if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                    }
+                    // The plan is rendered as a disclosure inside the report card.
+                    "plan" -> Unit
+                    "report" -> {
+                        ReportCard(
+                            report = segment.text.orEmpty(),
+                            citations = reportCitations,
+                            planSteps = planSteps,
+                            onCopy = copyAction,
+                        )
+                        if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                    }
+                    "data" -> {
+                        DataResultCard(
+                            json = segment.text.orEmpty(),
+                            citations = reportCitations,
+                            onCopy = copyAction,
+                        )
+                        if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                    }
+                    else -> {
+                        RichMarkdown(segment.text.orEmpty(), Modifier.fillMaxWidth())
+                        if (index != persistedSegments.lastIndex) Spacer(Modifier.height(Spacing.s))
+                    }
                 }
             }
-
-            if (!streaming && lastGeneratedMediaIndex == -1) {
-                Spacer(Modifier.height(Spacing.xs))
-                FilledTonalIconButton(
-                    onClick = onCopy,
-                    modifier = Modifier.size(32.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-                ) { Icon(Icons.Default.ContentCopy, "Copy", Modifier.size(16.dp)) }
+        }
+        else -> {
+            // Legacy messages saved before the timeline column existed.
+            val reasoningText = message.reasoning
+            if (!reasoningText.isNullOrBlank()) {
+                ReasoningSection(reasoning = reasoningText, active = false)
+                Spacer(Modifier.height(Spacing.s))
             }
+            val toolEvents = remember(messageKey, message.toolEventsJson) {
+                ToolEventJson.toolEventsFromJson(message.toolEventsJson)
+            }
+            toolEvents.forEach { event ->
+                SearchActivityCard(query = event.query, sources = event.sources, active = false)
+                Spacer(Modifier.height(Spacing.s))
+            }
+            RichMarkdown(message.content, Modifier.fillMaxWidth())
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatPromptActions.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatPromptActions.kt
@@ -1,0 +1,267 @@
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.echoflow.ui.theme.Spacing
+import com.echoflow.ui.theme.rememberReducedMotion
+
+/**
+ * User prompt bubble with long-press actions: always Copy; Edit only when this is the last
+ * user message in the conversation.
+ */
+@Composable
+internal fun UserPromptBubble(
+    content: String,
+    canEdit: Boolean,
+    onCopy: () -> Unit,
+    onEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+    attachment: @Composable (() -> Unit)? = null,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+
+    Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        Box {
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier.widthIn(max = 320.dp),
+            ) {
+                attachment?.invoke()
+                Surface(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp))
+                        .combinedClickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {},
+                            onLongClick = { menuOpen = true },
+                        ),
+                    shape = RoundedCornerShape(26.dp, 26.dp, 8.dp, 26.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Text(
+                        content,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(horizontal = 18.dp, vertical = Spacing.m),
+                    )
+                }
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Copy") },
+                    leadingIcon = { Icon(Icons.Default.ContentCopy, contentDescription = null) },
+                    onClick = {
+                        onCopy()
+                        menuOpen = false
+                    },
+                )
+                if (canEdit) {
+                    DropdownMenuItem(
+                        text = { Text("Edit prompt") },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        onClick = {
+                            menuOpen = false
+                            onEdit()
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Quiet answer toolbar: optional ‹ n/m › pager plus copy. Sized small so it never competes
+ * with the reply body; uses surface-container tonal chips like the rest of chat chrome.
+ */
+@Composable
+internal fun AnswerActionBar(
+    versionIndex: Int,
+    versionCount: Int,
+    onPreviousVersion: () -> Unit,
+    onNextVersion: () -> Unit,
+    onCopy: () -> Unit,
+    showCopy: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (versionCount <= 1 && !showCopy) return
+
+    Row(
+        modifier = modifier.padding(top = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        if (versionCount > 1) {
+            val canPrev = versionIndex > 0
+            val canNext = versionIndex < versionCount - 1
+            VersionChevron(
+                icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "Previous answer",
+                enabled = canPrev,
+                onClick = onPreviousVersion,
+            )
+            Text(
+                "${versionIndex + 1}/$versionCount",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+            )
+            VersionChevron(
+                icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Next answer",
+                enabled = canNext,
+                onClick = onNextVersion,
+            )
+            Spacer(Modifier.width(Spacing.xs))
+        }
+        if (showCopy) {
+            CompactActionButton(
+                contentDescription = "Copy answer",
+                onClick = onCopy,
+            ) {
+                Icon(Icons.Default.ContentCopy, contentDescription = "Copy answer", Modifier.size(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun VersionChevron(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    CompactActionButton(
+        contentDescription = contentDescription,
+        enabled = enabled,
+        visualSize = 26.dp,
+        onClick = onClick,
+    ) {
+        Icon(
+            icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(15.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                alpha = if (enabled) 1f else 0.45f,
+            ),
+        )
+    }
+}
+
+/**
+ * Keeps the visible chip deliberately compact while retaining Material's 48 dp touch target.
+ */
+@Composable
+private fun CompactActionButton(
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    visualSize: androidx.compose.ui.unit.Dp = 32.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .clickable(
+                enabled = enabled,
+                onClickLabel = contentDescription,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(
+                alpha = if (enabled) 0.9f else 0.4f,
+            ),
+            modifier = Modifier.size(visualSize),
+        ) {
+            Box(contentAlignment = Alignment.Center) { content() }
+        }
+    }
+}
+
+/** Cross-fades (and lightly slides) between reply versions. */
+@Composable
+internal fun AnimatedAnswerVersion(
+    versionIndex: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable (Int) -> Unit,
+) {
+    val reducedMotion = rememberReducedMotion()
+    AnimatedContent(
+        targetState = versionIndex,
+        modifier = modifier,
+        transitionSpec = {
+            if (reducedMotion) {
+                fadeIn(tween(120)) togetherWith fadeOut(tween(90))
+            } else {
+                val forward = targetState > initialState
+                val enter = fadeIn(spring(stiffness = Spring.StiffnessMediumLow)) +
+                    slideInHorizontally(
+                        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                        initialOffsetX = { if (forward) it / 14 else -it / 14 },
+                    )
+                val exit = fadeOut(tween(140)) +
+                    slideOutHorizontally(
+                        animationSpec = tween(140),
+                        targetOffsetX = { if (forward) -it / 18 else it / 18 },
+                    )
+                enter togetherWith exit
+            }
+        },
+        label = "answer-version",
+    ) { index ->
+        content(index)
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatPromptActions.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatPromptActions.kt
@@ -166,7 +166,7 @@ internal fun AnswerActionBar(
                 contentDescription = "Copy answer",
                 onClick = onCopy,
             ) {
-                Icon(Icons.Default.ContentCopy, contentDescription = "Copy answer", Modifier.size(16.dp))
+                Icon(Icons.Default.ContentCopy, contentDescription = null, Modifier.size(16.dp))
             }
         }
     }
@@ -187,7 +187,7 @@ private fun VersionChevron(
     ) {
         Icon(
             icon,
-            contentDescription = contentDescription,
+            contentDescription = null,
             modifier = Modifier.size(15.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                 alpha = if (enabled) 1f else 0.45f,

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -101,6 +101,7 @@ import com.echoflow.ui.theme.MorphPolygonShape
 import com.echoflow.ui.theme.Spacing
 import com.echoflow.ui.theme.rememberMorph
 import com.echoflow.ui.theme.rememberMorphProgress
+import com.echoflow.ui.theme.rememberReducedMotion
 import kotlinx.coroutines.launch
 
 /** Single built-in model. Everything else the user adds in Settings. */
@@ -140,6 +141,10 @@ internal fun ChatSurface(
     val localModelsList by settingsViewModel.localModels.collectAsState()
     val localModelsEnabled by settingsViewModel.localModelsEnabled.collectAsState()
     val currentThreadId by chatViewModel.currentChatThreadId.collectAsState()
+    val editingUserMessageId by chatViewModel.editingUserMessageId.collectAsState()
+    val replyVersionPick by chatViewModel.replyVersionPick.collectAsState()
+    val lastUserMessageId = remember(messages) { messages.lastOrNull { it.role == "user" }?.id }
+    val reducedMotion = rememberReducedMotion()
 
     val deepResearchActive by chatViewModel.deepResearchActive.collectAsState()
     val webSearchChipOn by chatViewModel.webSearchChipOn.collectAsState()
@@ -348,16 +353,69 @@ internal fun ChatSurface(
                     onCopy = { clipboard.setText(AnnotatedString(it)) },
                     onArtifactOpen = { chatViewModel.openArtifactWorkspace() },
                     observeVideo = chatViewModel::observeVideo,
+                    lastUserMessageId = lastUserMessageId,
+                    onEditUserMessage = { id ->
+                        chatViewModel.beginEditUserMessage(id)?.let { textInput = it }
+                    },
+                    replyVersionIndexFor = { messageId, total ->
+                        replyVersionPick[messageId]?.coerceIn(0, (total - 1).coerceAtLeast(0))
+                            ?: (total - 1).coerceAtLeast(0)
+                    },
+                    onReplyVersionChange = chatViewModel::selectReplyVersion,
+                    canEditMessages = !isStreaming && editingUserMessageId == null,
                 )
             }
         }
 
 
-        // Floating input toolbar over the bottom of the chat.
-        InputToolbar(
-            modifier = Modifier
+        // Floating composer stack (optional edit banner + input). Measure the whole stack so
+        // the message list clears both the banner and the toolbar.
+        Column(
+            Modifier
                 .align(Alignment.BottomCenter)
                 .onSizeChanged { inputHeightPx = it.height },
+        ) {
+            AnimatedVisibility(
+                visible = editingUserMessageId != null,
+                enter = if (reducedMotion) {
+                    fadeIn(tween(120))
+                } else {
+                    fadeIn(tween(160)) + expandVertically(expandFrom = Alignment.Bottom)
+                },
+                exit = if (reducedMotion) {
+                    fadeOut(tween(90))
+                } else {
+                    fadeOut(tween(120)) + shrinkVertically(shrinkTowards = Alignment.Bottom)
+                },
+            ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacing.base, vertical = Spacing.xs),
+                ) {
+                    Row(
+                        Modifier.padding(horizontal = Spacing.base, vertical = Spacing.s),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "Editing prompt",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = {
+                            chatViewModel.cancelEditMessage()
+                            textInput = ""
+                        }) {
+                            Text("Cancel")
+                        }
+                    }
+                }
+            }
+        InputToolbar(
+            modifier = Modifier,
             text = textInput,
             onText = { textInput = it },
             pendingUri = pendingUri?.toString(),
@@ -421,6 +479,7 @@ internal fun ChatSurface(
             onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
             onStop = { chatViewModel.stopStreaming() },
         )
+        }
 
 
         // One live browser session app-wide: starting a second is blocked with a choice.

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -362,7 +362,10 @@ internal fun ChatSurface(
                             ?: (total - 1).coerceAtLeast(0)
                     },
                     onReplyVersionChange = chatViewModel::selectReplyVersion,
-                    canEditMessages = !isStreaming && editingUserMessageId == null,
+                    canEditMessages = !isStreaming &&
+                        !progressLoading &&
+                        researchRun == null &&
+                        editingUserMessageId == null,
                 )
             }
         }

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -56,7 +56,7 @@ class DatabaseUpgradeTest {
     }
 
     @Test
-    fun `production database upgrades version one through version eighteen without data loss`() {
+    fun `production database upgrades version one through version nineteen without data loss`() {
         val database = AppDatabase.getDatabase(context).also { openedDatabase = it }
 
         // v13 tables exist and are queryable after the chained migration.
@@ -82,6 +82,14 @@ class DatabaseUpgradeTest {
         ).use { cursor ->
             cursor.moveToFirst()
             assertEquals("chat", cursor.getString(0))
+        }
+
+        // v19: reply version history for prompt edits.
+        database.openHelper.readableDatabase.query(
+            "SELECT replyVersionsJson FROM chat_messages WHERE id = 'message-1'"
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(null, cursor.getString(0))
         }
 
         database.openHelper.readableDatabase.query(

--- a/app/src/test/java/com/echoflow/data/PromptEditOrderingTest.kt
+++ b/app/src/test/java/com/echoflow/data/PromptEditOrderingTest.kt
@@ -1,0 +1,35 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PromptEditOrderingTest {
+    @Test
+    fun `failed regeneration restores assistant after edited prompt`() {
+        val originalUser = ChatMessage(
+            id = "user",
+            chatId = "chat",
+            role = "user",
+            content = "original prompt",
+            createdAt = 100L,
+        )
+        val originalAssistant = ChatMessage(
+            id = "assistant",
+            chatId = "chat",
+            role = "assistant",
+            content = "original answer",
+            createdAt = 200L,
+        )
+
+        val editedUser = originalUser.withEditedPrompt(
+            content = "edited prompt",
+            attachmentUri = null,
+            attachmentMimeType = null,
+            attachmentName = null,
+        )
+        val restoredTranscript = listOf(editedUser, originalAssistant).sortedBy { it.createdAt }
+
+        assertEquals(originalUser.createdAt, editedUser.createdAt)
+        assertEquals(listOf("user", "assistant"), restoredTranscript.map { it.role })
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
@@ -1,0 +1,76 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReplyVersionsTest {
+    @Test
+    fun `count is archived size plus current`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "newest",
+            createdAt = 1L,
+            replyVersionsJson = ToolEventJson.replyVersionsToJson(
+                listOf(
+                    ReplyVersion(content = "first"),
+                    ReplyVersion(content = "second"),
+                ),
+            ),
+        )
+        assertEquals(3, ReplyVersions.count(message))
+    }
+
+    @Test
+    fun `display returns archived snapshot then latest`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "newest",
+            createdAt = 1L,
+            segmentsJson = """[{"type":"text","text":"newest"}]""",
+            replyVersionsJson = ToolEventJson.replyVersionsToJson(
+                listOf(
+                    ReplyVersion(
+                        content = "older",
+                        segmentsJson = """[{"type":"text","text":"older"}]""",
+                    ),
+                ),
+            ),
+        )
+        assertEquals("older", ReplyVersions.display(message, 0).content)
+        assertEquals("newest", ReplyVersions.display(message, 1).content)
+    }
+
+    @Test
+    fun `copyText prefers segment timeline body`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "",
+            createdAt = 1L,
+            segmentsJson = """[{"type":"text","text":"Visible answer body"}]""",
+        )
+        assertEquals("Visible answer body", ReplyVersions.copyText(message, 0))
+    }
+
+    @Test
+    fun `snapshot captures the live assistant fields`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "live",
+            createdAt = 1L,
+            reasoning = "think",
+            segmentsJson = """[{"type":"text","text":"live"}]""",
+        )
+        val snap = ReplyVersions.snapshot(message)
+        assertEquals("live", snap.content)
+        assertEquals("think", snap.reasoning)
+        assertEquals(message.segmentsJson, snap.segmentsJson)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
@@ -73,4 +73,24 @@ class ReplyVersionsTest {
         assertEquals("think", snap.reasoning)
         assertEquals(message.segmentsJson, snap.segmentsJson)
     }
+
+    @Test
+    fun `retrying after a failed edit archives the restored answer only once`() {
+        val restored = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "original answer",
+            createdAt = 1L,
+            replyVersionsJson = ToolEventJson.replyVersionsToJson(
+                listOf(ReplyVersion(content = "older answer")),
+            ),
+        )
+
+        val firstAttempt = ReplyVersions.archiveCurrent(restored)
+        val retryAttempt = ReplyVersions.archiveCurrent(restored)
+
+        assertEquals(firstAttempt, retryAttempt)
+        assertEquals(2, ToolEventJson.replyVersionsFromJson(retryAttempt).size)
+    }
 }

--- a/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
+++ b/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
@@ -15,12 +15,6 @@ class AssistantMessagePersistenceTest {
         assertEquals("stopped", draft.segments.single().type)
     }
 
-    @Test fun `failureStub preserves a non-empty body for edit-turn recovery`() {
-        val draft = AssistantMessagePersistence.failureStub("Connection reset")
-        assertEquals("Connection reset", draft.content)
-        assertEquals("text", draft.segments.single().type)
-    }
-
     @Test fun `a finished image is durable even without answer text`() {
         val draft = AssistantMessagePersistence.draft(
             listOf(

--- a/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
+++ b/app/src/test/java/com/echoflow/ui/AssistantMessagePersistenceTest.kt
@@ -15,6 +15,12 @@ class AssistantMessagePersistenceTest {
         assertEquals("stopped", draft.segments.single().type)
     }
 
+    @Test fun `failureStub preserves a non-empty body for edit-turn recovery`() {
+        val draft = AssistantMessagePersistence.failureStub("Connection reset")
+        assertEquals("Connection reset", draft.content)
+        assertEquals("text", draft.segments.single().type)
+    }
+
     @Test fun `a finished image is durable even without answer text`() {
         val draft = AssistantMessagePersistence.draft(
             listOf(


### PR DESCRIPTION
## Summary

Fresh implementation on `agent/edit-prompt-answer-history` (the earlier local branch name was removed).

- Long-press any user prompt for **Copy**; show **Edit prompt** only on the latest user message.
- Load the latest prompt and its attachment into an animated edit composer, with cancellation and thread-transition cleanup.
- Atomically replace the edited user turn, archive the previous completed answer, and stream thinking, reasoning, and web-search activity normally.
- Keep failed or empty regeneration attempts out of answer history by restoring the exact replaced answer for retry.
- Show a subtle, accessible `‹ n/m ›` pager beside **Copy answer**, with reduced-motion-aware transitions.
- Persist answer history through follow-up messages and app restarts while reopening on the latest answer.
- Add Room v19 migration/schema coverage and reply-version regression tests.

## Review fixes

- Failed edited generations no longer create a browsable answer version; retrying archives the restored answer exactly once.
- Edit-loaded attachments are cleared by every conversation transition.
- Embedded report/data copy actions now copy the answer version currently displayed.
- Compact pager controls retain 48 dp Material touch targets.

## Validation

- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:lintDebug`
- [x] `./gradlew :app:assembleDebug`
- [x] Room 18 → 19 migration test
- [x] Reply archive/display/copy/retry regression tests

## Manual QA

- [ ] Long-press an older user message: Copy only.
- [ ] Long-press the latest user message: Copy and Edit prompt.
- [ ] Edit and send: old answer leaves the transcript and normal thinking/search UI starts.
- [ ] Switch `1/2` answers, send a follow-up, and confirm the pager remains.
- [ ] Reopen the conversation and confirm it defaults to the latest answer.
- [ ] Force a regeneration failure and retry; confirm no failed answer appears in the pager.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds prompt editing with persistent, retry-safe assistant reply history.
- I like the product direction: preserving prior answers makes prompt iteration safer while keeping the conversation easy to navigate.
- The implementation atomically replaces edited turns, restores the original answer after failed or empty regeneration, and preserves original timestamps so recovered turns remain correctly ordered.
- Conversation transitions centralize edit-state and attachment cleanup, while the reply pager includes accessible touch targets and reduced-motion handling.
- Room v19 persists reply history, with migration and regression coverage for ordering, display, copying, and retries.

<h3>Confidence Score: 4/5</h3>

The mode-switch attachment leak needs to be fixed before merging.

A mode restore superseded during its asynchronous lookup skips the cleanup in `openThread`, leaving the prior conversation's edit attachment available to the next send in the newly selected conversation.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/ChatViewModel.kt

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Coordinates edit lifecycle, transition cleanup, answer restoration, streaming, and retries, but an interrupted mode restore can retain edit attachment state across conversations. |
| app/src/main/java/com/echoflow/data/Daos.kt | Adds a transactional user-turn replacement operation that keeps the prompt update and old-answer deletion atomic. |
| app/src/main/java/com/echoflow/data/ChatStreamModels.kt | Defines reply-version serialization, archival, display, and copy behavior for historical answers. |
| app/src/main/java/com/echoflow/ui/AssistantMessagePersistence.kt | Separates durable completed, stopped, interrupted, and empty assistant outputs so failed edits can restore the prior answer. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Advances Room to version 19 with a nullable reply-history column and a registered 18-to-19 migration. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Renders historical answer selection and version-aware copy actions with accessible pager controls. |
| app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt | Covers reply archival, display, copying, and retry behavior that avoids duplicate history entries. |
| app/src/test/java/com/echoflow/data/PromptEditOrderingTest.kt | Verifies edited prompts retain their original timestamp and remain before the restored assistant answer. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant UI as Chat UI
    participant VM as ChatViewModel
    participant DB as Room Database
    participant Model as Chat Provider
    User->>UI: Long-press latest prompt and edit
    UI->>VM: Send edited prompt
    VM->>DB: Replace user turn and remove old answer atomically
    VM->>Model: Regenerate answer
    alt Completed answer
        Model-->>VM: Streamed response
        VM->>DB: Persist new answer with archived history
        DB-->>UI: Latest answer and version pager
    else Failed or empty response
        Model-->>VM: Failure or empty result
        VM->>DB: Restore exact previous answer
        DB-->>UI: Original answer available for retry
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/src/main/java/com/echoflow/ui/ChatViewModel.kt`, line 104-111 ([link](https://github.com/adityavardhansharma/echoflow/blob/12890f1a19c6f68a0840f36ba75459cca45af949/app/src/main/java/com/echoflow/ui/ChatViewModel.kt#L104-L111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mode switch preserves edit attachment**

   When a mode switch restore is superseded by another navigation while its database lookup is in flight, the navigation guard skips `openThread`, so `switchMode` leaves the previous edit ID and shared pending attachment active. The next ordinary message in the newly selected conversation then includes the attachment from the previous conversation.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix edit recovery turn ordering"](https://github.com/adityavardhansharma/echoflow/commit/12890f1a19c6f68a0840f36ba75459cca45af949) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48339034)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing user prompts and regenerating responses.
  * Added reply history, allowing users to browse, display, and copy previous assistant responses.
  * Added prompt editing actions, reply navigation controls, and reduced-motion animations.

* **Bug Fixes**
  * Improved recovery when edited or regenerated responses are interrupted or fail.
  * Preserved conversation ordering and interruption details during persistence.

* **Chores**
  * Updated database migration support to preserve existing conversations and reply history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->