### PR TITLE
Give send and stop a real haptic: a mirrored rising/falling pair

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Send/stop haptics. Normal permission, no runtime prompt. -->
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/echoflow/ui/Haptics.kt
+++ b/app/src/main/java/com/echoflow/ui/Haptics.kt
@@ -1,0 +1,165 @@
+package com.echoflow.ui
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.os.Build
+import android.os.VibrationAttributes
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.provider.Settings
+import android.view.HapticFeedbackConstants
+import android.view.View
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+
+/**
+ * Haptics for the composer's two hero actions: **send** and **stop**.
+ *
+ * The feel we're after is a single deliberate event with some body to it — a bare "tick" is too
+ * thin (it reads as a keypress, not as "the message left") and a buzz is too long (it reads as an
+ * error). Both cues are two beats inside ~80 ms, and they're deliberate mirrors of each other:
+ *
+ * - **Send** — rising envelope: a light tick of anticipation, then the firm click of release.
+ * - **Stop** — falling envelope: the firm hit lands first, then damps out. Halted, not launched.
+ *
+ * Vibration hardware varies enormously, so we take the best thing the device actually reports and
+ * degrade in tiers, keeping the two-beat shape for as long as the hardware allows:
+ *
+ * 1. **Composition primitives** (API 30+, when the motor supports them) — the real thing.
+ * 2. **Shaped waveform** (API 26+ with amplitude control) — same envelope, hand-rolled.
+ * 3. **Predefined effects** (API 29+) — one OEM-tuned blip, click vs. heavy click.
+ * 4. **Unshaped waveform / view constants** — two beats at whatever amplitude the motor has.
+ *
+ * No vibrator, or system touch feedback switched off, means we stay silent.
+ */
+@Composable
+internal fun rememberActionHaptics(): ActionHaptics {
+    val view = LocalView.current
+    val context = LocalContext.current
+    return remember(view) { ActionHaptics(context.applicationContext, view) }
+}
+
+internal class ActionHaptics(context: Context, private val view: View) {
+
+    private val resolver = context.contentResolver
+
+    private val vibration: VibrationHaptics? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) VibrationHaptics(context) else null
+
+    /** The user committed a message — fire as the reply starts streaming. */
+    fun send() = play(VibrationHaptics.Action.SEND, HapticFeedbackConstants.VIRTUAL_KEY)
+
+    /** The user cancelled an in-flight reply. */
+    fun stop() = play(VibrationHaptics.Action.STOP, HapticFeedbackConstants.LONG_PRESS)
+
+    private fun play(action: VibrationHaptics.Action, fallback: Int) {
+        // Read every time: the user can flip touch feedback off in Settings while we're alive.
+        val allowed = Settings.System.getInt(resolver, Settings.System.HAPTIC_FEEDBACK_ENABLED, 1) != 0
+        if (!allowed) return
+        if (vibration?.play(action) == true) return
+        // Pre-O, or a device with no vibrator: the platform constants are all we have.
+        view.performHapticFeedback(fallback)
+    }
+}
+
+/** The [Vibrator]-backed tiers. Split out so the API 26+ surface stays behind one version check. */
+@RequiresApi(Build.VERSION_CODES.O)
+private class VibrationHaptics(context: Context) {
+
+    enum class Action { SEND, STOP }
+
+    private val vibrator: Vibrator? = run {
+        val service = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+        service?.takeIf { it.hasVibrator() }
+    }
+
+    private val supportsPrimitives = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+        vibrator?.areAllPrimitivesSupported(
+            VibrationEffect.Composition.PRIMITIVE_CLICK,
+            VibrationEffect.Composition.PRIMITIVE_TICK,
+        ) == true
+
+    /** A low, weighty landing — the nicest possible "stop", where the motor can render it. */
+    private val supportsThud = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+        vibrator?.areAllPrimitivesSupported(VibrationEffect.Composition.PRIMITIVE_THUD) == true
+
+    /** @return true if the device actually played something. */
+    fun play(action: Action): Boolean {
+        val vibrator = vibrator ?: return false
+        val effect = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && supportsPrimitives -> composed(action)
+            vibrator.hasAmplitudeControl() -> shapedWaveform(action)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> predefined(action)
+            else -> plainWaveform(action)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            vibrator.vibrate(effect, VibrationAttributes.createForUsage(VibrationAttributes.USAGE_TOUCH))
+        } else {
+            // Tagged as touch feedback so the system scales and routes it like any other UI haptic.
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(effect, TOUCH_ATTRIBUTES)
+        }
+        return true
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun composed(action: Action): VibrationEffect {
+        val composition = VibrationEffect.startComposition()
+        return when (action) {
+            Action.SEND -> composition
+                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, 0.5f)
+                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.9f, SEND_GAP_MS)
+            Action.STOP ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && supportsThud) {
+                    composition
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.8f)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_THUD, 0.75f, STOP_GAP_MS)
+                } else {
+                    // Without a thud, a decaying second click still gives the falling envelope.
+                    composition
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.9f)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, 0.55f, STOP_GAP_MS)
+                }
+        }.compose()
+    }
+
+    private fun shapedWaveform(action: Action): VibrationEffect = when (action) {
+        Action.SEND -> VibrationEffect.createWaveform(
+            longArrayOf(0, 12, 34, 24), intArrayOf(0, 100, 0, 215), NO_REPEAT,
+        )
+        Action.STOP -> VibrationEffect.createWaveform(
+            longArrayOf(0, 24, 44, 16), intArrayOf(0, 225, 0, 120), NO_REPEAT,
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun predefined(action: Action): VibrationEffect = when (action) {
+        Action.SEND -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
+        Action.STOP -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+    }
+
+    private fun plainWaveform(action: Action): VibrationEffect = when (action) {
+        Action.SEND -> VibrationEffect.createWaveform(longArrayOf(0, 12, 34, 24), NO_REPEAT)
+        Action.STOP -> VibrationEffect.createWaveform(longArrayOf(0, 24, 44, 16), NO_REPEAT)
+    }
+
+    private companion object {
+        const val NO_REPEAT = -1
+        const val SEND_GAP_MS = 35
+        const val STOP_GAP_MS = 45
+
+        val TOUCH_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -98,6 +98,7 @@ import com.echoflow.data.FusionPanel
 import com.echoflow.data.ResearchRun
 import com.echoflow.data.ToolEventJson
 import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.rememberActionHaptics
 import com.echoflow.ui.SettingsViewModel
 import com.echoflow.ui.StreamSegment
 import com.echoflow.ui.components.AdvisorCard
@@ -665,6 +666,9 @@ private class PlusMenuPositionProvider(
 
 @Composable
 internal fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolean = false, onStop: () -> Unit = {}, onClick: () -> Unit) {
+    // Send and stop are the only two actions that change what the app is *doing*, so they're the
+    // two that earn a real haptic — a mirrored rising/falling pair, see [rememberActionHaptics].
+    val haptics = rememberActionHaptics()
     if (isStreaming) {
         // Tappable Stop that stays in visual sync with the "Thinking…" row: the same expressive
         // LoadingIndicator keeps spinning so the reply still feels live, with a Stop glyph centered
@@ -675,7 +679,10 @@ internal fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolea
                 .size(48.dp)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                .clickable(onClick = onStop),
+                .clickable {
+                    haptics.stop()
+                    onStop()
+                },
             contentAlignment = Alignment.Center,
         ) {
             LoadingIndicator(
@@ -693,7 +700,10 @@ internal fun SendButton(enabled: Boolean, isStreaming: Boolean, research: Boolea
         // The hero action gets the boldest shape — a "Sunny" that morphs to a rounder cookie on
         // press with an expressive (bouncy) spring. In research mode it starts the investigation.
         ShapedIconButton(
-            onClick = onClick,
+            onClick = {
+                haptics.send()
+                onClick()
+            },
             enabled = enabled,
             size = 48.dp,
             restShape = MaterialShapes.Sunny,


### PR DESCRIPTION
Send and stop are the only composer actions that change what the app is *doing*, so they are the two that earn a haptic. A bare tick reads as a keypress rather than "the message left", and a buzz reads as an error — so both cues are two beats inside ~80ms, and they are deliberate mirrors of each other so they are distinguishable by feel alone:

- **Send** — rising envelope: light tick (0.5), then a firm click (0.9) 35ms later. Anticipation, then release.
- **Stop** — falling envelope: firm click (0.8), then a `PRIMITIVE_THUD` (0.75) 45ms later. The hit lands, then damps out.

## Where available

Vibration hardware varies enormously, so we take the best thing the device actually reports and degrade in tiers, keeping the two-beat shape as long as the hardware allows:

1. **Composition primitives** (API 30+, only when `areAllPrimitivesSupported` says yes) — the real amplitude-shaped thing. `PRIMITIVE_THUD` is gated separately on API 31 + support since few motors render it; without it, stop falls back to click then a decaying tick, which still gives the falling envelope.
2. **Hand-rolled waveform** (API 26+ with `hasAmplitudeControl`) — same envelope, shaped by hand.
3. **Predefined effects** (API 29+) — one OEM-tuned blip, `EFFECT_CLICK` vs `EFFECT_HEAVY_CLICK`.
4. **Unshaped waveform**, then `HapticFeedbackConstants` on API 24/25 or a device with no vibrator at all.

`Settings.System.HAPTIC_FEEDBACK_ENABLED` is re-read on every fire rather than cached, since the user can switch touch feedback off while the app is alive, and the vibration is tagged as touch usage so the system scales and routes it like any other UI haptic.

## Wiring

Put inside `SendButton` rather than at the call sites, so both the chat composer and the Imagine composer get it from one place. The send haptic can only fire when the button is enabled. `VIBRATE` added to the manifest (normal permission, no runtime prompt).

## Verification

Haptics are not visible in a screenshot and there is no UI change here — nothing to capture. **Not yet verified on hardware:** the emulator has no vibration motor, so it exercises only the fallback path. The primitive tiers need a real device to confirm the feel, which is the point of the change. @adityavardhansharma to try on-device before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added haptic feedback for send and stop actions in the chat composer.
  - Feedback adapts to device capabilities and system touch-feedback settings.
  - Added graceful fallback behavior for devices with limited vibration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The mirrored rising/falling cues are a thoughtful product direction: they give send and stop distinct tactile identities without treating either action like an error. The implementation could be improved further through the planned physical-device verification across different motor classes, but no concrete changed-code defect was established.
- Adds a normal `VIBRATE` permission for composer action feedback.
- Introduces capability-based haptic tiers spanning composition primitives, amplitude-shaped waveforms, predefined effects, and view feedback.
- Centralizes send and stop feedback in `SendButton`, covering both chat and Imagine composers while respecting the enabled send state and system haptic preference.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with physical-device validation remaining advisable to tune the intended tactile feel.

The new vibration APIs are permissioned and runtime-guarded, unsupported hardware degrades through explicit fallback tiers, and no reachable blocking behavioral or security failure was established.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/AndroidManifest.xml | Adds the normal vibration permission required by the new direct-vibrator path. |
| app/src/main/java/com/echoflow/ui/Haptics.kt | Implements send and stop haptics with appropriately guarded capability and API-level fallbacks. |
| app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt | Wires centralized haptics into enabled send actions and active-stream stop actions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Send or stop clicked] --> B{System haptics enabled?}
    B -- No --> Z[Remain silent]
    B -- Yes --> C{API 26+ vibrator available?}
    C -- No --> H[View haptic feedback]
    C -- Yes --> D{Supported composition primitives?}
    D -- Yes --> E[Play mirrored primitive composition]
    D -- No --> F{Amplitude control?}
    F -- Yes --> G[Play shaped waveform]
    F -- No --> I{API 29+?}
    I -- Yes --> J[Play predefined effect]
    I -- No --> K[Play unshaped waveform]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Give send and stop a real haptic: a mirr..."](https://github.com/adityavardhansharma/echoflow/commit/b95d33a2093454c982f0c6fbdca4561e1a9adb56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51795473)</sub>

<!-- /greptile_comment -->