### PR TITLE
Fix gesture back navigation for Echo Labs sub-pages

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -166,6 +166,23 @@ internal const val PageCustomProviderOllama = "custom_provider_ollama"
 internal const val PageCustomProviderCompatible = "custom_provider_compatible"
 internal val CustomProviderSectionGap = 28.dp
 
+/** Parent page when backing out of [page]; null on the settings hub. */
+internal fun settingsParentPage(page: String): String? = when (page) {
+    PageHome -> null
+    PageAppearance, PageCloudModels, PageWebSearch, PageLocalModels,
+    PageDeepResearch, PageImagine, PageEchoLabs,
+    -> PageHome
+    PageDataAgent, PageBrowserFlow, PageEchoAdviser, PageEchoFusion,
+    PageEchoAgent, PageCustomProvider,
+    -> PageEchoLabs
+    PageCustomProviderCloud -> PageCustomProvider
+    PageCustomProviderOllama, PageCustomProviderCompatible -> PageCustomProvider
+    PageCustomProviderOpenAi, PageCustomProviderClaude, PageCustomProviderGemini,
+    PageCustomProviderCerebras, PageCustomProviderXAi,
+    -> PageCustomProviderCloud
+    else -> PageHome
+}
+
 /** Theme-driven Expressive motion for revealing/hiding blocks inside a page. */
 @Composable
 internal fun sectionEnter(): EnterTransition = expandVertically(
@@ -191,7 +208,10 @@ fun SettingsScreen(
     onBackClicked: () -> Unit,
 ) {
     var page by rememberSaveable { mutableStateOf(PageHome) }
-    BackHandler(enabled = page != PageHome) { page = PageHome }
+    val navigateBack: () -> Unit = {
+        settingsParentPage(page)?.let { page = it }
+    }
+    BackHandler(enabled = settingsParentPage(page) != null, onBack = navigateBack)
 
     val spatial = MaterialTheme.motionScheme.defaultSpatialSpec<IntOffset>()
     val effects = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
@@ -210,27 +230,27 @@ fun SettingsScreen(
         label = "settingsPages",
     ) { current ->
         when (current) {
-            PageAppearance -> AppearancePage(viewModel, onBack = { page = PageHome })
-            PageCloudModels -> CloudModelsPage(viewModel, onBack = { page = PageHome })
-            PageWebSearch -> WebSearchPage(viewModel, onBack = { page = PageHome })
-            PageLocalModels -> LocalModelsPage(viewModel, onBack = { page = PageHome })
-            PageDeepResearch -> DeepResearchPage(viewModel, onBack = { page = PageHome })
-            PageImagine -> ImaginePage(viewModel, onBack = { page = PageHome })
-            PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = { page = PageHome })
-            PageDataAgent -> DataAgentPage(viewModel, onBack = { page = PageEchoLabs })
-            PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = { page = PageEchoLabs })
-            PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = { page = PageEchoLabs })
-            PageEchoFusion -> EchoFusionPage(viewModel, onBack = { page = PageEchoLabs })
-            PageEchoAgent -> EchoAgentPage(viewModel, onBack = { page = PageEchoLabs })
-            PageCustomProvider -> CustomApiEndpointPage(viewModel, onOpen = { page = it }, onBack = { page = PageEchoLabs })
-            PageCustomProviderCloud -> DirectCloudApisPage(viewModel, onOpen = { page = it }, onBack = { page = PageCustomProvider })
-            PageCustomProviderOpenAi -> DirectCloudBrandPage(viewModel, CustomModelProvider.OpenAi, onBack = { page = PageCustomProviderCloud })
-            PageCustomProviderClaude -> DirectCloudBrandPage(viewModel, CustomModelProvider.Claude, onBack = { page = PageCustomProviderCloud })
-            PageCustomProviderGemini -> DirectCloudBrandPage(viewModel, CustomModelProvider.Gemini, onBack = { page = PageCustomProviderCloud })
-            PageCustomProviderCerebras -> DirectCloudBrandPage(viewModel, CustomModelProvider.Cerebras, onBack = { page = PageCustomProviderCloud })
-            PageCustomProviderXAi -> DirectCloudBrandPage(viewModel, CustomModelProvider.XAi, onBack = { page = PageCustomProviderCloud })
-            PageCustomProviderOllama -> OllamaEndpointPage(viewModel, onBack = { page = PageCustomProvider })
-            PageCustomProviderCompatible -> OpenAiCompatibleEndpointPage(viewModel, onBack = { page = PageCustomProvider })
+            PageAppearance -> AppearancePage(viewModel, onBack = navigateBack)
+            PageCloudModels -> CloudModelsPage(viewModel, onBack = navigateBack)
+            PageWebSearch -> WebSearchPage(viewModel, onBack = navigateBack)
+            PageLocalModels -> LocalModelsPage(viewModel, onBack = navigateBack)
+            PageDeepResearch -> DeepResearchPage(viewModel, onBack = navigateBack)
+            PageImagine -> ImaginePage(viewModel, onBack = navigateBack)
+            PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = navigateBack)
+            PageDataAgent -> DataAgentPage(viewModel, onBack = navigateBack)
+            PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = navigateBack)
+            PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = navigateBack)
+            PageEchoFusion -> EchoFusionPage(viewModel, onBack = navigateBack)
+            PageEchoAgent -> EchoAgentPage(viewModel, onBack = navigateBack)
+            PageCustomProvider -> CustomApiEndpointPage(viewModel, onOpen = { page = it }, onBack = navigateBack)
+            PageCustomProviderCloud -> DirectCloudApisPage(viewModel, onOpen = { page = it }, onBack = navigateBack)
+            PageCustomProviderOpenAi -> DirectCloudBrandPage(viewModel, CustomModelProvider.OpenAi, onBack = navigateBack)
+            PageCustomProviderClaude -> DirectCloudBrandPage(viewModel, CustomModelProvider.Claude, onBack = navigateBack)
+            PageCustomProviderGemini -> DirectCloudBrandPage(viewModel, CustomModelProvider.Gemini, onBack = navigateBack)
+            PageCustomProviderCerebras -> DirectCloudBrandPage(viewModel, CustomModelProvider.Cerebras, onBack = navigateBack)
+            PageCustomProviderXAi -> DirectCloudBrandPage(viewModel, CustomModelProvider.XAi, onBack = navigateBack)
+            PageCustomProviderOllama -> OllamaEndpointPage(viewModel, onBack = navigateBack)
+            PageCustomProviderCompatible -> OpenAiCompatibleEndpointPage(viewModel, onBack = navigateBack)
             else -> SettingsHomePage(viewModel, onBackClicked = onBackClicked, onOpen = { page = it })
         }
     }

