### PR TITLE
Make the dictation mic a 32dp circle matching the model pill

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/VoiceInput.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/VoiceInput.kt
@@ -1,20 +1,16 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
-
 package com.echoflow.ui.screens
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardVoice
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -25,8 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -117,50 +113,35 @@ fun rememberVoiceInputController(): VoiceInputController {
  * The mic that lives beside the model picker (never in the oval's corners). One fixed home: tap to
  * dictate, tap again to stop.
  *
- * It's built on the same expressive [ShapedIconButton] as the composer's "+" and Send — a filled
- * fun-shape with a 2.5D top-lit gradient that morphs on press — so it reads as one modern family,
- * not a bolted-on stock icon button. Rest is a soft nine-sided cookie; while recording it lifts to
- * the accent, breathes with a gentle pulse and shows a Stop; it's inert during transcription.
+ * A plain circle the same height as [com.echoflow.ui.components.ModelPill] (22.dp mark + 5.dp
+ * vertical padding). Theme roles only — no morphing shapes, no pulse that grows over the row.
+ * Recording lifts to primary and swaps the glyph for Stop; it's inert during transcription.
  */
 @Composable
 fun ModelRowMic(phase: VoicePhase, onClick: () -> Unit) {
     val recording = phase == VoicePhase.Recording
-    // Pulse only while recording so Idle does not keep a frame-by-frame animation running.
-    val pulseScale = remember { Animatable(1f) }
-    LaunchedEffect(recording) {
-        if (!recording) {
-            pulseScale.snapTo(1f)
-            return@LaunchedEffect
-        }
-        while (true) {
-            pulseScale.animateTo(1.14f, tween(620))
-            pulseScale.animateTo(1f, tween(620))
-        }
-    }
-    Box(
-        Modifier
-            .minimumInteractiveComponentSize()
-            .scale(pulseScale.value),
+    Surface(
+        onClick = onClick,
+        enabled = phase != VoicePhase.Transcribing,
+        shape = CircleShape,
+        color = if (recording) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.size(ModelRowMicSize),
     ) {
-        ShapedIconButton(
-            onClick = onClick,
-            enabled = phase != VoicePhase.Transcribing,
-            size = 48.dp,
-            restShape = MaterialShapes.Cookie9Sided,
-            pressedShape = MaterialShapes.Flower,
-            container = if (recording) MaterialTheme.colorScheme.primary
-            else MaterialTheme.colorScheme.secondaryContainer,
-        ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Icon(
                 if (recording) Icons.Default.Stop else Icons.Default.KeyboardVoice,
                 if (recording) "Stop dictation" else "Dictate",
-                Modifier.size(20.dp),
+                Modifier.size(18.dp),
                 tint = if (recording) MaterialTheme.colorScheme.onPrimary
                 else MaterialTheme.colorScheme.onSecondaryContainer,
             )
         }
     }
 }
+
+/** Matches [com.echoflow.ui.components.ModelPill]: 22.dp provider mark + 5.dp top/bottom padding. */
+private val ModelRowMicSize = 32.dp
 
 /**
  * A live voice waveform that takes over the composer's text area while recording. Keeps a rolling


### PR DESCRIPTION
## Summary

Follow-up to #112. The new mic kept the modern `KeyboardVoice` glyph, but the **button** was a 48dp cookie/flower `ShapedIconButton` that pulsed to ~55dp while recording — taller than the model picker and covering the chip row.

It is now a plain circle the same height as the model pill (32dp: 22dp mark + 5dp vertical padding). Theme roles stay as they were (`secondaryContainer` at rest, `primary` while recording). No morphing shapes, no grow-on-record pulse.

## Test plan

- [ ] Composer with STT available: mic sits beside the model picker, same height, circular
- [ ] Idle: modern mic icon on `secondaryContainer`
- [ ] Recording: same 32dp circle, `primary`, Stop glyph — does not grow over chips or the input
- [ ] Transcribing: mic is inert
- [ ] Themes (light/dark, palettes): colors still come from the scheme
- [ ] `./gradlew :app:compileDebugKotlin` (passed locally)

## Screenshots

Could not recapture on-device here (no emulator/device attached). Existing #112 shots show the previous larger control:

![previous idle](https://github.com/adityavardhansharma/EchoFlow/blob/main/docs/screenshots/stt/05-composer-with-mic.png?raw=true)
![previous recording](https://github.com/adityavardhansharma/EchoFlow/blob/main/docs/screenshots/stt/06-composer-recording-waveform.png?raw=true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the voice input microphone control to use a consistent circular design.
  * Preserved visual feedback for recording and transcription states, including icon and color changes.
  * Removed pulsing and morphing animations from the microphone control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is strong: matching the mic’s visual weight to the model pill and removing the recording pulse should make the composer calmer and prevent overlap with the chip row. The implementation can be improved by separating the desired 32dp circle from an accessibility-sized interaction container.
- Replaces the expressive, morphing mic button with a fixed circular Surface.
- Keeps theme-derived idle and recording colors while reducing the icon to 18dp.
- Removes recording-scale animation and experimental Material 3 dependencies.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking accessibility improvement needed to preserve a larger interaction target around the 32dp mic.

The visual simplification and removal of the pulse are localized, but constraining the clickable Surface itself to 32dp removes the previous explicit minimum-size wrapper and can make dictation harder to activate.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/screens/VoiceInput.kt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/screens/VoiceInput.kt | Simplifies ModelRowMic into a fixed 32dp circle, but should preserve a larger accessible hit target around the compact visual control. |

<sub>Reviews (1): Last reviewed commit: ["Make the dictation mic a 32dp circle mat..."](https://github.com/adityavardhansharma/echoflow/commit/800c7c2c105f8714ec273ad60f4f9c496dfe39f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52819166)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->