### PR TITLE
Collapse Parallel research SSE into objective chapters

### DIFF
--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -345,15 +345,14 @@ class DeepResearchEngine(
     /**
      * Parallel's progress feed: `GET /v1/tasks/runs/{id}/events`.
      *
-     * This is the richest timeline any provider gives us — planning, search objectives, tool use
-     * and intermediate findings, plus running counts of sources considered and read. It also
-     * replays the complete sequence from the start of execution, which is what makes it safe to
-     * (re)attach after the app was killed: a resumed run rebuilds its whole timeline instead of
-     * joining mid-stream. Steps are keyed by position, so a replay overwrites rather than doubles.
+     * The raw feed is a full execution log (plan lines, every Objective/Query, tools, intermediate
+     * findings). [ParallelProgressCollapser] compresses that into a few chapters before we emit
+     * steps — same ballpark as Firecrawl's activity list and the agentic plan — so the timeline
+     * stays scannable. The stream still replays from the start on reattach; collapsed ids are
+     * stable, so a resume upserts rather than doubles.
      *
-     * Progress only. The run's terminal state and result still come from the poll path, so if the
-     * stream 404s, drops, or carries a shape we don't recognise, the run is unaffected — it just
-     * shows the single "Researching with Parallel" row it showed before.
+     * Progress only. Terminal state and result still come from the poll path; if the stream
+     * fails, the run falls back to the single "Researching with Parallel" row.
      */
     private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.streamParallelEvents(
         apiKey: String,
@@ -366,10 +365,7 @@ class DeepResearchEngine(
             .get()
             .build()
 
-        var index = 0
-        var lastId: String? = null
-        var lastLabel: String? = null
-        var stats: String? = null
+        val collapser = ParallelProgressCollapser()
 
         streamSse(request, "Parallel") { frame ->
             val json = parseFrame(frame.data)
@@ -377,59 +373,38 @@ class DeepResearchEngine(
             when {
                 type.startsWith("task_run.progress_msg") -> {
                     val message = messageOf(json) ?: return@streamSse true
-                    val kind = when (type.substringAfterLast('.')) {
-                        "plan" -> ResearchStep.KIND_PLAN
-                        "search" -> ResearchStep.KIND_SEARCH
-                        "tool" -> ResearchStep.KIND_READ
-                        else -> ResearchStep.KIND_ANALYZE
-                    }
-                    // exec_status refines the step already running rather than adding a row.
-                    if (type.endsWith(".exec_status")) {
-                        lastId?.let { id ->
-                            step(id, message, ResearchStep.STATE_ACTIVE, kind, detail = stats)
-                        }
-                        return@streamSse true
-                    }
-                    // Close the previous row before opening the next: the feed is append-only, so
-                    // anything behind the newest entry is finished by definition.
-                    lastId?.let { id -> step(id, lastLabel ?: message, ResearchStep.STATE_DONE, kind) }
-                    val id = feedStepId(index++)
-                    lastId = id
-                    lastLabel = message
-                    step(id, message, ResearchStep.STATE_ACTIVE, kind, detail = stats)
+                    val subtype = type.substringAfterLast('.')
+                    emitParallelSteps(collapser.onProgressMessage(subtype, message))
                 }
                 type == "task_run.progress_stats" -> {
                     val read = (json?.get("num_sources_read") as? Double)?.toInt()
+                        ?: (json?.get("num_sources_read") as? Number)?.toInt()
                     val considered = (json?.get("num_sources_considered") as? Double)?.toInt()
-                    stats = when {
-                        read != null && considered != null -> "$read of $considered read"
-                        read != null -> "$read read"
-                        considered != null -> "$considered found"
-                        else -> stats
-                    }
-                    lastId?.let { id ->
-                        step(id, lastLabel ?: "Researching", ResearchStep.STATE_ACTIVE, ResearchStep.KIND_ANALYZE, detail = stats)
-                    }
+                        ?: (json?.get("num_sources_considered") as? Number)?.toInt()
+                    emitParallelSteps(collapser.onStats(read, considered))
                 }
                 type == "task_run.state" -> {
                     val status = ((json?.get("run") as? Map<*, *>)?.get("status") as? String)
                         ?: (json?.get("status") as? String).orEmpty()
                     if (status in PARALLEL_TERMINAL) {
-                        lastId?.let { id ->
-                            step(id, lastLabel ?: "Researching", ResearchStep.STATE_DONE, ResearchStep.KIND_ANALYZE, detail = stats)
-                        }
+                        emitParallelSteps(collapser.onTerminal(failed = status != "completed"))
                         return@streamSse false
                     }
                 }
                 type == "error" -> {
-                    lastId?.let { id ->
-                        step(id, lastLabel ?: "Researching", ResearchStep.STATE_FAILED, ResearchStep.KIND_ANALYZE)
-                    }
+                    emitParallelSteps(collapser.onTerminal(failed = true))
                     return@streamSse false
                 }
             }
             true
         }
+    }
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ResearchEvent>.emitParallelSteps(
+        steps: List<ResearchStep>,
+    ) {
+        if (steps.isEmpty()) return
+        emit(ResearchEvent.Steps(steps))
     }
 
     private fun pollParallel(apiKey: String, id: String): PollResult {

--- a/app/src/main/java/com/echoflow/data/ParallelProgressCollapser.kt
+++ b/app/src/main/java/com/echoflow/data/ParallelProgressCollapser.kt
@@ -1,0 +1,233 @@
+package com.echoflow.data
+
+/**
+ * Turns Parallel's SSE firehose into a short chapter timeline.
+ *
+ * Parallel emits one `task_run.progress_msg.*` event per plan line, search **Objective**,
+ * individual **Query**, tool call, and intermediate result. Treating each as a [ResearchStep]
+ * floods the UI (dozens–hundreds of rows). Firecrawl and the agentic path already speak in a
+ * handful of beats; this collapser makes Parallel match that shape **before** steps are
+ * persisted.
+ *
+ * Chapters:
+ *  - **one** plan step for all `.plan` messages
+ *  - **one** search step per `Objective:` (or free-form search that opens a new beat)
+ *  - `Query:` lines and tool/result chatter fold into the **active** chapter's [ResearchStep.detail]
+ *  - `progress_stats` refresh the active chapter's meta (`12 of 40 read`)
+ *
+ * Ids are stable for the life of a stream (`parallel-plan`, `parallel-obj-N`, …) so replay and
+ * upserts stay coherent. Pure: no IO — the engine feeds events and emits the returned steps.
+ */
+internal class ParallelProgressCollapser {
+
+    private var activeId: String? = null
+    private var activeLabel: String? = null
+    private var activeKind: String = ResearchStep.KIND_ANALYZE
+    private var planOpened = false
+    private var objectiveIndex = 0
+    private var workIndex = 0
+    private val queries = mutableListOf<String>()
+    private val notes = mutableListOf<String>()
+    private var stats: String? = null
+
+    /**
+     * @param subtype last segment of `task_run.progress_msg.<subtype>` (plan, search, tool, …)
+     * @param message human line from the event payload
+     * @return zero or more steps to upsert (close previous + open/update active)
+     */
+    fun onProgressMessage(subtype: String, message: String): List<ResearchStep> {
+        val trimmed = message.trim()
+        if (trimmed.isEmpty()) return emptyList()
+
+        return when (subtype) {
+            "exec_status" -> {
+                // Status noise — keep the chapter, refresh meta only.
+                activeId ?: return emptyList()
+                listOf(emitActive(ResearchStep.STATE_ACTIVE))
+            }
+            "plan" -> onPlan(trimmed)
+            "search" -> onSearch(trimmed)
+            "tool" -> onWork(trimmed, kind = ResearchStep.KIND_READ, fallbackLabel = "Using tools")
+            "result" -> onWork(trimmed, kind = ResearchStep.KIND_ANALYZE, fallbackLabel = "Gathering findings")
+            else -> onWork(trimmed, kind = ResearchStep.KIND_ANALYZE, fallbackLabel = "Researching")
+        }
+    }
+
+    fun onStats(sourcesRead: Int?, sourcesConsidered: Int?): List<ResearchStep> {
+        stats = when {
+            sourcesRead != null && sourcesConsidered != null -> "$sourcesRead of $sourcesConsidered read"
+            sourcesRead != null -> "$sourcesRead read"
+            sourcesConsidered != null -> "$sourcesConsidered found"
+            else -> stats
+        }
+        val id = activeId ?: return emptyList()
+        return listOf(
+            ResearchStep(
+                id = id,
+                kind = activeKind,
+                label = activeLabel ?: "Researching",
+                state = ResearchStep.STATE_ACTIVE,
+                detail = detailLine(),
+                startedAt = now(),
+            )
+        )
+    }
+
+    fun onTerminal(failed: Boolean): List<ResearchStep> {
+        val id = activeId ?: return emptyList()
+        val state = if (failed) ResearchStep.STATE_FAILED else ResearchStep.STATE_DONE
+        return listOf(emitActive(state))
+    }
+
+    private fun onPlan(message: String): List<ResearchStep> {
+        val out = mutableListOf<ResearchStep>()
+        if (activeId != null && activeId != PLAN_ID) {
+            out += emitActive(ResearchStep.STATE_DONE)
+            clearChapterExtras()
+        }
+        activeId = PLAN_ID
+        activeKind = ResearchStep.KIND_PLAN
+        if (!planOpened) {
+            planOpened = true
+            activeLabel = cleanLabel(message, fallback = "Planning the research")
+        } else {
+            // Keep the first plan line as the title; later plan chatter is detail.
+            notes.add(message.take(NOTE_MAX))
+            trimNotes()
+        }
+        out += emitActive(ResearchStep.STATE_ACTIVE)
+        return out
+    }
+
+    private fun onSearch(message: String): List<ResearchStep> {
+        parseObjective(message)?.let { objective ->
+            return openChapter(
+                id = "parallel-obj-${objectiveIndex++}",
+                label = objective,
+                kind = ResearchStep.KIND_SEARCH,
+            )
+        }
+        parseQuery(message)?.let { query ->
+            if (activeId == null || activeKind == ResearchStep.KIND_PLAN) {
+                // Query without a prior Objective still opens a search chapter.
+                return openChapter(
+                    id = "parallel-obj-${objectiveIndex++}",
+                    label = query,
+                    kind = ResearchStep.KIND_SEARCH,
+                )
+            }
+            queries.add(query)
+            return listOf(emitActive(ResearchStep.STATE_ACTIVE))
+        }
+        // Free-form search line: new chapter if we aren't already searching.
+        if (activeId == null || activeKind != ResearchStep.KIND_SEARCH) {
+            return openChapter(
+                id = "parallel-obj-${objectiveIndex++}",
+                label = cleanLabel(message, fallback = "Searching"),
+                kind = ResearchStep.KIND_SEARCH,
+            )
+        }
+        notes.add(message.take(NOTE_MAX))
+        trimNotes()
+        return listOf(emitActive(ResearchStep.STATE_ACTIVE))
+    }
+
+    private fun onWork(message: String, kind: String, fallbackLabel: String): List<ResearchStep> {
+        val out = mutableListOf<ResearchStep>()
+        if (activeId == null) {
+            // No chapter yet — open a single work row rather than one row per tool event.
+            out += openChapter(
+                id = "parallel-work-${workIndex++}",
+                label = fallbackLabel,
+                kind = kind,
+            )
+        }
+        // Prefer folding tool/result into the open objective rather than spawning micro-rows.
+        notes.add(message.take(NOTE_MAX))
+        trimNotes()
+        // Don't overwrite SEARCH/PLAN kind when we're nested under an objective.
+        if (activeKind != ResearchStep.KIND_SEARCH && activeKind != ResearchStep.KIND_PLAN) {
+            activeKind = kind
+        }
+        // Re-emit active so detail includes the new note (openChapter's last emit had empty detail).
+        if (out.isNotEmpty()) out.removeAt(out.lastIndex)
+        out += emitActive(ResearchStep.STATE_ACTIVE)
+        return out
+    }
+
+    private fun openChapter(id: String, label: String, kind: String): List<ResearchStep> {
+        val out = mutableListOf<ResearchStep>()
+        if (activeId != null) {
+            out += emitActive(ResearchStep.STATE_DONE)
+        }
+        clearChapterExtras()
+        activeId = id
+        activeLabel = label
+        activeKind = kind
+        out += emitActive(ResearchStep.STATE_ACTIVE)
+        return out
+    }
+
+    private fun emitActive(state: String): ResearchStep {
+        val id = activeId ?: error("emitActive without active chapter")
+        val now = now()
+        return ResearchStep(
+            id = id,
+            kind = activeKind,
+            label = activeLabel ?: "Researching",
+            state = state,
+            detail = detailLine(),
+            startedAt = now,
+            endedAt = if (state == ResearchStep.STATE_DONE || state == ResearchStep.STATE_FAILED) now else null,
+        )
+    }
+
+    private fun detailLine(): String? {
+        val parts = mutableListOf<String>()
+        when {
+            queries.isEmpty() -> Unit
+            queries.size == 1 -> parts.add(queries.first().take(QUERY_SHOW_MAX))
+            else -> parts.add("${queries.size} queries")
+        }
+        notes.lastOrNull()?.let { parts.add(it) }
+        stats?.let { parts.add(it) }
+        return parts.joinToString(" · ").ifBlank { null }
+    }
+
+    private fun clearChapterExtras() {
+        queries.clear()
+        notes.clear()
+        // stats stay run-wide — still useful on the next chapter
+    }
+
+    private fun trimNotes() {
+        while (notes.size > MAX_NOTES) notes.removeAt(0)
+    }
+
+    private fun now(): Long = System.currentTimeMillis()
+
+    companion object {
+        internal const val PLAN_ID = "parallel-plan"
+        private const val NOTE_MAX = 100
+        private const val QUERY_SHOW_MAX = 80
+        private const val MAX_NOTES = 4
+
+        private val OBJECTIVE_PREFIX = Regex("""^(?i)objective:\s*(.+)$""")
+        private val QUERY_PREFIX = Regex("""^(?i)query:\s*(.+)$""")
+
+        internal fun parseObjective(message: String): String? =
+            OBJECTIVE_PREFIX.matchEntire(message.trim())?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+
+        internal fun parseQuery(message: String): String? =
+            QUERY_PREFIX.matchEntire(message.trim())?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+
+        private fun cleanLabel(message: String, fallback: String): String {
+            val t = message.trim()
+            return when {
+                t.isEmpty() -> fallback
+                t.length <= 140 -> t
+                else -> t.take(137) + "…"
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ParallelProgressCollapserTest.kt
+++ b/app/src/test/java/com/echoflow/data/ParallelProgressCollapserTest.kt
@@ -1,0 +1,115 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ParallelProgressCollapserTest {
+
+    @Test
+    fun `parses Objective and Query prefixes`() {
+        assertEquals(
+            "Find cone suppliers",
+            ParallelProgressCollapser.parseObjective("Objective: Find cone suppliers"),
+        )
+        assertEquals(
+            "best waffle cone manufacturer",
+            ParallelProgressCollapser.parseQuery("Query: best waffle cone manufacturer"),
+        )
+        assertEquals(null, ParallelProgressCollapser.parseObjective("Query: not an objective"))
+    }
+
+    @Test
+    fun `many progress messages collapse to a handful of chapters`() {
+        val c = ParallelProgressCollapser()
+        // Simulate a noisy Parallel stream: plan spam + 2 objectives × several queries + tools.
+        val events = listOf(
+            "plan" to "Break the question into supplier and quality angles",
+            "plan" to "Also check seasonal demand",
+            "search" to "Objective: Identify major waffle cone manufacturers",
+            "search" to "Query: waffle cone suppliers USA",
+            "search" to "Query: commercial ice cream cone manufacturers",
+            "search" to "Query: Joy Cone company profile",
+            "tool" to "Reading joycone.com",
+            "result" to "Found product catalog",
+            "search" to "Objective: Compare quality and pricing signals",
+            "search" to "Query: waffle cone wholesale price",
+            "search" to "Query: food service cone reviews",
+            "tool" to "Extracting pricing tables",
+            "result" to "Three vendors stand out",
+        )
+
+        var maxOpenChapters = 0
+        val seenIds = linkedSetOf<String>()
+        events.forEach { (subtype, message) ->
+            val steps = c.onProgressMessage(subtype, message)
+            steps.forEach { seenIds += it.id }
+            // Active chapters that are not DONE in this emit batch
+            val open = steps.count { it.state == ResearchStep.STATE_ACTIVE }
+            maxOpenChapters = maxOf(maxOpenChapters, open)
+        }
+        val terminal = c.onTerminal(failed = false)
+        assertTrue(terminal.single().isTerminal)
+
+        // One plan + two objectives (+ maybe work only if tools arrived first — they didn't).
+        assertEquals(
+            setOf(ParallelProgressCollapser.PLAN_ID, "parallel-obj-0", "parallel-obj-1"),
+            seenIds,
+        )
+        // Never more than one ACTIVE row emitted at a time from a single event.
+        assertEquals(1, maxOpenChapters)
+        // Far fewer chapters than the 13 raw messages.
+        assertTrue(seenIds.size <= 4)
+        assertTrue(seenIds.size < events.size / 2)
+    }
+
+    @Test
+    fun `queries fold into the active objective detail`() {
+        val c = ParallelProgressCollapser()
+        c.onProgressMessage("search", "Objective: Map suppliers")
+        val afterQueries = c.onProgressMessage("search", "Query: alpha")
+            .last()
+            .let { active ->
+                c.onProgressMessage("search", "Query: beta")
+                c.onProgressMessage("search", "Query: gamma").last()
+            }
+        assertEquals("Map suppliers", afterQueries.label)
+        assertEquals(ResearchStep.KIND_SEARCH, afterQueries.kind)
+        assertEquals("3 queries", afterQueries.detail)
+        assertEquals(ResearchStep.STATE_ACTIVE, afterQueries.state)
+    }
+
+    @Test
+    fun `stats refresh active chapter meta without a new id`() {
+        val c = ParallelProgressCollapser()
+        val opened = c.onProgressMessage("search", "Objective: Read sources").single()
+        val withStats = c.onStats(sourcesRead = 12, sourcesConsidered = 40).single()
+        assertEquals(opened.id, withStats.id)
+        assertTrue(withStats.detail!!.contains("12 of 40 read"))
+    }
+
+    @Test
+    fun `replan-style second objective closes the first`() {
+        val c = ParallelProgressCollapser()
+        c.onProgressMessage("search", "Objective: First")
+        val secondBatch = c.onProgressMessage("search", "Objective: Second")
+        assertEquals(2, secondBatch.size)
+        assertEquals(ResearchStep.STATE_DONE, secondBatch[0].state)
+        assertEquals("First", secondBatch[0].label)
+        assertEquals(ResearchStep.STATE_ACTIVE, secondBatch[1].state)
+        assertEquals("Second", secondBatch[1].label)
+        assertFalse(secondBatch[0].id == secondBatch[1].id)
+    }
+
+    @Test
+    fun `tool events alone open one work chapter not one per tool`() {
+        val c = ParallelProgressCollapser()
+        val ids = buildSet {
+            c.onProgressMessage("tool", "call A").forEach { add(it.id) }
+            c.onProgressMessage("tool", "call B").forEach { add(it.id) }
+            c.onProgressMessage("result", "finding").forEach { add(it.id) }
+        }
+        assertEquals(setOf("parallel-work-0"), ids)
+    }
+}


### PR DESCRIPTION
## Summary

- Parallel Task API SSE is a full execution log (`plan` / every `Objective:` / every `Query:` / tools / results). We previously turned **each** message into a timeline step, so long runs looked like 50–100 pills while Firecrawl and agentic research stay around a handful of beats.
- Add `ParallelProgressCollapser`: **one plan chapter**, **one search chapter per Objective**, fold `Query:` lines and tool/result chatter into the active chapter’s `detail`, and put `progress_stats` on the active row (`12 of 40 read`).
- Engine-side so chat timeline, workspace Steps, and persistence all share the same sane step list. Firecrawl / Exa / agentic paths unchanged.

## Test plan

- [ ] Run Deep Research with Parallel — timeline should show ~plan + a few objectives, not a query-per-row firehose
- [ ] Expand an objective chapter — meta shows query count / stats, not dozens of sibling pills
- [ ] Confirm Firecrawl and OpenRouter+search timelines still look as before
- [ ] `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.ParallelProgressCollapserTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Research Progress**
  * Research activity is now displayed as a cleaner, more stable timeline with related updates grouped into concise chapters.
  * Progress messages, objectives, queries, tool activity, and source statistics are consolidated to reduce visual noise.
  * Completed, failed, and terminal research states are reflected consistently.
  * Duplicate tool updates and excessive notes are reduced for clearer progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Parallel’s verbose progress-feed normalization into the engine, producing stable plan and objective chapters shared by chat, workspace, and persistence.

- The product direction is strong: collapsing provider-specific execution noise before persistence gives every UI a consistent, readable timeline.
- `ParallelProgressCollapser` folds queries, tool messages, results, and source statistics into stable chapter rows while preserving terminal state transitions.
- Focused unit tests cover prefix parsing, chapter collapsing, query aggregation, statistics, objective transitions, and tool-only streams.
- The implementation could be strengthened with replay/resume integration coverage against the persisted timeline, especially to document assumptions about deterministic event ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable defects identified.

The collapsed step batches follow the existing upsert contract, IDs remain scoped to individual research runs, and existing start timestamps are preserved when chapters are updated.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/DeepResearchEngine.kt | Routes Parallel progress messages and statistics through the collapser while leaving terminal polling and other providers unchanged. |
| app/src/main/java/com/echoflow/data/ParallelProgressCollapser.kt | Implements stateful conversion of verbose Parallel events into stable plan, objective, and fallback work chapters. |
| app/src/test/java/com/echoflow/data/ParallelProgressCollapserTest.kt | Adds focused coverage for parsing, collapsing, detail aggregation, statistics, transitions, and tool-only input. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    SSE[Parallel SSE events] --> Parse[DeepResearchEngine parses event]
    Parse --> Collapse[ParallelProgressCollapser]
    Collapse -->|plan| Plan[Stable plan chapter]
    Collapse -->|Objective| Objective[Stable objective chapter]
    Collapse -->|Query/tool/result/stats| Detail[Update active chapter detail]
    Plan --> Steps[ResearchEvent.Steps]
    Objective --> Steps
    Detail --> Steps
    Steps --> Persist[Upsert timeline and persist stepsJson]
    Persist --> UI[Chat and workspace timelines]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Collapse Parallel research SSE into obje..."](https://github.com/adityavardhansharma/echoflow/commit/b8c2e0ede0275e88200c6e5fc63290dcb083bc9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52222013)</sub>

<!-- /greptile_comment -->