### PR TITLE
fix(chat): clear composer state synchronously on mode switch

### DIFF
--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -140,6 +140,10 @@ class ChatViewModel(
      */
     private fun restorePosition(mode: AppMode) {
         modeRestoreJob?.cancel()
+        // A mode switch is already a conversation transition, even if its suspended lookup is
+        // later superseded. Clear conversation-scoped composer state synchronously so a stale
+        // restore cannot leave the previous thread's edit attachment armed for the next send.
+        clearConversationComposerState()
         modeRestoreJob = viewModelScope.launch {
             val token = navigation.begin()
             val restored = restoredThreadId(mode)
@@ -162,6 +166,10 @@ class ChatViewModel(
         _currentChatThreadId.value = chatId
         // Version pick is session-only; reopening always lands on the latest answer.
         _replyVersionPick.value = emptyMap()
+        clearConversationComposerState()
+    }
+
+    private fun clearConversationComposerState() {
         _editingUserMessageId.value = null
         clearPendingAttachment()
     }
@@ -197,8 +205,7 @@ class ChatViewModel(
     }
 
     fun cancelEditMessage() {
-        _editingUserMessageId.value = null
-        clearPendingAttachment()
+        clearConversationComposerState()
     }
 
     fun selectReplyVersion(messageId: String, index: Int) {


### PR DESCRIPTION
## What

Clears conversation-scoped composer state (editing message id + pending attachment) **synchronously** when switching modes, instead of relying solely on the async `restorePosition` coroutine.

## Why

A mode switch is a conversation transition even when its suspended thread lookup is later superseded. Without a synchronous reset, a stale restore could leave the previous thread's **edit attachment armed for the next send** — attaching content from the old conversation to a message in the new one.

## Changes

- Extract the shared reset into `clearConversationComposerState()` (editing message id + pending attachment).
- Call it synchronously at the top of `restorePosition(mode)`, before launching the restore coroutine.
- Reuse it from `cancelEditMessage()` (dedupe).

Net: +9 / -2 in `ChatViewModel.kt`. No behavior change to the layout fix already in the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where draft edits and pending attachments could remain after switching conversations or opening a thread.
  * Cancelling an edit now reliably resets the composer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes conversation-scoped composer cleanup and performs it synchronously before asynchronous mode restoration, preventing an old thread’s edit attachment from leaking into the newly selected mode. I like that this strengthens conversation isolation while deduplicating cancellation behavior; the implementation could be improved further with focused ViewModel tests covering rapid mode switches, stale restores, and edit attachments.
- Adds `clearConversationComposerState()` to reset the editing message ID and pending attachment together.
- Invokes the reset before launching the suspended position lookup.
- Reuses the helper when opening a thread and cancelling message editing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly prevents conversation-scoped edit attachments from surviving a mode transition.

All current restoration callers represent genuine conversation transitions, and the synchronous reset occurs before asynchronous restoration can leave stale composer state active.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Centralizes composer-state cleanup and synchronously applies it at conversation transitions without introducing an observable regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): clear composer state synchron..."](https://github.com/adityavardhansharma/echoflow/commit/d9e1205c08aea22173f520ceb9dfb0a7593f95ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49320551)</sub>

<!-- /greptile_comment -->