--- a/app/src/test/java/com/echoflow/ui/screens/SettingsNavigationTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/SettingsNavigationTest.kt
@@ -1,0 +1,52 @@
+package com.echoflow.ui.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SettingsNavigationTest {
+
+    @Test
+    fun settingsHubHasNoParent() {
+        assertNull(settingsParentPage(PageHome))
+    }
+
+    @Test
+    fun topLevelPagesReturnToHub() {
+        listOf(
+            PageAppearance,
+            PageCloudModels,
+            PageWebSearch,
+            PageLocalModels,
+            PageDeepResearch,
+            PageImagine,
+            PageEchoLabs,
+        ).forEach { page ->
+            assertEquals(PageHome, settingsParentPage(page))
+        }
+    }
+
+    @Test
+    fun echoLabsPagesReturnToEchoLabs() {
+        listOf(
+            PageDataAgent,
+            PageBrowserFlow,
+            PageEchoAdviser,
+            PageEchoFusion,
+            PageEchoAgent,
+            PageCustomProvider,
+        ).forEach { page ->
+            assertEquals(PageEchoLabs, settingsParentPage(page))
+        }
+    }
+
+    @Test
+    fun customProviderPagesUseNestedParents() {
+        assertEquals(PageEchoLabs, settingsParentPage(PageCustomProvider))
+        assertEquals(PageCustomProvider, settingsParentPage(PageCustomProviderCloud))
+        assertEquals(PageCustomProvider, settingsParentPage(PageCustomProviderOllama))
+        assertEquals(PageCustomProvider, settingsParentPage(PageCustomProviderCompatible))
+        assertEquals(PageCustomProviderCloud, settingsParentPage(PageCustomProviderOpenAi))
+        assertEquals(PageCustomProviderCloud, settingsParentPage(PageCustomProviderClaude))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When navigating Settings → Echo Labs → a sub-page (e.g. Browser Flow), the toolbar back arrow correctly returned to Echo Labs, but the system gesture back jumped all the way to the Settings hub.

This affected every Echo Labs sub-page and the nested Custom API Endpoint pages.

## Root cause

`SettingsScreen` registered a single `BackHandler` that always set `page = PageHome` for any non-home page. Individual pages had their own `onBack` callbacks with the correct parent (e.g. `PageEchoLabs`), so toolbar and gesture back were out of sync.

## Fix

- Added `settingsParentPage()` to centralize the settings navigation hierarchy.
- Wired both gesture back (`BackHandler`) and toolbar back (`navigateBack`) through the same parent lookup.
- Added unit tests covering hub, Echo Labs, and Custom Provider nesting.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.echoflow.ui.screens.SettingsNavigationTest"` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d6a9b2-0d14-4d7e-b27b-73c0091be8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d6a9b2-0d14-4d7e-b27b-73c0091be8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly centralizes Settings back-navigation so toolbar and system gestures follow the same hierarchy.
- Adds a single parent-page lookup covering the Settings hub, Echo Labs pages, and nested custom-provider pages.
- Reuses the centralized navigation callback for both `BackHandler` and toolbar actions.
- Adds focused unit coverage for the navigation hierarchy.
- Product direction: Aligning gesture and toolbar navigation removes a frustrating platform inconsistency and makes nested Echo Labs features feel native.
- Implementation improvement: The centralized hierarchy is clearer and less error-prone than page-specific callbacks; future pages should continue to be added alongside explicit parent-mapping tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with toolbar and gesture navigation now consistently returning each known Settings page to its intended parent.

The parent lookup covers all current Settings page constants, and both back-entry paths use the same live page state without introducing a reachable navigation or security failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt | Centralizes the complete current page hierarchy and consistently routes gesture and toolbar back actions through it; no actionable defect found. |
| app/src/test/java/com/echoflow/ui/screens/SettingsNavigationTest.kt | Adds focused tests for hub, top-level, Echo Labs, and nested custom-provider parent mappings. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    BrandPages[Cloud brand pages] --> Cloud[Direct Cloud APIs]
    Cloud --> Custom[Custom API Endpoint]
    Ollama[Ollama endpoint] --> Custom
    Compatible[OpenAI-compatible endpoint] --> Custom
    Custom --> Labs[Echo Labs]
    LabPages[Echo Labs feature pages] --> Labs
    Labs --> Hub[Settings hub]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix gesture back navigation for Echo Lab..."](https://github.com/adityavardhansharma/echoflow/commit/a8d74fe870b39a682ee6fb570e67d69982b0be0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49021865)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation in Settings, ensuring nested pages return to the correct parent page.
  * Standardized navigation behavior for system back actions and detail screens.

* **Tests**
  * Added coverage for root, top-level, Echo Labs, and nested custom-provider navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->