### PR TITLE
Redesign Echo Fusion process UI

### DIFF
--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -401,10 +401,13 @@ fun FusionCard(
 ) {
     val reducedMotion = rememberReducedMotion()
     val roster = analysis?.models?.takeIf { it.isNotEmpty() } ?: models
-    // Resolved with nothing usable: every panel model failed or returned empty. Do not claim
-    // "writing final answer" — there is nothing for the judge to synthesize from.
-    val panelFailed = analysis != null && analysis.responses.isEmpty()
-    // Live process: panel waiting, or tool returned useful output and final answer not on screen yet.
+    // Total failure only when there is nothing usable at all: no raw panel answers AND no
+    // structured comparison. OpenRouter can return analysis without a responses[] list — that
+    // is still a successful fusion and must not be painted as "Panel could not respond".
+    val panelFailed = analysis != null &&
+        analysis.responses.isEmpty() &&
+        analysis.isEmpty
+    // Live process: panel waiting, or tool returned and final answer not on screen yet.
     // Total panel failure stays open while the turn is still streaming so the user sees the fail
     // state, but never enters the answer-writing phase.
     val processLive = active || (analysis != null && isStreaming && !answerStarted)
@@ -485,11 +488,16 @@ fun FusionCard(
     val panelMeta = when (panelState) {
         FusionStepState.Active -> "${roster.size} model${if (roster.size == 1) "" else "s"}"
         FusionStepState.Done -> {
-            val returned = analysis?.responses?.size ?: roster.size
+            val returned = analysis?.responses?.size ?: 0
             val failed = analysis?.failedModels?.size ?: 0
-            buildString {
-                append("$returned returned")
-                if (failed > 0) append(" · $failed failed")
+            when {
+                returned > 0 -> buildString {
+                    append("$returned returned")
+                    if (failed > 0) append(" · $failed failed")
+                }
+                // Structured analysis without raw responses — still a successful panel pass.
+                analysis != null && !analysis.isEmpty -> "${roster.size} model${if (roster.size == 1) "" else "s"}"
+                else -> null
             }
         }
         FusionStepState.Failed -> {
@@ -506,7 +514,7 @@ fun FusionCard(
                 val parts = mutableListOf<String>()
                 if (a.consensus.isNotEmpty()) parts += "${a.consensus.size} agreed"
                 if (a.contradictions.isNotEmpty()) parts += "${a.contradictions.size} disagreed"
-                if (parts.isEmpty() && a.responses.isNotEmpty()) parts += "compared"
+                if (parts.isEmpty() && (!a.isEmpty || a.responses.isNotEmpty())) parts += "compared"
                 append(parts.joinToString(" · "))
             }.takeIf { it.isNotBlank() }
         }
@@ -600,7 +608,10 @@ fun FusionCard(
                         FusionModelChips(
                             models = roster,
                             failed = analysis?.failedModels.orEmpty(),
-                            resolved = analysis != null,
+                            // Only mark chips resolved when we have per-model outcomes or a
+                            // confirmed total failure — not when we only have aggregate analysis.
+                            resolved = analysis != null &&
+                                (analysis.responses.isNotEmpty() || analysis.failedModels.isNotEmpty() || panelFailed),
                             allFailed = panelFailed,
                         )
                     }
@@ -610,7 +621,9 @@ fun FusionCard(
                         meta = compareMeta,
                         reducedMotion = reducedMotion,
                     )
-                    if (analysis != null && !analysis.isEmpty && !panelFailed) {
+                    // Count chips whenever structured comparison exists (even if raw responses
+                    // were omitted from the tool payload).
+                    if (analysis != null && !analysis.isEmpty) {
                         FusionCountChips(analysis)
                     }
                     FusionProcessStep(

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.echoflow.data.FusionAnalysis
@@ -400,7 +401,12 @@ fun FusionCard(
 ) {
     val reducedMotion = rememberReducedMotion()
     val roster = analysis?.models?.takeIf { it.isNotEmpty() } ?: models
-    // Live process: panel waiting, or tool returned but final answer not on screen yet.
+    // Resolved with nothing usable: every panel model failed or returned empty. Do not claim
+    // "writing final answer" — there is nothing for the judge to synthesize from.
+    val panelFailed = analysis != null && analysis.responses.isEmpty()
+    // Live process: panel waiting, or tool returned useful output and final answer not on screen yet.
+    // Total panel failure stays open while the turn is still streaming so the user sees the fail
+    // state, but never enters the answer-writing phase.
     val processLive = active || (analysis != null && isStreaming && !answerStarted)
 
     var userToggled by remember { mutableStateOf<Boolean?>(null) }
@@ -436,17 +442,16 @@ fun FusionCard(
     val panelState = when {
         analysis == null && processLive -> FusionStepState.Active
         analysis == null -> FusionStepState.Pending
-        analysis.failedModels.isNotEmpty() &&
-            analysis.responses.isEmpty() &&
-            analysis.failedModels.size >= roster.size.coerceAtLeast(1) -> FusionStepState.Failed
+        panelFailed -> FusionStepState.Failed
         else -> FusionStepState.Done
     }
     val compareState = when {
         analysis == null -> FusionStepState.Pending
-        processLive && !answerStarted -> FusionStepState.Done // comparison is tool result; answer is next
+        panelFailed -> FusionStepState.Failed
         else -> FusionStepState.Done
     }
     val answerState = when {
+        panelFailed -> FusionStepState.Failed
         answerStarted || (!processLive && analysis != null) -> FusionStepState.Done
         analysis != null && processLive -> FusionStepState.Active
         else -> FusionStepState.Pending
@@ -454,14 +459,19 @@ fun FusionCard(
 
     val statusLine = when {
         analysis == null && processLive -> "Panel answering in parallel"
+        panelFailed -> "Panel could not respond"
         analysis != null && processLive && !answerStarted -> "Writing final answer"
         else -> null
     }
 
     val headerTitle = when {
-        processLive -> {
+        processLive || panelFailed && isStreaming -> {
             val name = panelName.ifBlank { "Fusion" }
             if (panelName.isNotBlank()) "Fusion · $name" else "Fusion"
+        }
+        panelFailed -> {
+            val name = panelName.ifBlank { "Fusion" }
+            if (panelName.isNotBlank()) "Fusion failed · $name" else "Fusion failed"
         }
         else -> {
             val n = roster.size.coerceAtLeast(models.size)
@@ -482,21 +492,28 @@ fun FusionCard(
                 if (failed > 0) append(" · $failed failed")
             }
         }
-        FusionStepState.Failed -> "Did not respond"
+        FusionStepState.Failed -> {
+            val failed = analysis?.failedModels?.size ?: roster.size
+            if (failed > 0) "$failed failed" else "Did not respond"
+        }
         FusionStepState.Pending -> null
     }
-    val compareMeta = analysis?.let { a ->
-        if (a.isEmpty && a.responses.isEmpty()) null
-        else buildString {
-            val parts = mutableListOf<String>()
-            if (a.consensus.isNotEmpty()) parts += "${a.consensus.size} agreed"
-            if (a.contradictions.isNotEmpty()) parts += "${a.contradictions.size} disagreed"
-            if (parts.isEmpty() && a.responses.isNotEmpty()) parts += "compared"
-            append(parts.joinToString(" · "))
-        }.takeIf { it.isNotBlank() }
+    val compareMeta = when {
+        panelFailed -> "skipped"
+        else -> analysis?.let { a ->
+            if (a.isEmpty && a.responses.isEmpty()) null
+            else buildString {
+                val parts = mutableListOf<String>()
+                if (a.consensus.isNotEmpty()) parts += "${a.consensus.size} agreed"
+                if (a.contradictions.isNotEmpty()) parts += "${a.contradictions.size} disagreed"
+                if (parts.isEmpty() && a.responses.isNotEmpty()) parts += "compared"
+                append(parts.joinToString(" · "))
+            }.takeIf { it.isNotBlank() }
+        }
     }
     val answerMeta = when (answerState) {
         FusionStepState.Active -> "writing…"
+        FusionStepState.Failed -> "no answer"
         else -> null
     }
 
@@ -532,12 +549,9 @@ fun FusionCard(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                if (processLive) {
+                if (processLive && !panelFailed) {
                     Spacer(Modifier.width(Spacing.s))
-                    LoadingIndicator(
-                        color = MaterialTheme.colorScheme.secondary,
-                        modifier = Modifier.size(18.dp),
-                    )
+                    FusionBusyIndicator(reducedMotion = reducedMotion, size = 18.dp)
                 }
                 durationLabel?.let { dur ->
                     Spacer(Modifier.width(Spacing.s))
@@ -580,26 +594,30 @@ fun FusionCard(
                         label = "Panel",
                         state = panelState,
                         meta = panelMeta,
+                        reducedMotion = reducedMotion,
                     )
                     if (roster.isNotEmpty()) {
                         FusionModelChips(
                             models = roster,
                             failed = analysis?.failedModels.orEmpty(),
                             resolved = analysis != null,
+                            allFailed = panelFailed,
                         )
                     }
                     FusionProcessStep(
                         label = "Compare",
                         state = compareState,
                         meta = compareMeta,
+                        reducedMotion = reducedMotion,
                     )
-                    if (analysis != null && !analysis.isEmpty) {
+                    if (analysis != null && !analysis.isEmpty && !panelFailed) {
                         FusionCountChips(analysis)
                     }
                     FusionProcessStep(
                         label = "Answer",
                         state = answerState,
                         meta = answerMeta,
+                        reducedMotion = reducedMotion,
                     )
 
                     // Settled expand only: full comparison + per-model answers stay optional depth.
@@ -618,6 +636,7 @@ private fun FusionProcessStep(
     label: String,
     state: FusionStepState,
     meta: String?,
+    reducedMotion: Boolean,
 ) {
     val dimmed = state == FusionStepState.Pending
     Row(
@@ -626,7 +645,7 @@ private fun FusionProcessStep(
             .heightIn(min = 28.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        FusionStepMark(state)
+        FusionStepMark(state = state, reducedMotion = reducedMotion)
         Spacer(Modifier.width(Spacing.s))
         Text(
             label,
@@ -646,7 +665,11 @@ private fun FusionProcessStep(
             Text(
                 meta,
                 style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = if (state == FusionStepState.Failed) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -654,14 +677,31 @@ private fun FusionProcessStep(
     }
 }
 
+/**
+ * Active busy mark. [LoadingIndicator] keeps spinning even when animator duration scale is 0,
+ * so reduced-motion falls back to a still secondary ring (same stillness rule as Research reveals).
+ */
 @Composable
-private fun FusionStepMark(state: FusionStepState) {
+private fun FusionBusyIndicator(reducedMotion: Boolean, size: Dp) {
+    if (reducedMotion) {
+        Box(
+            Modifier
+                .size(size)
+                .border(1.5.dp, MaterialTheme.colorScheme.secondary, CircleShape),
+        )
+    } else {
+        LoadingIndicator(
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.size(size),
+        )
+    }
+}
+
+@Composable
+private fun FusionStepMark(state: FusionStepState, reducedMotion: Boolean) {
     Box(Modifier.size(18.dp), contentAlignment = Alignment.Center) {
         when (state) {
-            FusionStepState.Active -> LoadingIndicator(
-                color = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.size(16.dp),
-            )
+            FusionStepState.Active -> FusionBusyIndicator(reducedMotion = reducedMotion, size = 16.dp)
             FusionStepState.Done -> Box(
                 Modifier
                     .size(18.dp)
@@ -705,6 +745,7 @@ private fun FusionModelChips(
     models: List<String>,
     failed: List<String>,
     resolved: Boolean,
+    allFailed: Boolean = false,
 ) {
     val failedSet = remember(failed) { failed.map { it.lowercase() }.toSet() }
     Row(
@@ -716,7 +757,8 @@ private fun FusionModelChips(
     ) {
         models.forEach { model ->
             val isFailed = resolved && (
-                failedSet.contains(model.lowercase()) ||
+                allFailed ||
+                    failedSet.contains(model.lowercase()) ||
                     failed.any { model.endsWith(it) || it.endsWith(model) }
                 )
             Surface(

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -3,18 +3,19 @@
 package com.echoflow.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -24,9 +25,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lightbulb
@@ -37,7 +39,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
@@ -47,11 +48,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.echoflow.data.FusionAnalysis
+import com.echoflow.ui.theme.JetBrainsMono
 import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
-import kotlin.math.PI
-import kotlin.math.abs
-import kotlin.math.sin
+import com.echoflow.ui.theme.rememberReducedMotion
+import kotlinx.coroutines.delay
 
 /** Short, human label for an OpenRouter model id, e.g. "anthropic/claude-opus-4.8" → "claude-opus-4.8". */
 private fun shortModel(id: String): String = id.substringAfterLast('/').ifBlank { id }
@@ -365,13 +366,27 @@ fun AgentDeployingCard(modifier: Modifier = Modifier) {
 
 // ── Echo Fusion ─────────────────────────────────────────────────────────────────────────
 
+/** Honest process phases for a fusion turn. No fake per-model clocks mid-flight. */
+private enum class FusionStepState { Pending, Active, Done, Failed }
+
+private fun fusionRevealEnter(reducedMotion: Boolean): EnterTransition =
+    if (reducedMotion) fadeIn(tween(0)) else expandVertically(tween(300)) + fadeIn(tween(200))
+
+private fun fusionRevealExit(reducedMotion: Boolean): ExitTransition =
+    if (reducedMotion) fadeOut(tween(0)) else shrinkVertically(tween(240)) + fadeOut(tween(120))
+
 /**
- * One Echo Fusion deliberation in the reply timeline. While [active] it shows the real panel
- * roster as a travelling shimmer wave under a branded "deliberating" header. Once resolved it
- * becomes the headline ("synthesized from N models by <judge>") plus the judge's structured
- * comparison — consensus, disagreements, unique insights, blind spots — and an accordion of
- * every model's full answer. Fusion never picks a single winner; the judge blends them, which
- * the framing makes explicit.
+ * Echo Fusion process shell — Thinking header + Task rows + Tool chips, in EchoFlow chrome.
+ *
+ * While the panel is out ([active]) or the judge is about to write ([isStreaming] with analysis
+ * but no answer text yet), the shell stays open and steps advance honestly. Once the final
+ * answer has started ([answerStarted]) or the turn settles, it collapses like [ReasoningSection]
+ * so the chat body is only the synthesized answer. Expand anytime for the step replay,
+ * comparison digest, and per-model answers.
+ *
+ * @param active panel still waiting on the server tool (no analysis yet)
+ * @param isStreaming the assistant turn is still live
+ * @param answerStarted a [com.echoflow.ui.StreamSegment.Text] has appeared after this segment
  */
 @Composable
 fun FusionCard(
@@ -380,156 +395,483 @@ fun FusionCard(
     analysis: FusionAnalysis?,
     active: Boolean,
     modifier: Modifier = Modifier,
+    isStreaming: Boolean = false,
+    answerStarted: Boolean = false,
 ) {
+    val reducedMotion = rememberReducedMotion()
     val roster = analysis?.models?.takeIf { it.isNotEmpty() } ?: models
-    val judge = analysis?.judgeModel
+    // Live process: panel waiting, or tool returned but final answer not on screen yet.
+    val processLive = active || (analysis != null && isStreaming && !answerStarted)
+
+    var userToggled by remember { mutableStateOf<Boolean?>(null) }
+    val expanded = userToggled ?: processLive
+    val chevron by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(if (reducedMotion) 0 else 300),
+        label = "fusion-process-chevron",
+    )
+    val toggleInteraction = remember { MutableInteractionSource() }
+
+    // Elapsed clock while live; freezes when the process settles (Reasoning-weight meta).
+    val startMs = remember { System.currentTimeMillis() }
+    var elapsedMs by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(processLive) {
+        if (!processLive) return@LaunchedEffect
+        while (true) {
+            elapsedMs = (System.currentTimeMillis() - startMs).coerceAtLeast(0L)
+            delay(250)
+        }
+    }
+    // Capture final duration once when leaving live.
+    var settledMs by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(processLive, elapsedMs) {
+        if (!processLive && elapsedMs > 0L && settledMs == 0L) settledMs = elapsedMs
+    }
+    val durationLabel = when {
+        processLive && elapsedMs >= 1000L -> formatResearchDuration(elapsedMs)
+        !processLive && settledMs >= 1000L -> formatResearchDuration(settledMs)
+        else -> null
+    }
+
+    val panelState = when {
+        analysis == null && processLive -> FusionStepState.Active
+        analysis == null -> FusionStepState.Pending
+        analysis.failedModels.isNotEmpty() &&
+            analysis.responses.isEmpty() &&
+            analysis.failedModels.size >= roster.size.coerceAtLeast(1) -> FusionStepState.Failed
+        else -> FusionStepState.Done
+    }
+    val compareState = when {
+        analysis == null -> FusionStepState.Pending
+        processLive && !answerStarted -> FusionStepState.Done // comparison is tool result; answer is next
+        else -> FusionStepState.Done
+    }
+    val answerState = when {
+        answerStarted || (!processLive && analysis != null) -> FusionStepState.Done
+        analysis != null && processLive -> FusionStepState.Active
+        else -> FusionStepState.Pending
+    }
+
+    val statusLine = when {
+        analysis == null && processLive -> "Panel answering in parallel"
+        analysis != null && processLive && !answerStarted -> "Writing final answer"
+        else -> null
+    }
+
+    val headerTitle = when {
+        processLive -> {
+            val name = panelName.ifBlank { "Fusion" }
+            if (panelName.isNotBlank()) "Fusion · $name" else "Fusion"
+        }
+        else -> {
+            val n = roster.size.coerceAtLeast(models.size)
+            buildString {
+                append("Fused · $n model")
+                if (n != 1) append('s')
+            }
+        }
+    }
+
+    val panelMeta = when (panelState) {
+        FusionStepState.Active -> "${roster.size} model${if (roster.size == 1) "" else "s"}"
+        FusionStepState.Done -> {
+            val returned = analysis?.responses?.size ?: roster.size
+            val failed = analysis?.failedModels?.size ?: 0
+            buildString {
+                append("$returned returned")
+                if (failed > 0) append(" · $failed failed")
+            }
+        }
+        FusionStepState.Failed -> "Did not respond"
+        FusionStepState.Pending -> null
+    }
+    val compareMeta = analysis?.let { a ->
+        if (a.isEmpty && a.responses.isEmpty()) null
+        else buildString {
+            val parts = mutableListOf<String>()
+            if (a.consensus.isNotEmpty()) parts += "${a.consensus.size} agreed"
+            if (a.contradictions.isNotEmpty()) parts += "${a.contradictions.size} disagreed"
+            if (parts.isEmpty() && a.responses.isNotEmpty()) parts += "compared"
+            append(parts.joinToString(" · "))
+        }.takeIf { it.isNotBlank() }
+    }
+    val answerMeta = when (answerState) {
+        FusionStepState.Active -> "writing…"
+        else -> null
+    }
 
     Surface(
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.34f),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column(Modifier.padding(Spacing.base)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    Modifier.size(38.dp).clip(RoundedPolygonShape(MaterialShapes.Clover4Leaf))
-                        .background(MaterialTheme.colorScheme.secondary),
-                    contentAlignment = Alignment.Center,
-                ) { Icon(Icons.Default.AccountTree, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSecondary) }
-                Spacer(Modifier.width(Spacing.m))
-                Column(Modifier.weight(1f)) {
-                    ModeBadge("ECHO FUSION", MaterialTheme.colorScheme.secondary, MaterialTheme.colorScheme.onSecondary)
-                    Spacer(Modifier.height(3.dp))
-                    Text(
-                        if (panelName.isNotBlank()) panelName else "Fusion panel",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                    Text(
-                        if (active) "${roster.size} models deliberating…" else "Synthesized from ${roster.size} models",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
+            // Thinking-style header — open while live, collapses when the answer owns the turn.
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        interactionSource = toggleInteraction,
+                        indication = null,
+                        onClick = { userToggled = !expanded },
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.AccountTree,
+                    null,
+                    Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.secondary,
+                )
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    headerTitle,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (processLive) {
+                    Spacer(Modifier.width(Spacing.s))
+                    LoadingIndicator(
+                        color = MaterialTheme.colorScheme.secondary,
+                        modifier = Modifier.size(18.dp),
                     )
                 }
+                durationLabel?.let { dur ->
+                    Spacer(Modifier.width(Spacing.s))
+                    Text(
+                        dur,
+                        style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                }
+                Spacer(Modifier.width(Spacing.xs))
+                Icon(
+                    Icons.Default.KeyboardArrowDown,
+                    if (expanded) "Collapse" else "Expand",
+                    Modifier.size(20.dp).rotate(chevron),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
-            Spacer(Modifier.height(Spacing.m))
-            PanelRoster(roster, shimmer = active)
-
-            if (active) {
-                Spacer(Modifier.height(Spacing.m))
-                LinearWavyProgressIndicator(
-                    color = MaterialTheme.colorScheme.secondary,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Spacer(Modifier.height(Spacing.s))
+            if (statusLine != null) {
+                Spacer(Modifier.height(Spacing.xs))
                 Text(
-                    "Panel deliberating in parallel · the judge will synthesize their answers",
-                    style = MaterialTheme.typography.labelMedium,
+                    statusLine,
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            } else if (analysis != null) {
-                Spacer(Modifier.height(Spacing.m))
-                // Honest framing: the final answer below is a synthesis, not one model's reply.
-                Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.primaryContainer, modifier = Modifier.fillMaxWidth()) {
-                    Row(Modifier.padding(Spacing.m), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Default.Gavel, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onPrimaryContainer)
-                        Spacer(Modifier.width(Spacing.s))
-                        Text(
-                            buildString {
-                                append("Final answer synthesized from ${roster.size} models")
-                                judge?.takeIf { it.isNotBlank() }?.let { append(" by ${shortModel(it)}") }
-                            },
-                            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            }
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = fusionRevealEnter(reducedMotion),
+                exit = fusionRevealExit(reducedMotion),
+            ) {
+                Column(
+                    Modifier.padding(top = Spacing.m),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                ) {
+                    // Task-row steps with Research mark grammar (secondary accent).
+                    FusionProcessStep(
+                        label = "Panel",
+                        state = panelState,
+                        meta = panelMeta,
+                    )
+                    if (roster.isNotEmpty()) {
+                        FusionModelChips(
+                            models = roster,
+                            failed = analysis?.failedModels.orEmpty(),
+                            resolved = analysis != null,
                         )
                     }
+                    FusionProcessStep(
+                        label = "Compare",
+                        state = compareState,
+                        meta = compareMeta,
+                    )
+                    if (analysis != null && !analysis.isEmpty) {
+                        FusionCountChips(analysis)
+                    }
+                    FusionProcessStep(
+                        label = "Answer",
+                        state = answerState,
+                        meta = answerMeta,
+                    )
+
+                    // Settled expand only: full comparison + per-model answers stay optional depth.
+                    if (!processLive && analysis != null) {
+                        Spacer(Modifier.height(Spacing.xs))
+                        FusionDeliberation(analysis)
+                    }
                 }
-                FusionDeliberation(analysis)
             }
         }
     }
 }
 
-/**
- * The panel members as a horizontal strip of model chips. While [shimmer] they pulse as a
- * travelling wave (each chip phase-offset) so the panel reads as alive; once done each shows
- * a check. We can't observe true per-model completion in one request, so the wave is honest
- * "work in progress", not a fake per-model clock.
- */
 @Composable
-private fun PanelRoster(models: List<String>, shimmer: Boolean) {
-    val transition = rememberInfiniteTransition(label = "roster")
-    val phase by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(1400), RepeatMode.Restart),
-        label = "roster-phase",
-    )
+private fun FusionProcessStep(
+    label: String,
+    state: FusionStepState,
+    meta: String?,
+) {
+    val dimmed = state == FusionStepState.Pending
     Row(
-        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        Modifier
+            .fillMaxWidth()
+            .heightIn(min = 28.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FusionStepMark(state)
+        Spacer(Modifier.width(Spacing.s))
+        Text(
+            label,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = if (dimmed) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (meta != null) {
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                meta,
+                style = MaterialTheme.typography.labelSmall.copy(fontFamily = JetBrainsMono),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FusionStepMark(state: FusionStepState) {
+    Box(Modifier.size(18.dp), contentAlignment = Alignment.Center) {
+        when (state) {
+            FusionStepState.Active -> LoadingIndicator(
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.size(16.dp),
+            )
+            FusionStepState.Done -> Box(
+                Modifier
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = "Done",
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colorScheme.onSecondary,
+                )
+            }
+            FusionStepState.Failed -> Box(
+                Modifier
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.error),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = "Failed",
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colorScheme.onError,
+                )
+            }
+            FusionStepState.Pending -> Box(
+                Modifier
+                    .size(14.dp)
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape),
+            )
+        }
+    }
+}
+
+/** Tool-chip density for the panel roster — labels only; checks only after resolve. */
+@Composable
+private fun FusionModelChips(
+    models: List<String>,
+    failed: List<String>,
+    resolved: Boolean,
+) {
+    val failedSet = remember(failed) { failed.map { it.lowercase() }.toSet() }
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(start = 18.dp + Spacing.s)
+            .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
     ) {
-        models.forEachIndexed { index, model ->
-            val wave = 0.4f + 0.6f * abs(sin(PI * (phase + index * 0.18f)).toFloat())
+        models.forEach { model ->
+            val isFailed = resolved && (
+                failedSet.contains(model.lowercase()) ||
+                    failed.any { model.endsWith(it) || it.endsWith(model) }
+                )
             Surface(
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier.alpha(if (shimmer) wave else 1f),
             ) {
                 Row(
-                    Modifier.padding(start = Spacing.s, end = Spacing.m, top = 5.dp, bottom = 5.dp),
+                    Modifier.padding(start = Spacing.s, end = Spacing.m, top = 4.dp, bottom = 4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        if (shimmer) Icons.Default.Bolt else Icons.Default.CheckCircle,
-                        null, Modifier.size(13.dp), tint = MaterialTheme.colorScheme.secondary,
+                    if (resolved) {
+                        Icon(
+                            if (isFailed) Icons.Default.Close else Icons.Default.Check,
+                            null,
+                            Modifier.size(12.dp),
+                            tint = if (isFailed) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.secondary
+                            },
+                        )
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    Text(
+                        shortModel(model),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
                     )
-                    Spacer(Modifier.width(4.dp))
-                    Text(shortModel(model), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurface, maxLines = 1)
                 }
             }
         }
     }
 }
 
-/** The resolved fusion body: a collapsible deliberation digest + a per-model answers accordion. */
+/** Compact count chips after compare (agreed / disagreed) — not a full report. */
+@Composable
+private fun FusionCountChips(analysis: FusionAnalysis) {
+    val chips = buildList {
+        if (analysis.consensus.isNotEmpty()) add("${analysis.consensus.size} agreed")
+        if (analysis.contradictions.isNotEmpty()) add("${analysis.contradictions.size} disagreed")
+        if (analysis.uniqueInsights.isNotEmpty()) add("${analysis.uniqueInsights.size} unique")
+        if (analysis.blindSpots.isNotEmpty()) add("${analysis.blindSpots.size} gaps")
+    }
+    if (chips.isEmpty()) return
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(start = 18.dp + Spacing.s)
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        chips.forEach { label ->
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            ) {
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = Spacing.m, vertical = 4.dp),
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+/** Expanded settled depth: comparison digest + per-model answers (not the default surface). */
 @Composable
 private fun FusionDeliberation(analysis: FusionAnalysis) {
-    Column(Modifier.padding(top = Spacing.m), verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
         if (!analysis.isEmpty) {
-            var open by remember { mutableStateOf(true) }
-            val chevron by animateFloatAsState(if (open) 180f else 0f, label = "fusion-delib-chevron")
+            var open by remember { mutableStateOf(false) }
+            val reducedMotion = rememberReducedMotion()
+            val chevron by animateFloatAsState(
+                targetValue = if (open) 180f else 0f,
+                animationSpec = tween(if (reducedMotion) 0 else 300),
+                label = "fusion-delib-chevron",
+            )
             Surface(
                 onClick = { open = !open },
                 shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Row(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.AutoMirrored.Filled.CompareArrows, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                Row(
+                    Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.CompareArrows,
+                        null,
+                        Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.secondary,
+                    )
                     Spacer(Modifier.width(Spacing.s))
-                    Text("How the panel compared", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
-                    Icon(Icons.Default.KeyboardArrowDown, if (open) "Collapse" else "Expand", Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(
+                        "How the panel compared",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(
+                        Icons.Default.KeyboardArrowDown,
+                        if (open) "Collapse" else "Expand",
+                        Modifier.size(20.dp).rotate(chevron),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
-            AnimatedVisibility(visible = open, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+            AnimatedVisibility(
+                visible = open,
+                enter = fusionRevealEnter(reducedMotion),
+                exit = fusionRevealExit(reducedMotion),
+            ) {
                 Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
                     if (analysis.consensus.isNotEmpty()) {
-                        FusionSection("Consensus", Icons.Default.CheckCircle, MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onPrimaryContainer) {
+                        FusionSection(
+                            "Consensus",
+                            Icons.Default.CheckCircle,
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.onPrimaryContainer,
+                        ) {
                             BulletList(analysis.consensus, MaterialTheme.colorScheme.onPrimaryContainer)
                         }
                     }
                     if (analysis.contradictions.isNotEmpty()) {
-                        FusionSection("Disagreements", Icons.AutoMirrored.Filled.CompareArrows, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer) {
+                        FusionSection(
+                            "Disagreements",
+                            Icons.AutoMirrored.Filled.CompareArrows,
+                            MaterialTheme.colorScheme.errorContainer,
+                            MaterialTheme.colorScheme.onErrorContainer,
+                        ) {
                             Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
                                 analysis.contradictions.forEach { c ->
                                     Column {
-                                        Text(c.topic, style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold), color = MaterialTheme.colorScheme.onErrorContainer)
+                                        Text(
+                                            c.topic,
+                                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                            color = MaterialTheme.colorScheme.onErrorContainer,
+                                        )
                                         c.stances.forEach { stance ->
                                             Row(Modifier.padding(top = 2.dp)) {
-                                                Text("⟂  ", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-                                                Text(stance, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer)
+                                                Text(
+                                                    "⟂  ",
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.error,
+                                                )
+                                                Text(
+                                                    stance,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                                )
                                             }
                                         }
                                     }
@@ -538,21 +880,39 @@ private fun FusionDeliberation(analysis: FusionAnalysis) {
                         }
                     }
                     if (analysis.uniqueInsights.isNotEmpty()) {
-                        FusionSection("Unique insights", Icons.Default.Lightbulb, MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer) {
+                        FusionSection(
+                            "Unique insights",
+                            Icons.Default.Lightbulb,
+                            MaterialTheme.colorScheme.tertiaryContainer,
+                            MaterialTheme.colorScheme.onTertiaryContainer,
+                        ) {
                             Column(verticalArrangement = Arrangement.spacedBy(Spacing.s)) {
                                 analysis.uniqueInsights.forEach { i ->
                                     Column {
                                         if (i.model.isNotBlank()) {
-                                            Text(shortModel(i.model), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
+                                            Text(
+                                                shortModel(i.model),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.tertiary,
+                                            )
                                         }
-                                        Text(i.insight, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onTertiaryContainer)
+                                        Text(
+                                            i.insight,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                        )
                                     }
                                 }
                             }
                         }
                     }
                     if (analysis.blindSpots.isNotEmpty()) {
-                        FusionSection("Blind spots", Icons.Default.VisibilityOff, MaterialTheme.colorScheme.surfaceContainerHighest, MaterialTheme.colorScheme.onSurface) {
+                        FusionSection(
+                            "Blind spots",
+                            Icons.Default.VisibilityOff,
+                            MaterialTheme.colorScheme.surfaceContainerHighest,
+                            MaterialTheme.colorScheme.onSurface,
+                        ) {
                             BulletList(analysis.blindSpots, MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
@@ -610,7 +970,12 @@ private fun BulletList(items: List<String>, color: Color) {
 @Composable
 private fun ModelResponsesDisclosure(analysis: FusionAnalysis) {
     var expanded by remember { mutableStateOf(false) }
-    val chevron by animateFloatAsState(if (expanded) 180f else 0f, label = "fusion-resp-chevron")
+    val reducedMotion = rememberReducedMotion()
+    val chevron by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(if (reducedMotion) 0 else 300),
+        label = "fusion-resp-chevron",
+    )
     Surface(
         onClick = { expanded = !expanded },
         shape = MaterialTheme.shapes.large,
@@ -619,7 +984,12 @@ private fun ModelResponsesDisclosure(analysis: FusionAnalysis) {
     ) {
         Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.AutoAwesome, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                Icon(
+                    Icons.Default.AutoAwesome,
+                    null,
+                    Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.secondary,
+                )
                 Spacer(Modifier.width(Spacing.s))
                 Text(
                     "Each model's answer · ${analysis.responses.size}",
@@ -627,10 +997,22 @@ private fun ModelResponsesDisclosure(analysis: FusionAnalysis) {
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                 )
-                Icon(Icons.Default.KeyboardArrowDown, if (expanded) "Collapse" else "Expand", Modifier.size(20.dp).rotate(chevron), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(
+                    Icons.Default.KeyboardArrowDown,
+                    if (expanded) "Collapse" else "Expand",
+                    Modifier.size(20.dp).rotate(chevron),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
-            AnimatedVisibility(visible = expanded, enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
-                Column(Modifier.padding(top = Spacing.s), verticalArrangement = Arrangement.spacedBy(Spacing.m)) {
+            AnimatedVisibility(
+                visible = expanded,
+                enter = fusionRevealEnter(reducedMotion),
+                exit = fusionRevealExit(reducedMotion),
+            ) {
+                Column(
+                    Modifier.padding(top = Spacing.s),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.m),
+                ) {
                     analysis.responses.forEachIndexed { index, resp ->
                         Column {
                             Surface(shape = CircleShape, color = MaterialTheme.colorScheme.secondaryContainer) {
@@ -638,9 +1020,18 @@ private fun ModelResponsesDisclosure(analysis: FusionAnalysis) {
                                     Modifier.padding(start = Spacing.s, end = Spacing.m, top = 4.dp, bottom = 4.dp),
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    Icon(Icons.Default.Bolt, null, Modifier.size(13.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer)
+                                    Icon(
+                                        Icons.Default.Bolt,
+                                        null,
+                                        Modifier.size(13.dp),
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
                                     Spacer(Modifier.width(4.dp))
-                                    Text(shortModel(resp.model), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSecondaryContainer)
+                                    Text(
+                                        shortModel(resp.model),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
                                 }
                             }
                             Spacer(Modifier.height(Spacing.xs))

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -313,11 +313,18 @@ internal fun StreamingAssistantBubble(
                         Spacer(Modifier.height(Spacing.s))
                     }
                     is StreamSegment.Fusion -> {
+                        // Collapse the process shell once final answer text appears after this
+                        // segment — same hierarchy as Reasoning (process yields to the answer).
+                        val answerStarted = segments
+                            .subList(index + 1, segments.size)
+                            .any { it is StreamSegment.Text && it.text.isNotBlank() }
                         FusionCard(
                             panelName = segment.panelName,
                             models = segment.models,
                             analysis = segment.analysis,
                             active = segment.active,
+                            isStreaming = isStreaming,
+                            answerStarted = answerStarted,
                         )
                         Spacer(Modifier.height(Spacing.s))
                     }
@@ -628,11 +635,15 @@ private fun AssistantAnswerBody(
                     }
                     "fusion" -> {
                         segment.fusion?.let { f ->
+                            // History: process settled; default collapsed so only the final
+                            // answer body reads as the reply. Expand for steps / panel answers.
                             FusionCard(
                                 panelName = f.panelName,
                                 models = f.models,
                                 analysis = f,
                                 active = false,
+                                isStreaming = false,
+                                answerStarted = true,
                             )
                             Spacer(Modifier.height(Spacing.s))
                         }


### PR DESCRIPTION
## Summary
- Replaces the static Echo Fusion loader card with a process shell inspired by Thinking / Task rows / Tool chips, rendered in EchoFlow's Reasoning + Research design language
- Live: open header with elapsed time, Panel -> Compare -> Answer steps, model chips (honest — no fake per-model completion mid-flight)
- Settled: auto-collapses when final answer text starts so the reply is one answer; expand for comparison digest and per-model answers

## Test plan
- [ ] Enable Echo Fusion, pick a panel with 2+ models, send a prompt
- [ ] While waiting: process shell is open with Panel active, model chips, elapsed time (not a blank wavy loader)
- [ ] After tool returns: Panel/Compare complete, Answer shows writing, then shell collapses when answer streams
- [ ] Default finished turn shows collapsed `Fused · N models` + final answer only
- [ ] Expand settled shell: steps, count chips, optional comparison + each model's answer
- [ ] Open an older fusion message in history: process collapsed by default
- [ ] Reduced-motion system setting: expand/collapse without long motion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible fusion timelines showing panel, comparison, and answer phases.
  * Added live status, elapsed time, model indicators, failure states, and comparison counts.
  * Detailed deliberation now appears after processing settles.
  * Added reduced-motion support for smoother, accessible transitions.

* **Improvements**
  * Fusion cards now adapt during streaming and collapse once responses progress.
  * Updated model-response and deliberation disclosures with clearer layouts and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The redesign gives Echo Fusion a clearer product identity and honestly separates panel work, comparison, and answer generation without inventing per-model progress. I especially liked the automatic handoff from the expanded live process to the collapsed final answer; the implementation could be improved further with automated Compose UI coverage for live, failed, settled, history, and reduced-motion states.
- Replaces the static fusion loader with a collapsible three-phase process shell.
- Adds elapsed time, model and comparison chips, failure presentation, and expandable deliberation details.
- Corrects the previously reported total-failure, structured-analysis, and reduced-motion states.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt | Introduces the Fusion process shell and now consistently represents successful structured analysis, total panel failure, settled details, and reduced-motion states. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Connects streaming answer detection and settled history rendering to the Fusion shell’s automatic expansion and collapse behavior. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fusion starts] --> B[Panel active]
    B --> C{Analysis returned?}
    C -- No --> B
    C -- Yes, unusable --> D[Panel / Compare / Answer failed]
    C -- Yes, usable --> E[Panel and Compare complete]
    E --> F{Answer text started?}
    F -- No --> G[Answer writing]
    F -- Yes --> H[Collapse process shell]
    H --> I[Final answer]
    I --> J[User may expand deliberation]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix false Fusion panel-failure when anal..."](https://github.com/adityavardhansharma/echoflow/commit/3b42e4f9e634700fac6dc9a2f57e5c983702ce24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52554447)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->