### PR TITLE
Stop notifying for every chat turn; ping when slow work actually lands

### DIFF
--- a/app/src/main/java/com/echoflow/data/KeepAliveService.kt
+++ b/app/src/main/java/com/echoflow/data/KeepAliveService.kt
@@ -50,7 +50,12 @@ class KeepAliveService : Service() {
             .setContentText(text)
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            // No FOREGROUND_SERVICE_IMMEDIATE, deliberately: Android 12+ holds an FGS
+            // notification back for 10s, and drops it entirely if the service stops first.
+            // That is exactly the behaviour we want — a two-second reply shows nothing at
+            // all, while a video render or a download surfaces once it is worth mentioning.
+            // Duration is the honest signal for "the user has probably left"; which feature
+            // started the work never was. (Pre-31 there is no deferral and it shows at once.)
             .build()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(

--- a/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
+++ b/app/src/main/java/com/echoflow/data/ModelDownloadManager.kt
@@ -128,6 +128,13 @@ class ModelDownloadManager(
                     )
                     setState(entry.id, DownloadState.Done)
                     activeDownloads.remove(entry.id)
+                    // The longest-running thing in the app, and until now the only one that
+                    // finished in complete silence.
+                    ReplyNotifications.notifyDownloadReady(
+                        context, entry.id,
+                        title = "${entry.name} is ready",
+                        text = "The model finished downloading and can be used offline.",
+                    )
                 }
             } catch (e: Exception) {
                 partFile.delete()
@@ -251,6 +258,11 @@ class ModelDownloadManager(
             )
             localModelDao.insertLocalModel(model)
             setState(id, DownloadState.Done)
+            ReplyNotifications.notifyDownloadReady(
+                context, id,
+                title = "${model.name} is ready",
+                text = "The model finished importing and can be used offline.",
+            )
             model
         } catch (e: Exception) {
             partFile.delete()

--- a/app/src/main/java/com/echoflow/data/ReplyNotifications.kt
+++ b/app/src/main/java/com/echoflow/data/ReplyNotifications.kt
@@ -2,6 +2,7 @@ package com.echoflow.data
 
 import android.Manifest
 import android.app.ActivityManager
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -16,17 +17,37 @@ import com.echoflow.MainActivity
 import com.echoflow.R
 
 /**
- * One-shot "your reply is ready" notifications for long cloud generations (Echo Adviser /
- * Echo Fusion), which can take a while. While the app is minimized the reply keeps streaming
- * via [KeepAliveService]; this posts a heads-up only when it finishes and the app is NOT in
- * the foreground, so the user is pinged like Deep Research but never spammed while watching.
+ * One-shot "it's ready" notifications for the work that takes long enough that the user has
+ * probably walked away: Echo Adviser / Fusion / Agents replies, generated images and videos,
+ * and finished model downloads. While the app is minimized the work keeps running via
+ * [KeepAliveService]; this posts the heads-up when it lands.
+ *
+ * Plain chat replies deliberately never ping — they finish in seconds, and "your message got
+ * a reply" is not news worth a buzz.
  *
  * Tapping carries [EXTRA_OPEN_CHAT] so MainActivity can jump straight to that conversation.
  */
 object ReplyNotifications {
     const val EXTRA_OPEN_CHAT = "open_chat_id"
     private const val CHANNEL_ID = "echo_replies"
-    private const val NOTIFICATION_BASE = 7100
+
+    /**
+     * All of these bundle under one group so a few landing together read as one stack rather
+     * than a column. API 24+ auto-bundles at four; grouping explicitly gets us bundling from
+     * two and a summary line we write ourselves.
+     */
+    private const val GROUP_KEY = "com.echoflow.READY"
+    private const val SUMMARY_ID = 7000
+    private const val REPLY_BASE = 100_000
+    private const val DOWNLOAD_BASE = 200_000
+
+    /**
+     * The conversation currently on screen, pushed by ChatViewModel. Suppression is per-chat
+     * rather than per-app: if you are reading conversation A when B's answer lands, B is still
+     * worth a notification — you cannot see it, which is the whole test.
+     */
+    @Volatile
+    var visibleChatId: String? = null
 
     private fun ensureChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -34,7 +55,7 @@ object ReplyNotifications {
                 CHANNEL_ID,
                 "Replies",
                 NotificationManager.IMPORTANCE_DEFAULT,
-            ).apply { description = "Tells you when a long Echo reply is ready" }
+            ).apply { description = "Tells you when a long reply, image, video or download is ready" }
             context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }
     }
