### PR TITLE
Fix chat reply overlap and mode switch shadow

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ModeSwitch.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ModeSwitch.kt
@@ -71,17 +71,9 @@ private const val PulseCycleMs = 3000
 /**
  * The app's top-level surface switch: Chat or Imagine.
  *
- * Built as a **floating tray with a raised thumb** rather than a flat connected pair, so it
- * wears the same material recipe as the composer at the other edge of the screen —
- * `surfaceContainerHigh`, 3dp tonal, 8dp shadow. The two pills bookend the content between
- * them, and the screen reads as one composition instead of chrome plus a control.
- *
- * That construction is also where the recessed look comes from: the tray casts a soft shadow
- * *down* onto scrolling content while the thumb casts a tight one *into* the tray, so the
- * unselected side reads as carved out. Deliberately no true inner shadow — those need custom
- * drawing, they vanish in dark themes where shadows barely register, and they are foreign to
- * Material's lighting model. Here the tonal contrast carries the depth on its own when
- * shadows cannot.
+ * Built as a tonal segmented tray rather than a pair of independent buttons. Tonal contrast
+ * carries the hierarchy; avoiding nested cast shadows keeps the control crisp in both themes
+ * and prevents a dark halo where the selected thumb meets the tray.
  *
  * [renderingModes] marks a surface that still has a clip rendering, so switching away from a
  * long job never hides it.
@@ -117,7 +109,6 @@ fun ModeSwitch(
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         tonalElevation = 3.dp,
-        shadowElevation = 8.dp,
         modifier = modifier.height(TrayHeight),
     ) {
         BoxWithConstraints(Modifier.padding(TrayPadding)) {
@@ -131,7 +122,6 @@ fun ModeSwitch(
             Surface(
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.primary,
-                shadowElevation = if (anyPressed) 0.dp else 2.dp,
                 modifier = Modifier
                     .width(segmentWidth)
                     .fillMaxHeight()

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -467,14 +467,18 @@ internal fun MessageBubble(
             Spacer(Modifier.height(Spacing.s))
 
             AnimatedAnswerVersion(versionIndex = replyVersionIndex) { versionIndex ->
-                AssistantAnswerBody(
-                    message = ReplyVersions.display(message, versionIndex),
-                    messageKey = "${message.id}-$versionIndex",
-                    streaming = streaming,
-                    onArtifactOpen = onArtifactOpen,
-                    observeVideo = observeVideo,
-                    onCopy = onCopy,
-                )
+                // AnimatedContent overlays multiple root children. Give every answer version one
+                // root layout so its timeline is measured vertically and reports its true height.
+                Column(Modifier.fillMaxWidth()) {
+                    AssistantAnswerBody(
+                        message = ReplyVersions.display(message, versionIndex),
+                        messageKey = "${message.id}-$versionIndex",
+                        streaming = streaming,
+                        onArtifactOpen = onArtifactOpen,
+                        observeVideo = observeVideo,
+                        onCopy = onCopy,
+                    )
+                }
             }
 
             if (!streaming) {

--- a/app/src/test/java/com/echoflow/ui/screens/ChatMessageLayoutTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/ChatMessageLayoutTest.kt
@@ -1,0 +1,54 @@
+package com.echoflow.ui.screens
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.echoflow.data.ChatMessage
+import com.echoflow.data.PersistedSegment
+import com.echoflow.data.ToolEventJson
+import com.echoflow.ui.theme.EchoFlowTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class ChatMessageLayoutTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun persistedTimelineStacksReasoningAboveAnswer() {
+        val message = ChatMessage(
+            id = "assistant-1",
+            chatId = "chat-1",
+            role = "assistant",
+            content = "Visible answer",
+            createdAt = 1L,
+            segmentsJson = ToolEventJson.segmentsToJson(
+                listOf(
+                    PersistedSegment(type = "reasoning", text = "Hidden reasoning"),
+                    PersistedSegment(type = "text", text = "Visible answer"),
+                )
+            ),
+        )
+
+        composeRule.setContent {
+            EchoFlowTheme {
+                MessageBubble(message = message, onCopy = {})
+            }
+        }
+
+        val reasoningBounds = composeRule.onNodeWithText("Reasoning")
+            .fetchSemanticsNode().boundsInRoot
+        val answerBounds = composeRule.onNodeWithText("Visible answer")
+            .fetchSemanticsNode().boundsInRoot
+
+        assertTrue(
+            "Answer must be laid out below the reasoning section",
+            answerBounds.top >= reasoningBounds.bottom,
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- Wrap each animated assistant answer version in a single vertical layout so reasoning, web-search, markdown, and media segments measure and stack correctly.
- Remove the nested cast shadows from the Chat/Imagine tray and selected thumb, retaining tonal elevation for cleaner Material separation.
- Add a Robolectric Compose regression test that verifies persisted reasoning renders above answer text.

## Root cause

The prompt-edit/reply-version work moved `AssistantAnswerBody` under `AnimatedContent`. That body emitted multiple root layout nodes, which `AnimatedContent` measured and placed as overlapping children instead of a vertical timeline. This also under-reported the message height to the surrounding `LazyColumn`, allowing action rows and the floating composer to appear to collide.

The mode switch separately combined an 8 dp tray shadow with a 2 dp thumb shadow, producing the uneven dark halo around the control.

## Impact

Reasoning and web-search cards no longer draw over assistant answers, transcript rows reserve their correct height above the composer, and the Chat/Imagine switcher has a cleaner edge in light and dark themes.

## Validation

- `:app:compileDebugKotlin` on JDK 21
- `:app:testDebugUnitTest --tests com.echoflow.ui.screens.ChatMessageLayoutTest --tests com.echoflow.ui.components.ModeSwitchTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message animation sizing so assistant responses render completely and consistently.
  * Ensured persisted reasoning content appears above the visible answer in chat messages.

* **Style**
  * Removed raised-shadow styling from the mode switch tray and selected option for a flatter appearance.

* **Tests**
  * Added coverage confirming the correct ordering of reasoning content and answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes a focused product-quality improvement that restores readable assistant timelines and simplifies the mode switch’s visual elevation.
- Wraps each animated assistant answer in one full-width vertical layout so its segments contribute to the message’s measured height.
- Removes nested cast shadows from the mode-switch tray and selected thumb while retaining tonal hierarchy.
- Adds a useful Robolectric regression test for persisted reasoning and answer ordering; this could be implemented more comprehensively by adding representative search and media segment cases.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking opportunity to broaden the layout regression coverage to search and media segments.

The production change correctly gives AnimatedContent one vertically measured root per answer version, and the mode-switch change is visual-only; the remaining concern is that the test exercises only reasoning and text.

**Files Needing Attention:** app/src/test/java/com/echoflow/ui/screens/ChatMessageLayoutTest.kt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Adds the appropriate single-root Column around each animated answer version, fixing vertical measurement for multi-segment responses. |
| app/src/main/java/com/echoflow/ui/components/ModeSwitch.kt | Removes tray and thumb cast shadows while preserving tonal elevation and existing interaction behavior. |
| app/src/test/java/com/echoflow/ui/screens/ChatMessageLayoutTest.kt | Verifies reasoning stacks above answer text, but does not cover the search and media layouts affected by the same fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix chat reply layout and mode switch sh..."](https://github.com/adityavardhansharma/echoflow/commit/7ece4f7d53744192d0b3bb847ff173798306196a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48904361)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->