### PR TITLE
Migrate Parallel web search to v1 API (basic mode)

### DIFF
--- a/app/src/main/java/com/echoflow/data/ParallelSearchV1.kt
+++ b/app/src/main/java/com/echoflow/data/ParallelSearchV1.kt
@@ -1,0 +1,32 @@
+package com.echoflow.data
+
+/**
+ * Parallel GA Search API (`POST /v1/search`) request and response contract.
+ * Kept separate from [WebSearchService] so serialization and parsing stay unit-testable.
+ */
+internal object ParallelSearchV1 {
+    const val ENDPOINT = "https://api.parallel.ai/v1/search"
+    const val MODE = "basic"
+
+    fun requestBody(query: String, maxResults: Int): Map<String, Any> = mapOf(
+        "objective" to query,
+        "search_queries" to listOf(query),
+        "mode" to MODE,
+        "advanced_settings" to mapOf("max_results" to maxResults),
+    )
+
+    fun parseResults(response: Map<*, *>): List<SearchSource> {
+        val results = response["results"] as? List<*> ?: return emptyList()
+        return results.mapNotNull { raw ->
+            val result = raw as? Map<*, *> ?: return@mapNotNull null
+            val url = result["url"] as? String ?: return@mapNotNull null
+            val excerpts = (result["excerpts"] as? List<*>)?.filterIsInstance<String>()
+            SearchSource(
+                title = (result["title"] as? String).orEmpty().ifBlank { url },
+                url = url,
+                snippet = excerpts?.joinToString("\n")?.take(3000),
+                publishedDate = result["publish_date"] as? String,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/WebSearchService.kt
+++ b/app/src/main/java/com/echoflow/data/WebSearchService.kt
@@ -71,30 +71,13 @@ class WebSearchService {
     }
 
     private fun searchParallel(apiKey: String, query: String, maxResults: Int): List<SearchSource> {
-        val body = mapOf(
-            "objective" to query,
-            "search_queries" to listOf(query),
-            "mode" to "basic",
-            "advanced_settings" to mapOf("max_results" to maxResults),
-        )
         val json = executePost(
-            url = "https://api.parallel.ai/v1/search",
+            url = ParallelSearchV1.ENDPOINT,
             headers = mapOf("x-api-key" to apiKey),
-            body = body,
+            body = ParallelSearchV1.requestBody(query, maxResults),
             providerLabel = "Parallel"
         )
-        val results = json["results"] as? List<*> ?: return emptyList()
-        return results.mapNotNull { raw ->
-            val r = raw as? Map<*, *> ?: return@mapNotNull null
-            val url = r["url"] as? String ?: return@mapNotNull null
-            val excerpts = (r["excerpts"] as? List<*>)?.filterIsInstance<String>()
-            SearchSource(
-                title = (r["title"] as? String).orEmpty().ifBlank { url },
-                url = url,
-                snippet = excerpts?.joinToString("\n")?.take(3000),
-                publishedDate = r["publish_date"] as? String
-            )
-        }
+        return ParallelSearchV1.parseResults(json)
     }
 
     private fun searchFirecrawl(apiKey: String, query: String, maxResults: Int): List<SearchSource> {

--- a/app/src/main/java/com/echoflow/data/WebSearchService.kt
+++ b/app/src/main/java/com/echoflow/data/WebSearchService.kt
@@ -73,10 +73,12 @@ class WebSearchService {
     private fun searchParallel(apiKey: String, query: String, maxResults: Int): List<SearchSource> {
         val body = mapOf(
             "objective" to query,
-            "max_results" to maxResults
+            "search_queries" to listOf(query),
+            "mode" to "basic",
+            "advanced_settings" to mapOf("max_results" to maxResults),
         )
         val json = executePost(
-            url = "https://api.parallel.ai/v1beta/search",
+            url = "https://api.parallel.ai/v1/search",
             headers = mapOf("x-api-key" to apiKey),
             body = body,
             providerLabel = "Parallel"

--- a/app/src/test/java/com/echoflow/data/ParallelSearchV1Test.kt
+++ b/app/src/test/java/com/echoflow/data/ParallelSearchV1Test.kt
@@ -1,0 +1,118 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ParallelSearchV1Test {
+    private val jsonAdapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(Any::class.java)
+
+    @Test
+    fun `request body matches v1 search contract`() {
+        val body = ParallelSearchV1.requestBody("latest Android Compose news", 7)
+
+        assertEquals("latest Android Compose news", body["objective"])
+        assertEquals(listOf("latest Android Compose news"), body["search_queries"])
+        assertEquals("basic", body["mode"])
+        assertEquals(mapOf("max_results" to 7), body["advanced_settings"])
+    }
+
+    @Test
+    fun `request body serializes nested advanced_settings`() {
+        val body = ParallelSearchV1.requestBody("weather in Paris", 3)
+        val json = jsonAdapter.toJson(body)
+        val parsed = jsonAdapter.fromJson(json) as Map<*, *>
+
+        assertEquals("basic", parsed["mode"])
+        val advanced = parsed["advanced_settings"] as Map<*, *>
+        assertEquals(3.0, advanced["max_results"])
+        assertEquals(listOf("weather in Paris"), parsed["search_queries"])
+    }
+
+    @Test
+    fun `parseResults maps v1 response fields into SearchSource`() {
+        val response = mapOf(
+            "search_id" to "search_abc",
+            "session_id" to "session_xyz",
+            "results" to listOf(
+                mapOf(
+                    "url" to "https://example.com/article",
+                    "title" to "Example headline",
+                    "publish_date" to "2024-01-15",
+                    "excerpts" to listOf("First excerpt.", "Second excerpt."),
+                ),
+            ),
+        )
+
+        val sources = ParallelSearchV1.parseResults(response)
+
+        assertEquals(1, sources.size)
+        assertEquals(
+            SearchSource(
+                title = "Example headline",
+                url = "https://example.com/article",
+                snippet = "First excerpt.\nSecond excerpt.",
+                publishedDate = "2024-01-15",
+            ),
+            sources.single(),
+        )
+    }
+
+    @Test
+    fun `parseResults falls back to url when title is blank`() {
+        val response = mapOf(
+            "results" to listOf(
+                mapOf(
+                    "url" to "https://example.com/no-title",
+                    "title" to "   ",
+                    "excerpts" to listOf("Snippet"),
+                ),
+            ),
+        )
+
+        val source = ParallelSearchV1.parseResults(response).single()
+        assertEquals("https://example.com/no-title", source.title)
+    }
+
+    @Test
+    fun `parseResults returns empty list when results are missing`() {
+        assertTrue(ParallelSearchV1.parseResults(emptyMap<String, Any>()).isEmpty())
+        assertTrue(ParallelSearchV1.parseResults(mapOf("results" to null)).isEmpty())
+    }
+
+    @Test
+    fun `parseResults skips malformed entries without url`() {
+        val response = mapOf(
+            "results" to listOf(
+                mapOf("title" to "No URL", "excerpts" to listOf("orphan")),
+                mapOf("url" to "https://example.com/ok", "excerpts" to listOf("kept")),
+            ),
+        )
+
+        val sources = ParallelSearchV1.parseResults(response)
+        assertEquals(1, sources.size)
+        assertEquals("https://example.com/ok", sources.single().url)
+    }
+
+    @Test
+    fun `parseResults caps joined excerpts at 3000 characters`() {
+        val longExcerpt = "x".repeat(2000)
+        val response = mapOf(
+            "results" to listOf(
+                mapOf(
+                    "url" to "https://example.com/long",
+                    "title" to "Long",
+                    "excerpts" to listOf(longExcerpt, longExcerpt),
+                ),
+            ),
+        )
+
+        val snippet = ParallelSearchV1.parseResults(response).single().snippet
+        assertEquals(3000, snippet?.length)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates inline Parallel web search from the legacy beta endpoint to the GA Search API, defaulting to `basic` mode. Deep Research task endpoints are unchanged.

## Changes

- **`WebSearchService.searchParallel`**: `POST /v1beta/search` → `POST /v1/search`
- Explicitly sets `mode: "basic"` (Parallel's recommended default for most agent workloads)
- Adds required `search_queries` field (uses the user's query)
- Moves `max_results` under `advanced_settings` per the v1 schema
- Extracts **`ParallelSearchV1`** helper with `requestBody()` and `parseResults()` for contract testing

## Testing

- `./gradlew :app:testDebugUnitTest` — all unit tests pass
- **`ParallelSearchV1Test`** covers:
  - v1 request fields (`objective`, `search_queries`, `mode`, nested `advanced_settings.max_results`)
  - Moshi round-trip serialization of the nested payload
  - v1 response parsing into `SearchSource` (excerpts, title fallback, malformed entry skipping, excerpt cap)

## Notes

No UI changes in this PR. Deep Research (`/v1/tasks/runs`) is untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b532ba2d-beb5-4d38-8b0e-3f3de4d00bbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b532ba2d-beb5-4d38-8b0e-3f3de4d00bbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes the Parallel migration to the GA v1 basic-search API and directly addresses the previous request for focused contract coverage. I like the product direction of moving to the supported API while isolating the provider contract; the implementation is better structured now that payload construction and response normalization are independently testable.
- Sends Parallel searches to `/v1/search` with `basic` mode, `search_queries`, and nested `advanced_settings`.
- Routes production serialization and parsing through the extracted `ParallelSearchV1` helper.
- Adds focused tests for request construction, Moshi serialization, response mapping, malformed entries, fallbacks, and excerpt limits.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported contract-coverage gap is addressed by tests that exercise the same helper methods and Moshi serialization path used by production.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/ParallelSearchV1.kt | Defines the v1 request contract and response normalization used directly by production and covered by focused unit tests. |
| app/src/main/java/com/echoflow/data/WebSearchService.kt | Migrates Parallel search to the GA endpoint and delegates payload construction and parsing to the tested helper. |
| app/src/test/java/com/echoflow/data/ParallelSearchV1Test.kt | Resolves the prior coverage concern with focused request serialization and response-parsing tests. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[WebSearchService.search] --> B[searchParallel]
    B --> C[ParallelSearchV1.requestBody]
    C --> D[POST /v1/search]
    D --> E[ParallelSearchV1.parseResults]
    E --> F[List of SearchSource]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Add Parallel v1 search contract tests"](https://github.com/adityavardhansharma/echoflow/commit/f2b76beb3d0ac6b9ac9af091f90cb2ce21d9f70b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50901348)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search result handling for missing, malformed, or incomplete entries.
  * Added fallback behavior for missing titles.
  * Limited result excerpts to 3,000 characters for more consistent display.

* **Tests**
  * Added coverage for search requests, response parsing, fallback behavior, invalid results, and excerpt truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->