### PR TITLE
Don't replay the artifact build timeline on chat switch

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -137,10 +137,15 @@ fun ArtifactCard(
         value = withContext(Dispatchers.Default) { versionDeltas(lineage) }
     }
     val isHtml = artifactType == Artifact.TYPE_HTML
-    // Only a *live* stream may show the step capsule / thumbnail handoff. Persisted messages
-    // always arrive with building=false; without this flag they still entered "Fetching
-    // thumbnail" while versions loaded and replayed the build timeline for ~1s on chat switch.
-    var sawLiveBuild by remember(artifactId, version) { mutableStateOf(building) }
+    // Live-build memory must NOT key on artifactId/version. The reducer assigns those only on
+    // ArtifactCompleted, in the same update that sets building=false — so remember(id, version)
+    // was wiped at the exact moment we needed the handoff, re-init sawLiveBuild to false and
+    // skipping the thumbnail warm. Key on composition identity only (fresh when the Lazy item
+    // is disposed on chat switch).
+    //
+    // Historical opens: first frame has building=false → sawLiveBuild stays false → settled only.
+    // Live stream: building starts true → sawLiveBuild latches true for the rest of this card.
+    var sawLiveBuild by remember { mutableStateOf(building) }
     SideEffect {
         if (building) sawLiveBuild = true
     }
@@ -154,8 +159,8 @@ fun ArtifactCard(
         }
     }
 
