### PR TITLE
Fix Fusion false failure and single-invoke API usage

### DIFF
--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -174,9 +174,9 @@ data class FusionAnalysis(
      */
     val toolResultFound: Boolean = true,
     /**
-     * True when Echo Fusion was required (user opted in) but the outer model still never
-     * produced a fusion tool payload after force + retry. The UI must disclose this — a plain
-     * answer without deliberation is not a successful fuse.
+     * True when Echo Fusion was required (user opted in) but the outer model never produced a
+     * fusion tool payload after the forced call. The UI must disclose this — a plain answer
+     * without deliberation is not a successful fuse.
      */
     val deliberationSkipped: Boolean = false,
 ) {

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -196,9 +196,19 @@ data class FusionAnalysis(
     val isHardFailure: Boolean
         get() = toolResultFound && !hasUsableDetail && failedModels.isNotEmpty()
 
-    /** Panel never deliberated (skipped or missing tool payload). */
+    /**
+     * True only when deliberation was never invoked (not merely unparsed).
+     * Unparsed payloads keep [deliberationSkipped] false so the UI does not claim "panel did not run".
+     */
     val panelDidNotRun: Boolean
-        get() = deliberationSkipped || !toolResultFound
+        get() = deliberationSkipped
+
+    /**
+     * Fusion tool was used (or we expect it was) but we could not decode structured panel detail.
+     * Distinct from [panelDidNotRun].
+     */
+    val detailUnparsed: Boolean
+        get() = !toolResultFound && !deliberationSkipped
 }
 
 /**

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -170,10 +170,15 @@ data class FusionAnalysis(
     val failedModels: List<String> = emptyList(),
     /**
      * False when the HTTP response finished but we never located a fusion tool payload.
-     * That is **not** a panel failure — the outer model may still stream a full answer.
      * Defaults to true so older persisted rows keep previous behavior.
      */
     val toolResultFound: Boolean = true,
+    /**
+     * True when Echo Fusion was required (user opted in) but the outer model still never
+     * produced a fusion tool payload after force + retry. The UI must disclose this — a plain
+     * answer without deliberation is not a successful fuse.
+     */
+    val deliberationSkipped: Boolean = false,
 ) {
     /** True when the judge produced no structured analysis (only raw panel responses, or nothing). */
     val isEmpty: Boolean
@@ -186,11 +191,14 @@ data class FusionAnalysis(
 
     /**
      * Hard panel failure: we found a tool result and it has no usable content, with explicit
-     * failed models (or a completely empty tool payload after a successful locate).
-     * Unparsed results ([toolResultFound] = false) are never treated as failure.
+     * failed models. Unparsed / skipped results are handled separately in the UI.
      */
     val isHardFailure: Boolean
         get() = toolResultFound && !hasUsableDetail && failedModels.isNotEmpty()
+
+    /** Panel never deliberated (skipped or missing tool payload). */
+    val panelDidNotRun: Boolean
+        get() = deliberationSkipped || !toolResultFound
 }
 
 /**

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -168,11 +168,29 @@ data class FusionAnalysis(
     val blindSpots: List<String> = emptyList(),
     val responses: List<FusionResponse> = emptyList(),
     val failedModels: List<String> = emptyList(),
+    /**
+     * False when the HTTP response finished but we never located a fusion tool payload.
+     * That is **not** a panel failure — the outer model may still stream a full answer.
+     * Defaults to true so older persisted rows keep previous behavior.
+     */
+    val toolResultFound: Boolean = true,
 ) {
     /** True when the judge produced no structured analysis (only raw panel responses, or nothing). */
     val isEmpty: Boolean
         get() = consensus.isEmpty() && contradictions.isEmpty() && partialCoverage.isEmpty() &&
             uniqueInsights.isEmpty() && blindSpots.isEmpty()
+
+    /** Any structured or raw panel signal we can show in the process shell. */
+    val hasUsableDetail: Boolean
+        get() = !isEmpty || responses.isNotEmpty()
+
+    /**
+     * Hard panel failure: we found a tool result and it has no usable content, with explicit
+     * failed models (or a completely empty tool payload after a successful locate).
+     * Unparsed results ([toolResultFound] = false) are never treated as failure.
+     */
+    val isHardFailure: Boolean
+        get() = toolResultFound && !hasUsableDetail && failedModels.isNotEmpty()
 }
 
 /**

--- a/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
@@ -129,6 +129,47 @@ internal object OpenRouterEchoDecoder {
         return results.firstOrNull()
     }
 
+    /**
+     * True when the response tree shows the outer model requested fusion (tool call name /
+     * type contains "fusion"), even if we cannot decode the tool result body. Used to avoid
+     * labeling an unparsed success as "panel did not run".
+     */
+    fun responseMentionsFusionInvocation(node: Any?, depth: Int = 0): Boolean {
+        if (depth > 10) return false
+        when (node) {
+            is Map<*, *> -> {
+                val type = (node["type"] as? String).orEmpty()
+                val name = (node["name"] as? String)
+                    ?: ((node["function"] as? Map<*, *>)?.get("name") as? String).orEmpty()
+                if (type.contains("fusion", ignoreCase = true) || name.contains("fusion", ignoreCase = true)) {
+                    return true
+                }
+                // tool_calls arrays often sit under message
+                (node["tool_calls"] as? List<*>)?.let { list ->
+                    if (list.any { responseMentionsFusionInvocation(it, depth + 1) }) return true
+                }
+                for (v in node.values) {
+                    if (responseMentionsFusionInvocation(v, depth + 1)) return true
+                }
+            }
+            is List<*> -> for (v in node) {
+                if (responseMentionsFusionInvocation(v, depth + 1)) return true
+            }
+            is String -> if (node.contains("fusion", ignoreCase = true) &&
+                (node.contains("openrouter", ignoreCase = true) || node.contains("tool", ignoreCase = true))
+            ) {
+                // Avoid matching random prose; require tool-ish context.
+                if (node.contains("openrouter:fusion") ||
+                    node.contains("openrouter_fusion") ||
+                    node.contains("\"fusion\"")
+                ) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     fun buildFusionAnalysis(result: Map<*, *>): FusionAnalysis {
         val analysis = result["analysis"] as? Map<*, *>
         fun strList(key: String): List<String> =

--- a/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
@@ -63,23 +63,42 @@ internal object OpenRouterEchoDecoder {
 
     fun isFusionResponseList(list: List<*>?): Boolean =
         list != null && list.isNotEmpty() && list.all {
-            (it as? Map<*, *>)?.containsKey("content") == true && (it as? Map<*, *>)?.containsKey("model") == true
+            val m = it as? Map<*, *> ?: return@all false
+            m.containsKey("content") && (m.containsKey("model") || m.containsKey("model_id"))
         }
 
-    /** Walks an SSE chunk for a fusion result `{analysis?, responses?, failed_models?}`. */
+    private fun looksLikeFusionPayload(node: Map<*, *>): Boolean {
+        if (node["analysis"] is Map<*, *>) return true
+        if (isFusionResponseList(node["responses"] as? List<*>)) return true
+        if (node["failed_models"] is List<*> && (node["status"] as? String) == "error") return true
+        // status:ok with only failed_models / empty responses still counts as a located tool result
+        if ((node["status"] as? String) == "ok" &&
+            (node.containsKey("responses") || node.containsKey("analysis") || node.containsKey("failed_models"))
+        ) {
+            return true
+        }
+        return false
+    }
+
+    /** Walks a response for a fusion result `{analysis?, responses?, failed_models?, status?}`. */
     fun scanForFusionResult(node: Any?, depth: Int = 0): FusionAnalysis? {
-        if (depth > 8) return null
+        if (depth > 10) return null
         when (node) {
             is Map<*, *> -> {
-                val analysisObj = node["analysis"] as? Map<*, *>
-                val responses = node["responses"] as? List<*>
-                if (analysisObj != null || isFusionResponseList(responses)) {
+                if (looksLikeFusionPayload(node)) {
                     return buildFusionAnalysis(node)
                 }
-                (node["content"] as? String)?.let { c ->
-                    parseMaybeJson(c)?.let { scanForFusionResult(it, depth + 1)?.let { r -> return r } }
+                // Tool message content is often a JSON string; also try "text" / "output" aliases.
+                listOf("content", "text", "output", "result", "arguments").forEach { key ->
+                    when (val v = node[key]) {
+                        is String -> parseMaybeJson(v)?.let { scanForFusionResult(it, depth + 1)?.let { r -> return r } }
+                        else -> scanForFusionResult(v, depth + 1)?.let { return it }
+                    }
                 }
-                for (v in node.values) scanForFusionResult(v, depth + 1)?.let { return it }
+                for ((k, v) in node) {
+                    if (k == "content" || k == "text" || k == "output" || k == "result" || k == "arguments") continue
+                    scanForFusionResult(v, depth + 1)?.let { return it }
+                }
             }
             is List<*> -> for (v in node) scanForFusionResult(v, depth + 1)?.let { return it }
         }
@@ -94,7 +113,16 @@ internal object OpenRouterEchoDecoder {
         val contradictions = (analysis?.get("contradictions") as? List<*>)?.mapNotNull { raw ->
             val m = raw as? Map<*, *> ?: return@mapNotNull null
             val topic = m["topic"] as? String ?: return@mapNotNull null
-            val stances = (m["stances"] as? List<*>)?.map { it.toString() } ?: emptyList()
+            val stances = (m["stances"] as? List<*>)?.map { stance ->
+                when (stance) {
+                    is Map<*, *> -> {
+                        val model = (stance["model"] as? String).orEmpty()
+                        val text = (stance["stance"] as? String) ?: stance["text"] as? String ?: stance.toString()
+                        if (model.isNotBlank()) "$model: $text" else text
+                    }
+                    else -> stance.toString()
+                }
+            } ?: emptyList()
             FusionContradiction(topic, stances)
         } ?: emptyList()
 
@@ -115,10 +143,17 @@ internal object OpenRouterEchoDecoder {
         val responses = (result["responses"] as? List<*>)?.mapNotNull { raw ->
             val m = raw as? Map<*, *> ?: return@mapNotNull null
             val content = m["content"] as? String ?: return@mapNotNull null
-            FusionResponse((m["model"] as? String).orEmpty(), content)
+            val model = (m["model"] as? String) ?: (m["model_id"] as? String).orEmpty()
+            FusionResponse(model, content)
         } ?: emptyList()
 
-        val failed = (result["failed_models"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+        val failed = (result["failed_models"] as? List<*>)?.mapNotNull { item ->
+            when (item) {
+                is String -> item
+                is Map<*, *> -> (item["model"] as? String) ?: (item["id"] as? String)
+                else -> null
+            }
+        } ?: emptyList()
 
         return FusionAnalysis(
             panelName = "",
@@ -131,6 +166,7 @@ internal object OpenRouterEchoDecoder {
             blindSpots = strList("blind_spots"),
             responses = responses,
             failedModels = failed,
+            toolResultFound = true,
         )
     }
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt
@@ -68,11 +68,20 @@ internal object OpenRouterEchoDecoder {
         }
 
     private fun looksLikeFusionPayload(node: Map<*, *>): Boolean {
+        val status = node["status"] as? String
+        val failureReason = node["failure_reason"] as? String
+        // A second fusion call in the same turn is rejected — never treat that as the panel result.
+        if (status == "error" && failureReason == "fusion_invocation_capped") return false
+
         if (node["analysis"] is Map<*, *>) return true
         if (isFusionResponseList(node["responses"] as? List<*>)) return true
-        if (node["failed_models"] is List<*> && (node["status"] as? String) == "error") return true
+        if (node["failed_models"] is List<*> && status == "error") return true
+        // Explicit hard failures from the fusion tool (all panels failed, credits, etc.).
+        if (status == "error" && failureReason != null && failureReason != "fusion_invocation_capped") {
+            return true
+        }
         // status:ok with only failed_models / empty responses still counts as a located tool result
-        if ((node["status"] as? String) == "ok" &&
+        if (status == "ok" &&
             (node.containsKey("responses") || node.containsKey("analysis") || node.containsKey("failed_models"))
         ) {
             return true
@@ -80,29 +89,44 @@ internal object OpenRouterEchoDecoder {
         return false
     }
 
-    /** Walks a response for a fusion result `{analysis?, responses?, failed_models?, status?}`. */
-    fun scanForFusionResult(node: Any?, depth: Int = 0): FusionAnalysis? {
-        if (depth > 10) return null
+    /** Walks a response for the first fusion result (prefer [selectPreferredFusionResult] for multi-hit). */
+    fun scanForFusionResult(node: Any?, depth: Int = 0): FusionAnalysis? =
+        selectPreferredFusionResult(scanForAllFusionResults(node, depth))
+
+    /**
+     * Collects every fusion tool payload in the response tree. A single turn can contain a
+     * successful first result and a later `fusion_invocation_capped` error if the model
+     * re-invokes the tool — callers should prefer the successful payload.
+     */
+    fun scanForAllFusionResults(node: Any?, depth: Int = 0, out: MutableList<FusionAnalysis> = mutableListOf()): List<FusionAnalysis> {
+        if (depth > 10) return out
         when (node) {
             is Map<*, *> -> {
                 if (looksLikeFusionPayload(node)) {
-                    return buildFusionAnalysis(node)
+                    out.add(buildFusionAnalysis(node))
                 }
-                // Tool message content is often a JSON string; also try "text" / "output" aliases.
                 listOf("content", "text", "output", "result", "arguments").forEach { key ->
                     when (val v = node[key]) {
-                        is String -> parseMaybeJson(v)?.let { scanForFusionResult(it, depth + 1)?.let { r -> return r } }
-                        else -> scanForFusionResult(v, depth + 1)?.let { return it }
+                        is String -> parseMaybeJson(v)?.let { scanForAllFusionResults(it, depth + 1, out) }
+                        else -> scanForAllFusionResults(v, depth + 1, out)
                     }
                 }
                 for ((k, v) in node) {
                     if (k == "content" || k == "text" || k == "output" || k == "result" || k == "arguments") continue
-                    scanForFusionResult(v, depth + 1)?.let { return it }
+                    scanForAllFusionResults(v, depth + 1, out)
                 }
             }
-            is List<*> -> for (v in node) scanForFusionResult(v, depth + 1)?.let { return it }
+            is List<*> -> for (v in node) scanForAllFusionResults(v, depth + 1, out)
         }
-        return null
+        return out
+    }
+
+    /** Prefer a usable panel/analysis payload over empty or hard-failure shells. */
+    fun selectPreferredFusionResult(results: List<FusionAnalysis>): FusionAnalysis? {
+        if (results.isEmpty()) return null
+        results.firstOrNull { it.hasUsableDetail }?.let { return it }
+        results.firstOrNull { it.toolResultFound && !it.isHardFailure }?.let { return it }
+        return results.firstOrNull()
     }
 
     fun buildFusionAnalysis(result: Map<*, *>): FusionAnalysis {
@@ -155,6 +179,12 @@ internal object OpenRouterEchoDecoder {
             }
         } ?: emptyList()
 
+        // When the tool returns a hard error with no per-model list, still mark as found so UI
+        // can show failure — except fusion_invocation_capped, which is filtered earlier.
+        val status = result["status"] as? String
+        val failureReason = result["failure_reason"] as? String
+        val hardError = status == "error" && failureReason != null && failureReason != "fusion_invocation_capped"
+
         return FusionAnalysis(
             panelName = "",
             judgeModel = null,
@@ -165,7 +195,11 @@ internal object OpenRouterEchoDecoder {
             uniqueInsights = insights,
             blindSpots = strList("blind_spots"),
             responses = responses,
-            failedModels = failed,
+            failedModels = when {
+                failed.isNotEmpty() -> failed
+                hardError -> listOf(failureReason ?: "error")
+                else -> emptyList()
+            },
             toolResultFound = true,
         )
     }

--- a/app/src/main/java/com/echoflow/data/OpenRouterPayloads.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterPayloads.kt
@@ -12,9 +12,12 @@ internal object OpenRouterPayloads {
         history.any { it.role == "user" && it.localAttachmentUri != null && isPdf(it.localAttachmentMimeType) }
 
     fun enablePdfPlugin(request: MutableMap<String, Any>, enabled: Boolean) {
-        if (enabled) request["plugins"] = listOf(
-            mapOf("id" to "file-parser", "pdf" to mapOf("engine" to "cloudflare-ai"))
-        )
+        if (!enabled) return
+        val pdfPlugin = mapOf("id" to "file-parser", "pdf" to mapOf("engine" to "cloudflare-ai"))
+        @Suppress("UNCHECKED_CAST")
+        val existing = (request["plugins"] as? List<*>)?.filterIsInstance<Map<String, Any>>().orEmpty()
+        // Merge so callers that already set plugins (e.g. fusion) keep them.
+        request["plugins"] = existing + pdfPlugin
     }
 
     fun messages(

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -606,7 +606,13 @@ class OpenRouterService(private val context: Context) {
                 throw Exception(
                     "Echo Fusion did not run your panel. Try again — multi-model deliberation is required in this mode.",
                 )
-            } else if (!analysis.hasUsableDetail) {
+            } else if (analysis.hasUsableDetail || analysis.detailUnparsed) {
+                // Panel ran (or at least was invoked) but neither the tool turn nor the
+                // no-tools synthesis produced a final answer.
+                throw Exception(
+                    "Echo Fusion finished the panel but returned no final answer. Try again.",
+                )
+            } else {
                 throw Exception("No response content received from Echo Fusion.")
             }
             return@flow
@@ -696,19 +702,22 @@ class OpenRouterService(private val context: Context) {
             ),
         )
         val parsed = preferredFusionFrom(response)
-
-        val deliberationSkipped = parsed == null
+        // Distinguish "never called fusion" from "called fusion but we couldn't decode the body".
+        val fusionInvoked = parsed != null ||
+            OpenRouterEchoDecoder.responseMentionsFusionInvocation(response)
+        val deliberationSkipped = !fusionInvoked
         val analysis = (parsed ?: FusionAnalysis(
             panelName = fusion.panelName,
             judgeModel = fusion.judge,
             models = fusion.models,
             toolResultFound = false,
-            deliberationSkipped = true,
+            deliberationSkipped = deliberationSkipped,
         )).copy(
             panelName = fusion.panelName,
             judgeModel = fusion.judge ?: parsed?.judgeModel,
             models = fusion.models.ifEmpty { parsed?.models ?: emptyList() },
             toolResultFound = parsed != null,
+            // Only a true skip when there is no evidence the tool was requested/returned.
             deliberationSkipped = deliberationSkipped,
         )
 
@@ -719,8 +728,9 @@ class OpenRouterService(private val context: Context) {
             ?: (message?.get("reasoning_content") as? String)).orEmpty().trim()
         var annotations = message?.get("annotations") as? List<*>
 
-        // Panel ran but no user-facing answer (common when the model only emitted the tool result).
-        // Synthesize from the panel result with tools disabled so fusion cannot be invoked again.
+        // Panel detail available but no user-facing answer (common when the model only emitted
+        // the tool result, or after a capped second fusion call left content empty).
+        // Synthesize with tools disabled so fusion cannot be invoked again.
         if (answer.isBlank() && analysis.hasUsableDetail) {
             val synth = postForResponse(
                 apiKey,

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -562,17 +562,15 @@ class OpenRouterService(private val context: Context) {
     data class FusionRequest(val panelName: String, val models: List<String>, val judge: String?)
 
     /**
-     * Echo Adviser / Echo Fusion. Both are OpenRouter-only server tools forced via
-     * `tool_choice: "required"` (the user opted into the cost-heavy mode from "+"). Unlike
-     * normal chat these use a **non-streaming** request: the server-tool result (the advice /
-     * the panel analysis) is only delivered in the documented final response, and a single
-     * round-trip lets us lay the timeline out deterministically — Echo card → reasoning →
-     * answer — so reasoning can never trail the answer the way the streamed loop did.
+     * Echo Adviser / Echo Fusion. OpenRouter-only server tools. Non-streaming so the tool
+     * result and final answer can be ordered deterministically (Echo card → reasoning → answer).
      *
-     * We still drive a live experience: the consult/deliberation card is announced immediately
-     * (so the distinct "Echo is running" UI shows during the wait), then the structured result
-     * populates it, then the final answer is revealed with a paced typewriter so it reads as a
-     * live stream. The model resolves as: advisor → the answering model; fusion → the judge.
+     * **Fusion guarantee:** the user opted into a named panel. We force fusion with
+     * `tool_choice: "required"`, retry once if no tool payload appears, and if the panel ran
+     * but the model left no final text (e.g. after a capped second fusion call), we synthesize
+     * the answer in a follow-up request **without** tools. A silent single-model reply without
+     * deliberation is never treated as a successful fuse — the UI is told via
+     * [FusionAnalysis.deliberationSkipped].
      */
     fun sendWithEchoTools(
         apiKey: String,
@@ -587,8 +585,35 @@ class OpenRouterService(private val context: Context) {
             throw Exception("API key is missing! Please configure it in your Settings.")
         }
 
-        val tools = mutableListOf<Map<String, Any>>()
+        // ── Fusion path (guaranteed single panel deliberation) ─────────────────────────
+        if (fusion != null) {
+            emit(StreamChunk.FusionStarted(fusion.panelName, fusion.models))
+            val (analysis, answer, reasoning, annotations) = runFusionWithGuarantee(
+                apiKey = apiKey,
+                model = model,
+                history = history,
+                systemPrompt = systemPrompt,
+                fusion = fusion,
+                params = params,
+            )
+            emit(StreamChunk.FusionResolved(analysis))
+            emitAnnotationsAsSearch(annotations)
+            if (reasoning.isNotBlank()) emit(StreamChunk.Reasoning(reasoning))
+            if (answer.isNotBlank()) {
+                // May still be a single-model reply if deliberation was skipped — UI discloses that.
+                emitPacedContent(answer)
+            } else if (analysis.panelDidNotRun) {
+                throw Exception(
+                    "Echo Fusion did not run your panel. Try again — multi-model deliberation is required in this mode.",
+                )
+            } else if (!analysis.hasUsableDetail) {
+                throw Exception("No response content received from Echo Fusion.")
+            }
+            return@flow
+        }
 
+        // ── Adviser path ───────────────────────────────────────────────────────────────
+        val tools = mutableListOf<Map<String, Any>>()
         if (advisor != null) {
             val advisorParams = mutableMapOf<String, Any>(
                 "model" to advisor.model,
@@ -601,30 +626,10 @@ class OpenRouterService(private val context: Context) {
             )
             tools.add(mapOf("type" to "openrouter:advisor", "parameters" to advisorParams))
             tools.addAll(openRouterWebTools())
-            // Announce the consult up-front so the distinct Adviser card shows during the wait.
             emit(StreamChunk.AdvisorStarted(advisor.name, advisor.model, ""))
         }
 
-        if (fusion != null) {
-            val fusionParams = mutableMapOf<String, Any>(
-                "analysis_models" to fusion.models,
-            )
-            fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionParams["model"] = it }
-            // Server tool + matching plugin config (OpenRouter's recommended pair for a custom panel).
-            tools.add(mapOf("type" to "openrouter:fusion", "parameters" to fusionParams))
-            emit(StreamChunk.FusionStarted(fusion.panelName, fusion.models))
-        }
-
         val hasPdf = historyHasPdfAttachment(history)
-        // Fusion: do NOT use tool_choice "required". With only openrouter:fusion available,
-        // required forces another tool call after the first result → fusion_invocation_capped.
-        // Echo Fusion is already user-opted; the system prompt requires exactly one fusion call,
-        // then a final answer with no further tools. Adviser still uses required (single consult).
-        val toolChoice: Any = when {
-            fusion != null -> "auto"
-            advisor != null -> "required"
-            else -> "auto"
-        }
         val requestMap = mutableMapOf<String, Any>(
             "model" to model,
             "messages" to buildMessagesPayload(history, systemPrompt),
@@ -632,26 +637,10 @@ class OpenRouterService(private val context: Context) {
             "include_reasoning" to true,
             "reasoning" to mapOf("enabled" to true),
             "tools" to tools,
-            "tool_choice" to toolChoice,
+            "tool_choice" to "required",
         )
-        if (fusion != null) {
-            // One fusion call per turn; no parallel multi-tool fan-out on the outer model.
-            requestMap["parallel_tool_calls"] = false
-            val fusionPlugin = mutableMapOf<String, Any>(
-                "id" to "fusion",
-                "analysis_models" to fusion.models,
-            )
-            fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionPlugin["model"] = it }
-                ?: run { fusionPlugin["model"] = model }
-            requestMap["plugins"] = listOf(fusionPlugin)
-        }
         addPdfPluginIfNeeded(requestMap, hasPdf)
-        if (params != null) {
-            requestMap["temperature"] = params.temperature
-            requestMap["top_p"] = params.topP
-            if (params.topK > 0) requestMap["top_k"] = params.topK
-            if (params.maxTokens > 0) requestMap["max_tokens"] = params.maxTokens
-        }
+        applyInferenceParams(requestMap, params)
 
         val response = postForResponse(apiKey, requestMap)
         val choice = (response["choices"] as? List<*>)?.firstOrNull() as? Map<*, *>
@@ -660,8 +649,6 @@ class OpenRouterService(private val context: Context) {
         val reasoning = ((message?.get("reasoning") as? String)
             ?: (message?.get("reasoning_content") as? String)).orEmpty().trim()
 
-        // Resolve the server-tool result. Scan the whole response defensively because the exact
-        // location (a `role:"tool"` message, a tool_calls entry, or inline) is beta/undocumented.
         if (advisor != null) {
             val asked = findAskedPrompt(message)
             val result = OpenRouterEchoDecoder.scanForAdvisorResult(response)
@@ -676,57 +663,257 @@ class OpenRouterService(private val context: Context) {
                 )
             )
         }
-        if (fusion != null) {
-            // Prefer a successful panel payload over a later fusion_invocation_capped error if the
-            // model tried to call fusion twice in the same turn.
-            val parsed = OpenRouterEchoDecoder.selectPreferredFusionResult(
-                OpenRouterEchoDecoder.scanForAllFusionResults(response),
-            )
-            val analysis = (parsed ?: FusionAnalysis(
-                panelName = fusion.panelName,
-                judgeModel = fusion.judge,
-                models = fusion.models,
-                toolResultFound = false,
-            )).copy(
-                panelName = fusion.panelName,
-                judgeModel = fusion.judge ?: parsed?.judgeModel,
-                models = fusion.models.ifEmpty { parsed?.models ?: emptyList() },
-                toolResultFound = parsed != null,
-            )
-            emit(StreamChunk.FusionResolved(analysis))
-        }
 
-        // Any url_citation annotations the answer carries become a source card.
-        (message?.get("annotations") as? List<*>)?.let { annotations ->
-            val sources = mutableListOf<SearchSource>()
-            val seen = mutableSetOf<String>()
-            annotations.forEach { rawAnn ->
-                val ann = rawAnn as? Map<*, *> ?: return@forEach
-                if ((ann["type"] as? String) != "url_citation") return@forEach
-                val cite = ann["url_citation"] as? Map<*, *> ?: return@forEach
-                val url = cite["url"] as? String ?: return@forEach
-                if (!seen.add(url)) return@forEach
-                sources.add(SearchSource((cite["title"] as? String).orEmpty().ifBlank { url }, url, cite["content"] as? String))
-            }
-            if (sources.isNotEmpty()) emit(StreamChunk.SearchSources("", sources))
-        }
-
-        // Reasoning first (so it sits above the answer), then reveal the answer as a gentle live
-        // stream — a non-streaming response with a streamed feel.
+        emitAnnotationsAsSearch(message?.get("annotations") as? List<*>)
         if (reasoning.isNotBlank()) emit(StreamChunk.Reasoning(reasoning))
-        if (answer.isNotBlank()) {
-            val step = 18
-            var idx = 0
-            while (idx < answer.length) {
-                val end = (idx + step).coerceAtMost(answer.length)
-                emit(StreamChunk.Content(answer.substring(idx, end)))
-                idx = end
-                delay(14)
-            }
-        } else if (advisor == null && fusion == null) {
-            throw Exception("No response content received.")
-        }
+        if (answer.isNotBlank()) emitPacedContent(answer)
+        else throw Exception("No response content received.")
     }.flowOn(Dispatchers.IO)
+
+    /**
+     * Force fusion at least once, recover a final answer if the outer model stalls after the
+     * panel, and surface an honest skip when deliberation never ran.
+     */
+    private fun runFusionWithGuarantee(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        fusion: FusionRequest,
+        params: InferenceParams?,
+    ): FusionRunOutcome {
+        // Pass 1: force the fusion tool (user selected a panel — do not leave it to chance).
+        var response = postForResponse(
+            apiKey,
+            buildFusionToolRequest(
+                model = model,
+                history = history,
+                systemPrompt = systemPrompt,
+                fusion = fusion,
+                params = params,
+                toolChoice = "required",
+            ),
+        )
+        var parsed = preferredFusionFrom(response)
+
+        // Pass 2: if required still produced no payload, retry once with an explicit system nudge.
+        if (parsed == null) {
+            response = postForResponse(
+                apiKey,
+                buildFusionToolRequest(
+                    model = model,
+                    history = history,
+                    systemPrompt = systemPrompt + "\n\n" + FUSION_FORCE_NUDGE,
+                    fusion = fusion,
+                    params = params,
+                    toolChoice = "required",
+                ),
+            )
+            parsed = preferredFusionFrom(response)
+        }
+
+        val deliberationSkipped = parsed == null
+        val analysis = (parsed ?: FusionAnalysis(
+            panelName = fusion.panelName,
+            judgeModel = fusion.judge,
+            models = fusion.models,
+            toolResultFound = false,
+            deliberationSkipped = true,
+        )).copy(
+            panelName = fusion.panelName,
+            judgeModel = fusion.judge ?: parsed?.judgeModel,
+            models = fusion.models.ifEmpty { parsed?.models ?: emptyList() },
+            toolResultFound = parsed != null,
+            deliberationSkipped = deliberationSkipped,
+        )
+
+        var choice = (response["choices"] as? List<*>)?.firstOrNull() as? Map<*, *>
+        var message = choice?.get("message") as? Map<*, *>
+        var answer = (message?.get("content") as? String).orEmpty().trim()
+        var reasoning = ((message?.get("reasoning") as? String)
+            ?: (message?.get("reasoning_content") as? String)).orEmpty().trim()
+        var annotations = message?.get("annotations") as? List<*>
+
+        // Pass 3: panel ran but no user-facing answer (common after a capped second fusion call).
+        // Synthesize from the panel result with tools disabled so fusion cannot be invoked again.
+        if (answer.isBlank() && analysis.hasUsableDetail) {
+            val synth = postForResponse(
+                apiKey,
+                buildFusionAnswerRequest(
+                    model = model,
+                    history = history,
+                    systemPrompt = systemPrompt,
+                    fusion = fusion,
+                    analysis = analysis,
+                    params = params,
+                ),
+            )
+            choice = (synth["choices"] as? List<*>)?.firstOrNull() as? Map<*, *>
+            message = choice?.get("message") as? Map<*, *>
+            answer = (message?.get("content") as? String).orEmpty().trim()
+            reasoning = ((message?.get("reasoning") as? String)
+                ?: (message?.get("reasoning_content") as? String)).orEmpty().ifBlank { reasoning }
+            annotations = message?.get("annotations") as? List<*> ?: annotations
+        }
+
+        return FusionRunOutcome(analysis, answer, reasoning, annotations)
+    }
+
+    private data class FusionRunOutcome(
+        val analysis: FusionAnalysis,
+        val answer: String,
+        val reasoning: String,
+        val annotations: List<*>?,
+    )
+
+    private fun preferredFusionFrom(response: Map<*, *>): FusionAnalysis? =
+        OpenRouterEchoDecoder.selectPreferredFusionResult(
+            OpenRouterEchoDecoder.scanForAllFusionResults(response),
+        )
+
+    private fun buildFusionToolRequest(
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        fusion: FusionRequest,
+        params: InferenceParams?,
+        toolChoice: Any,
+    ): MutableMap<String, Any> {
+        val fusionParams = mutableMapOf<String, Any>("analysis_models" to fusion.models)
+        fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionParams["model"] = it }
+        val fusionPlugin = mutableMapOf<String, Any>(
+            "id" to "fusion",
+            "analysis_models" to fusion.models,
+            "model" to (fusion.judge?.takeIf { it.isNotBlank() } ?: model),
+        )
+        val requestMap = mutableMapOf<String, Any>(
+            "model" to model,
+            "messages" to buildMessagesPayload(history, systemPrompt),
+            "stream" to false,
+            "include_reasoning" to true,
+            "reasoning" to mapOf("enabled" to true),
+            "tools" to listOf(mapOf("type" to "openrouter:fusion", "parameters" to fusionParams)),
+            "tool_choice" to toolChoice,
+            // Avoid parallel multi-tool fan-out; fusion is the only tool we attach.
+            "parallel_tool_calls" to false,
+            "plugins" to listOf(fusionPlugin),
+        )
+        addPdfPluginIfNeeded(requestMap, historyHasPdfAttachment(history))
+        applyInferenceParams(requestMap, params)
+        return requestMap
+    }
+
+    /**
+     * Follow-up completion with **no** fusion tool: write one final answer from the panel digest.
+     * Prevents a second fusion invocation after `fusion_invocation_capped`.
+     */
+    private fun buildFusionAnswerRequest(
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        fusion: FusionRequest,
+        analysis: FusionAnalysis,
+        params: InferenceParams?,
+    ): MutableMap<String, Any> {
+        val digest = formatFusionDigestForJudge(analysis)
+        val synthSystem = buildString {
+            append(systemPrompt)
+            append("\n\n## Panel result (already ran — do not call tools)\n")
+            append("The fusion panel \"${fusion.panelName}\" has finished. Write ONE final user-facing answer from this digest. ")
+            append("Do not call tools. Do not reprint the digest or per-model transcripts.\n\n")
+            append(digest)
+        }
+        val requestMap = mutableMapOf<String, Any>(
+            "model" to model,
+            "messages" to buildMessagesPayload(history, synthSystem),
+            "stream" to false,
+            "include_reasoning" to true,
+            "reasoning" to mapOf("enabled" to true),
+            "tool_choice" to "none",
+        )
+        addPdfPluginIfNeeded(requestMap, historyHasPdfAttachment(history))
+        applyInferenceParams(requestMap, params)
+        return requestMap
+    }
+
+    private fun formatFusionDigestForJudge(analysis: FusionAnalysis): String = buildString {
+        if (analysis.consensus.isNotEmpty()) {
+            append("Consensus:\n")
+            analysis.consensus.forEach { append("- ").append(it).append('\n') }
+            append('\n')
+        }
+        if (analysis.contradictions.isNotEmpty()) {
+            append("Disagreements:\n")
+            analysis.contradictions.forEach { c ->
+                append("- ").append(c.topic)
+                if (c.stances.isNotEmpty()) append(": ").append(c.stances.joinToString(" | "))
+                append('\n')
+            }
+            append('\n')
+        }
+        if (analysis.uniqueInsights.isNotEmpty()) {
+            append("Unique insights:\n")
+            analysis.uniqueInsights.forEach { i ->
+                append("- ")
+                if (i.model.isNotBlank()) append(i.model).append(": ")
+                append(i.insight).append('\n')
+            }
+            append('\n')
+        }
+        if (analysis.blindSpots.isNotEmpty()) {
+            append("Blind spots:\n")
+            analysis.blindSpots.forEach { append("- ").append(it).append('\n') }
+            append('\n')
+        }
+        if (analysis.responses.isNotEmpty()) {
+            append("Per-model answers (for your synthesis only — do not paste back):\n")
+            analysis.responses.forEach { r ->
+                append("### ").append(r.model.ifBlank { "model" }).append('\n')
+                append(r.content.take(6000)).append("\n\n")
+            }
+        }
+    }.ifBlank { "(No structured digest fields; use any usable panel signal from context.)" }
+
+    private fun applyInferenceParams(requestMap: MutableMap<String, Any>, params: InferenceParams?) {
+        if (params == null) return
+        requestMap["temperature"] = params.temperature
+        requestMap["top_p"] = params.topP
+        if (params.topK > 0) requestMap["top_k"] = params.topK
+        if (params.maxTokens > 0) requestMap["max_tokens"] = params.maxTokens
+    }
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<StreamChunk>.emitAnnotationsAsSearch(annotations: List<*>?) {
+        if (annotations == null) return
+        val sources = mutableListOf<SearchSource>()
+        val seen = mutableSetOf<String>()
+        annotations.forEach { rawAnn ->
+            val ann = rawAnn as? Map<*, *> ?: return@forEach
+            if ((ann["type"] as? String) != "url_citation") return@forEach
+            val cite = ann["url_citation"] as? Map<*, *> ?: return@forEach
+            val url = cite["url"] as? String ?: return@forEach
+            if (!seen.add(url)) return@forEach
+            sources.add(SearchSource((cite["title"] as? String).orEmpty().ifBlank { url }, url, cite["content"] as? String))
+        }
+        if (sources.isNotEmpty()) emit(StreamChunk.SearchSources("", sources))
+    }
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<StreamChunk>.emitPacedContent(answer: String) {
+        val step = 18
+        var idx = 0
+        while (idx < answer.length) {
+            val end = (idx + step).coerceAtMost(answer.length)
+            emit(StreamChunk.Content(answer.substring(idx, end)))
+            idx = end
+            delay(14)
+        }
+    }
+
+    private companion object {
+        const val FUSION_FORCE_NUDGE =
+            "You must call the fusion tool now before any final answer. " +
+                "Do not reply to the user until the fusion tool has returned. " +
+                "Call it exactly once."
+    }
 
     /** One blocking non-streaming POST for the Echo modes; returns the parsed response map. */
     private fun postForResponse(apiKey: String, requestMap: Map<String, Any>): Map<*, *> {

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -657,12 +657,19 @@ class OpenRouterService(private val context: Context) {
         }
         if (fusion != null) {
             val parsed = OpenRouterEchoDecoder.scanForFusionResult(response)
-            val analysis = (parsed ?: FusionAnalysis(panelName = fusion.panelName, judgeModel = fusion.judge, models = fusion.models))
-                .copy(
-                    panelName = fusion.panelName,
-                    judgeModel = fusion.judge ?: parsed?.judgeModel,
-                    models = fusion.models.ifEmpty { parsed?.models ?: emptyList() },
-                )
+            // If the decoder misses the tool payload, mark toolResultFound=false so the UI does
+            // not paint a false "Panel could not respond" while the judge still answers.
+            val analysis = (parsed ?: FusionAnalysis(
+                panelName = fusion.panelName,
+                judgeModel = fusion.judge,
+                models = fusion.models,
+                toolResultFound = false,
+            )).copy(
+                panelName = fusion.panelName,
+                judgeModel = fusion.judge ?: parsed?.judgeModel,
+                models = fusion.models.ifEmpty { parsed?.models ?: emptyList() },
+                toolResultFound = parsed != null,
+            )
             emit(StreamChunk.FusionResolved(analysis))
         }
 

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -610,11 +610,21 @@ class OpenRouterService(private val context: Context) {
                 "analysis_models" to fusion.models,
             )
             fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionParams["model"] = it }
+            // Server tool + matching plugin config (OpenRouter's recommended pair for a custom panel).
             tools.add(mapOf("type" to "openrouter:fusion", "parameters" to fusionParams))
             emit(StreamChunk.FusionStarted(fusion.panelName, fusion.models))
         }
 
         val hasPdf = historyHasPdfAttachment(history)
+        // Fusion: do NOT use tool_choice "required". With only openrouter:fusion available,
+        // required forces another tool call after the first result → fusion_invocation_capped.
+        // Echo Fusion is already user-opted; the system prompt requires exactly one fusion call,
+        // then a final answer with no further tools. Adviser still uses required (single consult).
+        val toolChoice: Any = when {
+            fusion != null -> "auto"
+            advisor != null -> "required"
+            else -> "auto"
+        }
         val requestMap = mutableMapOf<String, Any>(
             "model" to model,
             "messages" to buildMessagesPayload(history, systemPrompt),
@@ -622,8 +632,19 @@ class OpenRouterService(private val context: Context) {
             "include_reasoning" to true,
             "reasoning" to mapOf("enabled" to true),
             "tools" to tools,
-            "tool_choice" to "required",
+            "tool_choice" to toolChoice,
         )
+        if (fusion != null) {
+            // One fusion call per turn; no parallel multi-tool fan-out on the outer model.
+            requestMap["parallel_tool_calls"] = false
+            val fusionPlugin = mutableMapOf<String, Any>(
+                "id" to "fusion",
+                "analysis_models" to fusion.models,
+            )
+            fusion.judge?.takeIf { it.isNotBlank() }?.let { fusionPlugin["model"] = it }
+                ?: run { fusionPlugin["model"] = model }
+            requestMap["plugins"] = listOf(fusionPlugin)
+        }
         addPdfPluginIfNeeded(requestMap, hasPdf)
         if (params != null) {
             requestMap["temperature"] = params.temperature
@@ -656,9 +677,11 @@ class OpenRouterService(private val context: Context) {
             )
         }
         if (fusion != null) {
-            val parsed = OpenRouterEchoDecoder.scanForFusionResult(response)
-            // If the decoder misses the tool payload, mark toolResultFound=false so the UI does
-            // not paint a false "Panel could not respond" while the judge still answers.
+            // Prefer a successful panel payload over a later fusion_invocation_capped error if the
+            // model tried to call fusion twice in the same turn.
+            val parsed = OpenRouterEchoDecoder.selectPreferredFusionResult(
+                OpenRouterEchoDecoder.scanForAllFusionResults(response),
+            )
             val analysis = (parsed ?: FusionAnalysis(
                 panelName = fusion.panelName,
                 judgeModel = fusion.judge,

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -565,12 +565,12 @@ class OpenRouterService(private val context: Context) {
      * Echo Adviser / Echo Fusion. OpenRouter-only server tools. Non-streaming so the tool
      * result and final answer can be ordered deterministically (Echo card → reasoning → answer).
      *
-     * **Fusion guarantee:** the user opted into a named panel. We force fusion with
-     * `tool_choice: "required"`, retry once if no tool payload appears, and if the panel ran
-     * but the model left no final text (e.g. after a capped second fusion call), we synthesize
-     * the answer in a follow-up request **without** tools. A silent single-model reply without
-     * deliberation is never treated as a successful fuse — the UI is told via
-     * [FusionAnalysis.deliberationSkipped].
+     * **Fusion guarantee:** the user opted into a named panel. We force fusion once with
+     * `tool_choice: "required"`. We never re-issue that request when the payload is missing or
+     * unparsed — a second independent call would run the cost-bearing panel again. If the panel
+     * ran but the model left no final text, we synthesize the answer in a follow-up **without**
+     * tools. A silent single-model reply without deliberation is never treated as a successful
+     * fuse — the UI is told via [FusionAnalysis.deliberationSkipped].
      */
     fun sendWithEchoTools(
         apiKey: String,
@@ -671,8 +671,9 @@ class OpenRouterService(private val context: Context) {
     }.flowOn(Dispatchers.IO)
 
     /**
-     * Force fusion at least once, recover a final answer if the outer model stalls after the
-     * panel, and surface an honest skip when deliberation never ran.
+     * Force fusion once, recover a final answer if the outer model stalls after the panel, and
+     * surface an honest skip when deliberation never ran. No second fusion request: missing or
+     * unparsed payloads must not re-bill the multi-model panel.
      */
     private fun runFusionWithGuarantee(
         apiKey: String,
@@ -682,8 +683,8 @@ class OpenRouterService(private val context: Context) {
         fusion: FusionRequest,
         params: InferenceParams?,
     ): FusionRunOutcome {
-        // Pass 1: force the fusion tool (user selected a panel — do not leave it to chance).
-        var response = postForResponse(
+        // Force the fusion tool once (user selected a panel — do not leave it to chance).
+        val response = postForResponse(
             apiKey,
             buildFusionToolRequest(
                 model = model,
@@ -694,23 +695,7 @@ class OpenRouterService(private val context: Context) {
                 toolChoice = "required",
             ),
         )
-        var parsed = preferredFusionFrom(response)
-
-        // Pass 2: if required still produced no payload, retry once with an explicit system nudge.
-        if (parsed == null) {
-            response = postForResponse(
-                apiKey,
-                buildFusionToolRequest(
-                    model = model,
-                    history = history,
-                    systemPrompt = systemPrompt + "\n\n" + FUSION_FORCE_NUDGE,
-                    fusion = fusion,
-                    params = params,
-                    toolChoice = "required",
-                ),
-            )
-            parsed = preferredFusionFrom(response)
-        }
+        val parsed = preferredFusionFrom(response)
 
         val deliberationSkipped = parsed == null
         val analysis = (parsed ?: FusionAnalysis(
@@ -734,7 +719,7 @@ class OpenRouterService(private val context: Context) {
             ?: (message?.get("reasoning_content") as? String)).orEmpty().trim()
         var annotations = message?.get("annotations") as? List<*>
 
-        // Pass 3: panel ran but no user-facing answer (common after a capped second fusion call).
+        // Panel ran but no user-facing answer (common when the model only emitted the tool result).
         // Synthesize from the panel result with tools disabled so fusion cannot be invoked again.
         if (answer.isBlank() && analysis.hasUsableDetail) {
             val synth = postForResponse(
@@ -906,13 +891,6 @@ class OpenRouterService(private val context: Context) {
             idx = end
             delay(14)
         }
-    }
-
-    private companion object {
-        const val FUSION_FORCE_NUDGE =
-            "You must call the fusion tool now before any final answer. " +
-                "Do not reply to the user until the fusion tool has returned. " +
-                "Call it exactly once."
     }
 
     /** One blocking non-streaming POST for the Echo modes; returns the parsed response map. */

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -277,12 +277,18 @@ object SystemPrompts {
     private fun fusionGuidance(panelName: String): String =
         """
         ## Echo Fusion
-        You are the judge of a multi-model panel — "$panelName". Invoke your fusion tool so the panel deliberates on the user's request, then write the single best answer yourself.
+        You are the judge of a multi-model panel — "$panelName". Invoke your fusion tool so the panel deliberates on the user's request, then write ONE final answer yourself.
 
+        How to use the panel:
         - Treat points of consensus as high-confidence.
-        - Surface genuine disagreements honestly instead of hiding them; note which view is better supported.
-        - Preserve insights only one model raised, and flag gaps the whole panel missed.
-        - Write a clean, well-structured markdown answer. The app shows the structured panel comparison and each model's full response separately, so do NOT paste the raw analysis JSON.
+        - When models disagree, pick the better-supported view (or briefly note the split in one sentence inside that single answer).
+        - Fold unique insights into the same answer; do not list them as a separate transcript.
+
+        What you must write (critical):
+        - Output only the user-facing final answer in clean markdown — one voice, as if a single expert replied.
+        - Do NOT paste raw analysis JSON.
+        - Do NOT structure the reply as "Panel responses", "Model A / Model B", "Luna said / DeepSeek said", or "Combined / Final answer" sections.
+        - Do NOT reprint each model's full answer. The app already shows panel comparison and per-model text in its own UI when available.
         """.trimIndent()
 
     // ── Artifacts ────────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -277,9 +277,15 @@ object SystemPrompts {
     private fun fusionGuidance(panelName: String): String =
         """
         ## Echo Fusion
-        You are the judge of a multi-model panel — "$panelName". Invoke your fusion tool so the panel deliberates on the user's request, then write ONE final answer yourself.
+        You are the judge of a multi-model panel — "$panelName".
 
-        How to use the panel:
+        Tool use (critical — follow exactly):
+        - Call the fusion tool **exactly once** as your first action so the panel deliberates on the user's request.
+        - After that single tool result arrives, write the final answer immediately.
+        - **Never** call fusion a second time. A second call is rejected (`fusion_invocation_capped`) and wastes the turn.
+        - Do not call any other tools after fusion; synthesis is your job from the tool result alone.
+
+        How to use the panel result:
         - Treat points of consensus as high-confidence.
         - When models disagree, pick the better-supported view (or briefly note the split in one sentence inside that single answer).
         - Fold unique insights into the same answer; do not list them as a separate transcript.

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -397,14 +397,14 @@ fun FusionCard(
 ) {
     val reducedMotion = rememberReducedMotion()
     val roster = (analysis?.models?.takeIf { it.isNotEmpty() } ?: models).ifEmpty { models }
-    // Hard fail only with a located tool result that reports failed models and no usable detail.
-    // Unparsed tool payloads (toolResultFound=false) are never painted as failure — the judge
-    // often still streams a full answer.
+    // Hard fail: tool ran and reported model failures. Skip: user asked for fusion but panel never ran.
     val panelFailed = analysis?.isHardFailure == true
+    val panelDidNotRun = analysis?.panelDidNotRun == true
     val processLive = active || (analysis != null && isStreaming && !answerStarted)
 
     var userToggled by remember { mutableStateOf<Boolean?>(null) }
-    val expanded = userToggled ?: processLive
+    // Stay open when deliberation was skipped so the user sees the disclosure, not a quiet success.
+    val expanded = userToggled ?: (processLive || (panelDidNotRun && !answerStarted))
     val chevron by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
         animationSpec = tween(if (reducedMotion) 0 else 300),
@@ -435,18 +435,17 @@ fun FusionCard(
     val panelState = when {
         panelActive -> FusionStepState.Active
         analysis == null -> FusionStepState.Pending
-        panelFailed -> FusionStepState.Failed
+        panelFailed || panelDidNotRun -> FusionStepState.Failed
         else -> FusionStepState.Done
     }
     val compareState = when {
         analysis == null -> FusionStepState.Pending
-        panelFailed -> FusionStepState.Failed
-        !analysis.toolResultFound -> FusionStepState.Done // unparsed: skip drama, move on
-        analysis.hasUsableDetail || analysis.responses.isNotEmpty() -> FusionStepState.Done
+        panelFailed || panelDidNotRun -> FusionStepState.Failed
         else -> FusionStepState.Done
     }
     val mergeState = when {
         panelFailed -> FusionStepState.Failed
+        panelDidNotRun && !answerStarted -> FusionStepState.Failed
         answerStarted || (!processLive && analysis != null) -> FusionStepState.Done
         analysis != null && processLive -> FusionStepState.Active
         else -> FusionStepState.Pending
@@ -455,6 +454,9 @@ fun FusionCard(
     val headerTitle = when {
         processLive -> {
             if (panelName.isNotBlank()) "Fusion · $panelName" else "Fusion"
+        }
+        panelDidNotRun -> {
+            if (panelName.isNotBlank()) "Fusion · $panelName · panel did not run" else "Fusion · panel did not run"
         }
         panelFailed -> {
             if (panelName.isNotBlank()) "Fusion · $panelName" else "Fusion"
@@ -534,12 +536,14 @@ fun FusionCard(
                     FusionProcessStep(
                         label = when {
                             panelActive -> "Asking the panel…"
+                            panelDidNotRun -> "Panel"
                             panelFailed -> "Panel"
                             else -> "Panel"
                         },
                         state = panelState,
                         meta = when {
                             panelActive -> "${roster.size}"
+                            panelDidNotRun -> "not invoked"
                             panelFailed -> {
                                 val n = analysis?.failedModels?.size ?: roster.size
                                 "$n failed"
@@ -559,7 +563,7 @@ fun FusionCard(
                             models = roster,
                             analysis = analysis,
                             panelActive = panelActive,
-                            panelFailed = panelFailed,
+                            panelFailed = panelFailed || panelDidNotRun,
                             reducedMotion = reducedMotion,
                         )
                     }
@@ -568,9 +572,8 @@ fun FusionCard(
                         label = "Compare",
                         state = compareState,
                         meta = when {
-                            panelFailed -> "skipped"
+                            panelDidNotRun || panelFailed -> "skipped"
                             analysis == null -> null
-                            !analysis.toolResultFound -> null
                             else -> buildString {
                                 val parts = mutableListOf<String>()
                                 if (analysis.consensus.isNotEmpty()) parts += "${analysis.consensus.size} agreed"
@@ -589,14 +592,24 @@ fun FusionCard(
                             else -> "Answer"
                         },
                         state = mergeState,
-                        meta = when (mergeState) {
-                            FusionStepState.Active -> null
-                            FusionStepState.Failed -> "no answer"
-                            FusionStepState.Done -> if (answerStarted || !processLive) "ready" else null
+                        meta = when {
+                            panelDidNotRun -> "no deliberation"
+                            mergeState == FusionStepState.Active -> null
+                            mergeState == FusionStepState.Failed -> "no answer"
+                            mergeState == FusionStepState.Done && (answerStarted || !processLive) -> "ready"
                             else -> null
                         },
                         reducedMotion = reducedMotion,
                     )
+
+                    if (panelDidNotRun && !processLive) {
+                        Text(
+                            "Your panel was not used — the model replied without multi-model deliberation. Try again.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = Spacing.xs),
+                        )
+                    }
 
                     // Optional depth only when settled and we actually have structured detail.
                     if (!processLive && analysis != null && analysis.hasUsableDetail) {

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -397,14 +397,17 @@ fun FusionCard(
 ) {
     val reducedMotion = rememberReducedMotion()
     val roster = (analysis?.models?.takeIf { it.isNotEmpty() } ?: models).ifEmpty { models }
-    // Hard fail: tool ran and reported model failures. Skip: user asked for fusion but panel never ran.
+    // Hard fail: tool ran and reported model failures.
+    // Skip: fusion was never invoked. Unparsed: invoked but structured body not decoded.
     val panelFailed = analysis?.isHardFailure == true
     val panelDidNotRun = analysis?.panelDidNotRun == true
+    val detailUnparsed = analysis?.detailUnparsed == true
     val processLive = active || (analysis != null && isStreaming && !answerStarted)
 
     var userToggled by remember { mutableStateOf<Boolean?>(null) }
-    // Stay open when deliberation was skipped so the user sees the disclosure, not a quiet success.
-    val expanded = userToggled ?: (processLive || (panelDidNotRun && !answerStarted))
+    // Stay open when we must disclose skip / unparsed so it is not a quiet "success".
+    val expanded = userToggled
+        ?: (processLive || ((panelDidNotRun || detailUnparsed) && !answerStarted))
     val chevron by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
         animationSpec = tween(if (reducedMotion) 0 else 300),
@@ -436,11 +439,13 @@ fun FusionCard(
         panelActive -> FusionStepState.Active
         analysis == null -> FusionStepState.Pending
         panelFailed || panelDidNotRun -> FusionStepState.Failed
+        detailUnparsed -> FusionStepState.Done // ran; detail missing — not a hard fail
         else -> FusionStepState.Done
     }
     val compareState = when {
         analysis == null -> FusionStepState.Pending
         panelFailed || panelDidNotRun -> FusionStepState.Failed
+        detailUnparsed -> FusionStepState.Done
         else -> FusionStepState.Done
     }
     val mergeState = when {
@@ -457,6 +462,9 @@ fun FusionCard(
         }
         panelDidNotRun -> {
             if (panelName.isNotBlank()) "Fusion · $panelName · panel did not run" else "Fusion · panel did not run"
+        }
+        detailUnparsed -> {
+            if (panelName.isNotBlank()) "Fusion · $panelName · detail unavailable" else "Fusion · detail unavailable"
         }
         panelFailed -> {
             if (panelName.isNotBlank()) "Fusion · $panelName" else "Fusion"
@@ -544,6 +552,7 @@ fun FusionCard(
                         meta = when {
                             panelActive -> "${roster.size}"
                             panelDidNotRun -> "not invoked"
+                            detailUnparsed -> "ran · detail missing"
                             panelFailed -> {
                                 val n = analysis?.failedModels?.size ?: roster.size
                                 "$n failed"
@@ -563,6 +572,7 @@ fun FusionCard(
                             models = roster,
                             analysis = analysis,
                             panelActive = panelActive,
+                            // Only mark every model failed on hard fail or true skip — not unparsed.
                             panelFailed = panelFailed || panelDidNotRun,
                             reducedMotion = reducedMotion,
                         )
@@ -573,6 +583,7 @@ fun FusionCard(
                         state = compareState,
                         meta = when {
                             panelDidNotRun || panelFailed -> "skipped"
+                            detailUnparsed -> "unavailable"
                             analysis == null -> null
                             else -> buildString {
                                 val parts = mutableListOf<String>()
@@ -607,6 +618,13 @@ fun FusionCard(
                             "Your panel was not used — the model replied without multi-model deliberation. Try again.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = Spacing.xs),
+                        )
+                    } else if (detailUnparsed && !processLive) {
+                        Text(
+                            "The panel ran, but structured comparison detail could not be read. The answer below may still be a fusion synthesis.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(top = Spacing.xs),
                         )
                     }

--- a/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt
@@ -14,10 +14,8 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.automirrored.filled.Assignment
@@ -49,6 +47,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.echoflow.data.FusionAnalysis
+import com.echoflow.data.FusionResponse
 import com.echoflow.ui.theme.JetBrainsMono
 import com.echoflow.ui.theme.RoundedPolygonShape
 import com.echoflow.ui.theme.Spacing
@@ -377,17 +376,14 @@ private fun fusionRevealExit(reducedMotion: Boolean): ExitTransition =
     if (reducedMotion) fadeOut(tween(0)) else shrinkVertically(tween(240)) + fadeOut(tween(120))
 
 /**
- * Echo Fusion process shell — Thinking header + Task rows + Tool chips, in EchoFlow chrome.
+ * Echo Fusion process shell — same family as [ReasoningSection]: soft meta block, open while
+ * live, collapses when the final answer starts so the chat body is one reply.
  *
- * While the panel is out ([active]) or the judge is about to write ([isStreaming] with analysis
- * but no answer text yet), the shell stays open and steps advance honestly. Once the final
- * answer has started ([answerStarted]) or the turn settles, it collapses like [ReasoningSection]
- * so the chat body is only the synthesized answer. Expand anytime for the step replay,
- * comparison digest, and per-model answers.
+ * Multi-line model rows (tool-call style, one spinner each) replace horizontal pills.
  *
  * @param active panel still waiting on the server tool (no analysis yet)
  * @param isStreaming the assistant turn is still live
- * @param answerStarted a [com.echoflow.ui.StreamSegment.Text] has appeared after this segment
+ * @param answerStarted final answer text has appeared after this segment
  */
 @Composable
 fun FusionCard(
@@ -400,16 +396,11 @@ fun FusionCard(
     answerStarted: Boolean = false,
 ) {
     val reducedMotion = rememberReducedMotion()
-    val roster = analysis?.models?.takeIf { it.isNotEmpty() } ?: models
-    // Total failure only when there is nothing usable at all: no raw panel answers AND no
-    // structured comparison. OpenRouter can return analysis without a responses[] list — that
-    // is still a successful fusion and must not be painted as "Panel could not respond".
-    val panelFailed = analysis != null &&
-        analysis.responses.isEmpty() &&
-        analysis.isEmpty
-    // Live process: panel waiting, or tool returned and final answer not on screen yet.
-    // Total panel failure stays open while the turn is still streaming so the user sees the fail
-    // state, but never enters the answer-writing phase.
+    val roster = (analysis?.models?.takeIf { it.isNotEmpty() } ?: models).ifEmpty { models }
+    // Hard fail only with a located tool result that reports failed models and no usable detail.
+    // Unparsed tool payloads (toolResultFound=false) are never painted as failure — the judge
+    // often still streams a full answer.
+    val panelFailed = analysis?.isHardFailure == true
     val processLive = active || (analysis != null && isStreaming && !answerStarted)
 
     var userToggled by remember { mutableStateOf<Boolean?>(null) }
@@ -421,7 +412,6 @@ fun FusionCard(
     )
     val toggleInteraction = remember { MutableInteractionSource() }
 
-    // Elapsed clock while live; freezes when the process settles (Reasoning-weight meta).
     val startMs = remember { System.currentTimeMillis() }
     var elapsedMs by remember { mutableLongStateOf(0L) }
     LaunchedEffect(processLive) {
@@ -431,7 +421,6 @@ fun FusionCard(
             delay(250)
         }
     }
-    // Capture final duration once when leaving live.
     var settledMs by remember { mutableLongStateOf(0L) }
     LaunchedEffect(processLive, elapsedMs) {
         if (!processLive && elapsedMs > 0L && settledMs == 0L) settledMs = elapsedMs
@@ -442,8 +431,9 @@ fun FusionCard(
         else -> null
     }
 
+    val panelActive = active && analysis == null
     val panelState = when {
-        analysis == null && processLive -> FusionStepState.Active
+        panelActive -> FusionStepState.Active
         analysis == null -> FusionStepState.Pending
         panelFailed -> FusionStepState.Failed
         else -> FusionStepState.Done
@@ -451,33 +441,26 @@ fun FusionCard(
     val compareState = when {
         analysis == null -> FusionStepState.Pending
         panelFailed -> FusionStepState.Failed
+        !analysis.toolResultFound -> FusionStepState.Done // unparsed: skip drama, move on
+        analysis.hasUsableDetail || analysis.responses.isNotEmpty() -> FusionStepState.Done
         else -> FusionStepState.Done
     }
-    val answerState = when {
+    val mergeState = when {
         panelFailed -> FusionStepState.Failed
         answerStarted || (!processLive && analysis != null) -> FusionStepState.Done
         analysis != null && processLive -> FusionStepState.Active
         else -> FusionStepState.Pending
     }
 
-    val statusLine = when {
-        analysis == null && processLive -> "Panel answering in parallel"
-        panelFailed -> "Panel could not respond"
-        analysis != null && processLive && !answerStarted -> "Writing final answer"
-        else -> null
-    }
-
     val headerTitle = when {
-        processLive || panelFailed && isStreaming -> {
-            val name = panelName.ifBlank { "Fusion" }
-            if (panelName.isNotBlank()) "Fusion · $name" else "Fusion"
+        processLive -> {
+            if (panelName.isNotBlank()) "Fusion · $panelName" else "Fusion"
         }
         panelFailed -> {
-            val name = panelName.ifBlank { "Fusion" }
-            if (panelName.isNotBlank()) "Fusion failed · $name" else "Fusion failed"
+            if (panelName.isNotBlank()) "Fusion · $panelName" else "Fusion"
         }
         else -> {
-            val n = roster.size.coerceAtLeast(models.size)
+            val n = roster.size.coerceAtLeast(1)
             buildString {
                 append("Fused · $n model")
                 if (n != 1) append('s')
@@ -485,53 +468,13 @@ fun FusionCard(
         }
     }
 
-    val panelMeta = when (panelState) {
-        FusionStepState.Active -> "${roster.size} model${if (roster.size == 1) "" else "s"}"
-        FusionStepState.Done -> {
-            val returned = analysis?.responses?.size ?: 0
-            val failed = analysis?.failedModels?.size ?: 0
-            when {
-                returned > 0 -> buildString {
-                    append("$returned returned")
-                    if (failed > 0) append(" · $failed failed")
-                }
-                // Structured analysis without raw responses — still a successful panel pass.
-                analysis != null && !analysis.isEmpty -> "${roster.size} model${if (roster.size == 1) "" else "s"}"
-                else -> null
-            }
-        }
-        FusionStepState.Failed -> {
-            val failed = analysis?.failedModels?.size ?: roster.size
-            if (failed > 0) "$failed failed" else "Did not respond"
-        }
-        FusionStepState.Pending -> null
-    }
-    val compareMeta = when {
-        panelFailed -> "skipped"
-        else -> analysis?.let { a ->
-            if (a.isEmpty && a.responses.isEmpty()) null
-            else buildString {
-                val parts = mutableListOf<String>()
-                if (a.consensus.isNotEmpty()) parts += "${a.consensus.size} agreed"
-                if (a.contradictions.isNotEmpty()) parts += "${a.contradictions.size} disagreed"
-                if (parts.isEmpty() && (!a.isEmpty || a.responses.isNotEmpty())) parts += "compared"
-                append(parts.joinToString(" · "))
-            }.takeIf { it.isNotBlank() }
-        }
-    }
-    val answerMeta = when (answerState) {
-        FusionStepState.Active -> "writing…"
-        FusionStepState.Failed -> "no answer"
-        else -> null
-    }
-
+    // Reasoning twin: soft tint, not a solid product slab.
     Surface(
         shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
+        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.22f),
         modifier = modifier.fillMaxWidth(),
     ) {
         Column(Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m)) {
-            // Thinking-style header — open while live, collapses when the answer owns the turn.
             Row(
                 Modifier
                     .fillMaxWidth()
@@ -579,15 +522,6 @@ fun FusionCard(
                 )
             }
 
-            if (statusLine != null) {
-                Spacer(Modifier.height(Spacing.xs))
-                Text(
-                    statusLine,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
             AnimatedVisibility(
                 visible = expanded,
                 enter = fusionRevealEnter(reducedMotion),
@@ -595,46 +529,77 @@ fun FusionCard(
             ) {
                 Column(
                     Modifier.padding(top = Spacing.m),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
-                    // Task-row steps with Research mark grammar (secondary accent).
                     FusionProcessStep(
-                        label = "Panel",
+                        label = when {
+                            panelActive -> "Asking the panel…"
+                            panelFailed -> "Panel"
+                            else -> "Panel"
+                        },
                         state = panelState,
-                        meta = panelMeta,
-                        reducedMotion = reducedMotion,
-                    )
-                    if (roster.isNotEmpty()) {
-                        FusionModelChips(
-                            models = roster,
-                            failed = analysis?.failedModels.orEmpty(),
-                            // Only mark chips resolved when we have per-model outcomes or a
-                            // confirmed total failure — not when we only have aggregate analysis.
-                            resolved = analysis != null &&
-                                (analysis.responses.isNotEmpty() || analysis.failedModels.isNotEmpty() || panelFailed),
-                            allFailed = panelFailed,
-                        )
-                    }
-                    FusionProcessStep(
-                        label = "Compare",
-                        state = compareState,
-                        meta = compareMeta,
-                        reducedMotion = reducedMotion,
-                    )
-                    // Count chips whenever structured comparison exists (even if raw responses
-                    // were omitted from the tool payload).
-                    if (analysis != null && !analysis.isEmpty) {
-                        FusionCountChips(analysis)
-                    }
-                    FusionProcessStep(
-                        label = "Answer",
-                        state = answerState,
-                        meta = answerMeta,
+                        meta = when {
+                            panelActive -> "${roster.size}"
+                            panelFailed -> {
+                                val n = analysis?.failedModels?.size ?: roster.size
+                                "$n failed"
+                            }
+                            analysis != null && analysis.responses.isNotEmpty() -> {
+                                val n = analysis.responses.size
+                                val f = analysis.failedModels.size
+                                if (f > 0) "$n ok · $f failed" else "$n ok"
+                            }
+                            else -> null
+                        },
                         reducedMotion = reducedMotion,
                     )
 
-                    // Settled expand only: full comparison + per-model answers stay optional depth.
-                    if (!processLive && analysis != null) {
+                    if (roster.isNotEmpty()) {
+                        FusionModelRows(
+                            models = roster,
+                            analysis = analysis,
+                            panelActive = panelActive,
+                            panelFailed = panelFailed,
+                            reducedMotion = reducedMotion,
+                        )
+                    }
+
+                    FusionProcessStep(
+                        label = "Compare",
+                        state = compareState,
+                        meta = when {
+                            panelFailed -> "skipped"
+                            analysis == null -> null
+                            !analysis.toolResultFound -> null
+                            else -> buildString {
+                                val parts = mutableListOf<String>()
+                                if (analysis.consensus.isNotEmpty()) parts += "${analysis.consensus.size} agreed"
+                                if (analysis.contradictions.isNotEmpty()) parts += "${analysis.contradictions.size} disagreed"
+                                if (parts.isEmpty() && analysis.hasUsableDetail) parts += "done"
+                                append(parts.joinToString(" · "))
+                            }.takeIf { it.isNotBlank() }
+                        },
+                        reducedMotion = reducedMotion,
+                    )
+
+                    FusionProcessStep(
+                        label = when (mergeState) {
+                            FusionStepState.Active -> "Merging into one answer…"
+                            FusionStepState.Failed -> "Answer"
+                            else -> "Answer"
+                        },
+                        state = mergeState,
+                        meta = when (mergeState) {
+                            FusionStepState.Active -> null
+                            FusionStepState.Failed -> "no answer"
+                            FusionStepState.Done -> if (answerStarted || !processLive) "ready" else null
+                            else -> null
+                        },
+                        reducedMotion = reducedMotion,
+                    )
+
+                    // Optional depth only when settled and we actually have structured detail.
+                    if (!processLive && analysis != null && analysis.hasUsableDetail) {
                         Spacer(Modifier.height(Spacing.xs))
                         FusionDeliberation(analysis)
                     }
@@ -670,7 +635,7 @@ private fun FusionProcessStep(
                 MaterialTheme.colorScheme.onSurface
             },
             modifier = Modifier.weight(1f),
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
         if (meta != null) {
@@ -692,7 +657,7 @@ private fun FusionProcessStep(
 
 /**
  * Active busy mark. [LoadingIndicator] keeps spinning even when animator duration scale is 0,
- * so reduced-motion falls back to a still secondary ring (same stillness rule as Research reveals).
+ * so reduced-motion falls back to a still secondary ring.
  */
 @Composable
 private fun FusionBusyIndicator(reducedMotion: Boolean, size: Dp) {
@@ -752,89 +717,74 @@ private fun FusionStepMark(state: FusionStepState, reducedMotion: Boolean) {
     }
 }
 
-/** Tool-chip density for the panel roster — labels only; checks only after resolve. */
-@Composable
-private fun FusionModelChips(
-    models: List<String>,
-    failed: List<String>,
-    resolved: Boolean,
-    allFailed: Boolean = false,
-) {
-    val failedSet = remember(failed) { failed.map { it.lowercase() }.toSet() }
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .padding(start = 18.dp + Spacing.s)
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-    ) {
-        models.forEach { model ->
-            val isFailed = resolved && (
-                allFailed ||
-                    failedSet.contains(model.lowercase()) ||
-                    failed.any { model.endsWith(it) || it.endsWith(model) }
-                )
-            Surface(
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            ) {
-                Row(
-                    Modifier.padding(start = Spacing.s, end = Spacing.m, top = 4.dp, bottom = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (resolved) {
-                        Icon(
-                            if (isFailed) Icons.Default.Close else Icons.Default.Check,
-                            null,
-                            Modifier.size(12.dp),
-                            tint = if (isFailed) {
-                                MaterialTheme.colorScheme.error
-                            } else {
-                                MaterialTheme.colorScheme.secondary
-                            },
-                        )
-                        Spacer(Modifier.width(4.dp))
-                    }
-                    Text(
-                        shortModel(model),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                    )
-                }
-            }
-        }
+private fun fusionModelFailed(model: String, failed: List<String>): Boolean {
+    if (failed.isEmpty()) return false
+    val id = model.lowercase()
+    val short = shortModel(model).lowercase()
+    return failed.any { f ->
+        val fl = f.lowercase()
+        fl == id || fl.endsWith(id) || id.endsWith(fl) ||
+            fl == short || fl.endsWith(short) || short.endsWith(fl)
     }
 }
 
-/** Compact count chips after compare (agreed / disagreed) — not a full report. */
-@Composable
-private fun FusionCountChips(analysis: FusionAnalysis) {
-    val chips = buildList {
-        if (analysis.consensus.isNotEmpty()) add("${analysis.consensus.size} agreed")
-        if (analysis.contradictions.isNotEmpty()) add("${analysis.contradictions.size} disagreed")
-        if (analysis.uniqueInsights.isNotEmpty()) add("${analysis.uniqueInsights.size} unique")
-        if (analysis.blindSpots.isNotEmpty()) add("${analysis.blindSpots.size} gaps")
+private fun fusionModelResponded(model: String, responses: List<FusionResponse>): Boolean {
+    if (responses.isEmpty()) return false
+    val id = model.lowercase()
+    val short = shortModel(model).lowercase()
+    return responses.any { r ->
+        val m = r.model.lowercase()
+        m == id || m.endsWith(id) || id.endsWith(m) ||
+            shortModel(r.model).lowercase() == short
     }
-    if (chips.isEmpty()) return
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .padding(start = 18.dp + Spacing.s)
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+}
+
+/**
+ * Multi-line tool-call style rows — one spinner (or check/fail) per panel model.
+ * While the panel is out every row is active; after resolve, marks follow real outcomes when known.
+ */
+@Composable
+private fun FusionModelRows(
+    models: List<String>,
+    analysis: FusionAnalysis?,
+    panelActive: Boolean,
+    panelFailed: Boolean,
+    reducedMotion: Boolean,
+) {
+    Column(
+        Modifier.padding(start = Spacing.base),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        chips.forEach { label ->
-            Surface(
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        models.forEach { model ->
+            val state = when {
+                panelActive || analysis == null -> FusionStepState.Active
+                panelFailed -> FusionStepState.Failed
+                !analysis.toolResultFound -> FusionStepState.Done
+                fusionModelFailed(model, analysis.failedModels) -> FusionStepState.Failed
+                fusionModelResponded(model, analysis.responses) -> FusionStepState.Done
+                analysis.responses.isNotEmpty() -> FusionStepState.Failed // others returned; this one silent
+                analysis.hasUsableDetail -> FusionStepState.Done
+                else -> FusionStepState.Done
+            }
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 26.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
+                FusionStepMark(state = state, reducedMotion = reducedMotion)
+                Spacer(Modifier.width(Spacing.s))
                 Text(
-                    label,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = Spacing.m, vertical = 4.dp),
+                    shortModel(model),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = when (state) {
+                        FusionStepState.Failed -> MaterialTheme.colorScheme.error
+                        FusionStepState.Pending -> MaterialTheme.colorScheme.onSurfaceVariant
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
             }
         }

--- a/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
@@ -26,4 +26,57 @@ class OpenRouterEchoDecoderTest {
         assertNull(OpenRouterEchoDecoder.scanForAdvisorResult(mapOf("content" to "hello")))
         assertNull(OpenRouterEchoDecoder.scanForFusionResult(emptyMap<String, Any>()))
     }
+
+    @Test fun `finds fusion result with analysis and responses`() {
+        val payload = mapOf(
+            "status" to "ok",
+            "analysis" to mapOf(
+                "consensus" to listOf("A is better"),
+                "contradictions" to emptyList<Any>(),
+            ),
+            "responses" to listOf(
+                mapOf("model" to "openai/gpt-test", "content" to "hello from gpt"),
+                mapOf("model" to "deepseek/v4", "content" to "hello from deepseek"),
+            ),
+        )
+        val direct = OpenRouterEchoDecoder.scanForFusionResult(payload)!!
+        assertEquals(2, direct.responses.size)
+        assertEquals(listOf("A is better"), direct.consensus)
+        assertEquals(true, direct.toolResultFound)
+        assertEquals(false, direct.isHardFailure)
+    }
+
+    @Test fun `finds fusion result nested inside content json string`() {
+        val inner = """{"status":"ok","responses":[{"model":"a/b","content":"hi"}],"analysis":{"consensus":["x"]}}"""
+        val found = OpenRouterEchoDecoder.scanForFusionResult(mapOf("content" to inner))!!
+        assertEquals(1, found.responses.size)
+        assertEquals(listOf("x"), found.consensus)
+    }
+
+    @Test fun `empty analysis without failed models is not a hard failure`() {
+        val empty = FusionAnalysis(panelName = "p", judgeModel = null, models = listOf("a"), toolResultFound = false)
+        assertEquals(false, empty.isHardFailure)
+        val hard = FusionAnalysis(
+            panelName = "p",
+            judgeModel = null,
+            models = listOf("a", "b"),
+            failedModels = listOf("a", "b"),
+            toolResultFound = true,
+        )
+        assertEquals(true, hard.isHardFailure)
+    }
+
+    @Test fun `parses failed_models maps and model_id responses`() {
+        val payload = mapOf(
+            "status" to "ok",
+            "responses" to listOf(
+                mapOf("model_id" to "openai/gpt", "content" to "ok"),
+            ),
+            "failed_models" to listOf(mapOf("model" to "deepseek/x")),
+        )
+        val result = OpenRouterEchoDecoder.scanForFusionResult(payload)!!
+        assertEquals(1, result.responses.size)
+        assertEquals("openai/gpt", result.responses.single().model)
+        assertEquals(listOf("deepseek/x"), result.failedModels)
+    }
 }

--- a/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
@@ -79,4 +79,29 @@ class OpenRouterEchoDecoderTest {
         assertEquals("openai/gpt", result.responses.single().model)
         assertEquals(listOf("deepseek/x"), result.failedModels)
     }
+
+    @Test fun `prefers successful fusion over later capped invocation`() {
+        val ok = mapOf(
+            "status" to "ok",
+            "analysis" to mapOf("consensus" to listOf("use solid panels")),
+            "responses" to listOf(mapOf("model" to "a/b", "content" to "hi")),
+        )
+        val capped = mapOf(
+            "status" to "error",
+            "error" to "Fusion has already been invoked for this request and cannot be called again.",
+            "failure_reason" to "fusion_invocation_capped",
+        )
+        val tree = mapOf(
+            "messages" to listOf(
+                mapOf("role" to "tool", "content" to ok),
+                mapOf("role" to "tool", "content" to capped),
+            ),
+        )
+        val preferred = OpenRouterEchoDecoder.scanForFusionResult(tree)!!
+        assertEquals(listOf("use solid panels"), preferred.consensus)
+        assertEquals(1, preferred.responses.size)
+        // Capped payload must not be collected as a fusion result at all.
+        val all = OpenRouterEchoDecoder.scanForAllFusionResults(tree)
+        assertEquals(1, all.size)
+    }
 }

--- a/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt
@@ -80,6 +80,40 @@ class OpenRouterEchoDecoderTest {
         assertEquals(listOf("deepseek/x"), result.failedModels)
     }
 
+    @Test fun `detects fusion tool call even without parseable result body`() {
+        val tree = mapOf(
+            "choices" to listOf(
+                mapOf(
+                    "message" to mapOf(
+                        "tool_calls" to listOf(
+                            mapOf(
+                                "type" to "function",
+                                "function" to mapOf("name" to "openrouter_fusion", "arguments" to "{}"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(true, OpenRouterEchoDecoder.responseMentionsFusionInvocation(tree))
+        assertEquals(false, OpenRouterEchoDecoder.responseMentionsFusionInvocation(mapOf("content" to "hello")))
+    }
+
+    @Test fun `unparsed is not panelDidNotRun`() {
+        val unparsed = FusionAnalysis(
+            panelName = "p",
+            judgeModel = null,
+            models = listOf("a"),
+            toolResultFound = false,
+            deliberationSkipped = false,
+        )
+        assertEquals(false, unparsed.panelDidNotRun)
+        assertEquals(true, unparsed.detailUnparsed)
+        val skipped = unparsed.copy(deliberationSkipped = true)
+        assertEquals(true, skipped.panelDidNotRun)
+        assertEquals(false, skipped.detailUnparsed)
+    }
+
     @Test fun `prefers successful fusion over later capped invocation`() {
         val ok = mapOf(
             "status" to "ok",


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #110: two commits that landed on the feature branch after merge
- Fixes false Fusion failure UI when the panel answered but tool payload was unparsed
- Reasoning-style process shell (soft meta block, multi-line model rows with per-model spinners, collapse to final answer)
- Stops double fusion invocation (usion_invocation_capped) by using `tool_choice: auto` + single-call system prompt + preferring the successful tool payload

## Test plan
- [ ] Echo Fusion with a 2-model panel: activity log shows **one** fusion tool call, not two
- [ ] No `fusion_invocation_capped` after a successful panel result
- [ ] Live UI shows multi-line model rows with spinners, then merge wording, then collapses when the answer streams
- [ ] Does **not** show `Fusion failed` when models answered and a final answer appears
- [ ] Normal (non-Fusion) chat unchanged
- [ ] Unit tests: `OpenRouterEchoDecoderTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Fusion response handling across varied payload formats.
  - Fusion now selects the best available result and provides clearer model status reporting.
  - Added more accurate distinction between completed, unavailable, and genuinely failed results.
  - PDF plugin configuration now preserves existing valid plugins.

- **Improvements**
  - Fusion responses provide cleaner summaries without exposing internal panel details.
  - Processing states and available deliberation details are presented more clearly.

- **Bug Fixes**
  - Prevented capped tool invocations from being incorrectly treated as failures.
  - Improved handling of nested responses and incomplete Fusion results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Echo Fusion toward a clearer and more trustworthy product experience: one cost-bearing panel invocation, explicit handling of unavailable detail, and a reasoning-style process shell that collapses into the final answer. I especially like the distinction between a panel that failed, one that did not run, and one whose detail could not be decoded; the implementation is also improved by centralizing request construction and inference parameters.
- Forces exactly one Fusion-enabled request and uses a tool-disabled synthesis request only when necessary.
- Expands decoding across nested payloads, model identifiers, structured disagreements, and hard-error responses.
- Introduces explicit Fusion outcome states and corresponding multi-line progress UI.
- Preserves existing plugins when PDF parsing is enabled and adds decoder coverage for the new response shapes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/OpenRouterService.kt | Replaces the retrying Fusion flow with one required tool request, optional tool-free synthesis, and explicit blank-answer failures. |
| app/src/main/java/com/echoflow/data/OpenRouterEchoDecoder.kt | Broadens nested Fusion-result decoding, separates invocation detection from payload parsing, and prefers usable results. |
| app/src/main/java/com/echoflow/data/ChatStreamModels.kt | Adds persisted state distinguishing hard failure, skipped deliberation, and unavailable structured detail. |
| app/src/main/java/com/echoflow/ui/components/EchoToolComponents.kt | Presents Fusion as a collapsible reasoning process with per-model status rows and outcome-specific messaging. |
| app/src/test/java/com/echoflow/data/OpenRouterEchoDecoderTest.kt | Covers the decoder behavior needed to distinguish successful, capped, unparsed, and model-id-based Fusion responses. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Fusion UI
    participant Service as OpenRouterService
    participant API as OpenRouter

    UI->>Service: Send panel-enabled turn
    Service-->>UI: FusionStarted
    Service->>API: Required Fusion request
    API-->>Service: Panel result and optional answer
    Service->>Service: Decode preferred Fusion payload
    alt Final answer present
        Service-->>UI: FusionResolved
        Service-->>UI: Final answer
    else Usable panel detail but no answer
        Service->>API: Tool-disabled synthesis request
        API-->>Service: Synthesized answer
        Service-->>UI: FusionResolved and final answer
    else Panel skipped, detail unparsed, or answer still blank
        Service-->>UI: FusionResolved
        Service-->>UI: Actionable error
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Distinguish unparsed fusion from skipped..."](https://github.com/adityavardhansharma/echoflow/commit/c24e2281c0a9c0a70c259b1199aee95e9bb06282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52632735)</sub>

<!-- /greptile_comment -->