### PR TITLE
Privacy page + opt-in encrypted, uninstall-surviving backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-sdk tools:overrideLibrary="com.google.ai.edge.litertlm" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Pre-Android-10 only: the encrypted backup (Privacy page) writes to public Downloads so it
+         survives uninstall. On API 29+ this uses MediaStore and needs no permission. -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -2,6 +2,7 @@ package com.echoflow
 
 import android.app.Application
 import com.echoflow.data.AppDatabase
+import com.echoflow.data.BackupManager
 import com.echoflow.data.LegacyImageModelCleanup
 import com.echoflow.data.LocalInferenceGate
 import com.echoflow.data.ModelDownloadManager
@@ -26,6 +27,10 @@ class EchoFlowAppGraph(application: Application) {
     // One gate app-wide: only one on-device LLM generation runs at a time.
     private val localInferenceGate = LocalInferenceGate()
 
+    // Encrypted uninstall-surviving backup (Privacy page). Exposed so MainActivity can re-export
+    // when the app goes to the background.
+    val backupManager = BackupManager(application.applicationContext, database, settingsRepository)
+
     init {
         // On-device image generation left its model bundles on disk — potentially several GB
         // for anyone who had downloaded one. Room migrations cannot touch the filesystem, so
@@ -47,6 +52,7 @@ class EchoFlowAppGraph(application: Application) {
             database.agentProfileDao(),
             database.imageModelDao(),
             database.videoModelDao(),
+            backupManager,
         )
     }
 

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -36,6 +36,8 @@ import com.echoflow.ui.components.ChatDrawerContent
 import com.echoflow.ui.screens.ChatScreen
 import com.echoflow.ui.screens.SettingsScreen
 import com.echoflow.ui.theme.EchoFlowTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -45,10 +47,24 @@ class MainActivity : ComponentActivity() {
     // A chat id to open, set when launched/resumed from a reply-ready notification tap.
     private val openChatRequest = MutableStateFlow<String?>(null)
 
+    // Held so the encrypted backup can be refreshed when the app goes to the background.
+    private var appGraph: EchoFlowAppGraph? = null
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         intent.getStringExtra(ReplyNotifications.EXTRA_OPEN_CHAT)?.let { openChatRequest.value = it }
+    }
+
+    /**
+     * Refresh the encrypted uninstall-surviving backup when the app leaves the foreground, so it
+     * stays current without hooking every write path. No-op unless the feature is on.
+     */
+    override fun onStop() {
+        super.onStop()
+        appGraph?.backupManager?.let { manager ->
+            CoroutineScope(Dispatchers.IO).launch { manager.exportIfEnabled() }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,6 +81,7 @@ class MainActivity : ComponentActivity() {
         }
 
         val appGraph = EchoFlowAppGraph(application)
+        this.appGraph = appGraph
 
         // Resume any Deep Research run that was interrupted by an app kill — but only spin
         // up the service when there is actually something to resume (no idle notification).

--- a/app/src/main/java/com/echoflow/MainActivity.kt
+++ b/app/src/main/java/com/echoflow/MainActivity.kt
@@ -36,7 +36,6 @@ import com.echoflow.ui.components.ChatDrawerContent
 import com.echoflow.ui.screens.ChatScreen
 import com.echoflow.ui.screens.SettingsScreen
 import com.echoflow.ui.theme.EchoFlowTheme
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -62,8 +61,10 @@ class MainActivity : ComponentActivity() {
      */
     override fun onStop() {
         super.onStop()
+        // lifecycleScope is cancelled with the Activity, so rapid stop/start does not pile up
+        // unscoped export jobs. BackupManager also serializes export/delete with a mutex.
         appGraph?.backupManager?.let { manager ->
-            CoroutineScope(Dispatchers.IO).launch { manager.exportIfEnabled() }
+            lifecycleScope.launch(Dispatchers.IO) { manager.exportIfEnabled() }
         }
     }
 

--- a/app/src/main/java/com/echoflow/data/BackupCrypto.kt
+++ b/app/src/main/java/com/echoflow/data/BackupCrypto.kt
@@ -1,0 +1,81 @@
+package com.echoflow.data
+
+import android.util.Base64
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * The encrypted envelope written to disk. The salt and IV are not secret — they must travel with
+ * the ciphertext so the same passkey can re-derive the key on another install — but the passkey
+ * itself never leaves the user's head, so the file is safe even if it leaks.
+ */
+data class BackupEnvelope(
+    val magic: String,
+    val v: Int,
+    val iter: Int,
+    val salt: String, // base64
+    val iv: String,   // base64
+    val ct: String,   // base64 ciphertext (AES-GCM, tag appended)
+)
+
+/**
+ * Password-based authenticated encryption for the uninstall-surviving backup.
+ *
+ * Key derivation is PBKDF2-HMAC-SHA256 (210k iterations, OWASP 2023 guidance) over a random
+ * 16-byte salt; the payload is sealed with AES-256-GCM under a random 12-byte IV. GCM's auth tag
+ * means a wrong passkey (or any tampering) fails loudly with [javax.crypto.AEADBadTagException]
+ * rather than returning garbage — which is exactly how the UI tells "wrong recovery key" apart
+ * from "corrupt file".
+ */
+object BackupCrypto {
+    const val MAGIC = "ECHOFLOW-BACKUP"
+    const val VERSION = 1
+    private const val ITERATIONS = 210_000
+    private const val KEY_BITS = 256
+    private const val SALT_BYTES = 16
+    private const val IV_BYTES = 12
+    private const val GCM_TAG_BITS = 128
+
+    fun encrypt(plaintext: ByteArray, passkey: String): BackupEnvelope {
+        val random = SecureRandom()
+        val salt = ByteArray(SALT_BYTES).also { random.nextBytes(it) }
+        val iv = ByteArray(IV_BYTES).also { random.nextBytes(it) }
+        val key = deriveKey(passkey, salt, ITERATIONS)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        val ct = cipher.doFinal(plaintext)
+        return BackupEnvelope(
+            magic = MAGIC,
+            v = VERSION,
+            iter = ITERATIONS,
+            salt = b64(salt),
+            iv = b64(iv),
+            ct = b64(ct),
+        )
+    }
+
+    /** @throws javax.crypto.AEADBadTagException when the passkey is wrong or the data was tampered. */
+    fun decrypt(env: BackupEnvelope, passkey: String): ByteArray {
+        val salt = unb64(env.salt)
+        val iv = unb64(env.iv)
+        val ct = unb64(env.ct)
+        val key = deriveKey(passkey, salt, env.iter.takeIf { it > 0 } ?: ITERATIONS)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        return cipher.doFinal(ct)
+    }
+
+    private fun deriveKey(passkey: String, salt: ByteArray, iterations: Int): SecretKeySpec {
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val spec = PBEKeySpec(passkey.toCharArray(), salt, iterations, KEY_BITS)
+        val bytes = factory.generateSecret(spec).encoded
+        return SecretKeySpec(bytes, "AES")
+    }
+
+    private fun b64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    private fun unb64(text: String): ByteArray = Base64.decode(text, Base64.NO_WRAP)
+}

--- a/app/src/main/java/com/echoflow/data/BackupCrypto.kt
+++ b/app/src/main/java/com/echoflow/data/BackupCrypto.kt
@@ -30,14 +30,22 @@ data class BackupEnvelope(
  * means a wrong passkey (or any tampering) fails loudly with [javax.crypto.AEADBadTagException]
  * rather than returning garbage — which is exactly how the UI tells "wrong recovery key" apart
  * from "corrupt file".
+ *
+ * Iteration count and sizes from the on-disk envelope are treated as untrusted input and bounded
+ * before PBKDF2 runs, so a crafted file cannot force unbounded CPU work during recovery.
  */
 object BackupCrypto {
     const val MAGIC = "ECHOFLOW-BACKUP"
     const val VERSION = 1
-    private const val ITERATIONS = 210_000
+    /** PBKDF2 iterations used when writing new backups (OWASP 2023 guidance). */
+    const val ITERATIONS = 210_000
+    /** Hard ceiling on envelope-supplied iterations so recovery cannot be DoS'd. */
+    const val MAX_ITERATIONS = 1_000_000
+    /** Floor: reject envelopes that advertise too-weak derivation. */
+    const val MIN_ITERATIONS = 100_000
     private const val KEY_BITS = 256
-    private const val SALT_BYTES = 16
-    private const val IV_BYTES = 12
+    const val SALT_BYTES = 16
+    const val IV_BYTES = 12
     private const val GCM_TAG_BITS = 128
 
     fun encrypt(plaintext: ByteArray, passkey: String): BackupEnvelope {
@@ -58,12 +66,23 @@ object BackupCrypto {
         )
     }
 
-    /** @throws javax.crypto.AEADBadTagException when the passkey is wrong or the data was tampered. */
+    /**
+     * @throws IllegalArgumentException when the envelope is unsupported or malformed
+     * @throws javax.crypto.AEADBadTagException when the passkey is wrong or the data was tampered
+     */
     fun decrypt(env: BackupEnvelope, passkey: String): ByteArray {
+        require(env.v == VERSION) { "Unsupported backup crypto version: ${env.v}" }
+        require(env.iter in MIN_ITERATIONS..MAX_ITERATIONS) {
+            "PBKDF2 iteration count out of range: ${env.iter}"
+        }
         val salt = unb64(env.salt)
         val iv = unb64(env.iv)
         val ct = unb64(env.ct)
-        val key = deriveKey(passkey, salt, env.iter.takeIf { it > 0 } ?: ITERATIONS)
+        require(salt.size == SALT_BYTES) { "Invalid salt length: ${salt.size}" }
+        require(iv.size == IV_BYTES) { "Invalid IV length: ${iv.size}" }
+        require(ct.isNotEmpty()) { "Empty ciphertext" }
+
+        val key = deriveKey(passkey, salt, env.iter)
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
         return cipher.doFinal(ct)

--- a/app/src/main/java/com/echoflow/data/BackupManager.kt
+++ b/app/src/main/java/com/echoflow/data/BackupManager.kt
@@ -10,7 +10,10 @@ import androidx.room.withTransaction
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
@@ -24,6 +27,9 @@ import java.io.File
  *
  * Scope is text data only (chats, keys/settings, profiles, model directory rows); large,
  * re-creatable files (downloaded models, generated media) are not backed up.
+ *
+ * Export, delete, and restore are serialized with a [Mutex] so lifecycle refreshes cannot race
+ * a user-requested disable and recreate the file after deletion.
  */
 class BackupManager(
     private val appContext: Context,
@@ -34,6 +40,9 @@ class BackupManager(
     private val bundleAdapter = moshi.adapter(BackupBundle::class.java)
     private val envelopeAdapter = moshi.adapter(BackupEnvelope::class.java)
 
+    /** Serializes export / delete / restore so they cannot interleave on the same file. */
+    private val ioMutex = Mutex()
+
     // ── Public API ─────────────────────────────────────────────────────────────────────
 
     /** Re-write the backup only when the feature is on and a passkey exists. Best-effort. */
@@ -43,31 +52,51 @@ class BackupManager(
         }
     }
 
-    /** Build, encrypt, and write the backup file using the stored passkey. */
+    /**
+     * Build, encrypt, and write the backup file using the stored passkey.
+     * Re-checks that backup is still enabled immediately before writing so a concurrent
+     * [deleteBackupFile] (after the user turns the feature off) wins.
+     */
     suspend fun export(): Boolean = withContext(Dispatchers.IO) {
-        val passkey = settings.getBackupPasskeyDirect()
-        if (passkey.isBlank()) return@withContext false
-        val bytes = encodeToBytes(buildBundle(), passkey)
-        writeBackupFile(bytes)
+        ioMutex.withLock {
+            if (!settings.getBackupEnabledDirect()) return@withLock false
+            val passkey = settings.getBackupPasskeyDirect()
+            if (passkey.isBlank()) return@withLock false
+            val bytes = encodeToBytes(buildBundle(), passkey)
+            // User may have disabled while we were building/encrypting — honour that.
+            if (!settings.getBackupEnabledDirect()) return@withLock false
+            writeBackupFile(bytes)
+        }
     }
 
     /** Read [uri], decrypt with [passkey], and restore its contents. */
     suspend fun restore(uri: Uri, passkey: String): BackupResult = withContext(Dispatchers.IO) {
-        val fileBytes = runCatching {
-            appContext.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-        }.getOrNull() ?: return@withContext BackupResult.Error("Couldn't read that file.")
+        ioMutex.withLock {
+            when (val read = readBackupBytesBounded(uri)) {
+                is BoundedRead.TooLarge -> BackupResult.Error(
+                    "File too large (max ${MAX_BACKUP_BYTES / (1024 * 1024)} MB).",
+                )
+                is BoundedRead.Failed -> BackupResult.Error("Couldn't read that file.")
+                is BoundedRead.Ok -> decryptAndApply(read.bytes, passkey)
+            }
+        }
+    }
 
+    private suspend fun decryptAndApply(fileBytes: ByteArray, passkey: String): BackupResult {
         val bundle = try {
             decodeFromBytes(fileBytes, passkey)
         } catch (e: javax.crypto.AEADBadTagException) {
-            return@withContext BackupResult.WrongKey
+            return BackupResult.WrongKey
+        } catch (e: IllegalArgumentException) {
+            // Unsupported version, out-of-range KDF params, bad salt/IV sizes, etc.
+            return BackupResult.Error("That doesn't look like an EchoFlow backup.")
         } catch (e: Exception) {
             // A bad-tag can also surface wrapped; treat auth failures as a wrong key.
-            if (e.isAuthFailure()) return@withContext BackupResult.WrongKey
-            return@withContext BackupResult.Error("That doesn't look like an EchoFlow backup.")
-        } ?: return@withContext BackupResult.Error("That doesn't look like an EchoFlow backup.")
+            if (e.isAuthFailure()) return BackupResult.WrongKey
+            return BackupResult.Error("That doesn't look like an EchoFlow backup.")
+        } ?: return BackupResult.Error("That doesn't look like an EchoFlow backup.")
 
-        runCatching { applyBundle(bundle) }
+        return runCatching { applyBundle(bundle) }
             .fold(
                 onSuccess = { BackupResult.Success },
                 onFailure = { BackupResult.Error("Restore failed: ${it.message ?: "unknown error"}") },
@@ -76,14 +105,16 @@ class BackupManager(
 
     /** Remove the backup file (called when the feature is turned off). Best-effort. */
     suspend fun deleteBackupFile() = withContext(Dispatchers.IO) {
-        runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                findBackupUri()?.let { appContext.contentResolver.delete(it, null, null) }
-            } else {
-                legacyBackupFile().takeIf { it.exists() }?.delete()
+        ioMutex.withLock {
+            runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    findBackupUri()?.let { appContext.contentResolver.delete(it, null, null) }
+                } else {
+                    legacyBackupFile().takeIf { it.exists() }?.delete()
+                }
             }
+            Unit
         }
-        Unit
     }
 
     // ── Codec (pure; unit-testable without Android IO) ───────────────────────────────────
@@ -105,27 +136,43 @@ class BackupManager(
 
     // ── Gather / apply ───────────────────────────────────────────────────────────────────
 
-    suspend fun buildBundle(): BackupBundle = BackupBundle(
-        schemaVersion = BackupBundle.SCHEMA_VERSION,
-        appVersionName = runCatching {
-            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
-        }.getOrNull().orEmpty(),
-        createdAt = System.currentTimeMillis(),
-        settings = settings.exportSettings(),
-        threads = db.chatDao().getAllThreadsSync(),
-        messages = db.messageDao().getAllMessagesSync(),
-        advisorProfiles = db.advisorProfileDao().getAllSync(),
-        fusionPanels = db.fusionPanelDao().getAllSync(),
-        agentProfiles = db.agentProfileDao().getAllSync(),
-        customModels = db.customModelDao().getAllCustomModelsSync(),
-        deepResearchModels = db.deepResearchModelDao().getAllSync(),
-        imageModels = db.imageModelDao().getAllSync(),
-        videoModels = db.videoModelDao().getAllSync(),
-    )
+    /**
+     * Snapshot all backed-up tables inside a single Room transaction so a chat+message pair
+     * created mid-export cannot produce a bundle with orphan messages (which would later fail
+     * foreign-key checks on restore).
+     */
+    suspend fun buildBundle(): BackupBundle = db.withTransaction {
+        BackupBundle(
+            schemaVersion = BackupBundle.SCHEMA_VERSION,
+            appVersionName = runCatching {
+                appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+            }.getOrNull().orEmpty(),
+            createdAt = System.currentTimeMillis(),
+            settings = settings.exportSettings(),
+            threads = db.chatDao().getAllThreadsSync(),
+            messages = db.messageDao().getAllMessagesSync(),
+            advisorProfiles = db.advisorProfileDao().getAllSync(),
+            fusionPanels = db.fusionPanelDao().getAllSync(),
+            agentProfiles = db.agentProfileDao().getAllSync(),
+            customModels = db.customModelDao().getAllCustomModelsSync(),
+            deepResearchModels = db.deepResearchModelDao().getAllSync(),
+            imageModels = db.imageModelDao().getAllSync(),
+            videoModels = db.videoModelDao().getAllSync(),
+        )
+    }
 
+    /**
+     * Apply a decrypted bundle. Room rows are written first inside a transaction; settings are
+     * imported only after that succeeds so a FK/constraint failure never leaves prefs half-restored.
+     *
+     * DAO inserts use REPLACE on conflict, so rows with the same primary key as the backup are
+     * overwritten with the backup version (matching recovery UI copy).
+     */
     suspend fun applyBundle(bundle: BackupBundle) {
-        // Keys/settings first, then DB rows. Threads before messages for the FK.
-        settings.importSettings(bundle.settings)
+        require(bundle.schemaVersion in 1..BackupBundle.SCHEMA_VERSION) {
+            "Unsupported backup schema version: ${bundle.schemaVersion}"
+        }
+        // DB first (transactional), then settings — never leave prefs mutated if Room fails.
         db.withTransaction {
             bundle.threads.forEach { db.chatDao().insertThread(it) }
             bundle.messages.forEach { db.messageDao().insertMessage(it) }
@@ -137,6 +184,7 @@ class BackupManager(
             bundle.imageModels.forEach { db.imageModelDao().insert(it) }
             bundle.videoModels.forEach { db.videoModelDao().insert(it) }
         }
+        settings.importSettings(bundle.settings)
     }
 
     // ── File location (survives uninstall) ───────────────────────────────────────────────
@@ -161,6 +209,41 @@ class BackupManager(
             true
         }
     }.getOrDefault(false)
+
+    /**
+     * Read the selected backup with a hard size cap to avoid OOM on a huge/crafted document.
+     */
+    private fun readBackupBytesBounded(uri: Uri): BoundedRead {
+        // Prefer a declared size when the provider exposes it.
+        runCatching {
+            appContext.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
+                val length = afd.length
+                if (length > MAX_BACKUP_BYTES) return BoundedRead.TooLarge
+            }
+        }
+
+        return runCatching {
+            appContext.contentResolver.openInputStream(uri)?.use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                val out = ByteArrayOutputStream()
+                var total = 0
+                while (true) {
+                    val n = input.read(buffer)
+                    if (n < 0) break
+                    total += n
+                    if (total > MAX_BACKUP_BYTES) return@runCatching BoundedRead.TooLarge
+                    out.write(buffer, 0, n)
+                }
+                BoundedRead.Ok(out.toByteArray())
+            } ?: BoundedRead.Failed
+        }.getOrElse { BoundedRead.Failed }
+    }
+
+    private sealed interface BoundedRead {
+        data class Ok(val bytes: ByteArray) : BoundedRead
+        data object TooLarge : BoundedRead
+        data object Failed : BoundedRead
+    }
 
     /** The existing backup's MediaStore Uri, if one is already in Downloads/EchoFlow (Q+). */
     private fun findBackupUri(): Uri? {
@@ -189,5 +272,7 @@ class BackupManager(
     companion object {
         const val SUBDIR = "EchoFlow"
         const val FILE_NAME = "echoflow-backup.efbak"
+        /** Soft cap for a text-only encrypted backup; well above realistic chat+settings size. */
+        const val MAX_BACKUP_BYTES = 50L * 1024 * 1024
     }
 }

--- a/app/src/main/java/com/echoflow/data/BackupManager.kt
+++ b/app/src/main/java/com/echoflow/data/BackupManager.kt
@@ -1,0 +1,193 @@
+package com.echoflow.data
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.room.withTransaction
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * The on-device, uninstall-surviving backup (Privacy page).
+ *
+ * The encrypted file is written to public Downloads/EchoFlow so it outlives an uninstall
+ * (app-private storage, and the Keystore key that protects the in-app prefs, are both wiped when
+ * the app is removed). Only the user's passkey can open it — see [BackupCrypto]. On a fresh
+ * install the user re-enters that passkey on the Recover screen and picks the file via the system
+ * document picker, so no persisted permission is needed to read it back.
+ *
+ * Scope is text data only (chats, keys/settings, profiles, model directory rows); large,
+ * re-creatable files (downloaded models, generated media) are not backed up.
+ */
+class BackupManager(
+    private val appContext: Context,
+    private val db: AppDatabase,
+    private val settings: SettingsRepository,
+) {
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val bundleAdapter = moshi.adapter(BackupBundle::class.java)
+    private val envelopeAdapter = moshi.adapter(BackupEnvelope::class.java)
+
+    // ── Public API ─────────────────────────────────────────────────────────────────────
+
+    /** Re-write the backup only when the feature is on and a passkey exists. Best-effort. */
+    suspend fun exportIfEnabled() {
+        if (settings.getBackupEnabledDirect() && settings.hasBackupPasskey()) {
+            runCatching { export() }
+        }
+    }
+
+    /** Build, encrypt, and write the backup file using the stored passkey. */
+    suspend fun export(): Boolean = withContext(Dispatchers.IO) {
+        val passkey = settings.getBackupPasskeyDirect()
+        if (passkey.isBlank()) return@withContext false
+        val bytes = encodeToBytes(buildBundle(), passkey)
+        writeBackupFile(bytes)
+    }
+
+    /** Read [uri], decrypt with [passkey], and restore its contents. */
+    suspend fun restore(uri: Uri, passkey: String): BackupResult = withContext(Dispatchers.IO) {
+        val fileBytes = runCatching {
+            appContext.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        }.getOrNull() ?: return@withContext BackupResult.Error("Couldn't read that file.")
+
+        val bundle = try {
+            decodeFromBytes(fileBytes, passkey)
+        } catch (e: javax.crypto.AEADBadTagException) {
+            return@withContext BackupResult.WrongKey
+        } catch (e: Exception) {
+            // A bad-tag can also surface wrapped; treat auth failures as a wrong key.
+            if (e.isAuthFailure()) return@withContext BackupResult.WrongKey
+            return@withContext BackupResult.Error("That doesn't look like an EchoFlow backup.")
+        } ?: return@withContext BackupResult.Error("That doesn't look like an EchoFlow backup.")
+
+        runCatching { applyBundle(bundle) }
+            .fold(
+                onSuccess = { BackupResult.Success },
+                onFailure = { BackupResult.Error("Restore failed: ${it.message ?: "unknown error"}") },
+            )
+    }
+
+    /** Remove the backup file (called when the feature is turned off). Best-effort. */
+    suspend fun deleteBackupFile() = withContext(Dispatchers.IO) {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                findBackupUri()?.let { appContext.contentResolver.delete(it, null, null) }
+            } else {
+                legacyBackupFile().takeIf { it.exists() }?.delete()
+            }
+        }
+        Unit
+    }
+
+    // ── Codec (pure; unit-testable without Android IO) ───────────────────────────────────
+
+    /** bundle → JSON → AES-GCM → envelope JSON bytes (the file body). */
+    fun encodeToBytes(bundle: BackupBundle, passkey: String): ByteArray {
+        val plaintext = bundleAdapter.toJson(bundle).toByteArray(Charsets.UTF_8)
+        val envelope = BackupCrypto.encrypt(plaintext, passkey)
+        return envelopeAdapter.toJson(envelope).toByteArray(Charsets.UTF_8)
+    }
+
+    /** Inverse of [encodeToBytes]. Throws [javax.crypto.AEADBadTagException] on a wrong passkey. */
+    fun decodeFromBytes(fileBytes: ByteArray, passkey: String): BackupBundle? {
+        val envelope = envelopeAdapter.fromJson(String(fileBytes, Charsets.UTF_8)) ?: return null
+        if (envelope.magic != BackupCrypto.MAGIC) return null
+        val plaintext = BackupCrypto.decrypt(envelope, passkey)
+        return bundleAdapter.fromJson(String(plaintext, Charsets.UTF_8))
+    }
+
+    // ── Gather / apply ───────────────────────────────────────────────────────────────────
+
+    suspend fun buildBundle(): BackupBundle = BackupBundle(
+        schemaVersion = BackupBundle.SCHEMA_VERSION,
+        appVersionName = runCatching {
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+        }.getOrNull().orEmpty(),
+        createdAt = System.currentTimeMillis(),
+        settings = settings.exportSettings(),
+        threads = db.chatDao().getAllThreadsSync(),
+        messages = db.messageDao().getAllMessagesSync(),
+        advisorProfiles = db.advisorProfileDao().getAllSync(),
+        fusionPanels = db.fusionPanelDao().getAllSync(),
+        agentProfiles = db.agentProfileDao().getAllSync(),
+        customModels = db.customModelDao().getAllCustomModelsSync(),
+        deepResearchModels = db.deepResearchModelDao().getAllSync(),
+        imageModels = db.imageModelDao().getAllSync(),
+        videoModels = db.videoModelDao().getAllSync(),
+    )
+
+    suspend fun applyBundle(bundle: BackupBundle) {
+        // Keys/settings first, then DB rows. Threads before messages for the FK.
+        settings.importSettings(bundle.settings)
+        db.withTransaction {
+            bundle.threads.forEach { db.chatDao().insertThread(it) }
+            bundle.messages.forEach { db.messageDao().insertMessage(it) }
+            bundle.advisorProfiles.forEach { db.advisorProfileDao().insert(it) }
+            bundle.fusionPanels.forEach { db.fusionPanelDao().upsert(it) }
+            bundle.agentProfiles.forEach { db.agentProfileDao().insert(it) }
+            bundle.customModels.forEach { db.customModelDao().insertCustomModel(it) }
+            bundle.deepResearchModels.forEach { db.deepResearchModelDao().insert(it) }
+            bundle.imageModels.forEach { db.imageModelDao().insert(it) }
+            bundle.videoModels.forEach { db.videoModelDao().insert(it) }
+        }
+    }
+
+    // ── File location (survives uninstall) ───────────────────────────────────────────────
+
+    private fun writeBackupFile(bytes: ByteArray): Boolean = runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val resolver = appContext.contentResolver
+            val target = findBackupUri() ?: resolver.insert(
+                MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                ContentValues().apply {
+                    put(MediaStore.Downloads.DISPLAY_NAME, FILE_NAME)
+                    put(MediaStore.Downloads.MIME_TYPE, "application/octet-stream")
+                    put(MediaStore.Downloads.RELATIVE_PATH, "${Environment.DIRECTORY_DOWNLOADS}/$SUBDIR")
+                },
+            ) ?: return@runCatching false
+            resolver.openOutputStream(target, "wt")?.use { it.write(bytes) } ?: return@runCatching false
+            true
+        } else {
+            val file = legacyBackupFile()
+            file.parentFile?.mkdirs()
+            file.writeBytes(bytes)
+            true
+        }
+    }.getOrDefault(false)
+
+    /** The existing backup's MediaStore Uri, if one is already in Downloads/EchoFlow (Q+). */
+    private fun findBackupUri(): Uri? {
+        val resolver = appContext.contentResolver
+        val projection = arrayOf(MediaStore.Downloads._ID)
+        val selection = "${MediaStore.Downloads.RELATIVE_PATH} LIKE ? AND ${MediaStore.Downloads.DISPLAY_NAME} = ?"
+        val args = arrayOf("%$SUBDIR%", FILE_NAME)
+        resolver.query(MediaStore.Downloads.EXTERNAL_CONTENT_URI, projection, selection, args, null)?.use { c ->
+            if (c.moveToFirst()) {
+                val id = c.getLong(c.getColumnIndexOrThrow(MediaStore.Downloads._ID))
+                return MediaStore.Downloads.EXTERNAL_CONTENT_URI.buildUpon().appendPath(id.toString()).build()
+            }
+        }
+        return null
+    }
+
+    @Suppress("DEPRECATION")
+    private fun legacyBackupFile(): File =
+        File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "$SUBDIR/$FILE_NAME")
+
+    private fun Throwable.isAuthFailure(): Boolean =
+        this is javax.crypto.AEADBadTagException ||
+            cause is javax.crypto.AEADBadTagException ||
+            (message?.contains("tag", ignoreCase = true) == true)
+
+    companion object {
+        const val SUBDIR = "EchoFlow"
+        const val FILE_NAME = "echoflow-backup.efbak"
+    }
+}

--- a/app/src/main/java/com/echoflow/data/BackupModels.kt
+++ b/app/src/main/java/com/echoflow/data/BackupModels.kt
@@ -1,0 +1,52 @@
+package com.echoflow.data
+
+/**
+ * The on-device backup format (see [BackupManager]).
+ *
+ * Everything here is durable, re-creatable-value data: conversations, the user's keys and
+ * settings, and Echo Labs profiles / model directory rows. Deliberately excluded are large,
+ * re-downloadable/re-creatable *files* (downloaded local models, generated images and videos)
+ * and transient rows (browser sessions, research runs) — their rows are skipped so a restore
+ * never points at a file that no longer exists.
+ */
+
+/** One persisted preference, tagged with its type so a restore writes it back correctly. */
+data class BackupSetting(
+    val key: String,
+    val type: String, // "string" | "bool" | "int" | "long" | "float" | "stringSet"
+    val value: String? = null,     // scalar values, stringified
+    val set: List<String>? = null, // members, for "stringSet"
+)
+
+/** The full backup payload, serialized to JSON and then encrypted. */
+data class BackupBundle(
+    val schemaVersion: Int,
+    val appVersionName: String,
+    val createdAt: Long,
+    val settings: List<BackupSetting>,
+    val threads: List<ChatThread>,
+    val messages: List<ChatMessage>,
+    val advisorProfiles: List<AdvisorProfile>,
+    val fusionPanels: List<FusionPanel>,
+    val agentProfiles: List<AgentProfile>,
+    val customModels: List<CustomModel>,
+    val deepResearchModels: List<DeepResearchModel>,
+    val imageModels: List<ImageModel>,
+    val videoModels: List<VideoModel>,
+) {
+    companion object {
+        const val SCHEMA_VERSION = 1
+    }
+}
+
+/** Outcome of a restore attempt, surfaced to the UI. */
+sealed interface BackupResult {
+    /** Restore succeeded; the caller should restart so every cached value is re-read. */
+    data object Success : BackupResult
+
+    /** Decryption failed — almost always the wrong passkey. */
+    data object WrongKey : BackupResult
+
+    /** The file was missing, unreadable, or not an EchoFlow backup. */
+    data class Error(val message: String) : BackupResult
+}

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -52,6 +52,10 @@ interface ChatDao {
 
     @Query("SELECT * FROM chat_threads WHERE id = :id LIMIT 1")
     suspend fun getThreadById(id: String): ChatThread?
+
+    /** Every thread, for a full backup export. */
+    @Query("SELECT * FROM chat_threads")
+    suspend fun getAllThreadsSync(): List<ChatThread>
 }
 
 @Dao
@@ -84,6 +88,10 @@ interface MessageDao {
     /** Chat ids whose message text matches the drawer search query. */
     @Query("SELECT DISTINCT chatId FROM chat_messages WHERE content LIKE '%' || :query || '%'")
     fun searchChatIdsByContent(query: String): Flow<List<String>>
+
+    /** Every message, for a full backup export. */
+    @Query("SELECT * FROM chat_messages")
+    suspend fun getAllMessagesSync(): List<ChatMessage>
 }
 
 @Dao

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -155,6 +155,11 @@ class SettingsRepository(context: Context) {
     private val _customProviderConfig = MutableStateFlow(getCustomProviderConfigDirect())
     val customProviderConfig: StateFlow<CustomProviderConfig> = _customProviderConfig.asStateFlow()
 
+    // Encrypted uninstall-surviving backup (Privacy page). Off by default; the passkey is
+    // write-once — set the first time it is turned on and never changeable afterwards.
+    private val _backupEnabled = MutableStateFlow(getBackupEnabledDirect())
+    val backupEnabled: StateFlow<Boolean> = _backupEnabled.asStateFlow()
+
     fun getApiKeyDirect(): String {
         return prefs.getString("openrouter_api_key", "").orEmpty()
     }
@@ -714,6 +719,64 @@ class SettingsRepository(context: Context) {
         _browserIdleMinutes.value = value
     }
 
+    // ── Encrypted backup (Privacy page) ────────────────────────────────────────────────
+
+    fun getBackupEnabledDirect(): Boolean = prefs.getBoolean(KEY_BACKUP_ENABLED, false)
+
+    fun saveBackupEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_BACKUP_ENABLED, enabled).apply()
+        _backupEnabled.value = enabled
+    }
+
+    fun getBackupPasskeyDirect(): String = prefs.getString(KEY_BACKUP_PASSKEY, "").orEmpty()
+
+    fun hasBackupPasskey(): Boolean = getBackupPasskeyDirect().isNotBlank()
+
+    /**
+     * Write-once: the passkey is stored only if none exists yet. This is what makes a passkey
+     * unchangeable — turning the feature off and on again reuses the same one, and there is no
+     * code path that overwrites it. Only an uninstall (which wipes secure prefs) clears it, and
+     * then the user re-enters it on the Recover screen.
+     */
+    fun saveBackupPasskeyIfAbsent(passkey: String) {
+        if (!hasBackupPasskey() && passkey.isNotBlank()) {
+            prefs.edit().putString(KEY_BACKUP_PASSKEY, passkey).apply()
+        }
+    }
+
+    /** All persisted settings/keys as a typed, backup-friendly list — minus backup-internal keys. */
+    fun exportSettings(): List<BackupSetting> =
+        prefs.all.mapNotNull { (key, value) ->
+            if (key in BACKUP_INTERNAL_KEYS) return@mapNotNull null
+            when (value) {
+                is String -> BackupSetting(key, "string", value = value)
+                is Boolean -> BackupSetting(key, "bool", value = value.toString())
+                is Int -> BackupSetting(key, "int", value = value.toString())
+                is Long -> BackupSetting(key, "long", value = value.toString())
+                is Float -> BackupSetting(key, "float", value = value.toString())
+                is Set<*> -> BackupSetting(key, "stringSet", set = value.filterIsInstance<String>())
+                else -> null
+            }
+        }
+
+    /** Writes restored settings/keys back into secure prefs. The app is restarted after, so the
+     *  cached StateFlows above do not need re-emitting here. */
+    fun importSettings(entries: List<BackupSetting>) {
+        val edit = prefs.edit()
+        entries.forEach { e ->
+            if (e.key in BACKUP_INTERNAL_KEYS) return@forEach
+            when (e.type) {
+                "string" -> edit.putString(e.key, e.value.orEmpty())
+                "bool" -> edit.putBoolean(e.key, e.value.toBoolean())
+                "int" -> e.value?.toIntOrNull()?.let { edit.putInt(e.key, it) }
+                "long" -> e.value?.toLongOrNull()?.let { edit.putLong(e.key, it) }
+                "float" -> e.value?.toFloatOrNull()?.let { edit.putFloat(e.key, it) }
+                "stringSet" -> edit.putStringSet(e.key, (e.set ?: emptyList()).toSet())
+            }
+        }
+        edit.apply()
+    }
+
     companion object {
         private const val KEY_APP_MODE = "app_mode"
 
@@ -728,6 +791,13 @@ class SettingsRepository(context: Context) {
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"
+        private const val KEY_BACKUP_ENABLED = "backup_enabled"
+        private const val KEY_BACKUP_PASSKEY = "backup_passkey"
+
+        /** Never round-tripped through a backup: the feature's own flags and the migration marker. */
+        private val BACKUP_INTERNAL_KEYS = setOf(
+            KEY_BACKUP_ENABLED, KEY_BACKUP_PASSKEY, SettingsPreferenceStorage.MIGRATED_KEY,
+        )
         const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
         const val DEFAULT_IMAGE_MODEL_ID = "google/gemini-2.5-flash-image"
 

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -679,20 +679,31 @@ class SettingsViewModel(
     /** True once a passkey has ever been set — after which it is fixed and never re-prompted. */
     fun hasBackupPasskey(): Boolean = repository.hasBackupPasskey()
 
-    /** First-time enable: set the write-once passkey, turn on, and write the first backup. */
+    /**
+     * First-time enable: set the write-once passkey, turn on, and write the first backup.
+     * The passkey is trimmed and must be at least [MIN_BACKUP_PASSKEY_LENGTH] non-whitespace
+     * characters — a spaces-only string must not enable the feature with no stored key.
+     */
     fun enableBackupWithPasskey(passkey: String) {
-        repository.saveBackupPasskeyIfAbsent(passkey.trim())
+        val normalized = passkey.trim()
+        if (normalized.length < MIN_BACKUP_PASSKEY_LENGTH) return
+        repository.saveBackupPasskeyIfAbsent(normalized)
+        if (!repository.hasBackupPasskey()) return
         repository.saveBackupEnabled(true)
         viewModelScope.launch(Dispatchers.IO) { backupManager.export() }
     }
 
     /** Re-enable when a passkey already exists — reuses the same one, no prompt. */
     fun reEnableBackup() {
+        if (!repository.hasBackupPasskey()) return
         repository.saveBackupEnabled(true)
         viewModelScope.launch(Dispatchers.IO) { backupManager.export() }
     }
 
-    /** Turn off and delete the external backup file; the passkey is kept for next time. */
+    /**
+     * Turn off and delete the external backup file; the passkey is kept for next time.
+     * The enabled flag is cleared first so any in-flight export rechecks and aborts before writing.
+     */
     fun disableBackup() {
         repository.saveBackupEnabled(false)
         viewModelScope.launch(Dispatchers.IO) { backupManager.deleteBackupFile() }
@@ -702,9 +713,14 @@ class SettingsViewModel(
     val restoreState: StateFlow<RestoreUiState> = _restoreState.asStateFlow()
 
     fun restoreFrom(uri: Uri, passkey: String) {
+        val normalized = passkey.trim()
+        if (normalized.isEmpty()) {
+            _restoreState.value = RestoreUiState.Failed("Enter your recovery key.")
+            return
+        }
         _restoreState.value = RestoreUiState.Working
         viewModelScope.launch(Dispatchers.IO) {
-            _restoreState.value = when (val result = backupManager.restore(uri, passkey)) {
+            _restoreState.value = when (val result = backupManager.restore(uri, normalized)) {
                 is BackupResult.Success -> RestoreUiState.Done
                 is BackupResult.WrongKey -> RestoreUiState.Failed("Couldn't unlock — check your recovery key.")
                 is BackupResult.Error -> RestoreUiState.Failed(result.message)
@@ -715,6 +731,8 @@ class SettingsViewModel(
     fun clearRestoreState() { _restoreState.value = RestoreUiState.Idle }
 
     companion object {
+        const val MIN_BACKUP_PASSKEY_LENGTH = 6
+
         fun provideFactory(
             repository: SettingsRepository,
             customModelDao: CustomModelDao,

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.echoflow.data.AdvisorProfile
 import com.echoflow.data.AdvisorProfileDao
+import com.echoflow.data.BackupManager
+import com.echoflow.data.BackupResult
 import com.echoflow.data.AgentProfile
 import com.echoflow.data.AgentProfileDao
 import com.echoflow.data.CatalogEntry
@@ -35,6 +37,7 @@ import com.echoflow.data.OpenRouterVideoModelInfo
 import com.echoflow.data.SettingsRepository
 import com.echoflow.data.VideoModel
 import com.echoflow.data.VideoModelDao
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collect
@@ -56,6 +59,7 @@ class SettingsViewModel(
     private val agentProfileDao: AgentProfileDao,
     private val imageModelDao: ImageModelDao,
     private val videoModelDao: VideoModelDao,
+    private val backupManager: BackupManager,
 ) : ViewModel() {
     private val hfModelSearch = HuggingFaceModelSearch()
     private val customProviderService = CustomProviderService()
@@ -668,6 +672,48 @@ class SettingsViewModel(
         }
     }
 
+    // ── Encrypted backup (Privacy page) ────────────────────────────────────────────────
+
+    val backupEnabled: StateFlow<Boolean> = repository.backupEnabled
+
+    /** True once a passkey has ever been set — after which it is fixed and never re-prompted. */
+    fun hasBackupPasskey(): Boolean = repository.hasBackupPasskey()
+
+    /** First-time enable: set the write-once passkey, turn on, and write the first backup. */
+    fun enableBackupWithPasskey(passkey: String) {
+        repository.saveBackupPasskeyIfAbsent(passkey.trim())
+        repository.saveBackupEnabled(true)
+        viewModelScope.launch(Dispatchers.IO) { backupManager.export() }
+    }
+
+    /** Re-enable when a passkey already exists — reuses the same one, no prompt. */
+    fun reEnableBackup() {
+        repository.saveBackupEnabled(true)
+        viewModelScope.launch(Dispatchers.IO) { backupManager.export() }
+    }
+
+    /** Turn off and delete the external backup file; the passkey is kept for next time. */
+    fun disableBackup() {
+        repository.saveBackupEnabled(false)
+        viewModelScope.launch(Dispatchers.IO) { backupManager.deleteBackupFile() }
+    }
+
+    private val _restoreState = MutableStateFlow<RestoreUiState>(RestoreUiState.Idle)
+    val restoreState: StateFlow<RestoreUiState> = _restoreState.asStateFlow()
+
+    fun restoreFrom(uri: Uri, passkey: String) {
+        _restoreState.value = RestoreUiState.Working
+        viewModelScope.launch(Dispatchers.IO) {
+            _restoreState.value = when (val result = backupManager.restore(uri, passkey)) {
+                is BackupResult.Success -> RestoreUiState.Done
+                is BackupResult.WrongKey -> RestoreUiState.Failed("Couldn't unlock — check your recovery key.")
+                is BackupResult.Error -> RestoreUiState.Failed(result.message)
+            }
+        }
+    }
+
+    fun clearRestoreState() { _restoreState.value = RestoreUiState.Idle }
+
     companion object {
         fun provideFactory(
             repository: SettingsRepository,
@@ -680,11 +726,20 @@ class SettingsViewModel(
             agentProfileDao: AgentProfileDao,
             imageModelDao: ImageModelDao,
             videoModelDao: VideoModelDao,
+            backupManager: BackupManager,
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao, videoModelDao) as T
+                return SettingsViewModel(repository, customModelDao, localModelDao, downloadManager, deepResearchModelDao, advisorProfileDao, fusionPanelDao, agentProfileDao, imageModelDao, videoModelDao, backupManager) as T
             }
         }
     }
+}
+
+/** UI state for the "Recover old data" flow on the Privacy page. */
+sealed interface RestoreUiState {
+    data object Idle : RestoreUiState
+    data object Working : RestoreUiState
+    data object Done : RestoreUiState
+    data class Failed(val message: String) : RestoreUiState
 }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCustomProviders.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCustomProviders.kt
@@ -199,6 +199,22 @@ internal fun EchoLabsPage(viewModel: SettingsViewModel, onOpen: (String) -> Unit
             )
         }
 
+        val backupEnabled by viewModel.backupEnabled.collectAsState()
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Privacy & data", "How EchoFlow handles your data, and on-device backup")
+        Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {
+            SettingsNavRow(
+                icon = Icons.Default.Lock,
+                polygon = MaterialShapes.Cookie7Sided,
+                title = "Privacy",
+                subtitle = if (backupEnabled) "Backup on · encrypted on this phone" else "On-device · nothing on our servers",
+                container = MaterialTheme.colorScheme.primaryContainer,
+                onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+                index = 0, count = 1,
+                onClick = { onOpen(PagePrivacy) },
+            )
+        }
+
         Spacer(Modifier.height(Spacing.xl))
         PageSection("Beta", "Experimental · may break · uses Firecrawl credits while open")
         Column(verticalArrangement = Arrangement.spacedBy(GroupedItemGap)) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsPrivacy.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsPrivacy.kt
@@ -1,0 +1,387 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.echoflow.ui.screens
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.echoflow.ui.RestoreUiState
+import com.echoflow.ui.SettingsViewModel
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * Privacy page (under Echo Labs): explains, in plain language, that EchoFlow keeps everything on
+ * the phone and what each provider sees — and hosts the opt-in encrypted, uninstall-surviving
+ * backup. The backup is locked with a write-once passkey; see [SettingsViewModel] / BackupManager.
+ */
+@Composable
+internal fun PrivacyPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val context = LocalContext.current
+    val backupEnabled by viewModel.backupEnabled.collectAsState()
+    val restoreState by viewModel.restoreState.collectAsState()
+
+    // The encrypted backup relies on modern scoped storage; require Android 13+ so behaviour is
+    // consistent. On older phones the controls stay visible but explain why they're unavailable.
+    val backupSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    var showSetPasskey by remember { mutableStateOf(false) }
+    var showTurnOffConfirm by remember { mutableStateOf(false) }
+    var showUnsupported by remember { mutableStateOf(false) }
+    var pendingRestoreUri by remember { mutableStateOf<android.net.Uri?>(null) }
+
+    val pickBackup = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> if (uri != null) pendingRestoreUri = uri }
+
+    // A successful restore means the on-disk data changed under our cached state — restart so
+    // every ViewModel and StateFlow re-reads it cleanly.
+    LaunchedEffect(restoreState) {
+        if (restoreState is RestoreUiState.Done) restartApp(context)
+    }
+
+    SettingsPageScaffold(title = "Privacy", subtitle = "Your data, and where it goes", onBack = onBack) {
+        FormCard {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Shield, null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(Spacing.s))
+                Text("On your phone, and yours", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            }
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "EchoFlow has no servers of its own. Your conversations live in a database on this " +
+                    "device, and your API keys are stored encrypted with the phone's hardware-backed " +
+                    "keystore (AES-256). There is no EchoFlow account and nothing is uploaded to us — " +
+                    "there is no \"us\" to upload it to.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("When you use a cloud model", "Your request goes straight from your phone to the provider you set up")
+        InfoCard(
+            "To write a reply, the app sends your conversation directly to whichever provider you " +
+                "configured — never through an EchoFlow server. What that provider keeps is set by " +
+                "their policy, not ours:\n\n" +
+                "• OpenRouter routes your request to the underlying model. It supports zero-data-" +
+                "retention (ZDR) routing, but not every model or provider offers it — you control " +
+                "this in your OpenRouter account.\n" +
+                "• Direct provider keys (OpenAI, Anthropic, Google, Cerebras, xAI, Ollama, or any " +
+                "OpenAI-compatible endpoint) send your data straight to that provider under their " +
+                "terms. Some don't retain or train on API data; others do — check the one you use."
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Web search", "Only when a search provider is turned on")
+        InfoCard(
+            "With Exa, Parallel, or Firecrawl enabled, your search query — and the page text they " +
+                "fetch for you — passes through that service to bring results back. With search off, " +
+                "nothing is sent to them."
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Local models", "Fully offline")
+        InfoCard(
+            "On-device models run entirely on your phone. Your messages never leave the device and " +
+                "work with no connection at all."
+        )
+
+        Spacer(Modifier.height(Spacing.xl))
+        PageSection("Keep my data if I uninstall", "Off by default")
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text("Encrypted backup on this phone", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+                    Text(
+                        "Survives uninstall · unlocked only by your passkey",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.s))
+                Switch(
+                    checked = backupEnabled,
+                    onCheckedChange = { on ->
+                        when {
+                            !backupSupported -> showUnsupported = true
+                            on && viewModel.hasBackupPasskey() -> viewModel.reEnableBackup()
+                            on -> showSetPasskey = true
+                            else -> showTurnOffConfirm = true
+                        }
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(Spacing.m))
+        InfoCard(
+            "When on, EchoFlow writes an encrypted copy of your chats and keys to " +
+                "Downloads/EchoFlow on this phone, locked with a passkey only you know. Because it " +
+                "lives outside the app, it survives uninstalling EchoFlow: reinstall, tap Recover " +
+                "old data, and enter your passkey to bring everything back. It never goes to any " +
+                "server. Your passkey is set once and can't be changed — and if you forget it, the " +
+                "backup can't be opened, not even by us."
+        )
+
+        if (!backupSupported) {
+            Spacer(Modifier.height(Spacing.s))
+            Text(
+                "Requires Android 13 or newer.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(start = Spacing.xs),
+            )
+        }
+
+        Spacer(Modifier.height(Spacing.l))
+        OutlinedButton(
+            onClick = {
+                if (!backupSupported) {
+                    showUnsupported = true
+                } else {
+                    viewModel.clearRestoreState()
+                    pickBackup.launch(arrayOf("*/*"))
+                }
+            },
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Restore, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text("Recover old data")
+        }
+        Text(
+            "Pick your echoflow-backup.efbak file, then enter your passkey. If there's no backup, " +
+                "just carry on — EchoFlow starts fresh.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.s, start = Spacing.xs, end = Spacing.xs),
+        )
+    }
+
+    if (showSetPasskey) {
+        SetPasskeyDialog(
+            onDismiss = { showSetPasskey = false },
+            onConfirm = { passkey ->
+                viewModel.enableBackupWithPasskey(passkey)
+                showSetPasskey = false
+            },
+        )
+    }
+
+    if (showUnsupported) {
+        AlertDialog(
+            onDismissRequest = { showUnsupported = false },
+            icon = { Icon(Icons.Default.Lock, null) },
+            title = { Text("Needs Android 13 or newer") },
+            text = {
+                Text(
+                    "The encrypted, uninstall-surviving backup requires Android 13 or newer, so it's " +
+                        "not available on this phone. Everything else on this page still applies — your " +
+                        "data stays on the device either way.",
+                )
+            },
+            confirmButton = { TextButton(onClick = { showUnsupported = false }) { Text("OK") } },
+        )
+    }
+
+    if (showTurnOffConfirm) {
+        AlertDialog(
+            onDismissRequest = { showTurnOffConfirm = false },
+            icon = { Icon(Icons.Default.CloudOff, null) },
+            title = { Text("Turn off and delete the backup?") },
+            text = {
+                Text(
+                    "The encrypted backup file on this phone will be deleted. Your chats and keys " +
+                        "stay in the app as normal. Your passkey is remembered, so turning this back " +
+                        "on later uses the same one.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.disableBackup(); showTurnOffConfirm = false }) {
+                    Text("Turn off")
+                }
+            },
+            dismissButton = { TextButton(onClick = { showTurnOffConfirm = false }) { Text("Cancel") } },
+        )
+    }
+
+    pendingRestoreUri?.let { uri ->
+        RestorePasskeyDialog(
+            restoreState = restoreState,
+            onDismiss = {
+                pendingRestoreUri = null
+                viewModel.clearRestoreState()
+            },
+            onConfirm = { passkey -> viewModel.restoreFrom(uri, passkey) },
+        )
+    }
+}
+
+/** Plain informational slab used for the explainer sections. */
+@Composable
+private fun InfoCard(text: String) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(Spacing.base),
+        )
+    }
+}
+
+/** First-time enable: choose the write-once passkey (entered twice), with a clear warning. */
+@Composable
+private fun SetPasskeyDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    var passkey by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+    val longEnough = passkey.length >= 6
+    val matches = passkey.isNotBlank() && passkey == confirm
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Lock, null) },
+        title = { Text("Set your backup passkey") },
+        text = {
+            Column {
+                Text(
+                    "This locks your backup. It's set once and can't be changed later. If you " +
+                        "forget it, the backup can't be recovered — write it down somewhere safe.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.m))
+                OutlinedTextField(
+                    value = passkey,
+                    onValueChange = { passkey = it },
+                    singleLine = true,
+                    label = { Text("Passkey") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(Spacing.s))
+                OutlinedTextField(
+                    value = confirm,
+                    onValueChange = { confirm = it },
+                    singleLine = true,
+                    label = { Text("Confirm passkey") },
+                    isError = confirm.isNotEmpty() && confirm != passkey,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (passkey.isNotEmpty() && !longEnough) {
+                    Spacer(Modifier.height(Spacing.xs))
+                    Text(
+                        "Use at least 6 characters.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(passkey) }, enabled = longEnough && matches) {
+                Text("Turn on")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/** Recovery: enter the passkey for the picked backup file; shows progress and errors inline. */
+@Composable
+private fun RestorePasskeyDialog(
+    restoreState: RestoreUiState,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var passkey by remember { mutableStateOf("") }
+    val working = restoreState is RestoreUiState.Working || restoreState is RestoreUiState.Done
+    AlertDialog(
+        onDismissRequest = { if (!working) onDismiss() },
+        icon = { Icon(Icons.Default.Key, null) },
+        title = { Text("Enter your passkey") },
+        text = {
+            Column {
+                Text(
+                    "Unlock and restore the backup you picked. This adds its chats and keys to this " +
+                        "install, then restarts EchoFlow.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.m))
+                OutlinedTextField(
+                    value = passkey,
+                    onValueChange = { passkey = it },
+                    singleLine = true,
+                    enabled = !working,
+                    label = { Text("Passkey") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                (restoreState as? RestoreUiState.Failed)?.let {
+                    Spacer(Modifier.height(Spacing.s))
+                    Text(it.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                }
+                if (working) {
+                    Spacer(Modifier.height(Spacing.m))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(Modifier.width(Spacing.s))
+                        Text("Restoring…", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(passkey) }, enabled = passkey.isNotBlank() && !working) {
+                Text("Recover")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss, enabled = !working) { Text("Cancel") } },
+    )
+}
+
+/** Fully relaunch the app so all singletons and cached flows re-read restored data. */
+private fun restartApp(context: Context) {
+    val ctx = context.applicationContext
+    val intent = ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
+    if (intent != null) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        ctx.startActivity(intent)
+    }
+    Runtime.getRuntime().exit(0)
+}

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsPrivacy.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsPrivacy.kt
@@ -263,8 +263,10 @@ private fun InfoCard(text: String) {
 private fun SetPasskeyDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
     var passkey by remember { mutableStateOf("") }
     var confirm by remember { mutableStateOf("") }
-    val longEnough = passkey.length >= 6
-    val matches = passkey.isNotBlank() && passkey == confirm
+    // Validate the trimmed value so a spaces-only string cannot enable a non-functional backup.
+    val normalized = passkey.trim()
+    val longEnough = normalized.length >= SettingsViewModel.MIN_BACKUP_PASSKEY_LENGTH
+    val matches = normalized.isNotEmpty() && passkey == confirm
     AlertDialog(
         onDismissRequest = onDismiss,
         icon = { Icon(Icons.Default.Lock, null) },
@@ -303,7 +305,7 @@ private fun SetPasskeyDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit)
                 if (passkey.isNotEmpty() && !longEnough) {
                     Spacer(Modifier.height(Spacing.xs))
                     Text(
-                        "Use at least 6 characters.",
+                        "Use at least ${SettingsViewModel.MIN_BACKUP_PASSKEY_LENGTH} characters (not just spaces).",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -311,7 +313,7 @@ private fun SetPasskeyDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit)
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(passkey) }, enabled = longEnough && matches) {
+            TextButton(onClick = { onConfirm(normalized) }, enabled = longEnough && matches) {
                 Text("Turn on")
             }
         },
@@ -335,8 +337,9 @@ private fun RestorePasskeyDialog(
         text = {
             Column {
                 Text(
-                    "Unlock and restore the backup you picked. This adds its chats and keys to this " +
-                        "install, then restarts EchoFlow.",
+                    "Unlock and restore the backup you picked. Matching chats, profiles, and " +
+                        "settings already on this install are replaced with the backup versions; " +
+                        "anything new is added. EchoFlow then restarts.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -367,7 +370,10 @@ private fun RestorePasskeyDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(passkey) }, enabled = passkey.isNotBlank() && !working) {
+            TextButton(
+                onClick = { onConfirm(passkey.trim()) },
+                enabled = passkey.trim().isNotEmpty() && !working,
+            ) {
                 Text("Recover")
             }
         },

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -152,6 +152,7 @@ internal const val PageImagine = "imagine"
 internal const val PageDataAgent = "data_agent"
 internal const val PageBrowserFlow = "browser_flow"
 internal const val PageEchoLabs = "echo_labs"
+internal const val PagePrivacy = "privacy"
 internal const val PageEchoAdviser = "echo_adviser"
 internal const val PageEchoFusion = "echo_fusion"
 internal const val PageEchoAgent = "echo_agent"
@@ -173,7 +174,7 @@ internal fun settingsParentPage(page: String): String? = when (page) {
     PageDeepResearch, PageImagine, PageEchoLabs,
     -> PageHome
     PageDataAgent, PageBrowserFlow, PageEchoAdviser, PageEchoFusion,
-    PageEchoAgent, PageCustomProvider,
+    PageEchoAgent, PageCustomProvider, PagePrivacy,
     -> PageEchoLabs
     PageCustomProviderCloud -> PageCustomProvider
     PageCustomProviderOllama, PageCustomProviderCompatible -> PageCustomProvider
@@ -237,6 +238,7 @@ fun SettingsScreen(
             PageDeepResearch -> DeepResearchPage(viewModel, onBack = navigateBack)
             PageImagine -> ImaginePage(viewModel, onBack = navigateBack)
             PageEchoLabs -> EchoLabsPage(viewModel, onOpen = { page = it }, onBack = navigateBack)
+            PagePrivacy -> PrivacyPage(viewModel, onBack = navigateBack)
             PageDataAgent -> DataAgentPage(viewModel, onBack = navigateBack)
             PageBrowserFlow -> BrowserFlowPage(viewModel, onBack = navigateBack)
             PageEchoAdviser -> EchoAdviserPage(viewModel, onBack = navigateBack)

--- a/app/src/test/java/com/echoflow/data/BackupCryptoTest.kt
+++ b/app/src/test/java/com/echoflow/data/BackupCryptoTest.kt
@@ -1,0 +1,50 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import javax.crypto.AEADBadTagException
+
+/** Robolectric so [android.util.Base64] is real. */
+@RunWith(RobolectricTestRunner::class)
+class BackupCryptoTest {
+
+    private val payload = "the quick brown fox — chats & keys".toByteArray(Charsets.UTF_8)
+
+    @Test
+    fun round_trips_with_the_correct_passkey() {
+        val env = BackupCrypto.encrypt(payload, "correct horse battery")
+        assertArrayEquals(payload, BackupCrypto.decrypt(env, "correct horse battery"))
+    }
+
+    @Test
+    fun wrong_passkey_fails_loudly() {
+        val env = BackupCrypto.encrypt(payload, "right-key")
+        assertThrows(AEADBadTagException::class.java) {
+            BackupCrypto.decrypt(env, "wrong-key")
+        }
+    }
+
+    @Test
+    fun tampered_ciphertext_fails_the_auth_tag() {
+        val env = BackupCrypto.encrypt(payload, "key")
+        // Flip a character in the base64 ciphertext.
+        val ch = env.ct[0]
+        val swapped = (if (ch == 'A') 'B' else 'A') + env.ct.substring(1)
+        assertThrows(Exception::class.java) {
+            BackupCrypto.decrypt(env.copy(ct = swapped), "key")
+        }
+    }
+
+    @Test
+    fun each_encryption_uses_a_fresh_salt_and_iv() {
+        val a = BackupCrypto.encrypt(payload, "key")
+        val b = BackupCrypto.encrypt(payload, "key")
+        // Same plaintext + passkey must not produce identical ciphertext.
+        assert(a.salt != b.salt)
+        assert(a.iv != b.iv)
+        assert(a.ct != b.ct)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/BackupCryptoTest.kt
+++ b/app/src/test/java/com/echoflow/data/BackupCryptoTest.kt
@@ -1,6 +1,7 @@
 package com.echoflow.data
 
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,8 +44,32 @@ class BackupCryptoTest {
         val a = BackupCrypto.encrypt(payload, "key")
         val b = BackupCrypto.encrypt(payload, "key")
         // Same plaintext + passkey must not produce identical ciphertext.
-        assert(a.salt != b.salt)
-        assert(a.iv != b.iv)
-        assert(a.ct != b.ct)
+        assertNotEquals(a.salt, b.salt)
+        assertNotEquals(a.iv, b.iv)
+        assertNotEquals(a.ct, b.ct)
+    }
+
+    @Test
+    fun rejects_unbounded_iteration_count_before_kdf() {
+        val env = BackupCrypto.encrypt(payload, "key")
+        assertThrows(IllegalArgumentException::class.java) {
+            BackupCrypto.decrypt(env.copy(iter = Int.MAX_VALUE), "key")
+        }
+    }
+
+    @Test
+    fun rejects_too_few_iterations() {
+        val env = BackupCrypto.encrypt(payload, "key")
+        assertThrows(IllegalArgumentException::class.java) {
+            BackupCrypto.decrypt(env.copy(iter = 1), "key")
+        }
+    }
+
+    @Test
+    fun rejects_unsupported_crypto_version() {
+        val env = BackupCrypto.encrypt(payload, "key")
+        assertThrows(IllegalArgumentException::class.java) {
+            BackupCrypto.decrypt(env.copy(v = 99), "key")
+        }
     }
 }

--- a/app/src/test/java/com/echoflow/data/BackupManagerTest.kt
+++ b/app/src/test/java/com/echoflow/data/BackupManagerTest.kt
@@ -1,0 +1,84 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import javax.crypto.AEADBadTagException
+
+@RunWith(RobolectricTestRunner::class)
+class BackupManagerTest {
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private lateinit var repo: SettingsRepository
+    private lateinit var manager: BackupManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        repo = SettingsRepository(context)
+        manager = BackupManager(context, db, repo)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun bundle_captures_chats_and_keys_and_survives_encode_decode() = runBlocking {
+        db.chatDao().insertThread(ChatThread(id = "t1", title = "Hello", createdAt = 1, updatedAt = 2))
+        db.messageDao().insertMessage(ChatMessage("m1", "t1", "user", "hi there", 1))
+        repo.saveApiKey("sk-test-123")
+        repo.saveSelectedModel("acme/model-x")
+
+        val bundle = manager.buildBundle()
+        assertEquals(listOf("t1"), bundle.threads.map { it.id })
+        assertEquals(listOf("m1"), bundle.messages.map { it.id })
+        assertTrue(bundle.settings.any { it.key == "openrouter_api_key" && it.value == "sk-test-123" })
+
+        val bytes = manager.encodeToBytes(bundle, "pass-1234")
+        val decoded = manager.decodeFromBytes(bytes, "pass-1234")
+        assertNotNull(decoded)
+        assertEquals("hi there", decoded!!.messages.single().content)
+    }
+
+    @Test
+    fun wrong_passkey_cannot_decode() = runBlocking {
+        val bytes = manager.encodeToBytes(manager.buildBundle(), "the-real-key")
+        assertThrows(AEADBadTagException::class.java) {
+            manager.decodeFromBytes(bytes, "not-the-key")
+        }
+        Unit
+    }
+
+    @Test
+    fun apply_restores_into_a_fresh_database() = runBlocking {
+        db.chatDao().insertThread(ChatThread(id = "t9", title = "Keep me", createdAt = 5, updatedAt = 6))
+        db.messageDao().insertMessage(ChatMessage("m9", "t9", "assistant", "restored body", 5))
+        db.advisorProfileDao().insert(AdvisorProfile("a1", "Coding", "x/adv", "Adv", 1))
+        val bundle = manager.buildBundle()
+
+        val db2 = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        try {
+            val manager2 = BackupManager(context, db2, repo)
+            manager2.applyBundle(bundle)
+
+            assertNotNull(db2.chatDao().getThreadById("t9"))
+            assertEquals("restored body", db2.messageDao().getMessagesForChatSync("t9").single().content)
+            assertEquals(listOf("a1"), db2.advisorProfileDao().getAllSync().map { it.id })
+        } finally {
+            db2.close()
+        }
+    }
+}


### PR DESCRIPTION
## Why

EchoFlow is fully phone-based: there is **no EchoFlow server** — inference and web-search calls go straight from the device to whichever provider key the user entered. Nothing communicated that, and users had no way to carry their data across an uninstall/reinstall or a new phone. This adds, under **Echo Labs → Privacy**, a plain-language explainer plus an **opt-in encrypted backup that can survive an uninstall**.

## The Android constraint (and how it's resolved)

Uninstalling wipes all app-private data **and** the Keystore master key that protects it, so "reinstall and my data returns" is impossible from private storage alone. And an *automatic*, *cloud-free*, *truly-encrypted* restore can't all coexist — an automatic restore needs the decryption key to survive too, which means it would ride with the file. Chosen resolution (agreed with the author): **an on-device encrypted file locked by a user passkey** — Signal's model. No cloud, genuinely encrypted, and safe if the file leaks.

## What's in it

**Privacy explainer** — on-device storage; keys encrypted with the hardware Keystore (AES-256); what each provider sees when you use a cloud model (OpenRouter routing + **ZDR**, or direct provider keys); web-search APIs; local models fully offline. ZDR is explained conceptually, with no per-provider guarantees.

**Encrypted backup**
- `BackupCrypto` — PBKDF2-HMAC-SHA256 (210k) → AES-256-GCM. A wrong passkey fails on the GCM auth tag, which is how the UI distinguishes "wrong recovery key" from "corrupt file".
- `BackupManager` — gathers chats + settings/keys + Echo Labs profiles + model directory rows into a Moshi bundle, encrypts it, and writes it to **Downloads/EchoFlow** (survives uninstall). Restore reads a user-picked file via SAF, decrypts, and bulk-inserts inside a Room transaction. Large re-creatable files (downloaded models, generated images/videos) are intentionally **not** backed up.
- **Passkey is write-once**: set on first enable, reused if the feature is toggled off then on, and never changeable; only an uninstall clears it (then it's re-entered on recovery).
- Turning the feature **off** deletes the external backup file but keeps the passkey.
- Auto-refresh on `MainActivity.onStop` when enabled. **No Room schema change** (DB stays v20).
- **Gated to Android 13+**: older phones get a "needs Android 13 or newer" popup, and the explainer still applies.

## Files
New: `data/BackupCrypto.kt`, `data/BackupModels.kt`, `data/BackupManager.kt`, `ui/screens/SettingsPrivacy.kt`, + two tests. Wiring: `SettingsRepository`, `SettingsViewModel`, `EchoFlowAppGraph`, `MainActivity`, `SettingsScreen`, `SettingsCustomProviders` (Echo Labs row), `AndroidManifest`.

## Tests
- `BackupCryptoTest` — round-trip, wrong key, tampered ciphertext, fresh salt/IV per encryption.
- `BackupManagerTest` — bundle build captures chats + keys; encode→decode round-trip; wrong key rejected; `applyBundle` restores into a fresh in-memory Room DB.

## Verification status
- **Not build-verified in this push** — at the author's request I stopped before running Gradle. One compile error found earlier (an unclosed KDoc comment where `EchoFlow/**` opened a nested block comment) was fixed; the remaining errors were all downstream of it. A `compileDebugKotlin` + unit-test run and on-device screenshots (per repo policy) are still to be done before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional encrypted backups for app data, stored locally in public device storage.
  * Added passkey setup, backup enable/disable controls, export, restore, and backup deletion.
  * Added Privacy & data settings with backup status and privacy information.
  * Backups can restore conversations, messages, profiles, settings, and related app data.
* **Bug Fixes**
  * Added validation and clear errors for incorrect passkeys, corrupted files, unsupported formats, and oversized backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: a plain-language privacy page and passkey-encrypted, uninstall-surviving backup give users clearer control without introducing an EchoFlow server. The follow-up also improves the implementation around the previously reported failure paths.
- Serializes export and deletion, rechecks backup state before writing, and snapshots Room data in one transaction.
- Applies Room restoration before importing preferences and clearly discloses replacement behavior during recovery.
- Bounds untrusted KDF parameters and backup input size before expensive processing.
- Adds recovery UI, lifecycle refresh wiring, secure preference serialization, and backup round-trip tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported blocking failures are no longer present.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/BackupManager.kt | Coordinates bounded encrypted file I/O, transactional Room snapshots and restores, and serialized export/delete operations; the previously reported races and inconsistent snapshot path are addressed. |
| app/src/main/java/com/echoflow/data/BackupCrypto.kt | Implements PBKDF2-HMAC-SHA256 and AES-GCM while validating envelope version, KDF iterations, salt, IV, and ciphertext before expensive or sensitive operations. |
| app/src/main/java/com/echoflow/ui/SettingsViewModel.kt | Wires enable, disable, export, and recovery state while clearing the enabled flag before deletion and enforcing passkey normalization. |
| app/src/main/java/com/echoflow/ui/screens/SettingsPrivacy.kt | Adds the privacy and recovery experience, including explicit disclosure that matching restored records replace installed versions. |
| app/src/main/java/com/echoflow/data/SettingsRepository.kt | Persists opt-in backup state and write-once passkeys while serializing preferences and excluding backup-internal metadata. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant UI as Privacy UI
    participant BM as BackupManager
    participant DB as Room
    participant SP as Secure Preferences
    participant FS as Downloads
    U->>UI: Enable with passkey
    UI->>SP: Store passkey and enable flag
    UI->>BM: Export
    BM->>DB: Read snapshot in transaction
    BM->>SP: Export settings
    BM->>BM: PBKDF2 + AES-GCM
    BM->>FS: Write encrypted backup
    U->>UI: Select backup and enter passkey
    UI->>BM: Restore URI
    BM->>BM: Validate, derive key, decrypt
    BM->>DB: Restore rows in transaction
    BM->>SP: Import settings
    BM-->>UI: Success and restart
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Harden encrypted backup against Qodo/Gre..."](https://github.com/adityavardhansharma/echoflow/commit/d6e32ea3fc1218328a4ebee508d80f79170b1c37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51018465)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->