### PR TITLE
Deep Research step timeline with batch capsules and workspace

### DIFF
--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1862,7 +1862,9 @@ class ChatViewModel(
             )
             DeepResearchForegroundService.start(getApplication(), runId)
             clearPendingAttachment()
-            setMode(ChatMode.Normal) // deliberate, per-question opt-in
+            // Stay in Deep Research mode so the model pill keeps the research engine list until
+            // the user toggles the capability off. Exiting to Normal on send made the composer
+            // jump back to chat models mid-run, which reads as the wrong selector.
         }
     }
 
@@ -1965,7 +1967,8 @@ class ChatViewModel(
                 )
             )
             DeepResearchForegroundService.start(getApplication(), runId)
-            setMode(ChatMode.Normal)
+            // Stay in Data Agent mode for the same reason as Deep Research: the engine pill must
+            // keep its agent list until the user turns the capability off.
         }
     }
 

--- a/app/src/main/java/com/echoflow/ui/components/ResearchTimeline.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ResearchTimeline.kt
@@ -97,6 +97,11 @@ internal fun formatResearchDuration(millis: Long): String {
 /**
  * One on-screen capsule: up to [RESEARCH_BATCH_SIZE] engine steps, filled progressively as the
  * run grows (never re-chunked after the fact).
+ *
+ * [contentKey] identifies *which* steps sit in this capsule (ids + labels). Expand/collapse is
+ * keyed by that, not by [index]: a replan that reuses position-based step ids with new questions
+ * must not inherit the previous occupant’s open state. Appending steps to a batch keeps a
+ * prefix-compatible key so a manual toggle survives growth (see [resolveBatchOpen]).
  */
 internal data class ResearchBatch(
     val index: Int,
@@ -106,6 +111,13 @@ internal data class ResearchBatch(
     val hasFailed: Boolean get() = steps.any { it.state == ResearchStep.STATE_FAILED }
     val allTerminal: Boolean get() = steps.isNotEmpty() && steps.all { it.isTerminal }
     val allPending: Boolean get() = steps.isNotEmpty() && steps.all { it.state == ResearchStep.STATE_PENDING }
+
+    /**
+     * Stable for pure state transitions (active → done) on the same steps; changes when a step
+     * is replaced, relabelled, or the batch membership changes.
+     */
+    val contentKey: String
+        get() = steps.joinToString("\u001f") { "${it.id}\u001e${it.label}" }
 
     val state: String
         get() = when {
@@ -138,6 +150,47 @@ internal fun chunkResearchSteps(steps: List<ResearchStep>): List<ResearchBatch> 
         ResearchBatch(index = index + 1, steps = group)
     }
 
+/**
+ * Resolve whether [batch] is expanded under [manualOpen].
+ *
+ * Exact [ResearchBatch.contentKey] wins. If the batch only grew (new steps appended), a stored
+ * key that is a strict content prefix still applies so the user's toggle is not wiped every
+ * time a fifth step lands. A replan that swaps labels or membership has no matching key and
+ * falls through to [defaultOpen].
+ */
+internal fun resolveBatchOpen(
+    batch: ResearchBatch,
+    manualOpen: Map<String, Boolean>,
+    defaultOpen: Boolean,
+): Boolean {
+    val key = batch.contentKey
+    manualOpen[key]?.let { return it }
+    // Longest prefix key: the batch grew after the user toggled.
+    val prefixMatch = manualOpen.entries
+        .filter { (stored, _) -> key.startsWith(stored + "\u001f") }
+        .maxByOrNull { it.key.length }
+        ?.value
+    return prefixMatch ?: defaultOpen
+}
+
+/**
+ * Record a toggle for [batch], dropping any obsolete prefix/sibling keys for the same lineage
+ * so a later replan cannot resurrect a stale override under an old key.
+ */
+internal fun manualOpenAfterToggle(
+    batch: ResearchBatch,
+    manualOpen: Map<String, Boolean>,
+    expanded: Boolean,
+): Map<String, Boolean> {
+    val key = batch.contentKey
+    return manualOpen
+        .filterKeys { stored ->
+            stored != key &&
+                !key.startsWith(stored + "\u001f") &&
+                !stored.startsWith(key + "\u001f")
+        } + (key to expanded)
+}
+
 // ── Live timeline ────────────────────────────────────────────────────────────────────
 
 /**
@@ -158,9 +211,10 @@ fun ResearchTimeline(
     val sourceByUrl = remember(sources) { sources.associateBy { it.url } }
     val batches = remember(steps) { chunkResearchSteps(steps) }
     // Only the batch currently working starts open; earlier ones stay collapsed until the user
-    // reopens them. Manual toggles win over the auto-open default.
+    // reopens them. Manual toggles win over the auto-open default — keyed by content, not index,
+    // so a replan cannot move an expanded flag onto replacement questions.
     val activeBatchIndex = batches.indexOfFirst { it.hasActive }.let { if (it < 0) batches.lastIndex else it }
-    var manualOpen by remember(run.id) { mutableStateOf<Map<Int, Boolean>>(emptyMap()) }
+    var manualOpen by remember(run.id) { mutableStateOf<Map<String, Boolean>>(emptyMap()) }
 
     Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
         // Quiet engine line only — no Cancel. The composer Stop cancels the run.
@@ -201,14 +255,14 @@ fun ResearchTimeline(
 
         batches.forEachIndexed { index, batch ->
             val defaultOpen = index == activeBatchIndex && !batch.allTerminal
-            val open = manualOpen[batch.index] ?: defaultOpen
+            val open = resolveBatchOpen(batch, manualOpen, defaultOpen)
             BatchCapsule(
                 batch = batch,
                 phaseFallback = run.phase,
                 sourceByUrl = sourceByUrl,
                 expanded = open,
                 onToggle = {
-                    manualOpen = manualOpen + (batch.index to !open)
+                    manualOpen = manualOpenAfterToggle(batch, manualOpen, expanded = !open)
                 },
                 staggerIndex = index,
                 reducedMotion = reducedMotion,
@@ -227,8 +281,10 @@ private fun BatchCapsule(
     staggerIndex: Int,
     reducedMotion: Boolean,
 ) {
-    var shown by remember(batch.index) { mutableStateOf(reducedMotion) }
-    LaunchedEffect(batch.index) {
+    // contentKey — not index — so a replan that reuses batch slot 2 still plays enter for the
+    // new questions rather than treating them as the same row that was already on screen.
+    var shown by remember(batch.contentKey) { mutableStateOf(reducedMotion) }
+    LaunchedEffect(batch.contentKey) {
         if (!shown) {
             delay(staggerIndex * 60L)
             shown = true

--- a/app/src/main/java/com/echoflow/ui/components/ResearchTimeline.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ResearchTimeline.kt
@@ -49,26 +49,24 @@ import com.echoflow.ui.theme.rememberReducedMotion
 import kotlinx.coroutines.delay
 
 /**
- * The Deep Research surface: a stack of capsule step rows while the run is live, resolving into
- * a single result card when it finishes.
+ * The Deep Research surface: live work as expandable **batch capsules** (≤5 engine steps each),
+ * resolving into a single result card when the run finishes.
  *
- * Both halves deliberately share one row anatomy — a 24dp state slot, a label, a right-aligned
- * mono meta column, a chevron — so the finished card reads as the last capsule of the run rather
- * than a different component that happens to appear underneath. Emphasis is carried by fill
- * (steps sit on a translucent container, the result card at full `primaryContainer`), never by
- * introducing a new shape.
+ * Engines can emit dozens of steps. Rendering one pill per step floods a phone; instead steps
+ * fill a capsule as they arrive — 1…5 in batch 1, 6 starts batch 2 — so 73 steps become 15
+ * capsules. Each capsule expands like the Task Rows / Thinking references: a header with a mark
+ * and a short thinking line, nested detail rows on open.
  *
  * Everything renders from the persisted [ResearchRun] / [ResearchRef], so a backgrounded run
- * replays its whole history on reopen instead of resuming at "currently working".
- *
- * Pre-redesign research is not drawn here at all — see `ui/legacy/LegacyResearchComponents.kt`.
+ * replays its whole history on reopen. Pre-redesign research is drawn by
+ * `ui/legacy/LegacyResearchComponents.kt`.
  */
 
 private const val ROW_HEIGHT_DP = 48
 private const val MARK_SIZE_DP = 24
 
-/** Completed steps kept visible above the active one before the rest fold into a summary row. */
-private const val DONE_TAIL = 2
+/** How many engine steps share one capsule before a new one opens. */
+internal const val RESEARCH_BATCH_SIZE = 5
 
 private fun hostOfUrl(url: String): String =
     runCatching { android.net.Uri.parse(url).host?.removePrefix("www.") }.getOrNull() ?: url
@@ -80,12 +78,9 @@ private fun openInBrowser(context: android.content.Context, url: String) {
     runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
 }
 
-/** A step paired with its position in the full run, so folding a prefix doesn't renumber rows. */
-private data class NumberedStep(val step: ResearchStep, val ordinal: Int)
-
-// Every disclosure in this feature — step capsules, the result card's provenance, the workspace
-// slide-up — reveals through the same pair, collapsing to an instant cut under reduced motion so
-// the whole surface degrades to stillness rather than only its entry animation doing so.
+// Every disclosure in this feature — batch capsules, the workspace slide-up — reveals through
+// the same pair, collapsing to an instant cut under reduced motion so the whole surface degrades
+// to stillness rather than only its entry animation doing so.
 private fun researchRevealEnter(reducedMotion: Boolean): EnterTransition =
     if (reducedMotion) fadeIn(tween(0)) else expandVertically(tween(300)) + fadeIn(tween(200))
 
@@ -99,39 +94,76 @@ internal fun formatResearchDuration(millis: Long): String {
     return if (minutes > 0) "${minutes}m ${seconds}s" else "${seconds}s"
 }
 
+/**
+ * One on-screen capsule: up to [RESEARCH_BATCH_SIZE] engine steps, filled progressively as the
+ * run grows (never re-chunked after the fact).
+ */
+internal data class ResearchBatch(
+    val index: Int,
+    val steps: List<ResearchStep>,
+) {
+    val hasActive: Boolean get() = steps.any { it.state == ResearchStep.STATE_ACTIVE }
+    val hasFailed: Boolean get() = steps.any { it.state == ResearchStep.STATE_FAILED }
+    val allTerminal: Boolean get() = steps.isNotEmpty() && steps.all { it.isTerminal }
+    val allPending: Boolean get() = steps.isNotEmpty() && steps.all { it.state == ResearchStep.STATE_PENDING }
+
+    val state: String
+        get() = when {
+            hasFailed && steps.none { it.state == ResearchStep.STATE_ACTIVE } -> ResearchStep.STATE_FAILED
+            hasActive -> ResearchStep.STATE_ACTIVE
+            allTerminal -> ResearchStep.STATE_DONE
+            allPending -> ResearchStep.STATE_PENDING
+            else -> ResearchStep.STATE_ACTIVE
+        }
+
+    /** Header line: what the agent is doing now, or a settled "Thought for …" once the batch ends. */
+    fun headerText(phaseFallback: String?): String {
+        steps.firstOrNull { it.state == ResearchStep.STATE_ACTIVE }?.label?.let { return it }
+        if (allTerminal) {
+            val start = steps.mapNotNull { it.startedAt.takeIf { t -> t > 0L } }.minOrNull()
+            val end = steps.mapNotNull { it.endedAt }.maxOrNull()
+            if (start != null && end != null && end >= start) {
+                return "Thought for ${formatResearchDuration(end - start)}"
+            }
+            return if (hasFailed) "Couldn't finish" else "Thought through ${steps.size} step${if (steps.size == 1) "" else "s"}"
+        }
+        steps.lastOrNull { it.state != ResearchStep.STATE_PENDING }?.label?.let { return it }
+        return phaseFallback?.takeIf { it.isNotBlank() } ?: "Thinking"
+    }
+}
+
+/** Progressive groups of [RESEARCH_BATCH_SIZE] — last group may be shorter. */
+internal fun chunkResearchSteps(steps: List<ResearchStep>): List<ResearchBatch> =
+    steps.chunked(RESEARCH_BATCH_SIZE).mapIndexed { index, group ->
+        ResearchBatch(index = index + 1, steps = group)
+    }
+
 // ── Live timeline ────────────────────────────────────────────────────────────────────
 
 /**
- * The live run: a label line naming the engine, then one capsule per step.
+ * The live run: one expandable capsule per batch of up to five steps.
  *
- * Steps arrive from the engine and are only as granular as the engine can honestly report — the
- * agentic path narrates every sub-question, Firecrawl replays its activity feed, and the
- * single-shot providers show one row rather than invented stages.
+ * Stop lives on the composer (send → stop), not as a Cancel chip on this card — same grammar as
+ * a streaming chat reply.
  */
 @Composable
 fun ResearchTimeline(
     run: ResearchRun,
     steps: List<ResearchStep>,
     sources: List<SearchSource>,
-    onCancel: () -> Unit,
+    onCancel: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val reducedMotion = rememberReducedMotion()
     val sourceByUrl = remember(sources) { sources.associateBy { it.url } }
+    val batches = remember(steps) { chunkResearchSteps(steps) }
+    // Only the batch currently working starts open; earlier ones stay collapsed until the user
+    // reopens them. Manual toggles win over the auto-open default.
+    val activeBatchIndex = batches.indexOfFirst { it.hasActive }.let { if (it < 0) batches.lastIndex else it }
+    var manualOpen by remember(run.id) { mutableStateOf<Map<Int, Boolean>>(emptyMap()) }
 
-    // Everything finished more than DONE_TAIL rows back folds away, so a long plan can't push
-    // the composer off a phone screen. Failures never fold — they are the reason to look.
-    val activeIndex = steps.indexOfFirst { !it.isTerminal }.let { if (it < 0) steps.size else it }
-    val foldEnd = (activeIndex - DONE_TAIL).coerceAtLeast(0)
-    val folded = steps.take(foldEnd).filter { it.state != ResearchStep.STATE_FAILED }
-    val foldedIds = remember(folded) { folded.map { it.id }.toSet() }
-    // Keep each step's position in the full run so a folded prefix doesn't renumber the rows.
-    val visibleSteps = steps
-        .mapIndexed { index, step -> NumberedStep(step, index + 1) }
-        .filter { it.step.id !in foldedIds }
-    var showFolded by remember { mutableStateOf(false) }
-
-    Column(modifier.fillMaxWidth()) {
+    Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        // Quiet engine line only — no Cancel. The composer Stop cancels the run.
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 if (run.engineKind == "data-agent") "Data Agent" else "Deep Research",
@@ -152,75 +184,51 @@ fun ResearchTimeline(
                     style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Spacer(Modifier.width(Spacing.s))
-            }
-            TextButton(onClick = onCancel, contentPadding = PaddingValues(horizontal = Spacing.s)) {
-                Text("Cancel", style = MaterialTheme.typography.labelMedium)
             }
         }
 
-        Spacer(Modifier.height(Spacing.s))
+        Spacer(Modifier.height(Spacing.xs))
 
-        // No steps yet (a run that just started, or an engine that failed before narrating
-        // anything) still needs to look alive.
-        if (steps.isEmpty()) {
+        // No steps yet — still look alive (queued / first network hop).
+        if (batches.isEmpty()) {
             ResearchCapsule(
                 mark = { StepMark(ResearchStep.STATE_ACTIVE, 0) },
-                label = run.phase ?: "Starting…",
+                label = run.phase?.takeIf { it.isNotBlank() } ?: "Thinking",
                 meta = null,
                 expandable = false,
             )
         }
 
-        if (folded.isNotEmpty()) {
-            ResearchCapsule(
-                mark = { StepMark(ResearchStep.STATE_DONE, 0) },
-                label = "${folded.size} earlier step${if (folded.size == 1) "" else "s"}",
-                meta = null,
-                expanded = showFolded,
-                onToggle = { showFolded = !showFolded },
-                expandable = true,
-            ) {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-                    folded.forEach { step ->
-                        DetailRow(step.label, step.detail)
-                    }
-                }
-            }
-            Spacer(Modifier.height(Spacing.xs))
-        }
-
-        visibleSteps.forEachIndexed { index, entry ->
-            StepCapsule(
-                step = entry.step,
-                ordinal = entry.ordinal,
+        batches.forEachIndexed { index, batch ->
+            val defaultOpen = index == activeBatchIndex && !batch.allTerminal
+            val open = manualOpen[batch.index] ?: defaultOpen
+            BatchCapsule(
+                batch = batch,
+                phaseFallback = run.phase,
                 sourceByUrl = sourceByUrl,
+                expanded = open,
+                onToggle = {
+                    manualOpen = manualOpen + (batch.index to !open)
+                },
                 staggerIndex = index,
                 reducedMotion = reducedMotion,
             )
-            if (index != visibleSteps.lastIndex) Spacer(Modifier.height(Spacing.xs))
         }
     }
 }
 
 @Composable
-private fun StepCapsule(
-    step: ResearchStep,
-    ordinal: Int,
+private fun BatchCapsule(
+    batch: ResearchBatch,
+    phaseFallback: String?,
     sourceByUrl: Map<String, SearchSource>,
+    expanded: Boolean,
+    onToggle: () -> Unit,
     staggerIndex: Int,
     reducedMotion: Boolean,
 ) {
-    var expanded by remember(step.id) { mutableStateOf(false) }
-    val stepSources = remember(step.sourceUrls, sourceByUrl) {
-        step.sourceUrls.mapNotNull { sourceByUrl[it] }
-    }
-    val expandable = stepSources.isNotEmpty()
-
-    // Rows fade up as they arrive, 60ms apart, so a seeded plan lands as a sequence rather than
-    // a block. Reduced motion skips straight to the resting frame.
-    var shown by remember(step.id) { mutableStateOf(reducedMotion) }
-    LaunchedEffect(step.id) {
+    var shown by remember(batch.index) { mutableStateOf(reducedMotion) }
+    LaunchedEffect(batch.index) {
         if (!shown) {
             delay(staggerIndex * 60L)
             shown = true
@@ -229,24 +237,101 @@ private fun StepCapsule(
     val enter by animateFloatAsState(
         targetValue = if (shown) 1f else 0f,
         animationSpec = if (reducedMotion) tween(0) else spring(stiffness = 380f, dampingRatio = 0.85f),
-        label = "step-enter",
+        label = "batch-enter",
     )
 
     ResearchCapsule(
-        mark = { StepMark(step.state, ordinal) },
-        label = step.label,
-        meta = step.detail,
+        mark = { StepMark(batch.state, batch.index) },
+        label = batch.headerText(phaseFallback),
+        meta = null,
         expanded = expanded,
-        onToggle = if (expandable) ({ expanded = !expanded }) else null,
-        expandable = expandable,
-        dimmed = step.state == ResearchStep.STATE_PENDING,
+        onToggle = onToggle,
+        expandable = true,
+        dimmed = batch.allPending,
         modifier = Modifier.graphicsLayer {
             alpha = enter
             translationY = (1f - enter) * 12.dp.toPx()
         },
     ) {
+        // Nested detail — same rail + row grammar as the Thinking "Steps" reference.
         Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-            stepSources.forEach { source -> SourceDetailRow(source) }
+            batch.steps.forEach { step ->
+                StepDetailRow(step = step, sourceByUrl = sourceByUrl)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepDetailRow(
+    step: ResearchStep,
+    sourceByUrl: Map<String, SearchSource>,
+) {
+    val stepSources = remember(step.sourceUrls, sourceByUrl) {
+        step.sourceUrls.mapNotNull { sourceByUrl[it] }
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            DetailMark(step.state)
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                step.label,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                color = if (step.state == ResearchStep.STATE_PENDING) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            step.detail?.let { meta ->
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    meta,
+                    style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+        }
+        stepSources.forEach { source ->
+            SourceDetailRow(source, indent = true)
+        }
+    }
+}
+
+/** Compact check / spinner / digit for rows nested inside a batch. */
+@Composable
+private fun DetailMark(state: String) {
+    Box(Modifier.size(14.dp), contentAlignment = Alignment.Center) {
+        when (state) {
+            ResearchStep.STATE_ACTIVE -> LoadingIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(14.dp),
+            )
+            ResearchStep.STATE_DONE -> Icon(
+                Icons.Default.Check,
+                null,
+                Modifier.size(13.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            ResearchStep.STATE_FAILED -> Icon(
+                Icons.Default.Close,
+                null,
+                Modifier.size(13.dp),
+                tint = MaterialTheme.colorScheme.error,
+            )
+            else -> Box(
+                Modifier
+                    .size(10.dp)
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape),
+            )
         }
     }
 }
@@ -290,7 +375,7 @@ private fun ResearchCapsule(
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .then(if (onToggle != null) Modifier.clickable(onClick =onToggle) else Modifier)
+                    .then(if (onToggle != null) Modifier.clickable(onClick = onToggle) else Modifier)
                     .heightIn(min = ROW_HEIGHT_DP.dp)
                     .padding(horizontal = Spacing.m, vertical = Spacing.s),
                 verticalAlignment = Alignment.CenterVertically,
@@ -411,34 +496,13 @@ private fun FilledMark(
 }
 
 @Composable
-private fun DetailRow(label: String, meta: String?) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            label,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        if (meta != null) {
-            Spacer(Modifier.width(Spacing.s))
-            Text(
-                meta,
-                style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@Composable
-private fun SourceDetailRow(source: SearchSource) {
+private fun SourceDetailRow(source: SearchSource, indent: Boolean = false) {
     val context = LocalContext.current
     Row(
         Modifier
             .fillMaxWidth()
-            .clickable {openInBrowser(context, source.url) }
+            .then(if (indent) Modifier.padding(start = 14.dp + Spacing.s) else Modifier)
+            .clickable { openInBrowser(context, source.url) }
             .padding(vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -466,15 +530,11 @@ private fun SourceDetailRow(source: SearchSource) {
 // ── Result card ──────────────────────────────────────────────────────────────────────
 
 /**
- * The finished run — the last capsule, grown up.
+ * The finished run — one tappable card: open the report (or retry on failure).
  *
- * Same anatomy as a step row (mark, title, mono meta) so it rhymes with the timeline it replaced,
- * but filled at full `primaryContainer`: it is the only element in the stack carrying that
- * weight, which is how it reads as the payoff without needing a new shape or a bigger icon. The
- * chevron folds the run's own provenance back open inside it; the report itself lives one tap
- * away in the workspace, because a deep research answer is far too long to sit in a bubble.
- *
- * A failed run uses the same geometry against `errorContainer` and swaps Open for Retry.
+ * Steps already lived in the live batch timeline (and in the workspace Steps tab), so this card
+ * does not re-expand them. The whole surface is the action — same visual weight as before, but
+ * no chevron / provenance disclosure competing with Open report.
  */
 @Composable
 fun ResearchResultCard(
@@ -485,8 +545,6 @@ fun ResearchResultCard(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val reducedMotion = rememberReducedMotion()
-    var showSteps by remember(research.runId) { mutableStateOf(false) }
     val failed = research.error != null
     val container = if (failed) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.primaryContainer
     val onContainer = if (failed) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onPrimaryContainer
@@ -500,22 +558,23 @@ fun ResearchResultCard(
             research.costInfo?.takeIf { it.isNotBlank() }?.let { add(it) }
         }.joinToString(" · ")
     }
-    val chevron by animateFloatAsState(
-        targetValue = if (showSteps) 180f else 0f,
-        animationSpec = tween(if (reducedMotion) 0 else 300),
-        label = "result-chevron",
-    )
+    val actionLabel = when {
+        failed -> "Try again"
+        research.structured -> "Open data"
+        else -> "Open report"
+    }
 
     Surface(
         shape = RoundedCornerShape(22.dp),
         color = container,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = if (failed) onRetry else onOpen),
     ) {
         Column {
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .then(if (steps.isNotEmpty()) Modifier.clickable {showSteps = !showSteps } else Modifier)
                     .heightIn(min = ROW_HEIGHT_DP.dp)
                     .padding(horizontal = Spacing.m, vertical = Spacing.m),
                 verticalAlignment = Alignment.CenterVertically,
@@ -547,21 +606,21 @@ fun ResearchResultCard(
                         )
                     }
                 }
-                if (steps.isNotEmpty()) {
+                if (failed) {
+                    Icon(Icons.Default.Refresh, actionLabel, Modifier.size(18.dp), tint = onContainer)
+                } else {
                     Icon(
                         Icons.Default.KeyboardArrowDown,
-                        if (showSteps) "Hide steps" else "Show steps",
-                        Modifier.padding(start = Spacing.xs).size(18.dp).rotate(chevron),
+                        actionLabel,
+                        Modifier.size(18.dp).rotate(-90f),
                         tint = onContainer,
                     )
                 }
             }
 
-            // The proof of work: only research has this, and it is what makes a long wait feel
-            // like it bought something.
             if (sources.isNotEmpty()) {
                 Row(
-                    Modifier.padding(start = Spacing.m + MARK_SIZE_DP.dp + Spacing.m, end = Spacing.m, bottom = Spacing.m),
+                    Modifier.padding(start = Spacing.m + MARK_SIZE_DP.dp + Spacing.m, end = Spacing.m, bottom = Spacing.s),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Row(horizontalArrangement = Arrangement.spacedBy((-6).dp)) {
@@ -582,59 +641,12 @@ fun ResearchResultCard(
                 }
             }
 
-            AnimatedVisibility(
-                visible = showSteps,
-                enter = researchRevealEnter(reducedMotion),
-                exit = researchRevealExit(reducedMotion),
-            ) {
-                Column(
-                    Modifier.padding(start = Spacing.m, end = Spacing.m, bottom = Spacing.m),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-                ) {
-                    steps.forEach { step ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Box(Modifier.size(16.dp), contentAlignment = Alignment.Center) {
-                                Icon(
-                                    if (step.state == ResearchStep.STATE_FAILED) Icons.Default.Close else Icons.Default.Check,
-                                    null,
-                                    Modifier.size(13.dp),
-                                    tint = if (step.state == ResearchStep.STATE_FAILED) {
-                                        MaterialTheme.colorScheme.error
-                                    } else {
-                                        onContainer.copy(alpha = 0.72f)
-                                    },
-                                )
-                            }
-                            Spacer(Modifier.width(Spacing.s))
-                            Text(
-                                step.label,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = onContainer.copy(alpha = 0.86f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f),
-                            )
-                            step.detail?.let {
-                                Spacer(Modifier.width(Spacing.s))
-                                Text(
-                                    it,
-                                    style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
-                                    color = onContainer.copy(alpha = 0.72f),
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            // One action, full width — the grouped-list idiom the capsules above speak, not a
-            // tonal button floating in the corner.
+            // Full-card affordance: the action label is part of the same tappable surface.
             HorizontalDivider(color = onContainer.copy(alpha = 0.16f))
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .clickable(onClick =if (failed) onRetry else onOpen)
-                    .heightIn(min = ROW_HEIGHT_DP.dp)
+                    .heightIn(min = 40.dp)
                     .padding(horizontal = Spacing.base),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -643,11 +655,7 @@ fun ResearchResultCard(
                     Spacer(Modifier.width(Spacing.s))
                 }
                 Text(
-                    when {
-                        failed -> "Try again"
-                        research.structured -> "Open data"
-                        else -> "Open report"
-                    },
+                    actionLabel,
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.SemiBold,
                     color = onContainer,

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -395,10 +395,13 @@ internal fun InputToolbar(
                 )
 
                 val researchMode = deepResearchActive || dataAgentActive
+                // A live research run owns the same Stop control as a streaming reply — not a
+                // separate Cancel chip on the timeline card.
+                val showStop = isStreaming || researchInProgress
                 val hasText = text.trim().isNotEmpty()
                 val hasContent = hasText || (pendingUri != null && !researchMode)
-                val canSend = hasContent && !isStreaming && !researchInProgress && blockedReason == null
-                SendButton(enabled = canSend, isStreaming = isStreaming, research = researchMode, onStop = onStop) {
+                val canSend = hasContent && !showStop && blockedReason == null
+                SendButton(enabled = canSend, isStreaming = showStop, research = researchMode, onStop = onStop) {
                     if (canSend) onSend()
                 }
             }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -218,10 +218,14 @@ internal fun MessagesPane(
                 }
             }
         }
-        if (modelLoading && segments.isEmpty()) {
-            item { ModelLoadingRow() }
-        } else if (progressLoading && segments.isEmpty()) {
-            item { ThinkingRow() }
+        // While research owns the timeline, don't also draw a chat Thinking / model-loading row —
+        // that reads as a second reply starting under the research work.
+        if (researchRun == null) {
+            if (modelLoading && segments.isEmpty()) {
+                item { ModelLoadingRow() }
+            } else if (progressLoading && segments.isEmpty()) {
+                item { ThinkingRow() }
+            }
         }
         if (segments.isNotEmpty()) item(key = "streaming") {
             StreamingAssistantBubble(segments = segments, statusNote = statusNote, isStreaming = isStreaming, onArtifactOpen = onArtifactOpen)

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -475,12 +475,15 @@ internal fun ChatSurface(
             onSelectEffort = { settingsViewModel.saveDeepResearchExaEffort(it) },
             blockedReason = when {
                 browserBusy -> "Browser is working — please wait…"
-                researchRun != null -> "A run is in progress — see the card above"
                 localSendBlocked -> "On-device model is busy in another chat"
                 else -> null
             },
             onSend = { val t = textInput; textInput = ""; chatViewModel.sendMessage(t) },
-            onStop = { chatViewModel.stopStreaming() },
+            onStop = {
+                // One Stop for both chat streams and Deep Research / Data Agent runs.
+                chatViewModel.stopStreaming()
+                if (researchRun != null) chatViewModel.cancelResearch()
+            },
         )
         }
 

--- a/app/src/test/java/com/echoflow/ui/components/ResearchBatchTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/ResearchBatchTest.kt
@@ -1,0 +1,83 @@
+package com.echoflow.ui.components
+
+import com.echoflow.data.ResearchStep
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResearchBatchTest {
+
+    private fun step(id: String, state: String = ResearchStep.STATE_DONE) = ResearchStep(
+        id = id,
+        label = "Step $id",
+        state = state,
+    )
+
+    @Test
+    fun `empty timeline yields no batches`() {
+        assertTrue(chunkResearchSteps(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `fewer than five steps stay in a single batch`() {
+        val batches = chunkResearchSteps(listOf(step("1"), step("2"), step("3")))
+        assertEquals(1, batches.size)
+        assertEquals(3, batches[0].steps.size)
+        assertEquals(1, batches[0].index)
+    }
+
+    @Test
+    fun `exactly five steps fill one batch`() {
+        val steps = (1..5).map { step(it.toString()) }
+        val batches = chunkResearchSteps(steps)
+        assertEquals(1, batches.size)
+        assertEquals(5, batches[0].steps.size)
+    }
+
+    @Test
+    fun `sixth step opens a second batch`() {
+        val steps = (1..6).map { step(it.toString()) }
+        val batches = chunkResearchSteps(steps)
+        assertEquals(2, batches.size)
+        assertEquals(5, batches[0].steps.size)
+        assertEquals(1, batches[1].steps.size)
+        assertEquals(2, batches[1].index)
+    }
+
+    @Test
+    fun `seventy three steps become fifteen batches with a short tail`() {
+        val steps = (1..73).map { step(it.toString()) }
+        val batches = chunkResearchSteps(steps)
+        assertEquals(15, batches.size)
+        assertTrue(batches.dropLast(1).all { it.steps.size == RESEARCH_BATCH_SIZE })
+        assertEquals(3, batches.last().steps.size)
+    }
+
+    @Test
+    fun `header prefers the active step label`() {
+        val batch = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                step("1", ResearchStep.STATE_DONE),
+                ResearchStep(id = "2", label = "Scanning suppliers", state = ResearchStep.STATE_ACTIVE),
+                step("3", ResearchStep.STATE_PENDING),
+            ),
+        )
+        assertEquals("Scanning suppliers", batch.headerText("Researching…"))
+        assertTrue(batch.hasActive)
+        assertFalse(batch.allTerminal)
+    }
+
+    @Test
+    fun `settled batch reports thought duration when timestamps exist`() {
+        val batch = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                ResearchStep(id = "1", label = "A", state = ResearchStep.STATE_DONE, startedAt = 1_000L, endedAt = 3_000L),
+                ResearchStep(id = "2", label = "B", state = ResearchStep.STATE_DONE, startedAt = 3_000L, endedAt = 5_500L),
+            ),
+        )
+        assertEquals("Thought for 4s", batch.headerText(null))
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/components/ResearchBatchTest.kt
+++ b/app/src/test/java/com/echoflow/ui/components/ResearchBatchTest.kt
@@ -80,4 +80,89 @@ class ResearchBatchTest {
         )
         assertEquals("Thought for 4s", batch.headerText(null))
     }
+
+    @Test
+    fun `content key ignores state transitions on the same steps`() {
+        val active = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                ResearchStep(id = "search-0", label = "Who supplies cones?", state = ResearchStep.STATE_ACTIVE),
+            ),
+        )
+        val done = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                ResearchStep(id = "search-0", label = "Who supplies cones?", state = ResearchStep.STATE_DONE),
+            ),
+        )
+        assertEquals(active.contentKey, done.contentKey)
+    }
+
+    @Test
+    fun `replan with same positional ids gets a new content key`() {
+        // Engines key search rows by position (search-0, …). A replan reuses those ids with new
+        // questions — contentKey must change so expand state does not follow the old plan.
+        val before = ResearchBatch(
+            index = 2,
+            steps = listOf(
+                ResearchStep(id = "search-0", label = "Old question A", state = ResearchStep.STATE_PENDING),
+                ResearchStep(id = "search-1", label = "Old question B", state = ResearchStep.STATE_PENDING),
+            ),
+        )
+        val after = ResearchBatch(
+            index = 2,
+            steps = listOf(
+                ResearchStep(id = "search-0", label = "New question A", state = ResearchStep.STATE_PENDING),
+                ResearchStep(id = "search-1", label = "New question B", state = ResearchStep.STATE_PENDING),
+            ),
+        )
+        assertTrue(before.contentKey != after.contentKey)
+        val manual = mapOf(before.contentKey to true)
+        assertFalse(resolveBatchOpen(after, manual, defaultOpen = false))
+        assertTrue(resolveBatchOpen(before, manual, defaultOpen = false))
+    }
+
+    @Test
+    fun `manual open survives batch growth via content prefix`() {
+        val small = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                step("1"),
+                step("2"),
+            ),
+        )
+        val grown = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                step("1"),
+                step("2"),
+                step("3"),
+            ),
+        )
+        val manual = mapOf(small.contentKey to false)
+        // User collapsed while the batch still had two steps; third step landing must not reopen it.
+        assertFalse(resolveBatchOpen(grown, manual, defaultOpen = true))
+        assertTrue(grown.contentKey.startsWith(small.contentKey + "\u001f"))
+    }
+
+    @Test
+    fun `toggle replaces prefix keys so a replan cannot resurrect them`() {
+        val small = ResearchBatch(index = 1, steps = listOf(step("1"), step("2")))
+        val grown = ResearchBatch(index = 1, steps = listOf(step("1"), step("2"), step("3")))
+        val afterCollapse = manualOpenAfterToggle(small, emptyMap(), expanded = false)
+        val afterGrowToggle = manualOpenAfterToggle(grown, afterCollapse, expanded = true)
+        // Only the grown key remains — the short key must not linger for a later replan match.
+        assertEquals(setOf(grown.contentKey), afterGrowToggle.keys)
+        assertTrue(afterGrowToggle.getValue(grown.contentKey))
+
+        val replanned = ResearchBatch(
+            index = 1,
+            steps = listOf(
+                ResearchStep(id = "1", label = "Relabelled", state = ResearchStep.STATE_DONE),
+                step("2"),
+                step("3"),
+            ),
+        )
+        assertTrue(resolveBatchOpen(replanned, afterGrowToggle, defaultOpen = false) == false)
+    }
 }


### PR DESCRIPTION
## Summary

- Redesign Deep Research as a live **step timeline** (not one pill per engine event): steps fill progressive **batches of 5**, each expandable like Task Rows / Thinking, so long runs (e.g. 73 steps → 15 capsules) stay scannable.
- Finished runs land on a single **result card** whose whole surface opens the report (or retries on failure) — no re-expand of every step — plus a fullscreen **Research Workspace** for report / sources / steps.
- Engines **narrate real steps** (Parallel / Exa Agent SSE, Firecrawl activity, agentic plan/search), with schema versioning so in-flight legacy runs keep the old UI.
- **Composer Stop** cancels research (header Cancel removed); Deep Research / Data Agent mode **stays on** after send so the model pill keeps research engines until the user toggles off.
- Race hardening: transactional idle insert for retries, workspace open last-wins, re-plan `replaceKinds`, drop unstarted pending steps on close, reduced-motion support.

## Test plan

- [ ] Start Deep Research with a provider engine that emits many steps — confirm batches of ≤5, expand/collapse, active batch feels live
- [ ] Confirm composer Send becomes Stop during a run and cancels cleanly
- [ ] Confirm model pill shows research engines while Deep Research mode is on, including after send, until mode is toggled off
- [ ] Finish a run — result card opens workspace; no step-expand on the card
- [ ] Retry a failed run — only one run starts on double-tap
- [ ] Open a pre-redesign research chat — legacy UI still renders
- [ ] `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.Research* --tests com.echoflow.ui.components.ResearchBatchTest --tests com.echoflow.data.SseDecoderTest`

## Notes

UI screenshots for the batch timeline / result card / workspace should be added under `docs/screenshots/` when an emulator/device capture is available (project PR requirement for UI changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Research and Data Agent modes now remain selected while a run is active.
  - Research timelines group progress into expandable batches with status headers and source links.
  - Result cards are fully tappable, with clearer actions for retrying, reports, and structured data.

- **Improvements**
  - Stop controls now work consistently for streaming, research, and agent runs.
  - Research displays no longer show redundant loading indicators.
  - Empty research states provide phase-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: the batch timeline keeps long research runs scannable, while the unified result card, workspace, and composer Stop control make the flow feel more coherent. The previously reported positional batch-identity issue is better implemented by keying disclosure state to step content and preserving it only across genuine batch growth.
- Groups research steps into progressive batches of five with expandable details and source links.
- Uses content-based expansion keys so replanned questions do not inherit unrelated disclosure state.
- Makes completed result cards open or retry from the whole surface.
- Keeps research modes selected after sending and routes cancellation through the composer.
- Suppresses redundant chat loading rows while a research timeline is active.
- Adds focused unit coverage for batching, state transitions, replanning, and expansion-state inheritance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ResearchTimeline.kt | Reworks the live timeline into content-keyed step batches and simplifies completed runs into whole-card actions; the prior positional-identity issue is resolved. |
| app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt | Makes the send control present a Stop action for both streaming replies and active research runs. |
| app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt | Routes the unified Stop action to both stream shutdown and research cancellation. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Preserves Deep Research and Data Agent modes after submission so engine selection remains stable. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Avoids rendering redundant model or thinking indicators alongside an active research timeline. |
| app/src/test/java/com/echoflow/ui/components/ResearchBatchTest.kt | Covers batch sizing, headers, content identity, replanning, growth inheritance, and stale-prefix cleanup. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Research run starts] --> B{Steps available?}
    B -- No --> C[Show active placeholder]
    B -- Yes --> D[Group steps into batches of five]
    D --> E[Key each batch by step IDs and labels]
    E --> F{Current active batch?}
    F -- Yes --> G[Open by default]
    F -- No --> H[Collapse by default]
    G --> I[Manual disclosure state overrides default]
    H --> I
    I --> J{Run finished?}
    J -- No --> D
    J -- Yes --> K[Show result card]
    K --> L[Open workspace or retry failure]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Key research batch expand state by step ..."](https://github.com/adityavardhansharma/echoflow/commit/d519dcf71b59ca67ad30a548c522ad36106337cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52185083)</sub>

<!-- /greptile_comment -->