-    // Live HTML handoff only: warm preview off-screen after the stream ends, then settle once.
-    var liveThumbnailReady by remember(artifactId, version) { mutableStateOf(false) }
+    // Same stability rule: do not key on artifactId/version or completion resets the warm wait.
+    var liveThumbnailReady by remember { mutableStateOf(false) }
     LaunchedEffect(building, sawLiveBuild, isHtml) {
         if (!sawLiveBuild) return@LaunchedEffect
         if (building) {

--- a/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt
@@ -8,7 +8,6 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -18,7 +17,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -55,6 +53,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -138,42 +137,54 @@ fun ArtifactCard(
         value = withContext(Dispatchers.Default) { versionDeltas(lineage) }
     }
     val isHtml = artifactType == Artifact.TYPE_HTML
-    val previewHtml = remember(lineage, version, isHtml, building) {
-        if (!building && isHtml) {
+    // Only a *live* stream may show the step capsule / thumbnail handoff. Persisted messages
+    // always arrive with building=false; without this flag they still entered "Fetching
+    // thumbnail" while versions loaded and replayed the build timeline for ~1s on chat switch.
+    var sawLiveBuild by remember(artifactId, version) { mutableStateOf(building) }
+    SideEffect {
+        if (building) sawLiveBuild = true
+    }
+
+    val previewHtml = remember(lineage, version, isHtml) {
+        if (isHtml) {
             (lineage.lastOrNull { it.versionNumber == version } ?: lineage.lastOrNull())?.content
                 ?.takeIf { it.isNotBlank() }
         } else {
             null
         }
     }
-    // HTML waits on body rows (async) then on a warm WebView paint. Non-HTML settles immediately.
-    val waitingForHtmlBody = !building && isHtml && previewHtml == null
-    val needsThumbnailWarm = !previewHtml.isNullOrBlank()
-    var thumbnailReady by remember(previewHtml) { mutableStateOf(!needsThumbnailWarm) }
-    // Never hang the UI if onPageFinished is slow/missing (empty doc, WebView quirk).
-    LaunchedEffect(previewHtml, needsThumbnailWarm) {
-        if (needsThumbnailWarm && !thumbnailReady) {
-            delay(2_800)
-            thumbnailReady = true
+
+    // Live HTML handoff only: warm preview off-screen after the stream ends, then settle once.
+    var liveThumbnailReady by remember(artifactId, version) { mutableStateOf(false) }
+    LaunchedEffect(building, sawLiveBuild, isHtml) {
+        if (!sawLiveBuild) return@LaunchedEffect
+        if (building) {
+            liveThumbnailReady = false
+        } else if (!isHtml) {
+            // Non-HTML settles as soon as the stream ends — no warm step.
+            liveThumbnailReady = true
         }
     }
-    val preparingThumbnail =
-        !building && isHtml && (waitingForHtmlBody || (needsThumbnailWarm && !thumbnailReady))
-    val showTrace = building || preparingThumbnail
-    val showSettled = !building && !preparingThumbnail
+    LaunchedEffect(previewHtml, sawLiveBuild, building, isHtml, liveThumbnailReady) {
+        // Timeout so a silent WebView never leaves the capsule stuck.
+        if (sawLiveBuild && !building && isHtml && previewHtml != null && !liveThumbnailReady) {
+            delay(2_800)
+            liveThumbnailReady = true
+        }
+    }
 
-    val reducedMotion = rememberReducedMotion()
+    val preparingThumbnail =
+        sawLiveBuild && !building && isHtml && !liveThumbnailReady
+    val showTrace = building || preparingThumbnail
+
     val openSettled: () -> Unit = { artifactId?.let { onOpen(it, version) } }
 
     Column(modifier.fillMaxWidth()) {
-        // Off-screen warm load: real layout size so the WebView paints, parked far below the
-        // viewport. onPageFinished unlocks the settled card so the visible preview is not a
-        // second-class fade layered onto chrome that already appeared.
         if (preparingThumbnail && previewHtml != null) {
             ArtifactPreviewWebView(
                 html = previewHtml,
                 interactive = false,
-                onReady = { thumbnailReady = true },
+                onReady = { liveThumbnailReady = true },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(PREVIEW_HEIGHT_DP.dp)
@@ -182,37 +193,24 @@ fun ArtifactCard(
             )
         }
 
-        AnimatedContent(
-            targetState = showSettled,
-            transitionSpec = {
-                if (reducedMotion) {
-                    fadeIn(tween(0)) togetherWith fadeOut(tween(0))
-                } else {
-                    (fadeIn(tween(280)) + expandVertically(tween(320))) togetherWith
-                        (fadeOut(tween(160)) + shrinkVertically(tween(220)))
-                }
-            },
-            label = "artifact-handoff",
-            modifier = Modifier.fillMaxWidth(),
-        ) { settled ->
-            if (settled) {
-                SettledArtifactCard(
-                    title = title,
-                    artifactType = artifactType,
-                    truncated = truncated,
-                    deltas = deltas,
-                    previewHtml = previewHtml,
-                    onOpen = openSettled,
-                )
-            } else {
-                BuildingArtifactTrace(
-                    title = title,
-                    artifactType = artifactType,
-                    charCount = charCount,
-                    streamFinished = !building,
-                    fetchingThumbnail = preparingThumbnail,
-                )
-            }
+        if (showTrace) {
+            BuildingArtifactTrace(
+                title = title,
+                artifactType = artifactType,
+                charCount = charCount,
+                streamFinished = !building,
+                fetchingThumbnail = preparingThumbnail,
+            )
+        } else {
+            // Historical reopen and post-handoff: settled card only — never the build capsule.
+            SettledArtifactCard(
+                title = title,
+                artifactType = artifactType,
+                truncated = truncated,
+                deltas = deltas,
+                previewHtml = previewHtml,
+                onOpen = openSettled,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the flash where switching into a chat with a finished artifact briefly replayed the expandable build timeline.

### Cause
For completed HTML cards, `building` is already false, but the card still entered a post-stream **Fetching thumbnail** path while version rows / preview content loaded. That path reuses the build capsule, so reopen looked like the artifact was building again for ~1s.

### Fix
Track whether this composition ever saw a **live** `building=true` stream (`sawLiveBuild`).

- **Historical / chat switch** (starts finished) → settled card only, first frame
- **Live stream** → step capsule, then optional HTML thumbnail warm, then settle

## Test plan

- [ ] Open a chat that already has a completed HTML artifact — no build step capsule flash
- [ ] Switch away and back — still just the settled card
- [ ] Generate a new artifact live — build capsule + steps still appear while streaming
- [ ] Live HTML still gets the post-stream thumbnail handoff before the settled card

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: completed artifacts now reopen directly as settled cards while live generation retains its build progress and thumbnail handoff. The implementation improves the lifecycle handling by latching live-build state across the completion update instead of tying it to artifact fields assigned during completion.
- Preserves `sawLiveBuild` and thumbnail readiness across the live-to-completed reducer transition.
- Avoids replaying build UI when a historical artifact first enters composition.
- Replaces the animated handoff with direct rendering of the active artifact phase.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/ArtifactComponents.kt | The card now distinguishes historical composition from a live build and preserves the live thumbnail handoff through completion; the previously reported state reset is resolved. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Artifact card enters composition] --> B{building?}
    B -->|Yes| C[Latch sawLiveBuild]
    C --> D[Show build trace]
    B -->|No| E{sawLiveBuild?}
    E -->|No| F[Show settled card immediately]
    E -->|Yes, HTML| G[Warm thumbnail]
    G --> H{WebView ready or timeout}
    H -->|Yes| F
    E -->|Yes, non-HTML| F
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep live HTML thumbnail handoff across ..."](https://github.com/adityavardhansharma/echoflow/commit/36fe677c2b593610be2a73be427e4087132e5ba2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52541824)</sub>

<!-- /greptile_comment -->