### PR TITLE
Redesign sidebar list + long-press action sheet

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
+++ b/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
@@ -235,7 +235,8 @@ private fun ThreadRow(
  *
  * A sheet reads as a first-class surface — a titled header naming the conversation, plus big
  * touch-friendly action rows — where the old anchored dropdown read as a leftover from stock
- * Android. Each action fires immediately on tap, then the sheet animates itself away.
+ * Android. Tapping a row slides the sheet out and only then runs the action, so a Rename/Delete
+ * dialog never lands on top of a still-animating sheet.
  */
 @Composable
 private fun ThreadActionSheet(
@@ -248,11 +249,17 @@ private fun ThreadActionSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
-    // Run the action now (so it's never dropped), then let the sheet slide out before it leaves
-    // the composition.
+    // Slide the sheet out first, then dismiss and run the action. Rename and Delete each raise a
+    // dialog, so firing the action up front would stack that dialog over a still-animating sheet
+    // (double scrim, plus a sheet-exit flash when the dialog later closes). Waiting for the hide
+    // animation keeps it to one modal on screen at a time.
     fun act(action: () -> Unit) {
-        action()
-        scope.launch { sheetState.hide() }.invokeOnCompletion { onDismiss() }
+        scope.launch { sheetState.hide() }.invokeOnCompletion {
+            if (!sheetState.isVisible) {
+                onDismiss()
+                action()
+            }
+        }
     }
 
     ModalBottomSheet(

--- a/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
+++ b/app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt
@@ -3,56 +3,67 @@
 package com.echoflow.ui.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Chat
-import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.PushPin
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.echoflow.data.AppMode
 import com.echoflow.data.ChatThread
 import com.echoflow.ui.theme.Spacing
 import com.echoflow.ui.theme.rememberReducedMotion
+import kotlinx.coroutines.launch
 import java.util.Calendar
 
-private val PillShape = RoundedCornerShape(28.dp)
 private const val PINNED_SECTION = "Pinned"
+
+// Rows within a section share a slab: large radius on the section's outer corners, tight radius
+// where rows meet. This is the same grouped-list vocabulary the Settings screens use, so the
+// drawer stops looking like a stack of detached buttons and starts looking looked-after.
+private val RowGap = GroupedItemGap
 
 /**
  * One mode's conversations, grouped by when they were last touched.
@@ -74,6 +85,11 @@ fun DrawerThreadList(
     modifier: Modifier = Modifier,
 ) {
     val reducedMotion = rememberReducedMotion()
+    // A single action sheet for the whole list, driven by whichever row was long-pressed. One
+    // lifted sheet beats a DropdownMenu per row: less state, and it's the modern mobile pattern
+    // for long-press actions.
+    var actionTarget by remember { mutableStateOf<ChatThread?>(null) }
+
     val sections = remember(threads, grouped) {
         val pinned = threads.filter { it.isPinned }
         val unpinned = threads.filter { !it.isPinned }
@@ -81,20 +97,24 @@ fun DrawerThreadList(
         if (pinned.isEmpty()) unpinnedSections
         else listOf(PINNED_SECTION to pinned) + unpinnedSections
     }
-    LazyColumn(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+    LazyColumn(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(RowGap)) {
         sections.forEach { (label, sectionThreads) ->
             if (label != null) {
                 item(key = "section-$label") {
-                    Box(Modifier.padding(top = Spacing.s, bottom = Spacing.xs)) { SectionLabel(label) }
+                    // Extra top space above the header separates one slab from the next; the
+                    // rows inside a slab stay tight at RowGap.
+                    Box(Modifier.padding(top = Spacing.m, bottom = Spacing.xs)) { SectionLabel(label) }
                 }
             }
-            items(sectionThreads, key = { it.id }) { thread ->
-                ThreadPill(
+            itemsIndexed(sectionThreads, key = { _, t -> t.id }) { index, thread ->
+                ThreadRow(
                     thread = thread,
                     selected = thread.id == currentThreadId,
                     rendering = thread.id in renderingChatIds,
                     reducedMotion = reducedMotion,
+                    shape = groupedItemShape(index, sectionThreads.size),
                     onClick = { onThreadSelected(thread) },
+                    onLongPress = { actionTarget = thread },
                     onPin = { onPin(thread) },
                     onUnpin = { onUnpin(thread) },
                     onRename = { onRename(thread) },
@@ -103,21 +123,33 @@ fun DrawerThreadList(
             }
         }
     }
+
+    actionTarget?.let { thread ->
+        ThreadActionSheet(
+            thread = thread,
+            onDismiss = { actionTarget = null },
+            onPin = { onPin(thread) },
+            onUnpin = { onUnpin(thread) },
+            onRename = { onRename(thread) },
+            onDelete = { onDelete(thread) },
+        )
+    }
 }
 
 @Composable
-private fun ThreadPill(
+private fun ThreadRow(
     thread: ChatThread,
     selected: Boolean,
     rendering: Boolean,
     reducedMotion: Boolean,
+    shape: androidx.compose.ui.graphics.Shape,
     onClick: () -> Unit,
+    onLongPress: () -> Unit,
     onPin: () -> Unit,
     onUnpin: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    var menuOpen by remember { mutableStateOf(false) }
     val contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
     else MaterialTheme.colorScheme.onSurface
     val mutedColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
@@ -127,112 +159,204 @@ private fun ThreadPill(
         if (thread.isPinned) append(", pinned")
         if (rendering) append(", video rendering")
     }
-    Box {
-        val interactionSource = remember { MutableInteractionSource() }
-        Surface(
-            shape = PillShape,
-            color = if (selected) MaterialTheme.colorScheme.secondaryContainer
-            else MaterialTheme.colorScheme.surfaceContainerLow,
-            modifier = Modifier
-                .fillMaxWidth()
-                .combinedClickable(
-                    interactionSource = interactionSource,
-                    indication = ripple(bounded = true),
-                    onClick = onClick,
-                    onLongClick = { menuOpen = true },
-                )
-                .semantics {
-                    contentDescription = description
-                    customActions = buildList {
-                        add(
-                            CustomAccessibilityAction(
-                                if (thread.isPinned) "Unpin" else "Pin",
-                            ) {
-                                if (thread.isPinned) onUnpin() else onPin()
-                                true
-                            },
-                        )
-                        add(CustomAccessibilityAction("Rename") { onRename(); true })
-                        add(CustomAccessibilityAction("Delete") { onDelete(); true })
-                    }
-                },
+    val interactionSource = remember { MutableInteractionSource() }
+    Surface(
+        shape = shape,
+        color = if (selected) MaterialTheme.colorScheme.secondaryContainer
+        else MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                interactionSource = interactionSource,
+                indication = ripple(bounded = true),
+                onClick = onClick,
+                onLongClick = onLongPress,
+            )
+            .semantics {
+                contentDescription = description
+                customActions = buildList {
+                    add(
+                        CustomAccessibilityAction(
+                            if (thread.isPinned) "Unpin" else "Pin",
+                        ) {
+                            if (thread.isPinned) onUnpin() else onPin()
+                            true
+                        },
+                    )
+                    add(CustomAccessibilityAction("Rename") { onRename(); true })
+                    add(CustomAccessibilityAction("Delete") { onDelete(); true })
+                }
+            },
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.base).heightIn(min = 54.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                Modifier.padding(start = Spacing.base, end = Spacing.base).heightIn(min = 52.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    if (thread.mode == AppMode.Imagine) Icons.Default.AutoFixHigh else Icons.AutoMirrored.Filled.Chat,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = mutedColor,
+            // On the selected row a slim accent bar marks the active conversation — quieter and
+            // more modern than stamping the same chat icon on every single row.
+            if (selected) {
+                Box(
+                    Modifier
+                        .size(width = 3.dp, height = 20.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(MaterialTheme.colorScheme.primary),
                 )
                 Spacer(Modifier.width(Spacing.m))
-                Text(
-                    thread.title,
-                    maxLines = 1, overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = contentColor,
-                    modifier = Modifier.weight(1f),
+            }
+            Text(
+                thread.title,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
+                color = contentColor,
+                modifier = Modifier.weight(1f),
+            )
+            if (thread.isPinned) {
+                Spacer(Modifier.width(Spacing.s))
+                Icon(
+                    Icons.Filled.PushPin,
+                    contentDescription = "Pinned",
+                    modifier = Modifier.size(16.dp),
+                    tint = mutedColor,
                 )
-                if (thread.isPinned) {
-                    Spacer(Modifier.width(Spacing.s))
-                    Icon(
-                        Icons.Default.PushPin,
-                        contentDescription = "Pinned",
-                        modifier = Modifier.size(16.dp),
-                        tint = mutedColor,
-                    )
-                }
-                // Same 6dp breathing dot as the mode switch: one vocabulary for "still working",
-                // so a single glance always means the same thing wherever it appears.
-                if (rendering) {
-                    Spacer(Modifier.width(Spacing.s))
-                    RenderingPulse(color = MaterialTheme.colorScheme.primary, reducedMotion = reducedMotion)
-                }
+            }
+            // Same 6dp breathing dot as the mode switch: one vocabulary for "still working",
+            // so a single glance always means the same thing wherever it appears.
+            if (rendering) {
+                Spacer(Modifier.width(Spacing.s))
+                RenderingPulse(color = MaterialTheme.colorScheme.primary, reducedMotion = reducedMotion)
             }
         }
-        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
-            if (thread.isPinned) {
-                DropdownMenuItem(
-                    text = { Text("Unpin") },
-                    leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
-                    onClick = {
-                        onUnpin()
-                        menuOpen = false
-                    },
+    }
+}
+
+/**
+ * Long-press actions for a conversation, as an expressive bottom sheet.
+ *
+ * A sheet reads as a first-class surface — a titled header naming the conversation, plus big
+ * touch-friendly action rows — where the old anchored dropdown read as a leftover from stock
+ * Android. Each action fires immediately on tap, then the sheet animates itself away.
+ */
+@Composable
+private fun ThreadActionSheet(
+    thread: ChatThread,
+    onDismiss: () -> Unit,
+    onPin: () -> Unit,
+    onUnpin: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    // Run the action now (so it's never dropped), then let the sheet slide out before it leaves
+    // the composition.
+    fun act(action: () -> Unit) {
+        action()
+        scope.launch { sheetState.hide() }.invokeOnCompletion { onDismiss() }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.base)
+                .padding(bottom = Spacing.xl),
+        ) {
+            Text(
+                thread.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = Spacing.xs),
+            )
+            Text(
+                if (thread.isPinned) "Pinned conversation" else "Conversation",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = Spacing.xs, vertical = Spacing.xs),
+            )
+            Spacer(Modifier.height(Spacing.s))
+            Column(verticalArrangement = Arrangement.spacedBy(RowGap)) {
+                if (thread.isPinned) {
+                    ActionSheetRow(
+                        icon = Icons.Outlined.PushPin,
+                        label = "Unpin",
+                        shape = groupedItemShape(0, 3),
+                        chipColor = MaterialTheme.colorScheme.secondaryContainer,
+                        chipContent = MaterialTheme.colorScheme.onSecondaryContainer,
+                        onClick = { act(onUnpin) },
+                    )
+                } else {
+                    ActionSheetRow(
+                        icon = Icons.Filled.PushPin,
+                        label = "Pin",
+                        shape = groupedItemShape(0, 3),
+                        chipColor = MaterialTheme.colorScheme.secondaryContainer,
+                        chipContent = MaterialTheme.colorScheme.onSecondaryContainer,
+                        onClick = { act(onPin) },
+                    )
+                }
+                ActionSheetRow(
+                    icon = Icons.Filled.Edit,
+                    label = "Rename",
+                    shape = groupedItemShape(1, 3),
+                    chipColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    chipContent = MaterialTheme.colorScheme.onSurfaceVariant,
+                    onClick = { act(onRename) },
                 )
-            } else {
-                DropdownMenuItem(
-                    text = { Text("Pin") },
-                    leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
-                    onClick = {
-                        onPin()
-                        menuOpen = false
-                    },
+                ActionSheetRow(
+                    icon = Icons.Filled.DeleteOutline,
+                    label = "Delete",
+                    shape = groupedItemShape(2, 3),
+                    chipColor = MaterialTheme.colorScheme.errorContainer,
+                    chipContent = MaterialTheme.colorScheme.onErrorContainer,
+                    labelColor = MaterialTheme.colorScheme.error,
+                    onClick = { act(onDelete) },
                 )
             }
-            DropdownMenuItem(
-                text = { Text("Rename") },
-                leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
-                onClick = {
-                    onRename()
-                    menuOpen = false
-                },
-            )
-            DropdownMenuItem(
-                text = { Text("Delete") },
-                leadingIcon = {
-                    Icon(
-                        Icons.Default.DeleteOutline,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                },
-                onClick = {
-                    onDelete()
-                    menuOpen = false
-                },
+        }
+    }
+}
+
+@Composable
+private fun ActionSheetRow(
+    icon: ImageVector,
+    label: String,
+    shape: androidx.compose.ui.graphics.Shape,
+    chipColor: Color,
+    chipContent: Color,
+    onClick: () -> Unit,
+    labelColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Surface(
+        onClick = onClick,
+        shape = shape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.m, vertical = Spacing.s).heightIn(min = 48.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(chipColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(icon, contentDescription = null, Modifier.size(20.dp), tint = chipContent)
+            }
+            Spacer(Modifier.width(Spacing.base))
+            Text(
+                label,
+                style = MaterialTheme.typography.titleSmall,
+                color = labelColor,
             )
         }
     }


### PR DESCRIPTION
## What changed

The drawer's conversation list and its long-press menu were the two parts that still read as dated stock-Android UI. This reworks both while leaving the two elements that were fine — the New-conversation button and the Settings tile in `ChatDrawer.kt` — untouched.

### Conversation list
- Rows within a section now form a single **connected slab** via the app's existing `groupedItemShape()` + `GroupedItemGap`, the same grouped-list vocabulary already used across every Settings screen — so the drawer stops looking like a stack of detached buttons.
- Dropped the redundant per-row chat/wand icon (the drawer is single-mode, so it carried no information). The active conversation is now marked by a slim primary accent bar, medium weight, and a `secondaryContainer` fill.
- Kept the recency grouping (Today / Yesterday / …), the pinned marker, and the rendering pulse.

### Long-press actions
- Replaced the stock `DropdownMenu` with an expressive **`ModalBottomSheet`**: the conversation title as a header, then large tap-friendly action rows (Pin/Unpin, Rename, Delete with a destructive red accent and tonal icon chips).
- A single sheet is lifted to the list level instead of one menu per row. Each action fires immediately on tap, then the sheet animates itself out.

## Testing
- `:app:compileDebugKotlin` — clean.
- `DrawerThreadListTest` — passes. Action labels ("Pin"/"Unpin"/"Rename"/"Delete") are unchanged, so the existing functional assertions still hold against the bottom sheet.

## Note for reviewers
The Roborazzi screenshot **baselines** for the drawer (`drawer_pinned_section.png`, `drawer_long_press_menu.png`, `drawer_pinned_unpin_menu.png`) are now intentionally stale and need re-recording:

```
./gradlew recordRoborazziDebug --tests "com.echoflow.ui.components.DrawerThreadListScreenshotTest"
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The redesign moves the drawer toward a more cohesive product language: connected conversation slabs, a clearer active-state treatment, and a centralized, touch-friendly action sheet are strong improvements over the stock menu. The previously reported stacked-modal transition is better implemented now by waiting for the sheet to hide before opening Rename or Delete; the remaining implementation follow-through is to re-record the intentionally stale visual baselines.
- Replaces detached conversation pills with grouped rows and a primary active indicator.
- Replaces per-row dropdown menus with one list-level modal bottom sheet.
- Preserves pin, rename, delete, accessibility, rendering, and recency-grouping behavior.
- Sequences dialog-producing actions after the bottom-sheet exit animation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the action sheet now finishes hiding before Rename or Delete presents the next modal.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/DrawerThreadList.kt | The drawer list and long-press actions were comprehensively restyled, and the prior stacked-modal issue is resolved by completing the sheet hide before invoking dialog-producing callbacks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Hide action sheet before running Rename/..."](https://github.com/adityavardhansharma/echoflow/commit/074e5849a2f5d09b94608dad7cfb52878dc518c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49323552)</sub>

<!-- /greptile_comment -->