@@ -50,29 +71,28 @@ object ReplyNotifications {
         }
     }
 
-    /**
-     * Post a "reply ready / failed" notification for [chatId]. No-op if the app is foreground
-     * (the user is already watching) or if notifications are blocked.
-     */
+    /** Post a "reply / image / video ready" (or "couldn't finish") notification for [chatId]. */
     fun notifyReplyReady(context: Context, chatId: String, title: String, text: String) {
+        if (isAppForeground(context) && visibleChatId == chatId) return
+        post(context, REPLY_BASE + (chatId.hashCode() and 0xFFFF), chatId, title, text)
+    }
+
+    /**
+     * Post a "model is ready to use" notification. A download has no conversation, so being
+     * anywhere in the app counts as seeing it — the model list shows its own progress.
+     */
+    fun notifyDownloadReady(context: Context, modelId: String, title: String, text: String) {
         if (isAppForeground(context)) return
+        post(context, DOWNLOAD_BASE + (modelId.hashCode() and 0xFFFF), null, title, text)
+    }
+
+    private fun post(context: Context, id: Int, chatId: String?, title: String, text: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
             PackageManager.PERMISSION_GRANTED
         ) return
         if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
         ensureChannel(context)
-
-        val openIntent = Intent(context, MainActivity::class.java).apply {
-            putExtra(EXTRA_OPEN_CHAT, chatId)
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-        }
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            chatId.hashCode(),
-            openIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.logo)
@@ -81,13 +101,65 @@ object ReplyNotifications {
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
+            .setGroup(GROUP_KEY)
+            .setContentIntent(openIntent(context, chatId))
             .build()
 
         // notify() throws SecurityException if POST_NOTIFICATIONS was denied — degrade silently.
         runCatching {
-            NotificationManagerCompat.from(context)
-                .notify(NOTIFICATION_BASE + (chatId.hashCode() and 0xFFFF), notification)
+            NotificationManagerCompat.from(context).notify(id, notification)
+            refreshSummary(context)
         }
+    }
+
+    private fun openIntent(context: Context, chatId: String?): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            if (chatId != null) putExtra(EXTRA_OPEN_CHAT, chatId)
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        return PendingIntent.getActivity(
+            context,
+            chatId?.hashCode() ?: 0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    /**
+     * Rebuild the group summary from what is *actually* on screen rather than from a list we
+     * keep ourselves — the user can swipe any one of these away at any moment, and our copy
+     * would quietly drift out of date.
+     *
+     * A lone notification needs no summary, so below two we take it down instead.
+     */
+    private fun refreshSummary(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        val titles = runCatching {
+            manager.activeNotifications
+                .filter { it.id != SUMMARY_ID && it.notification.group == GROUP_KEY }
+                .mapNotNull { it.notification.extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() }
+        }.getOrDefault(emptyList())
+
+        if (titles.size < 2) {
+            manager.cancel(SUMMARY_ID)
+            return
+        }
+
+        val inbox = NotificationCompat.InboxStyle().setBigContentTitle("EchoFlow")
+        titles.forEach { inbox.addLine(it) }
+        val summary = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo)
+            .setContentTitle("EchoFlow")
+            .setContentText("${titles.size} things are ready")
+            .setStyle(inbox)
+            .setGroup(GROUP_KEY)
+            .setGroupSummary(true)
+            // The children already buzzed on their way in; the summary appearing behind them
+            // must not buzz again.
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+            .setAutoCancel(true)
+            .setContentIntent(openIntent(context, null))
+            .build()
+        runCatching { NotificationManagerCompat.from(context).notify(SUMMARY_ID, summary) }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -453,6 +453,11 @@ class ChatViewModel(
 
     init {
         viewModelScope.launch { videoRecovery.resumeInterrupted() }
+        // Completion pings suppress per-conversation rather than per-app, so they need to know
+        // which one is actually on screen. Reading chat A is no reason to swallow chat B.
+        viewModelScope.launch {
+            _currentChatThreadId.collect { ReplyNotifications.visibleChatId = it }
+        }
         // Reopen exactly where the user left off — including on a blank composer. Through the
         // same guarded path as a mode switch, because a cold database makes this the slowest
         // this lookup ever is, and the drawer is reachable throughout.
@@ -1483,6 +1488,8 @@ class ChatViewModel(
                 // A clip renders for minutes, almost always with the app in the background —
                 // the ping is what tells the user it landed.
                 videoGenMode -> "Video"
+                // An image is quicker than a clip but still long enough to switch away from.
+                imageGenMode -> "Image"
                 else -> null
             }
             val keepAliveText = when {
@@ -1588,6 +1595,19 @@ class ChatViewModel(
                                     text = "Tap to watch it in EchoFlow.",
                                 )
                             }
+                        }
+                } else if (imageGenMode) {
+                    // Same "did anything actually land?" test as video, and it runs after the
+                    // reveal delay above — being buzzed while watching the animation that is
+                    // already telling you the image arrived is just noise.
+                    segments.filterIsInstance<StreamSegment.Image>()
+                        .lastOrNull { it.filePath != null && !it.generating }
+                        ?.let {
+                            ReplyNotifications.notifyReplyReady(
+                                getApplication(), chatId,
+                                title = "Your image is ready",
+                                text = "Tap to see it in EchoFlow.",
+                            )
                         }
                 } else if (echoLabel != null) {
                     ReplyNotifications.notifyReplyReady(


### PR DESCRIPTION
The keep-alive foreground service was acquired when *work started* rather than when the app was backgrounded, so sending "hi" put a persistent notification on screen for the two seconds the reply took.

## The ongoing notification: stop overriding the platform

Android 12+ already holds an FGS notification back for 10 seconds, and drops it entirely if the service stops first. `setForegroundServiceBehavior(FOREGROUND_SERVICE_IMMEDIATE)` in `KeepAliveService` was opting out of exactly that. Removing it gives:

| Work | Result |
|---|---|
| 3s plain reply | **never appears** |
| 40s Echo Fusion | appears at 10s |
| image / video gen, downloads, recovery | appear at 10s |

No lifecycle observer, no Android 12 foreground-service-start restrictions to work around, and every `acquire`/`release` pairing is untouched — which also avoids a trap I nearly walked into: making the acquire conditional would have let a plain turn's unconditional `release()` decrement past a *download's* holder and kill its service mid-transfer.

This makes the axis **duration**, which is what actually determines whether you have left the app, instead of *which feature*, which was only ever a crude proxy. It also settles video-job recovery consistently — it keeps its acquire like everything else and simply does not show unless it is genuinely slow.

Deep Research is unaffected and keeps showing immediately: a notification carrying action buttons (its Cancel) is exempt from the deferral. Below API 31 there is no deferral at all, which is fine — those devices need the service more anyway.

## Completion pings: two gaps filled

- **Generated images** — reuses the existing `StreamSegment.Image && !generating` test, fired after the 2600ms reveal delay so it does not buzz over the animation already telling you it arrived.
- **Finished model downloads** — the longest-running thing in the app, and until now the only one that completed in total silence. Covers both the catalog download and the file import path.

Video and the Echo modes keep theirs. Plain replies stay silent by design.

## Suppression is now per-conversation

`isAppForeground` suppressed app-wide, so reading chat A when chat B's Fusion answer landed got you nothing at all — no ping and nothing waiting. `ChatViewModel` now pushes the visible thread id, and only that conversation is suppressed. Downloads have no conversation, so being anywhere in the app still counts as seeing them.

## Grouping

All of these bundle under one group. The summary is rebuilt from `getActiveNotifications()` rather than a list we maintain, which would drift the moment the user swipes a child away. `GROUP_ALERT_CHILDREN` keeps the summary from buzzing a second time behind children that already did, and below two children there is nothing to summarise so the summary is taken down instead.

One channel, not two. At most a handful of these land at once; splitting adds a settings surface nobody asked for, and channels are easy to add later and impossible to rename cleanly once shipped.

## Verification

`:app:compileDebugKotlin` passes (pre-existing deprecation warnings only). **Not verified on device.** No UI surface changed, so there is nothing to screenshot per the PR rule — but the behaviour here is inherently timing- and OEM-dependent and wants a real run before merge:

- Send a short message and confirm no notification flashes up.
- Start a video or a large download, background the app, confirm it appears ~10s in.
- Let two completions land together and check the group summary, then tap through and confirm the summary does not linger. Platform auto-removal of a summary when its last child goes has historically been flaky on some OEM skins; if it lingers here, that needs a delete-intent receiver, which I deliberately did not add up front.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves the product direction by replacing noisy immediate foreground-service notifications with duration-based platform behavior and by adding targeted completion notifications for work users are likely to leave running. The implementation also centralizes per-conversation suppression and notification grouping; it could be strengthened with the device/OEM timing and dismissal coverage already identified in the PR description.

- Removes forced immediate display of the keep-alive foreground-service notification.
- Adds completion notifications for generated images, downloaded models, and imported models.
- Suppresses reply notifications only for the conversation currently being viewed.
- Groups concurrent completion notifications and derives summary content from active children.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with device-level validation still advisable for the intentionally platform-dependent notification timing and group-dismissal behavior.

The changed notification paths preserve keep-alive acquisition and release behavior, correctly distinguish visible-conversation suppression from app-wide download suppression, and no concrete blocking failure remains after accounting for the explicitly acknowledged OEM summary limitation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/KeepAliveService.kt | Removes the immediate foreground-service behavior so Android 12+ can defer short-lived service notifications. |
| app/src/main/java/com/echoflow/data/ModelDownloadManager.kt | Posts completion notifications after successful catalog downloads and local-model imports. |
| app/src/main/java/com/echoflow/data/ReplyNotifications.kt | Adds per-conversation suppression, separate notification ID ranges, shared grouping, and active-notification-derived summaries; the acknowledged OEM dismissal behavior remains device-dependent. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Publishes the selected conversation for notification suppression and adds image-generation completion pings. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Long-running work starts] --> B[KeepAliveService starts foreground]
    B --> C{Finishes within Android deferral?}
    C -->|Yes| D[No ongoing notification shown]
    C -->|No| E[Platform shows ongoing notification]
    A --> F[Work completes]
    F --> G{Completion type}
    G -->|Reply, image, or video| H{Same chat currently visible?}
    H -->|Yes| I[Suppress completion ping]
    H -->|No| J[Post grouped completion child]
    G -->|Model download or import| K{App foreground?}
    K -->|Yes| I
    K -->|No| J
    J --> L{At least two active children?}
    L -->|Yes| M[Post or rebuild group summary]
    L -->|No| N[Remove group summary]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Stop notifying for every chat turn; ping..."](https://github.com/adityavardhansharma/echoflow/commit/b16e8f39efcb56d761735256284354075d2f8346) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51803942)</sub>

<!-- /greptile_comment -->