### PR TITLE
Remove ripple from reasoning and web search cards

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/SearchTimeline.kt
+++ b/app/src/main/java/com/echoflow/ui/components/SearchTimeline.kt
@@ -10,6 +10,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -63,12 +65,20 @@ fun SearchActivityCard(
     var expanded by remember { mutableStateOf(false) }
     val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "search-chevron")
     val context = LocalContext.current
+    val toggleInteraction = remember { MutableInteractionSource() }
+    val canToggle = !active && sources.isNotEmpty()
 
     Surface(
-        onClick = { if (!active && sources.isNotEmpty()) expanded = !expanded },
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = toggleInteraction,
+                indication = null,
+                enabled = canToggle,
+                onClick = { expanded = !expanded },
+            ),
     ) {
         Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -757,11 +757,17 @@ internal fun ReasoningSection(reasoning: String, active: Boolean) {
     var userToggled by remember { mutableStateOf<Boolean?>(null) }
     val expanded = userToggled ?: active
     val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "reasoning-chevron")
+    val toggleInteraction = remember { MutableInteractionSource() }
     Surface(
-        onClick = { userToggled = !expanded },
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = toggleInteraction,
+                indication = null,
+                onClick = { userToggled = !expanded },
+            ),
     ) {
         Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
             Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the default Material circular ripple when tapping the reasoning trace and web search activity cards to expand or collapse them. Expand/collapse animation (chevron rotation, `AnimatedVisibility`) is unchanged.

## Changes

- **ReasoningSection** (`ChatMessages.kt`): `Surface(onClick)` → `Modifier.clickable(indication = null)`
- **SearchActivityCard** (`SearchTimeline.kt`): same for the outer expand/collapse card

Individual source rows inside an expanded search card still use clickable surfaces (they open URLs).

## Testing

- [ ] Tap reasoning card — expands/collapses without circular ripple
- [ ] Tap completed web search card — expands/collapses without circular ripple
- [ ] Source links inside expanded search still open in browser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b307618-d9b6-4975-9b90-e96ea01c6c8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b307618-d9b6-4975-9b90-e96ea01c6c8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

I like the product direction: removing ripple from these disclosure-style cards reduces distracting feedback while preserving their useful expansion animation. The implementation consistently moves both cards to no-indication click handlers; it could be better protected with focused Compose UI coverage for the nested source-link interaction.

- Replaces clickable Material surfaces with no-indication clickable modifiers.
- Keeps search-card eligibility checks and expansion behavior intact.
- Preserves independently clickable source rows inside expanded search cards.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking opportunity to add regression coverage for nested source-link interaction.

The new click handlers preserve the existing expansion conditions and state changes, and no current behavioral or security failure was established; the remaining concern is test coverage for the parent-and-child clickable arrangement.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/components/SearchTimeline.kt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/SearchTimeline.kt | Removes the outer card ripple while preserving expansion gating and nested URL actions; focused UI regression coverage would strengthen the interaction refactor. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Removes ripple feedback from the reasoning card without changing its expansion state logic. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove ripple from reasoning and web sea..."](https://github.com/adityavardhansharma/echoflow/commit/e3b80f141827fcc65f5d9adfd49fa6048339eef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51373821)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined tap interactions for search timeline cards, with toggling available only when applicable.
  * Improved expand/collapse behavior for reasoning sections in chat messages.
  * Removed distracting visual tap indicators while preserving clear interactive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->