### PR TITLE
Rebuild the artifact card to match the tool-chip hybrid

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -2,20 +2,38 @@
 
 package com.echoflow.ui.components
 
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -25,11 +43,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -45,12 +63,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.ui.viewinterop.AndroidView
 import com.echoflow.data.Artifact
 import com.echoflow.data.ArtifactVersion
 import com.echoflow.data.VersionDelta
@@ -65,27 +85,29 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withContext
 
-// The most recent versions carried as chips; older ones fold into a single "+N" marker so the row
-// never wraps past a couple of lines on a phone.
+// Most recent versions as chips; older ones fold into "+N earlier".
 private const val MAX_VERSION_CHIPS = 4
 private const val CARD_RADIUS_DP = 22
 private const val MARK_SIZE_DP = 24
 private const val ROW_MIN_DP = 48
+private const val PREVIEW_HEIGHT_DP = 150
 
 /**
- * The in-chat artifact card for **current** artifacts ([ArtifactRef.UI_VERSION_CURRENT]).
+ * In-chat artifact surface for current-app artifacts.
  *
- * Hybrid of the coding-agent tool-chip reference and EchoFlow's research-capsule grammar:
- * - **Building** is a live tool-row trace (mark + label + mono filename chip + size), not a
- *   greyed-out copy of the old tertiary card.
- * - **Settled** is a result object in the same anatomy as [ResearchResultCard] (filled mark,
- *   title, type meta, open action) with **file-diff-style version chips** at the bottom —
- *   `v1 84 lines`, `v2 +74 −41` — the glanceable edit history from the reference.
+ * **Building** — research-style expandable capsule, **open by default**, with a short narrative
+ * step list (planning → scaffolding → writing → …). Not real engine steps; a readable progress
+ * story driven by stream size so the card feels alive.
  *
- * No live HTML WebView thumbnail: that path was janky (white flash + fade) and not in the
- * reference language. Preview lives in the fullscreen workspace the user deliberately opens.
+ * **Handoff** — when the stream finishes, the capsule stays for HTML and adds a final
+ * "Fetching thumbnail" step while a sandboxed WebView warms the preview **off-screen**. Only
+ * once that paint is ready does the **full settled card** animate in as one unit (header +
+ * preview + chips). No "card first, WebView fades in later" jank.
  *
- * Pre-redesign messages are not drawn here — see `ui/legacy/LegacyArtifactComponents.kt`.
+ * **Settled** — primaryContainer result object (sibling of [ResearchResultCard]) with
+ * file-diff version chips. Non-HTML skips the thumbnail handoff and settles immediately.
+ *
+ * Pre-redesign rows stay on `ui/legacy`.
  */
 @Composable
 fun ArtifactCard(
@@ -100,18 +122,6 @@ fun ArtifactCard(
     modifier: Modifier = Modifier,
     observeVersions: (String) -> Flow<List<ArtifactVersion>> = { flowOf(emptyList()) },
 ) {
-    if (building) {
-        BuildingArtifactCard(
-            title = title,
-            artifactType = artifactType,
-            charCount = charCount,
-            modifier = modifier,
-        )
-        return
-    }
-
-    // All versions of this lineage up to and including the one this card was written at — a card in
-    // scrolled-back history shows its own era's chips, not the lineage's latest state.
     val versionsFlow = remember(artifactId) {
         if (artifactId != null) observeVersions(artifactId) else flowOf(emptyList())
     }
@@ -122,27 +132,329 @@ fun ArtifactCard(
     val deltas by produceState(initialValue = emptyList<VersionDelta>(), lineage) {
         value = withContext(Dispatchers.Default) { versionDeltas(lineage) }
     }
+    val isHtml = artifactType == Artifact.TYPE_HTML
+    val previewHtml = remember(lineage, version, isHtml, building) {
+        if (!building && isHtml) {
+            (lineage.lastOrNull { it.versionNumber == version } ?: lineage.lastOrNull())?.content
+                ?.takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
+    }
+    // HTML waits on body rows (async) then on a warm WebView paint. Non-HTML settles immediately.
+    val waitingForHtmlBody = !building && isHtml && previewHtml == null
+    val needsThumbnailWarm = !previewHtml.isNullOrBlank()
+    var thumbnailReady by remember(previewHtml) { mutableStateOf(!needsThumbnailWarm) }
+    // Never hang the UI if onPageFinished is slow/missing (empty doc, WebView quirk).
+    LaunchedEffect(previewHtml, needsThumbnailWarm) {
+        if (needsThumbnailWarm && !thumbnailReady) {
+            delay(2_800)
+            thumbnailReady = true
+        }
+    }
+    val preparingThumbnail =
+        !building && isHtml && (waitingForHtmlBody || (needsThumbnailWarm && !thumbnailReady))
+    val showTrace = building || preparingThumbnail
+    val showSettled = !building && !preparingThumbnail
 
-    SettledArtifactCard(
-        title = title,
-        artifactType = artifactType,
-        truncated = truncated,
-        deltas = deltas,
-        onOpen = { artifactId?.let { onOpen(it, version) } },
-        modifier = modifier,
-    )
+    val reducedMotion = rememberReducedMotion()
+    val openSettled: () -> Unit = { artifactId?.let { onOpen(it, version) } }
+
+    Column(modifier.fillMaxWidth()) {
+        // Off-screen warm load: real layout size so the WebView paints, parked far below the
+        // viewport. onPageFinished unlocks the settled card so the visible preview is not a
+        // second-class fade layered onto chrome that already appeared.
+        if (preparingThumbnail && previewHtml != null) {
+            ArtifactPreviewWebView(
+                html = previewHtml,
+                interactive = false,
+                onReady = { thumbnailReady = true },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(PREVIEW_HEIGHT_DP.dp)
+                    .offset(y = 4000.dp)
+                    .graphicsLayer { alpha = 0f },
+            )
+        }
+
+        AnimatedContent(
+            targetState = showSettled,
+            transitionSpec = {
+                if (reducedMotion) {
+                    fadeIn(tween(0)) togetherWith fadeOut(tween(0))
+                } else {
+                    (fadeIn(tween(280)) + expandVertically(tween(320))) togetherWith
+                        (fadeOut(tween(160)) + shrinkVertically(tween(220)))
+                }
+            },
+            label = "artifact-handoff",
+            modifier = Modifier.fillMaxWidth(),
+        ) { settled ->
+            if (settled) {
+                SettledArtifactCard(
+                    title = title,
+                    artifactType = artifactType,
+                    truncated = truncated,
+                    deltas = deltas,
+                    previewHtml = previewHtml,
+                    onOpen = openSettled,
+                )
+            } else {
+                BuildingArtifactTrace(
+                    title = title,
+                    artifactType = artifactType,
+                    charCount = charCount,
+                    streamFinished = !building,
+                    fetchingThumbnail = preparingThumbnail,
+                )
+            }
+        }
+    }
 }
 
+// ── Building trace (expandable capsule) ──────────────────────────────────────────────
+
+private enum class StepState { Pending, Active, Done }
+
+private data class TraceStep(val label: String, val state: StepState)
+
 /**
- * Settled result — same weight as [ResearchResultCard]: primary container, filled check mark,
- * title + type, open affordance, then file-diff chips for the version lineage.
+ * Narrative steps from stream progress. Not engine telemetry — a readable story that advances
+ * as the body grows, then ends on "Fetching thumbnail" when HTML is warming.
  */
+private fun buildTraceSteps(
+    charCount: Int,
+    streamFinished: Boolean,
+    fetchingThumbnail: Boolean,
+    typeLabel: String,
+): List<TraceStep> {
+    // Thresholds are soft UX beats, not protocol.
+    val planDone = charCount > 0 || streamFinished
+    val scaffoldDone = charCount > 180 || streamFinished
+    val writeDone = charCount > 900 || streamFinished
+    val polishDone = streamFinished
+
+    fun state(done: Boolean, activeGate: Boolean): StepState = when {
+        done -> StepState.Done
+        activeGate -> StepState.Active
+        else -> StepState.Pending
+    }
+
+    val steps = mutableListOf(
+        TraceStep("Planning $typeLabel structure", state(planDone, !planDone)),
+        TraceStep("Scaffolding layout", state(scaffoldDone, planDone && !scaffoldDone)),
+        TraceStep(
+            if (charCount > 0) "Writing body · $charCount chars" else "Writing body",
+            state(writeDone, scaffoldDone && !writeDone),
+        ),
+        TraceStep("Polishing details", state(polishDone, writeDone && !polishDone)),
+    )
+    if (fetchingThumbnail || (streamFinished && fetchingThumbnail)) {
+        steps.add(
+            TraceStep(
+                "Fetching thumbnail",
+                if (fetchingThumbnail) StepState.Active else StepState.Done,
+            ),
+        )
+    } else if (streamFinished) {
+        // Non-HTML settle path: last beat marks complete before the card swap.
+        steps.add(TraceStep("Ready", StepState.Done))
+    }
+    return steps
+}
+
+@Composable
+private fun BuildingArtifactTrace(
+    title: String,
+    artifactType: String,
+    charCount: Int,
+    streamFinished: Boolean,
+    fetchingThumbnail: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val (_, typeLabel) = artifactGlyph(artifactType)
+    val fileName = artifactFileLabel(title, typeLabel, artifactType)
+    val steps = remember(charCount, streamFinished, fetchingThumbnail, typeLabel) {
+        buildTraceSteps(charCount, streamFinished, fetchingThumbnail, typeLabel)
+    }
+    val reducedMotion = rememberReducedMotion()
+    // Open by default while the artifact is under construction / warming the preview.
+    var expanded by remember { mutableStateOf(true) }
+    val radius by animateDpAsState(
+        targetValue = if (expanded) 14.dp else CARD_RADIUS_DP.dp,
+        animationSpec = tween(if (reducedMotion) 0 else 300),
+        label = "artifact-capsule-radius",
+    )
+    val chevron by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(if (reducedMotion) 0 else 300),
+        label = "artifact-capsule-chevron",
+    )
+    val headerLabel = when {
+        fetchingThumbnail -> "Finishing artifact"
+        streamFinished -> "Finishing artifact"
+        charCount > 0 -> "Building artifact"
+        else -> "Starting artifact"
+    }
+    val meta = when {
+        fetchingThumbnail -> "preview"
+        charCount > 0 -> "$charCount"
+        else -> null
+    }
+
+    Surface(
+        shape = RoundedCornerShape(radius),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded }
+                    .heightIn(min = ROW_MIN_DP.dp)
+                    .padding(horizontal = Spacing.m, vertical = Spacing.s),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(Modifier.size(MARK_SIZE_DP.dp), contentAlignment = Alignment.Center) {
+                    if (streamFinished && !fetchingThumbnail) {
+                        FilledArtifactMark(
+                            container = MaterialTheme.colorScheme.primary,
+                            content = MaterialTheme.colorScheme.onPrimary,
+                            icon = Icons.Default.Check,
+                            description = "Done",
+                        )
+                    } else {
+                        LoadingIndicator(
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(MARK_SIZE_DP.dp),
+                        )
+                    }
+                }
+                Spacer(Modifier.width(Spacing.m))
+                Text(
+                    headerLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(Spacing.s))
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+                    Text(
+                        fileName,
+                        Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (meta != null) {
+                    Spacer(Modifier.width(Spacing.s))
+                    Text(
+                        meta,
+                        style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    Icons.Default.KeyboardArrowDown,
+                    if (expanded) "Collapse" else "Expand",
+                    Modifier.padding(start = Spacing.xs).size(18.dp).rotate(chevron),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = if (reducedMotion) fadeIn(tween(0)) else expandVertically(tween(300)) + fadeIn(tween(200)),
+                exit = if (reducedMotion) fadeOut(tween(0)) else shrinkVertically(tween(240)) + fadeOut(tween(120)),
+            ) {
+                Row(
+                    Modifier
+                        .height(IntrinsicSize.Min)
+                        .padding(start = Spacing.m, end = Spacing.m, bottom = Spacing.m),
+                ) {
+                    Box(
+                        Modifier.width(MARK_SIZE_DP.dp).fillMaxHeight(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            Modifier
+                                .width(1.dp)
+                                .fillMaxHeight()
+                                .background(MaterialTheme.colorScheme.outlineVariant),
+                        )
+                    }
+                    Spacer(Modifier.width(Spacing.m))
+                    Column(
+                        Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                    ) {
+                        steps.forEach { step ->
+                            TraceStepRow(step)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TraceStepRow(step: TraceStep) {
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when (step.state) {
+            StepState.Done -> FilledArtifactMark(
+                container = MaterialTheme.colorScheme.primary,
+                content = MaterialTheme.colorScheme.onPrimary,
+                icon = Icons.Default.Check,
+                description = "Done",
+                sizeDp = 18,
+            )
+            StepState.Active -> Box(Modifier.size(18.dp), contentAlignment = Alignment.Center) {
+                LoadingIndicator(
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            StepState.Pending -> Box(
+                Modifier
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)),
+            )
+        }
+        Spacer(Modifier.width(Spacing.s))
+        Text(
+            step.label,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = if (step.state == StepState.Active) FontWeight.Medium else FontWeight.Normal,
+            color = when (step.state) {
+                StepState.Pending -> MaterialTheme.colorScheme.onSurfaceVariant
+                else -> MaterialTheme.colorScheme.onSurface
+            },
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+// ── Settled result ───────────────────────────────────────────────────────────────────
+
 @Composable
 private fun SettledArtifactCard(
     title: String,
     artifactType: String,
     truncated: Boolean,
     deltas: List<VersionDelta>,
+    previewHtml: String?,
     onOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -162,7 +474,6 @@ private fun SettledArtifactCard(
                     .padding(horizontal = Spacing.m, vertical = Spacing.m),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Same 24dp filled mark as the research result card — one system, not a 40dp tile.
                 FilledArtifactMark(
                     container = MaterialTheme.colorScheme.primary,
                     content = MaterialTheme.colorScheme.onPrimary,
@@ -195,7 +506,26 @@ private fun SettledArtifactCard(
                 )
             }
 
-            // File-diff chip row from the reference: mono pills with green + / red − counts.
+            // Preview rides with the settled card — no separate fade after chrome is up.
+            if (!previewHtml.isNullOrBlank()) {
+                Box(
+                    Modifier
+                        .padding(start = Spacing.m, end = Spacing.m, bottom = Spacing.m)
+                        .fillMaxWidth()
+                        .height(PREVIEW_HEIGHT_DP.dp)
+                        .clip(RoundedCornerShape(14.dp)),
+                ) {
+                    ArtifactPreviewWebView(
+                        html = previewHtml,
+                        interactive = false,
+                        onReady = null,
+                        modifier = Modifier.matchParentSize(),
+                    )
+                    // Card is the gesture target; swallow WebView touches.
+                    Box(Modifier.matchParentSize().clickable(onClick = onOpen))
+                }
+            }
+
             if (deltas.isNotEmpty()) {
                 VersionChipRow(
                     deltas = deltas,
@@ -207,7 +537,6 @@ private fun SettledArtifactCard(
     }
 }
 
-/** The edit history as glanceable file-diff chips — newest few, older ones folded into "+N". */
 @Composable
 private fun VersionChipRow(
     deltas: List<VersionDelta>,
@@ -216,7 +545,6 @@ private fun VersionChipRow(
 ) {
     val shown = remember(deltas) { deltas.takeLast(MAX_VERSION_CHIPS) }
     val hidden = deltas.size - shown.size
-    // Hairline above the chips, like the reference's separator before the file pills.
     Column(modifier.fillMaxWidth()) {
         Box(
             Modifier
@@ -231,7 +559,6 @@ private fun VersionChipRow(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             if (hidden > 0) MoreChip("+$hidden earlier")
-            // Leading file pill (reference puts the filename on the diff chips).
             FileNameChip(fileHint)
             shown.forEachIndexed { index, delta ->
                 VersionChip(delta = delta, staggerIndex = index)
@@ -270,7 +597,6 @@ private fun VersionChip(delta: VersionDelta, staggerIndex: Int) {
         animationSpec = if (reducedMotion) tween(0) else spring(stiffness = 520f, dampingRatio = 0.75f),
         label = "chip-appear",
     )
-    // Chip sits on a slightly lifted surface so green/red meta read on primaryContainer.
     Surface(
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -293,18 +619,11 @@ private fun VersionChip(delta: VersionDelta, staggerIndex: Int) {
                 color = MaterialTheme.colorScheme.onSurface,
             )
             when {
-                delta.isFirst -> ChipMeta(
-                    "${delta.lineCount} lines",
-                    MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                delta.isFirst -> ChipMeta("${delta.lineCount} lines", MaterialTheme.colorScheme.onSurfaceVariant)
                 delta.delta.isEmpty -> ChipMeta("±0", MaterialTheme.colorScheme.onSurfaceVariant)
                 else -> {
-                    if (delta.delta.added > 0) {
-                        ChipMeta("+${delta.delta.added}", MaterialTheme.colorScheme.diffAdded)
-                    }
-                    if (delta.delta.removed > 0) {
-                        ChipMeta("−${delta.delta.removed}", MaterialTheme.colorScheme.error)
-                    }
+                    if (delta.delta.added > 0) ChipMeta("+${delta.delta.added}", MaterialTheme.colorScheme.diffAdded)
+                    if (delta.delta.removed > 0) ChipMeta("−${delta.delta.removed}", MaterialTheme.colorScheme.error)
                 }
             }
         }
@@ -312,7 +631,7 @@ private fun VersionChip(delta: VersionDelta, staggerIndex: Int) {
 }
 
 @Composable
-private fun ChipMeta(text: String, color: androidx.compose.ui.graphics.Color) {
+private fun ChipMeta(text: String, color: Color) {
     Text(
         text,
         style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
@@ -332,127 +651,121 @@ private fun MoreChip(text: String) {
     }
 }
 
+// ── Sandboxed HTML preview ───────────────────────────────────────────────────────────
+
 /**
- * Live build as a **tool-chip row**, not a greyscale clone of the old card.
- *
- * Anatomy matches the reference and [ResearchCapsule]: 24dp mark slot, action label, mono
- * filename chip, right-aligned size meta, wavy progress under the row. Building → settled
- * keeps the mark slot so the object resolves in place.
+ * Auto-rendered HTML preview. Network is fully blocked (model HTML must not phone home on
+ * mere compose). [onReady] fires on first [WebViewClient.onPageFinished] so the handoff can
+ * wait before revealing the settled card.
  */
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
 @Composable
-private fun BuildingArtifactCard(
-    title: String,
-    artifactType: String,
-    charCount: Int,
+private fun ArtifactPreviewWebView(
+    html: String,
+    interactive: Boolean,
+    onReady: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
-    val (_, typeLabel) = artifactGlyph(artifactType)
-    val fileName = artifactFileLabel(title, typeLabel, artifactType)
-    val phaseLabel = if (charCount > 0) "Writing" else "Starting"
-    val sizeMeta = when {
-        charCount <= 0 -> null
-        charCount < 1000 -> "$charCount chars"
-        else -> "${charCount / 1000}k chars"
-    }
+    var lastHtml by remember { mutableStateOf<String?>(null) }
+    var readyFired by remember(html) { mutableStateOf(false) }
 
-    Surface(
-        shape = RoundedCornerShape(CARD_RADIUS_DP.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        modifier = modifier.fillMaxWidth(),
+    Box(
+        modifier
+            .clip(RoundedCornerShape(14.dp))
+            .background(Color.White),
     ) {
-        Column(Modifier.padding(horizontal = Spacing.m, vertical = Spacing.m)) {
-            // Primary tool row — the reference's "Write 204 lines  [ChurnSchedule.tsx]" line.
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = ROW_MIN_DP.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Box(Modifier.size(MARK_SIZE_DP.dp), contentAlignment = Alignment.Center) {
-                    LoadingIndicator(
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(MARK_SIZE_DP.dp),
+        AndroidView(
+            modifier = Modifier.matchParentSize(),
+            factory = { ctx ->
+                WebView(ctx).apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
                     )
-                }
-                Spacer(Modifier.width(Spacing.m))
-                Text(
-                    phaseLabel,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Spacer(Modifier.width(Spacing.s))
-                // Mono filename chip — the reference's grey pill next to the action.
-                Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                ) {
-                    Text(
-                        fileName,
-                        Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Spacer(Modifier.weight(1f))
-                if (sizeMeta != null) {
-                    Text(
-                        sizeMeta,
-                        style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+                    isVerticalScrollBarEnabled = false
+                    isHorizontalScrollBarEnabled = false
+                    isClickable = interactive
+                    isLongClickable = interactive
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    @Suppress("DEPRECATION") settings.allowFileAccessFromFileURLs = false
+                    @Suppress("DEPRECATION") settings.allowUniversalAccessFromFileURLs = false
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
+                    @Suppress("DEPRECATION") settings.setSupportZoom(false)
+                    // Auto-preview: never let model HTML phone home.
+                    settings.blockNetworkLoads = true
+                    settings.blockNetworkImage = true
+                    if (!interactive) {
+                        setOnTouchListener { _, _ -> true }
+                    }
+                    setBackgroundColor(android.graphics.Color.WHITE)
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView?, url: String?) {
+                            if (!readyFired) {
+                                readyFired = true
+                                onReady?.invoke()
+                            }
+                        }
 
-            // Quiet second beat once content is flowing — echoes the expanded "detail" lines
-            // under a Write row without dumping code into the bubble.
-            if (charCount > 0) {
-                Spacer(Modifier.height(Spacing.s))
-                Row(
-                    Modifier.padding(start = MARK_SIZE_DP.dp + Spacing.m),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Box(
-                        Modifier
-                            .width(1.dp)
-                            .height(14.dp)
-                            .background(MaterialTheme.colorScheme.outlineVariant),
-                    )
-                    Spacer(Modifier.width(Spacing.m))
-                    Text(
-                        "Streaming into $typeLabel…",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                        ): Boolean = true
 
-            Spacer(Modifier.height(Spacing.m))
-            LinearWavyProgressIndicator(
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
+                        @Deprecated("Pre-24 navigation guard")
+                        override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
+
+                        override fun shouldInterceptRequest(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                        ): WebResourceResponse? {
+                            val scheme = request?.url?.scheme?.lowercase()
+                            return if (scheme == "http" || scheme == "https" || scheme == "ws" || scheme == "wss") {
+                                WebResourceResponse("text/plain", "utf-8", null)
+                            } else {
+                                null
+                            }
+                        }
+                    }
+                    loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+                    lastHtml = html
+                }
+            },
+            update = { web ->
+                if (lastHtml != html) {
+                    readyFired = false
+                    web.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+                    lastHtml = html
+                }
+            },
+            onRelease = { web ->
+                web.stopLoading()
+                web.loadUrl("about:blank")
+                web.destroy()
+            },
+        )
     }
 }
 
 @Composable
 private fun FilledArtifactMark(
-    container: androidx.compose.ui.graphics.Color,
-    content: androidx.compose.ui.graphics.Color,
+    container: Color,
+    content: Color,
     icon: ImageVector,
     description: String,
+    sizeDp: Int = MARK_SIZE_DP,
 ) {
     Box(
         Modifier
-            .size(MARK_SIZE_DP.dp)
+            .size(sizeDp.dp)
             .clip(CircleShape)
             .background(container),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, description, Modifier.size(MARK_SIZE_DP.dp * 0.6f), tint = content)
+        Icon(icon, description, Modifier.size(sizeDp.dp * 0.6f), tint = content)
     }
 }
 
@@ -462,7 +775,6 @@ private fun artifactGlyph(type: String): Pair<ImageVector, String> = when (type)
     else -> Icons.Default.Code to "Web page"
 }
 
-/** A short mono filename-style label for chips — `Pricing.html`, `Report.md`. */
 private fun artifactFileLabel(title: String, typeLabel: String, artifactType: String): String {
     val base = title.trim().ifBlank { typeLabel }.replace(Regex("\\s+"), "-")
     val ext = when (artifactType) {
@@ -470,6 +782,5 @@ private fun artifactFileLabel(title: String, typeLabel: String, artifactType: St
         Artifact.TYPE_LATEX -> "tex"
         else -> "html"
     }
-    // Avoid double extensions if the model already put one in the title.
     return if (base.contains('.')) base else "$base.$ext"
 }

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -91,6 +92,10 @@ private const val CARD_RADIUS_DP = 22
 private const val MARK_SIZE_DP = 24
 private const val ROW_MIN_DP = 48
 private const val PREVIEW_HEIGHT_DP = 150
+// Mono filename chips must be width-bounded or long model titles grow the Surface to fit
+// the full string and TextOverflow.Ellipsis never engages.
+private val FileChipMaxWidth = 160.dp
+private val KnownArtifactExtensions = setOf("md", "tex", "html", "htm")
 
 /**
  * In-chat artifact surface for current-app artifacts.
@@ -342,10 +347,18 @@ private fun BuildingArtifactTrace(
                     modifier = Modifier.weight(1f),
                 )
                 Spacer(Modifier.width(Spacing.s))
-                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+                // widthIn is required: without a max, Surface sizes to the full string and
+                // TextOverflow.Ellipsis never engages. Header label keeps weight(1f) and yields.
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    modifier = Modifier.widthIn(max = FileChipMaxWidth),
+                ) {
                     Text(
                         fileName,
-                        Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
+                        Modifier
+                            .padding(horizontal = Spacing.s, vertical = 4.dp)
+                            .fillMaxWidth(),
                         style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
@@ -569,10 +582,16 @@ private fun VersionChipRow(
 
 @Composable
 private fun FileNameChip(name: String) {
-    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier.widthIn(max = FileChipMaxWidth),
+    ) {
         Text(
             name,
-            Modifier.padding(horizontal = Spacing.s, vertical = 5.dp),
+            Modifier
+                .padding(horizontal = Spacing.s, vertical = 5.dp)
+                .fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
             fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurface,
@@ -775,12 +794,20 @@ private fun artifactGlyph(type: String): Pair<ImageVector, String> = when (type)
     else -> Icons.Default.Code to "Web page"
 }
 
-private fun artifactFileLabel(title: String, typeLabel: String, artifactType: String): String {
+/**
+ * Mono chip label for the artifact. Always ends with the type suffix unless the title already
+ * ends in a known artifact extension (`.md` / `.tex` / `.html`). A mid-title period must not
+ * suppress the suffix — "Dr. Smith report" → `Dr.-Smith-report.html`, not bare `Dr.-Smith-report`.
+ */
+internal fun artifactFileLabel(title: String, typeLabel: String, artifactType: String): String {
     val base = title.trim().ifBlank { typeLabel }.replace(Regex("\\s+"), "-")
     val ext = when (artifactType) {
         Artifact.TYPE_MARKDOWN -> "md"
         Artifact.TYPE_LATEX -> "tex"
         else -> "html"
     }
-    return if (base.contains('.')) base else "$base.$ext"
+    val lastDot = base.lastIndexOf('.')
+    val hasKnownExt = lastDot in 1 until base.lastIndex &&
+        base.substring(lastDot + 1).lowercase() in KnownArtifactExtensions
+    return if (hasKnownExt) base else "$base.$ext"
 }

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -2,12 +2,6 @@
 
 package com.echoflow.ui.components
 
-import android.annotation.SuppressLint
-import android.view.ViewGroup
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
@@ -21,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,6 +23,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material.icons.filled.PictureAsPdf
@@ -40,6 +36,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -48,15 +45,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.runtime.collectAsState
 import com.echoflow.data.Artifact
 import com.echoflow.data.ArtifactVersion
 import com.echoflow.data.VersionDelta
@@ -75,22 +69,23 @@ import kotlinx.coroutines.withContext
 // never wraps past a couple of lines on a phone.
 private const val MAX_VERSION_CHIPS = 4
 private const val CARD_RADIUS_DP = 22
-private const val PREVIEW_HEIGHT_DP = 150
+private const val MARK_SIZE_DP = 24
+private const val ROW_MIN_DP = 48
 
 /**
  * The in-chat artifact card for **current** artifacts ([ArtifactRef.UI_VERSION_CURRENT]).
  *
- * While [building] it is a live trace — a spinner, what's being written, and a running size — with
- * no code ever leaking into the bubble. Once finished it settles into a result object: a type
- * glyph, its title, and a row of **version chips** that put the otherwise invisible edit history
- * (`v1 · 84 lines`, `v2 +74 −41`) right on the card. The whole settled card is the tap target for
- * the fullscreen workspace.
+ * Hybrid of the coding-agent tool-chip reference and EchoFlow's research-capsule grammar:
+ * - **Building** is a live tool-row trace (mark + label + mono filename chip + size), not a
+ *   greyed-out copy of the old tertiary card.
+ * - **Settled** is a result object in the same anatomy as [ResearchResultCard] (filled mark,
+ *   title, type meta, open action) with **file-diff-style version chips** at the bottom —
+ *   `v1 84 lines`, `v2 +74 −41` — the glanceable edit history from the reference.
  *
- * It owns no artifact content itself: given the lineage's [artifactId] it observes [observeVersions]
- * and derives the chips (and, for HTML, a preview) from the persisted rows — so a backgrounded or
- * scrolled-back card always reflects the real store.
+ * No live HTML WebView thumbnail: that path was janky (white flash + fade) and not in the
+ * reference language. Preview lives in the fullscreen workspace the user deliberately opens.
  *
- * Pre-redesign messages are not drawn here at all — see `ui/legacy/LegacyArtifactComponents.kt`.
+ * Pre-redesign messages are not drawn here — see `ui/legacy/LegacyArtifactComponents.kt`.
  */
 @Composable
 fun ArtifactCard(
@@ -106,7 +101,12 @@ fun ArtifactCard(
     observeVersions: (String) -> Flow<List<ArtifactVersion>> = { flowOf(emptyList()) },
 ) {
     if (building) {
-        BuildingArtifactCard(title = title, artifactType = artifactType, charCount = charCount, modifier = modifier)
+        BuildingArtifactCard(
+            title = title,
+            artifactType = artifactType,
+            charCount = charCount,
+            modifier = modifier,
+        )
         return
     }
 
@@ -119,78 +119,70 @@ fun ArtifactCard(
     val lineage = remember(versions, version) {
         versions.filter { it.versionNumber <= version }.sortedBy { it.versionNumber }
     }
-    // Diffing can span large HTML, so fold it off the main thread; the chip row simply appears once
-    // the counts land.
     val deltas by produceState(initialValue = emptyList<VersionDelta>(), lineage) {
         value = withContext(Dispatchers.Default) { versionDeltas(lineage) }
-    }
-    // HTML artifacts get a live render preview on the card — the thing markdown/report artifacts
-    // can't offer. Non-HTML stays glyph + chips.
-    val previewHtml = remember(lineage, version, artifactType) {
-        if (artifactType == Artifact.TYPE_HTML) {
-            (lineage.lastOrNull { it.versionNumber == version } ?: lineage.lastOrNull())?.content
-        } else {
-            null
-        }
     }
 
     SettledArtifactCard(
         title = title,
         artifactType = artifactType,
-        version = version,
         truncated = truncated,
         deltas = deltas,
-        previewHtml = previewHtml,
-        // Pass the lineage id with the version so the workspace opens *this* artifact, not
-        // whatever the chat's "latest" row happens to be.
         onOpen = { artifactId?.let { onOpen(it, version) } },
         modifier = modifier,
     )
 }
 
+/**
+ * Settled result — same weight as [ResearchResultCard]: primary container, filled check mark,
+ * title + type, open affordance, then file-diff chips for the version lineage.
+ */
 @Composable
 private fun SettledArtifactCard(
     title: String,
     artifactType: String,
-    version: Int,
     truncated: Boolean,
     deltas: List<VersionDelta>,
-    previewHtml: String?,
     onOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val (icon, typeLabel) = artifactGlyph(artifactType)
+    val (_, typeLabel) = artifactGlyph(artifactType)
+    val fileName = artifactFileLabel(title, typeLabel, artifactType)
+
     Surface(
         shape = RoundedCornerShape(CARD_RADIUS_DP.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        color = MaterialTheme.colorScheme.primaryContainer,
         modifier = modifier.fillMaxWidth().clickable(onClick = onOpen),
     ) {
         Column {
             Row(
-                Modifier.fillMaxWidth().padding(horizontal = Spacing.base, vertical = Spacing.m),
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = ROW_MIN_DP.dp)
+                    .padding(horizontal = Spacing.m, vertical = Spacing.m),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Tertiary glyph tile — artifacts keep their tertiary identity while the card body
-                // stays neutral so the mono chips carry the colour, like the reference.
-                Box(
-                    Modifier.size(40.dp).clip(RoundedCornerShape(12.dp))
-                        .background(MaterialTheme.colorScheme.tertiary),
-                    contentAlignment = Alignment.Center,
-                ) { Icon(icon, null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onTertiary) }
+                // Same 24dp filled mark as the research result card — one system, not a 40dp tile.
+                FilledArtifactMark(
+                    container = MaterialTheme.colorScheme.primary,
+                    content = MaterialTheme.colorScheme.onPrimary,
+                    icon = Icons.Default.Check,
+                    description = "Artifact ready",
+                )
                 Spacer(Modifier.width(Spacing.m))
                 Column(Modifier.weight(1f)) {
                     Text(
                         title.ifBlank { typeLabel },
-                        style = MaterialTheme.typography.titleSmall,
+                        style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         if (truncated) "$typeLabel · incomplete" else typeLabel,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
                         maxLines = 1,
                     )
                 }
@@ -199,68 +191,92 @@ private fun SettledArtifactCard(
                     Icons.Default.OpenInFull,
                     "Open artifact",
                     Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
                 )
             }
 
-            if (!previewHtml.isNullOrBlank()) {
-                ArtifactPreviewThumbnail(
-                    html = previewHtml,
-                    onOpen = onOpen,
-                    modifier = Modifier.padding(start = Spacing.base, end = Spacing.base, bottom = Spacing.m),
-                )
-            }
-
+            // File-diff chip row from the reference: mono pills with green + / red − counts.
             if (deltas.isNotEmpty()) {
                 VersionChipRow(
                     deltas = deltas,
-                    modifier = Modifier.padding(start = Spacing.base, end = Spacing.base, bottom = Spacing.m),
+                    fileHint = fileName,
+                    modifier = Modifier.padding(start = Spacing.m, end = Spacing.m, bottom = Spacing.m),
                 )
             }
         }
     }
 }
 
-/** The edit history laid out as glanceable chips: newest few, older ones folded into a "+N" marker. */
+/** The edit history as glanceable file-diff chips — newest few, older ones folded into "+N". */
 @Composable
-private fun VersionChipRow(deltas: List<VersionDelta>, modifier: Modifier = Modifier) {
+private fun VersionChipRow(
+    deltas: List<VersionDelta>,
+    fileHint: String,
+    modifier: Modifier = Modifier,
+) {
     val shown = remember(deltas) { deltas.takeLast(MAX_VERSION_CHIPS) }
     val hidden = deltas.size - shown.size
-    FlowRow(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-    ) {
-        if (hidden > 0) MoreChip("+$hidden earlier")
-        shown.forEachIndexed { index, delta ->
-            VersionChip(delta = delta, staggerIndex = index)
+    // Hairline above the chips, like the reference's separator before the file pills.
+    Column(modifier.fillMaxWidth()) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.12f)),
+        )
+        Spacer(Modifier.height(Spacing.m))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            if (hidden > 0) MoreChip("+$hidden earlier")
+            // Leading file pill (reference puts the filename on the diff chips).
+            FileNameChip(fileHint)
+            shown.forEachIndexed { index, delta ->
+                VersionChip(delta = delta, staggerIndex = index)
+            }
         }
+    }
+}
+
+@Composable
+private fun FileNameChip(name: String) {
+    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+        Text(
+            name,
+            Modifier.padding(horizontal = Spacing.s, vertical = 5.dp),
+            style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
 @Composable
 private fun VersionChip(delta: VersionDelta, staggerIndex: Int) {
     val reducedMotion = rememberReducedMotion()
-    // A gentle staggered settle as chips arrive, echoing the research capsule enter. Keyed by the
-    // chip's identity so it plays once on appear, not on every delta recompute.
     var visible by remember(delta.version) { mutableStateOf(reducedMotion) }
     LaunchedEffect(delta.version) {
         if (!visible) {
-            delay(staggerIndex * 55L)
+            delay(staggerIndex * 45L)
             visible = true
         }
     }
     val appear by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
-        animationSpec = if (reducedMotion) tween(0) else spring(stiffness = 520f, dampingRatio = 0.7f),
+        animationSpec = if (reducedMotion) tween(0) else spring(stiffness = 520f, dampingRatio = 0.75f),
         label = "chip-appear",
     )
+    // Chip sits on a slightly lifted surface so green/red meta read on primaryContainer.
     Surface(
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         modifier = Modifier.graphicsLayer {
             alpha = appear
-            val s = 0.9f + 0.1f * appear
+            val s = 0.92f + 0.08f * appear
             scaleX = s
             scaleY = s
         },
@@ -283,8 +299,12 @@ private fun VersionChip(delta: VersionDelta, staggerIndex: Int) {
                 )
                 delta.delta.isEmpty -> ChipMeta("±0", MaterialTheme.colorScheme.onSurfaceVariant)
                 else -> {
-                    if (delta.delta.added > 0) ChipMeta("+${delta.delta.added}", MaterialTheme.colorScheme.diffAdded)
-                    if (delta.delta.removed > 0) ChipMeta("−${delta.delta.removed}", MaterialTheme.colorScheme.error)
+                    if (delta.delta.added > 0) {
+                        ChipMeta("+${delta.delta.added}", MaterialTheme.colorScheme.diffAdded)
+                    }
+                    if (delta.delta.removed > 0) {
+                        ChipMeta("−${delta.delta.removed}", MaterialTheme.colorScheme.error)
+                    }
                 }
             }
         }
@@ -313,106 +333,11 @@ private fun MoreChip(text: String) {
 }
 
 /**
- * A live, non-interactive render of an HTML artifact — the card preview markdown/report artifacts
- * can't give. The page renders in the same sandbox as the workspace (opaque origin, no file/content
- * access); a transparent tap layer keeps the gesture with the card, and the render fades in once the
- * page settles so the white band never flashes empty.
- */
-@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-@Composable
-private fun ArtifactPreviewThumbnail(html: String, onOpen: () -> Unit, modifier: Modifier = Modifier) {
-    val reducedMotion = rememberReducedMotion()
-    var loaded by remember(html) { mutableStateOf(false) }
-    val appear by animateFloatAsState(
-        targetValue = if (loaded || reducedMotion) 1f else 0f,
-        animationSpec = tween(if (reducedMotion) 0 else 260),
-        label = "preview-appear",
-    )
-    var lastHtml by remember { mutableStateOf<String?>(null) }
-    Box(
-        modifier
-            .fillMaxWidth()
-            .height(PREVIEW_HEIGHT_DP.dp)
-            .clip(RoundedCornerShape(14.dp))
-            .background(Color.White),
-    ) {
-        AndroidView(
-            modifier = Modifier.matchParentSize().graphicsLayer { alpha = appear },
-            factory = { ctx ->
-                WebView(ctx).apply {
-                    layoutParams = ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                    isVerticalScrollBarEnabled = false
-                    isHorizontalScrollBarEnabled = false
-                    isClickable = false
-                    isLongClickable = false
-                    settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = true
-                    settings.allowFileAccess = false
-                    settings.allowContentAccess = false
-                    @Suppress("DEPRECATION") settings.allowFileAccessFromFileURLs = false
-                    @Suppress("DEPRECATION") settings.allowUniversalAccessFromFileURLs = false
-                    settings.useWideViewPort = true
-                    settings.loadWithOverviewMode = true
-                    @Suppress("DEPRECATION") settings.setSupportZoom(false)
-                    // This preview auto-renders — the user never chose to open it — so untrusted
-                    // model HTML must not phone home. Block every network load (remote <script>,
-                    // <img>, fetch/XHR, beacons) and refuse navigations; only the inline document
-                    // paints, in an opaque origin with no way out. The full workspace (which the
-                    // user explicitly opens) keeps normal loading.
-                    settings.blockNetworkLoads = true
-                    settings.blockNetworkImage = true
-                    // Swallow touches so scrolling/taps belong to the card, not the page.
-                    setOnTouchListener { _, _ -> true }
-                    setBackgroundColor(android.graphics.Color.WHITE)
-                    webViewClient = object : WebViewClient() {
-                        override fun onPageFinished(view: WebView?, url: String?) { loaded = true }
-
-                        // No navigation out of the inline document, ever.
-                        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean = true
-
-                        @Deprecated("Pre-24 navigation guard")
-                        override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean = true
-
-                        // Belt-and-suspenders over blockNetworkLoads: drop any remote subresource.
-                        override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
-                            val scheme = request?.url?.scheme?.lowercase()
-                            return if (scheme == "http" || scheme == "https" || scheme == "ws" || scheme == "wss") {
-                                WebResourceResponse("text/plain", "utf-8", null)
-                            } else {
-                                null
-                            }
-                        }
-                    }
-                    loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
-                    lastHtml = html
-                }
-            },
-            update = { web ->
-                if (lastHtml != html) {
-                    loaded = false
-                    web.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
-                    lastHtml = html
-                }
-            },
-            onRelease = { web ->
-                web.stopLoading()
-                web.loadUrl("about:blank")
-                web.destroy()
-            },
-        )
-        // Transparent tap layer: tapping the preview opens the workspace like the rest of the card.
-        Box(Modifier.matchParentSize().clickable(onClick = onOpen))
-    }
-}
-
-/**
- * The live "Building…" state as a trace, in the research-capsule grammar: a spinner where the glyph
- * tile will settle, the file being written as a mono chip, and a running size — then a wavy line
- * for liveliness. No code ever leaks into the bubble. When it finishes the spinner gives way to the
- * settled card's tertiary glyph tile, so building → done reads as one object resolving rather than
- * a component swap.
+ * Live build as a **tool-chip row**, not a greyscale clone of the old card.
+ *
+ * Anatomy matches the reference and [ResearchCapsule]: 24dp mark slot, action label, mono
+ * filename chip, right-aligned size meta, wavy progress under the row. Building → settled
+ * keeps the mark slot so the object resolves in place.
  */
 @Composable
 private fun BuildingArtifactCard(
@@ -422,54 +347,112 @@ private fun BuildingArtifactCard(
     modifier: Modifier = Modifier,
 ) {
     val (_, typeLabel) = artifactGlyph(artifactType)
+    val fileName = artifactFileLabel(title, typeLabel, artifactType)
+    val phaseLabel = if (charCount > 0) "Writing" else "Starting"
+    val sizeMeta = when {
+        charCount <= 0 -> null
+        charCount < 1000 -> "$charCount chars"
+        else -> "${charCount / 1000}k chars"
+    }
+
     Surface(
         shape = RoundedCornerShape(CARD_RADIUS_DP.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column(Modifier.padding(Spacing.base)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+        Column(Modifier.padding(horizontal = Spacing.m, vertical = Spacing.m)) {
+            // Primary tool row — the reference's "Write 204 lines  [ChurnSchedule.tsx]" line.
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = ROW_MIN_DP.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(Modifier.size(MARK_SIZE_DP.dp), contentAlignment = Alignment.Center) {
                     LoadingIndicator(
-                        color = MaterialTheme.colorScheme.tertiary,
-                        modifier = Modifier.size(28.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(MARK_SIZE_DP.dp),
                     )
                 }
                 Spacer(Modifier.width(Spacing.m))
                 Text(
-                    if (charCount > 0) "Writing" else "Starting",
+                    phaseLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(Modifier.width(Spacing.s))
-                // The "file" being written — the reference's mono filename chip.
-                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceContainerHighest) {
+                // Mono filename chip — the reference's grey pill next to the action.
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                ) {
                     Text(
-                        title.ifBlank { typeLabel },
-                        Modifier.padding(horizontal = Spacing.s, vertical = 5.dp),
+                        fileName,
+                        Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
                         style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                Spacer(Modifier.width(Spacing.s))
                 Spacer(Modifier.weight(1f))
-                if (charCount > 0) {
+                if (sizeMeta != null) {
                     Text(
-                        "$charCount",
+                        sizeMeta,
                         style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
+
+            // Quiet second beat once content is flowing — echoes the expanded "detail" lines
+            // under a Write row without dumping code into the bubble.
+            if (charCount > 0) {
+                Spacer(Modifier.height(Spacing.s))
+                Row(
+                    Modifier.padding(start = MARK_SIZE_DP.dp + Spacing.m),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        Modifier
+                            .width(1.dp)
+                            .height(14.dp)
+                            .background(MaterialTheme.colorScheme.outlineVariant),
+                    )
+                    Spacer(Modifier.width(Spacing.m))
+                    Text(
+                        "Streaming into $typeLabel…",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
             Spacer(Modifier.height(Spacing.m))
             LinearWavyProgressIndicator(
-                color = MaterialTheme.colorScheme.tertiary,
+                color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+    }
+}
+
+@Composable
+private fun FilledArtifactMark(
+    container: androidx.compose.ui.graphics.Color,
+    content: androidx.compose.ui.graphics.Color,
+    icon: ImageVector,
+    description: String,
+) {
+    Box(
+        Modifier
+            .size(MARK_SIZE_DP.dp)
+            .clip(CircleShape)
+            .background(container),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(icon, description, Modifier.size(MARK_SIZE_DP.dp * 0.6f), tint = content)
     }
 }
 
@@ -477,4 +460,16 @@ private fun artifactGlyph(type: String): Pair<ImageVector, String> = when (type)
     Artifact.TYPE_MARKDOWN -> Icons.AutoMirrored.Filled.Article to "Document"
     Artifact.TYPE_LATEX -> Icons.Default.PictureAsPdf to "Report"
     else -> Icons.Default.Code to "Web page"
+}
+
+/** A short mono filename-style label for chips — `Pricing.html`, `Report.md`. */
+private fun artifactFileLabel(title: String, typeLabel: String, artifactType: String): String {
+    val base = title.trim().ifBlank { typeLabel }.replace(Regex("\\s+"), "-")
+    val ext = when (artifactType) {
+        Artifact.TYPE_MARKDOWN -> "md"
+        Artifact.TYPE_LATEX -> "tex"
+        else -> "html"
+    }
+    // Avoid double extensions if the model already put one in the title.
+    return if (base.contains('.')) base else "$base.$ext"
 }

--- a/app/src/test/java/com/echoflow/ArtifactFileLabelTest.kt
+++ b/app/src/test/java/com/echoflow/ArtifactFileLabelTest.kt
@@ -1,0 +1,58 @@
+package com.echoflow
+
+import com.echoflow.data.Artifact
+import com.echoflow.ui.components.artifactFileLabel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtifactFileLabelTest {
+
+    @Test
+    fun plainTitleGetsTypeSuffix() {
+        assertEquals(
+            "Pricing-page.html",
+            artifactFileLabel("Pricing page", "Web page", Artifact.TYPE_HTML),
+        )
+        assertEquals(
+            "Quarterly-notes.md",
+            artifactFileLabel("Quarterly notes", "Document", Artifact.TYPE_MARKDOWN),
+        )
+    }
+
+    @Test
+    fun dottedHumanTitleStillGetsSuffix() {
+        // A period mid-title is not a file extension — must not suppress .html / .md / .tex.
+        assertEquals(
+            "Dr.-Smith-report.html",
+            artifactFileLabel("Dr. Smith report", "Web page", Artifact.TYPE_HTML),
+        )
+        assertEquals(
+            "v2.0-design.md",
+            artifactFileLabel("v2.0 design", "Document", Artifact.TYPE_MARKDOWN),
+        )
+        assertEquals(
+            "Section-1.2-outline.tex",
+            artifactFileLabel("Section 1.2 outline", "Report", Artifact.TYPE_LATEX),
+        )
+    }
+
+    @Test
+    fun knownExtensionIsNotDoubled() {
+        assertEquals(
+            "page.html",
+            artifactFileLabel("page.html", "Web page", Artifact.TYPE_HTML),
+        )
+        assertEquals(
+            "Notes.MD",
+            artifactFileLabel("Notes.MD", "Document", Artifact.TYPE_MARKDOWN),
+        )
+    }
+
+    @Test
+    fun blankTitleFallsBackToTypeLabel() {
+        assertEquals(
+            "Web-page.html",
+            artifactFileLabel("  ", "Web page", Artifact.TYPE_HTML),
+        )
+    }
+}


### PR DESCRIPTION
## Why

The artifact redesign that landed in #106 missed the design we agreed from your tool-chip / expandable-trace references. What shipped read as **the old card, greyer**, plus a **janky live HTML thumbnail** fade.

## What this does

Reimplements the in-chat card as the hybrid we picked:

1. **Settled result** — same anatomy as the research result card (`primaryContainer`, 24dp filled check mark, title + type, open). Below: hairline + **file-diff chips** from the reference (filename pill, `v1 84 lines`, `v2 +74 -41` with green/red).
2. **Building as a tool row** — loading mark, Writing/Starting, mono filename chip, size meta, quiet rail line, wavy progress. Not a grey clone of the legacy tertiary tile.
3. **No live WebView thumbnail** — removed. Preview lives in the workspace you open on purpose.

Legacy chats are unchanged (`ui/legacy` + `uiVersion`).

## Test plan

- [ ] New HTML artifact: building row then settled primary card with version chips
- [ ] Edit an artifact (v2+): chips show green + / red -
- [ ] Markdown/LaTeX: same card chrome, no preview band
- [ ] Tap card opens correct version
- [ ] Old pre-redesign chats still show the frozen legacy card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned artifact cards with clearer building and completed states.
  * Added generated filename and character-count details while content is being created.
  * Added streaming status and progress indicators for in-progress artifacts.
  * Improved completed artifact cards with compact layouts, check marks, filenames, and version-difference details.

* **Improvements**
  * Refined version-chip animations and visual presentation.
  * Removed the embedded HTML preview from artifact cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: the tool-trace building state, intentional workspace opening, and compact diff chips make artifacts feel more consistent with the rest of the conversation UI. The implementation also bounds long filename chips and adds focused filename-label tests.
- Replaces the artifact building tile with an expandable progress trace.
- Reworks settled artifacts around primary-container styling and version-diff chips.
- Adds type-aware filename labels and tests for dotted titles.
- Preserves legacy-chat rendering through the existing legacy UI path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt | Rebuilds current artifact cards with expandable building traces, settled result styling, bounded filename chips, version metadata, and sandboxed HTML preview handling. |
| app/src/test/java/com/echoflow/ArtifactFileLabelTest.kt | Adds focused coverage for suffix generation, dotted human titles, matching known extensions, and blank-title fallback. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Bound filename chips and keep type suffi..."](https://github.com/adityavardhansharma/echoflow/commit/1e6b7d57f2e356189475cdd2e7c0e268629dfcde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52430729)</sub>

<!-- /greptile_comment -->