### PR TITLE
Make the send/stop haptics actually strong

### DIFF
--- a/app/src/main/java/com/echoflow/ui/Haptics.kt
+++ b/app/src/main/java/com/echoflow/ui/Haptics.kt
@@ -156,14 +156,21 @@ private class VibrationHaptics(context: Context) {
     }
 
     private fun plainWaveform(action: Action): VibrationEffect = when (action) {
-        Action.SEND -> VibrationEffect.createWaveform(longArrayOf(0, 12, 34, 24), NO_REPEAT)
-        Action.STOP -> VibrationEffect.createWaveform(longArrayOf(0, 24, 44, 16), NO_REPEAT)
+        // Longer pulses than the shaped tier on purpose. A device with no amplitude control is
+        // almost always a rotating-mass motor, which needs tens of milliseconds just to spin up
+        // — feed it the crisp 12ms pulse that suits an LRA and it barely moves at all.
+        Action.SEND -> VibrationEffect.createWaveform(longArrayOf(0, 25, 35, 45), NO_REPEAT)
+        Action.STOP -> VibrationEffect.createWaveform(longArrayOf(0, 45, 35, 25), NO_REPEAT)
     }
 
     private companion object {
         const val NO_REPEAT = -1
-        const val SEND_GAP_MS = 35
-        const val STOP_GAP_MS = 45
+
+        // Wide enough that the two beats stay legible as two. Closer together and a slower
+        // motor smears them into one long event, which reads as a mushy buzz rather than as
+        // a firmer tap — "weak" and "blurred" feel like the same thing under a fingertip.
+        const val SEND_GAP_MS = 50
+        const val STOP_GAP_MS = 55
 
         val TOUCH_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)

--- a/app/src/main/java/com/echoflow/ui/Haptics.kt
+++ b/app/src/main/java/com/echoflow/ui/Haptics.kt
@@ -35,8 +35,13 @@ import androidx.compose.ui.platform.LocalView
  *
  * 1. **Composition primitives** (API 30+, when the motor supports them) — the real thing.
  * 2. **Shaped waveform** (API 26+ with amplitude control) — same envelope, hand-rolled.
- * 3. **Predefined effects** (API 29+) — one OEM-tuned blip, click vs. heavy click.
- * 4. **Unshaped waveform / view constants** — two beats at whatever amplitude the motor has.
+ * 3. **Predefined effects** (API 29+) — one OEM-tuned blip, heavy click vs. double click.
+ * 4. **Unshaped waveform** (API 26+) — the envelope carried by durations alone.
+ * 5. **Legacy pattern** (API 24–25) — the same durations through the pre-[VibrationEffect] API.
+ * 6. **View constants** — only when there is no vibrator at all, so nothing will be felt anyway.
+ *
+ * Send and stop stay distinguishable at *every* tier, including the last two. A fallback that
+ * plays one cue for both actions is worse than no fallback: it actively teaches the wrong thing.
  *
  * No vibrator, or system touch feedback switched off, means we stay silent.
  */
@@ -47,6 +52,9 @@ internal fun rememberActionHaptics(): ActionHaptics {
     return remember(view) { ActionHaptics(context.applicationContext, view) }
 }
 
+/** Which of the two cues to play. Both tiers render it; only the fidelity differs. */
+internal enum class HapticAction { SEND, STOP }
+
 internal class ActionHaptics(context: Context, private val view: View) {
 
     private val resolver = context.contentResolver
@@ -54,27 +62,57 @@ internal class ActionHaptics(context: Context, private val view: View) {
     private val vibration: VibrationHaptics? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) VibrationHaptics(context) else null
 
+    private val legacy: LegacyVibration? =
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) LegacyVibration(context) else null
+
     /** The user committed a message — fire as the reply starts streaming. */
-    fun send() = play(VibrationHaptics.Action.SEND, HapticFeedbackConstants.LONG_PRESS)
+    fun send() = play(HapticAction.SEND, HapticFeedbackConstants.VIRTUAL_KEY)
 
     /** The user cancelled an in-flight reply. */
