### PR TITLE
Drop the duplicate filename chip on the settled artifact card

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -472,7 +472,6 @@ private fun SettledArtifactCard(
     modifier: Modifier = Modifier,
 ) {
     val (_, typeLabel) = artifactGlyph(artifactType)
-    val fileName = artifactFileLabel(title, typeLabel, artifactType)
 
     Surface(
         shape = RoundedCornerShape(CARD_RADIUS_DP.dp),
@@ -542,7 +541,6 @@ private fun SettledArtifactCard(
             if (deltas.isNotEmpty()) {
                 VersionChipRow(
                     deltas = deltas,
-                    fileHint = fileName,
                     modifier = Modifier.padding(start = Spacing.m, end = Spacing.m, bottom = Spacing.m),
                 )
             }
@@ -550,10 +548,13 @@ private fun SettledArtifactCard(
     }
 }
 
+/**
+ * Version history only — no filename chip. The settled header already carries the human title;
+ * repeating it as `Title-slug.html` was a leftover from the multi-file tool-chip reference.
+ */
 @Composable
 private fun VersionChipRow(
     deltas: List<VersionDelta>,
-    fileHint: String,
     modifier: Modifier = Modifier,
 ) {
     val shown = remember(deltas) { deltas.takeLast(MAX_VERSION_CHIPS) }
@@ -572,32 +573,10 @@ private fun VersionChipRow(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             if (hidden > 0) MoreChip("+$hidden earlier")
-            FileNameChip(fileHint)
             shown.forEachIndexed { index, delta ->
                 VersionChip(delta = delta, staggerIndex = index)
             }
         }
-    }
-}
-
-@Composable
-private fun FileNameChip(name: String) {
-    Surface(
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        modifier = Modifier.widthIn(max = FileChipMaxWidth),
-    ) {
-        Text(
-            name,
-            Modifier
-                .padding(horizontal = Spacing.s, vertical = 5.dp)
-                .fillMaxWidth(),
-            style = MaterialTheme.typography.labelMedium.copy(fontFamily = JetBrainsMono),
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

Removes the redundant mono filename chip on the settled artifact card.

The header already shows the human title; repeating it as `Title-slug.html` next to the version chips was leftover from the multi-file tool-chip reference. One lineage only needs one name.

Building still keeps a mono file chip next to the action label (Write-style row), which is intentional.

## Test plan

- [ ] Settled artifact card: title once in the header, version chips only below (no second filename pill)
- [ ] Building capsule still shows mono filename chip beside Building/Starting
- [ ] Long titles and dotted titles still behave correctly from #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed filename labels from the settled artifact’s version history.
  * Simplified version history to show only the earlier version and version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The focused removal improves the product direction by making settled artifact cards less repetitive while preserving the distinct filename treatment during active builds. The implementation is appropriately narrow; adding a Compose UI assertion for the settled-versus-building states would make this behavior easier to protect.
- Removes the derived filename and filename chip from settled artifact version history.
- Keeps version chips and overflow behavior unchanged.
- Deletes the now-unused settled-card filename chip composable.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the settled-card cleanup remaining scoped to the intended duplicate filename presentation.

The change removes only the settled artifact filename derivation, parameter, and chip while leaving version history rendering and the separate building-state presentation intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt | Cleanly removes the redundant settled-card filename chip without changing the intentional building-state filename presentation. |

<sub>Reviews (1): Last reviewed commit: ["Drop the duplicate filename chip on the ..."](https://github.com/adityavardhansharma/echoflow/commit/c227eb95c0a19b7cda43128f300cb90368bd3916) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52540137)</sub>

<!-- /greptile_comment -->