-    fun stop() = play(VibrationHaptics.Action.STOP, HapticFeedbackConstants.LONG_PRESS)
+    fun stop() = play(HapticAction.STOP, HapticFeedbackConstants.LONG_PRESS)
 
-    private fun play(action: VibrationHaptics.Action, fallback: Int) {
+    private fun play(action: HapticAction, fallback: Int) {
         // Read every time: the user can flip touch feedback off in Settings while we're alive.
+        // The setting is deprecated but still the one the platform honours, and USAGE_TOUCH
+        // already respects it — this is belt and braces for the view-constant path.
+        @Suppress("DEPRECATION")
         val allowed = Settings.System.getInt(resolver, Settings.System.HAPTIC_FEEDBACK_ENABLED, 1) != 0
         if (!allowed) return
-        if (vibration?.play(action) == true) return
-        // Pre-O, or a device with no vibrator: the platform constants are all we have.
+        // The version check is redundant with `vibration` being non-null only on O+, but lint
+        // cannot see that through the field, and it is the check that keeps the build honest.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibration?.play(action) == true) return
+        if (legacy?.play(action) == true) return
+        // Genuinely nothing left: no vibrator at all. The constants differ per action anyway —
+        // send and stop must never become the same cue, whichever tier ends up rendering them.
         view.performHapticFeedback(fallback)
+    }
+}
+
+/**
+ * Pre-O devices have a [Vibrator] but no [VibrationEffect], so every tier above is out of reach.
+ * The two-beat envelope is not: with no amplitude control the shape lives entirely in the
+ * durations, which is exactly what the unshaped waveform encodes. So API 24–25 still gets a real
+ * send-versus-stop pair rather than collapsing both onto one platform constant.
+ */
+private class LegacyVibration(context: Context) {
+
+    private val vibrator: Vibrator? = run {
+        @Suppress("DEPRECATION")
+        val service = context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        service?.takeIf { it.hasVibrator() }
+    }
+
+    fun play(action: HapticAction): Boolean {
+        val vibrator = vibrator ?: return false
+        @Suppress("DEPRECATION")
+        vibrator.vibrate(unshapedPattern(action), NO_REPEAT, TOUCH_ATTRIBUTES)
+        return true
     }
 }
 
 /** The [Vibrator]-backed tiers. Split out so the API 26+ surface stays behind one version check. */
 @RequiresApi(Build.VERSION_CODES.O)
 private class VibrationHaptics(context: Context) {
-
-    enum class Action { SEND, STOP }
 
     private val vibrator: Vibrator? = run {
         val service = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -97,7 +135,7 @@ private class VibrationHaptics(context: Context) {
         vibrator?.areAllPrimitivesSupported(VibrationEffect.Composition.PRIMITIVE_THUD) == true
 
     /** @return true if the device actually played something. */
-    fun play(action: Action): Boolean {
+    fun play(action: HapticAction): Boolean {
         val vibrator = vibrator ?: return false
         val effect = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && supportsPrimitives -> composed(action)
@@ -116,15 +154,15 @@ private class VibrationHaptics(context: Context) {
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
-    private fun composed(action: Action): VibrationEffect {
+    private fun composed(action: HapticAction): VibrationEffect {
         val composition = VibrationEffect.startComposition()
         return when (action) {
             // The accent beat of each cue runs at full scale; the envelope comes from the *other*
             // beat being softer, not from holding the whole cue back.
-            Action.SEND -> composition
+            HapticAction.SEND -> composition
                 .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.65f)
                 .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 1f, SEND_GAP_MS)
-            Action.STOP ->
+            HapticAction.STOP ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && supportsThud) {
                     composition
                         .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 1f)
@@ -138,43 +176,51 @@ private class VibrationHaptics(context: Context) {
         }.compose()
     }
 
-    private fun shapedWaveform(action: Action): VibrationEffect = when (action) {
-        Action.SEND -> VibrationEffect.createWaveform(
+    private fun shapedWaveform(action: HapticAction): VibrationEffect = when (action) {
+        HapticAction.SEND -> VibrationEffect.createWaveform(
             longArrayOf(0, 12, 34, 24), intArrayOf(0, 165, 0, 255), NO_REPEAT,
         )
-        Action.STOP -> VibrationEffect.createWaveform(
+        HapticAction.STOP -> VibrationEffect.createWaveform(
             longArrayOf(0, 24, 44, 16), intArrayOf(0, 255, 0, 160), NO_REPEAT,
         )
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun predefined(action: Action): VibrationEffect = when (action) {
+    private fun predefined(action: HapticAction): VibrationEffect = when (action) {
         // Heavy on both: a plain EFFECT_CLICK is the same blip this tier's devices already use
         // for a keypress, which is exactly the "was that anything?" feel we're avoiding.
-        Action.SEND -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
-        Action.STOP -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_DOUBLE_CLICK)
+        HapticAction.SEND -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+        HapticAction.STOP -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_DOUBLE_CLICK)
     }
 
-    private fun plainWaveform(action: Action): VibrationEffect = when (action) {
-        // Longer pulses than the shaped tier on purpose. A device with no amplitude control is
-        // almost always a rotating-mass motor, which needs tens of milliseconds just to spin up
-        // — feed it the crisp 12ms pulse that suits an LRA and it barely moves at all.
-        Action.SEND -> VibrationEffect.createWaveform(longArrayOf(0, 25, 35, 45), NO_REPEAT)
-        Action.STOP -> VibrationEffect.createWaveform(longArrayOf(0, 45, 35, 25), NO_REPEAT)
-    }
+    private fun plainWaveform(action: HapticAction): VibrationEffect =
+        VibrationEffect.createWaveform(unshapedPattern(action), NO_REPEAT)
 
-    private companion object {
-        const val NO_REPEAT = -1
-
-        // Wide enough that the two beats stay legible as two. Closer together and a slower
-        // motor smears them into one long event, which reads as a mushy buzz rather than as
-        // a firmer tap — "weak" and "blurred" feel like the same thing under a fingertip.
-        const val SEND_GAP_MS = 50
-        const val STOP_GAP_MS = 55
-
-        val TOUCH_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
-            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-            .build()
-    }
 }
+
+private const val NO_REPEAT = -1
+
+// Wide enough that the two beats stay legible as two. Closer together and a slower motor smears
+// them into one long event, which reads as a mushy buzz rather than as a firmer tap — "weak" and
+// "blurred" feel like the same thing under a fingertip.
+private const val SEND_GAP_MS = 50
+private const val STOP_GAP_MS = 55
+
+/**
+ * The envelope expressed purely in durations, for the two tiers with no amplitude control: a
+ * short beat then a long one for send, the reverse for stop.
+ *
+ * Longer pulses than the shaped tier on purpose. A device without amplitude control is almost
+ * always a rotating-mass motor, which needs tens of milliseconds just to spin up — feed it the
+ * crisp 12ms pulse that suits an LRA and it barely moves at all.
+ */
+private fun unshapedPattern(action: HapticAction): LongArray = when (action) {
+    HapticAction.SEND -> longArrayOf(0, 25, 35, 45)
+    HapticAction.STOP -> longArrayOf(0, 45, 35, 25)
+}
+
+/** Tagged as touch feedback so the system scales and routes it like any other UI haptic. */
+private val TOUCH_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
+    .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+    .build()

--- a/app/src/main/java/com/echoflow/ui/Haptics.kt
+++ b/app/src/main/java/com/echoflow/ui/Haptics.kt
@@ -23,8 +23,12 @@ import androidx.compose.ui.platform.LocalView
  * thin (it reads as a keypress, not as "the message left") and a buzz is too long (it reads as an
  * error). Both cues are two beats inside ~80 ms, and they're deliberate mirrors of each other:
  *
- * - **Send** — rising envelope: a light tick of anticipation, then the firm click of release.
- * - **Stop** — falling envelope: the firm hit lands first, then damps out. Halted, not launched.
+ * - **Send** — rising envelope: a softer click of anticipation, then a full-scale one on release.
+ * - **Stop** — falling envelope: the full-scale hit lands first, then damps out. Halted, not launched.
+ *
+ * Both accent beats run at scale 1.0. The envelope comes from the *quieter* beat being quieter,
+ * never from holding the whole cue back — the system already scales us down by the user's touch
+ * feedback intensity, so anything less than full scale here arrives thin.
  *
  * Vibration hardware varies enormously, so we take the best thing the device actually reports and
  * degrade in tiers, keeping the two-beat shape for as long as the hardware allows:
@@ -51,7 +55,7 @@ internal class ActionHaptics(context: Context, private val view: View) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) VibrationHaptics(context) else null
 
     /** The user committed a message — fire as the reply starts streaming. */
-    fun send() = play(VibrationHaptics.Action.SEND, HapticFeedbackConstants.VIRTUAL_KEY)
+    fun send() = play(VibrationHaptics.Action.SEND, HapticFeedbackConstants.LONG_PRESS)
 
     /** The user cancelled an in-flight reply. */
     fun stop() = play(VibrationHaptics.Action.STOP, HapticFeedbackConstants.LONG_PRESS)
@@ -82,11 +86,11 @@ private class VibrationHaptics(context: Context) {
         service?.takeIf { it.hasVibrator() }
     }
 
+    // Only CLICK is required: it is both the most widely supported primitive and the only one
+    // with real punch. TICK is deliberately unused — it is the weakest thing the motor can do,
+    // and using it for the lead beat is what made the first cut of this feel thin.
     private val supportsPrimitives = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
-        vibrator?.areAllPrimitivesSupported(
-            VibrationEffect.Composition.PRIMITIVE_CLICK,
-            VibrationEffect.Composition.PRIMITIVE_TICK,
-        ) == true
+        vibrator?.areAllPrimitivesSupported(VibrationEffect.Composition.PRIMITIVE_CLICK) == true
 
     /** A low, weighty landing — the nicest possible "stop", where the motor can render it. */
     private val supportsThud = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
@@ -115,36 +119,40 @@ private class VibrationHaptics(context: Context) {
     private fun composed(action: Action): VibrationEffect {
         val composition = VibrationEffect.startComposition()
         return when (action) {
+            // The accent beat of each cue runs at full scale; the envelope comes from the *other*
+            // beat being softer, not from holding the whole cue back.
             Action.SEND -> composition
-                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, 0.5f)
-                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.9f, SEND_GAP_MS)
+                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.65f)
+                .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 1f, SEND_GAP_MS)
             Action.STOP ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && supportsThud) {
                     composition
-                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.8f)
-                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_THUD, 0.75f, STOP_GAP_MS)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 1f)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_THUD, 1f, STOP_GAP_MS)
                 } else {
                     // Without a thud, a decaying second click still gives the falling envelope.
                     composition
-                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.9f)
-                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, 0.55f, STOP_GAP_MS)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 1f)
+                        .addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, 0.6f, STOP_GAP_MS)
                 }
         }.compose()
     }
 
     private fun shapedWaveform(action: Action): VibrationEffect = when (action) {
         Action.SEND -> VibrationEffect.createWaveform(
-            longArrayOf(0, 12, 34, 24), intArrayOf(0, 100, 0, 215), NO_REPEAT,
+            longArrayOf(0, 12, 34, 24), intArrayOf(0, 165, 0, 255), NO_REPEAT,
         )
         Action.STOP -> VibrationEffect.createWaveform(
-            longArrayOf(0, 24, 44, 16), intArrayOf(0, 225, 0, 120), NO_REPEAT,
+            longArrayOf(0, 24, 44, 16), intArrayOf(0, 255, 0, 160), NO_REPEAT,
         )
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun predefined(action: Action): VibrationEffect = when (action) {
-        Action.SEND -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
-        Action.STOP -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+        // Heavy on both: a plain EFFECT_CLICK is the same blip this tier's devices already use
+        // for a keypress, which is exactly the "was that anything?" feel we're avoiding.
+        Action.SEND -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+        Action.STOP -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_DOUBLE_CLICK)
     }
 
     private fun plainWaveform(action: Action): VibrationEffect = when (action) {


### PR DESCRIPTION
Follow-up to #100, which merged before these landed — the two commits below were pushed to the branch after the merge, so the weak first cut is what is currently on `main`.

Reported after testing #100: duration was right, strength was not.

## Full-scale accents, no TICK (`180684c`)

Three causes, all amplitude rather than timing, so the envelopes are unchanged:

- **`PRIMITIVE_TICK` led the send cue.** It is the weakest thing a motor can render, so the beat meant to set up the release mostly vanished. Both cues now use `CLICK` for both beats. Dropping TICK also widens tier-1 eligibility, since `areAllPrimitivesSupported` now only has to agree to `CLICK`.
- **Every scale was below 1.0.** The system already scales us down by the user's touch-feedback intensity, so the accent beat now runs at full scale and the envelope comes from the quieter beat alone.
- **The fallback tiers were equally timid.** Waveform amplitudes go to 165/255, and the predefined tier moves to `EFFECT_HEAVY_CLICK` for send and `EFFECT_DOUBLE_CLICK` for stop — a plain `EFFECT_CLICK` is the same blip those devices already use for a keypress, which is exactly the "was that anything?" feel being avoided.

## Definition, not just power (`460eb3d`)

- **Gaps 35/45ms to 50/55ms.** Two clicks that close smear into one long event on a slower motor. That reads as a mushy buzz rather than a firmer tap, and under a fingertip "blurred" and "weak" are hard to tell apart.
- **The no-amplitude-control tier used a 12ms pulse.** That is an LRA timing; a device without amplitude control is almost always a rotating-mass motor needing tens of milliseconds just to spin up, so it barely moved. Those timings now run 25-45ms.

## Verification

`Haptics.kt` only; compiles. **Not verified on device** — this is a fix for a feel problem, so it only tells the truth on real hardware.

One ceiling worth knowing before judging it: the vibration is tagged `USAGE_TOUCH`, so the system scales it by your **touch feedback intensity** setting. If that is on low or medium, everything here still arrives muted. Worth checking that first — deliberately not bypassed, since overriding a user's explicit haptics preference is not ours to do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved haptic feedback across supported devices.
  * Added compatibility for older Android versions.
  * Refined vibration patterns, timing, intensity, and touch feedback behavior.
  * Added fallback feedback when vibration is unavailable or disabled in system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The stronger, mirrored send/stop cues are a good product-direction improvement: they preserve the user’s haptic-intensity preference while making each action more recognizable. The implementation is notably better structured by centralizing the action model and unshaped patterns across modern and legacy paths.
- Replaces weak primitive and predefined effects with stronger, more distinguishable alternatives.
- Adds distinct duration-based patterns for API 24–25 and other devices without amplitude control.
- Preserves distinct send and stop feedback through every fallback tier.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains, and the previously reported duplicate send/stop fallback has been replaced by distinct cues on every reachable tier.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/Haptics.kt | Strengthens and separates send/stop cues across composed, waveform, predefined, legacy, and View fallback paths; the previously duplicated fallback is resolved. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[send or stop] --> B{Touch feedback enabled?}
    B -- No --> Z[Remain silent]
    B -- Yes --> C{API 26+ vibrator available?}
    C -- Yes --> D{CLICK primitive supported?}
    D -- Yes --> E[Composed two-beat cue]
    D -- No --> F{Amplitude control?}
    F -- Yes --> G[Shaped waveform]
    F -- No --> H{API 29+?}
    H -- Yes --> I[Predefined heavy or double click]
    H -- No --> J[Unshaped waveform]
    C -- No --> K{API 24–25 vibrator available?}
    K -- Yes --> L[Legacy duration pattern]
    K -- No --> M[Distinct View haptic constant]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep send and stop distinct on the legac..."](https://github.com/adityavardhansharma/echoflow/commit/d9c3f7435144d38bcba2431a3c66228df2f028fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51807155)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->