### PR TITLE
Replace Fish STT with GPT Transcribe as the default

### DIFF
--- a/app/src/main/java/com/echoflow/data/SpeechToTextService.kt
+++ b/app/src/main/java/com/echoflow/data/SpeechToTextService.kt
@@ -162,21 +162,17 @@ class SpeechToTextTranscriber {
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(120, TimeUnit.SECONDS)
         .build()
-    private val json = Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(Any::class.java)
 
     suspend fun transcribe(apiKey: String, modelId: String, wav: ByteArray): Result<String> =
         withContext(Dispatchers.IO) {
             if (apiKey.isBlank()) {
                 return@withContext Result.failure(IllegalStateException("No OpenRouter key"))
             }
-            val payload = mapOf(
-                "model" to modelId,
-                "input_audio" to mapOf(
-                    "data" to Base64.encodeToString(wav, Base64.NO_WRAP),
-                    "format" to "wav",
-                ),
+            val payload = SttPayloads.requestBody(
+                modelId,
+                Base64.encodeToString(wav, Base64.NO_WRAP),
             )
-            val body = json.toJson(payload).toRequestBody("application/json".toMediaType())
+            val body = SttPayloads.encode(payload).toRequestBody("application/json".toMediaType())
             val request = Request.Builder()
                 .url("https://openrouter.ai/api/v1/audio/transcriptions")
                 .header("Authorization", "Bearer $apiKey")
@@ -190,12 +186,31 @@ class SpeechToTextTranscriber {
                     if (!resp.isSuccessful) {
                         error(ProviderHttpSupport.errorMessage("Speech to text", resp.code, text))
                     }
-                    parseTranscript(text) ?: error("Couldn't hear that — try again.")
+                    SttPayloads.parseTranscript(text) ?: error("Couldn't hear that — try again.")
                 }
             }
         }
+}
 
-    private fun parseTranscript(body: String): String? {
+/**
+ * The JSON posted to `/audio/transcriptions` and the two response shapes we accept.
+ * Kept separate from the HTTP client so the default model id and the `{ "text": ... }`
+ * parse can be asserted without opening a socket.
+ */
+internal object SttPayloads {
+    private val json = Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(Any::class.java)
+
+    fun requestBody(modelId: String, wavBase64: String): Map<String, Any> = mapOf(
+        "model" to modelId,
+        "input_audio" to mapOf(
+            "data" to wavBase64,
+            "format" to "wav",
+        ),
+    )
+
+    fun encode(payload: Map<String, Any>): String = json.toJson(payload)
+
+    fun parseTranscript(body: String): String? {
         val map = runCatching { json.fromJson(body) as? Map<*, *> }.getOrNull() ?: return null
         (map["text"] as? String)?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
         val choice = (map["choices"] as? List<*>)?.firstOrNull() as? Map<*, *>

--- a/app/src/main/java/com/echoflow/data/SttCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/SttCatalog.kt
@@ -37,11 +37,12 @@ object SttCatalog {
     /** The three cloud options offered on the STT settings page, in display order. */
     val CLOUD_MODELS = listOf(
         SttModel(
-            id = "fish-audio/transcribe-1",
-            name = "Fish Audio Transcribe 1",
-            provider = "Fish Audio",
-            pricing = "~\$0.006 / min",
-            blurb = "Fast, budget multilingual transcription.",
+            id = "openai/gpt-transcribe",
+            name = "GPT Transcribe",
+            provider = "OpenAI",
+            // OpenRouter lists \$0.0045/min.
+            pricing = "~\$0.0045 / min",
+            blurb = "High-accuracy dictation, strong on mixed or quiet speech.",
         ),
         SttModel(
             id = "x-ai/grok-stt-1.0",
@@ -61,7 +62,7 @@ object SttCatalog {
         ),
     )
 
-    const val DEFAULT_MODEL_ID = "fish-audio/transcribe-1"
+    const val DEFAULT_MODEL_ID = "openai/gpt-transcribe"
 
     fun byId(id: String): SttModel? = CLOUD_MODELS.firstOrNull { it.id == id }
 

--- a/app/src/test/java/com/echoflow/data/SttCatalogTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttCatalogTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
  * Update both the catalog strings and these expectations when OpenRouter changes STT pricing.
  *
  * Reference (as of 2026-08):
- * - fish-audio/transcribe-1 ≈ \$0.006/min (\$0.0001/s duration billing)
+ * - openai/gpt-transcribe = \$0.0045/min
  * - x-ai/grok-stt-1.0 = \$0.10/hour ≈ \$0.0017/min
  * - google/chirp-3 = \$0.016/min
  */
@@ -17,21 +17,27 @@ class SttCatalogTest {
 
     @Test fun `catalog lists the three curated cloud models`() {
         assertEquals(
-            listOf("fish-audio/transcribe-1", "x-ai/grok-stt-1.0", "google/chirp-3"),
+            listOf("openai/gpt-transcribe", "x-ai/grok-stt-1.0", "google/chirp-3"),
             SttCatalog.CLOUD_MODELS.map { it.id },
         )
     }
 
     @Test fun `user-facing prices match current OpenRouter STT listings`() {
-        assertEquals("~\$0.006 / min", SttCatalog.byId("fish-audio/transcribe-1")!!.pricing)
+        assertEquals("~\$0.0045 / min", SttCatalog.byId("openai/gpt-transcribe")!!.pricing)
         assertEquals("~\$0.0017 / min", SttCatalog.byId("x-ai/grok-stt-1.0")!!.pricing)
         assertEquals("~\$0.016 / min", SttCatalog.byId("google/chirp-3")!!.pricing)
+    }
+
+    @Test fun `default is GPT Transcribe and sits first so unknown ids fall through to it`() {
+        assertEquals("openai/gpt-transcribe", SttCatalog.DEFAULT_MODEL_ID)
+        assertEquals(SttCatalog.DEFAULT_MODEL_ID, SttCatalog.CLOUD_MODELS.first().id)
+        assertNotNull(SttCatalog.byId(SttCatalog.DEFAULT_MODEL_ID))
     }
 
     @Test fun `resolve falls back to the default model for blank or unknown ids`() {
         assertEquals(SttCatalog.DEFAULT_MODEL_ID, SttCatalog.resolve("").id)
         assertEquals(SttCatalog.DEFAULT_MODEL_ID, SttCatalog.resolve("gone/model").id)
-        assertNotNull(SttCatalog.byId(SttCatalog.DEFAULT_MODEL_ID))
+        assertEquals(SttCatalog.DEFAULT_MODEL_ID, SttCatalog.resolve("fish-audio/transcribe-1").id)
         assertEquals("x-ai/grok-stt-1.0", SttCatalog.resolve("x-ai/grok-stt-1.0").id)
     }
 }

--- a/app/src/test/java/com/echoflow/data/SttRequestTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttRequestTest.kt
@@ -1,0 +1,46 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Request-level coverage for the curated STT default. [SttCatalogTest] only sees the catalog;
+ * a swapped default that never reaches `/audio/transcriptions`, or a GPT Transcribe body we
+ * fail to parse, would pass that suite and break only on a real dictation.
+ */
+class SttRequestTest {
+
+    @Test fun `the catalog default is the model id posted on the transcription request`() {
+        val body = SttPayloads.requestBody(SttCatalog.DEFAULT_MODEL_ID, "dGVzdA==")
+        assertEquals("openai/gpt-transcribe", body["model"])
+        assertEquals(SttCatalog.DEFAULT_MODEL_ID, body["model"])
+        val audio = body["input_audio"] as Map<*, *>
+        assertEquals("wav", audio["format"])
+        assertEquals("dGVzdA==", audio["data"])
+    }
+
+    @Test fun `encoded body still carries the GPT Transcribe model id`() {
+        val json = SttPayloads.encode(SttPayloads.requestBody(SttCatalog.DEFAULT_MODEL_ID, "dGVzdA=="))
+        assertTrue(json.contains("\"model\":\"openai/gpt-transcribe\""))
+    }
+
+    @Test fun `parses the OpenRouter text field GPT Transcribe returns`() {
+        assertEquals("hello there", SttPayloads.parseTranscript("""{"text":"hello there"}"""))
+        assertEquals("trimmed", SttPayloads.parseTranscript("""{"text":"  trimmed  "}"""))
+    }
+
+    @Test fun `parses chat-completions content as a fallback`() {
+        assertEquals(
+            "from chat",
+            SttPayloads.parseTranscript("""{"choices":[{"message":{"content":"from chat"}}]}"""),
+        )
+    }
+
+    @Test fun `blank or missing text is not a transcript`() {
+        assertNull(SttPayloads.parseTranscript("""{"text":"  "}"""))
+        assertNull(SttPayloads.parseTranscript("{}"))
+        assertNull(SttPayloads.parseTranscript("not-json"))
+    }
+}

--- a/app/src/test/java/com/echoflow/data/SttSettingsTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttSettingsTest.kt
@@ -1,0 +1,35 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SttSettingsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetPreferences() {
+        SettingsPreferenceStorage.legacy(context).edit().clear().commit()
+        SettingsPreferenceStorage.secureOrNull(context)?.edit()?.clear()?.commit()
+    }
+
+    @Test fun `a fresh install dictates with GPT Transcribe`() {
+        val repository = SettingsRepository(context)
+        assertEquals("openai/gpt-transcribe", repository.getSttCloudModelDirect())
+        assertEquals(SttCatalog.DEFAULT_MODEL_ID, repository.sttCloudModel.value)
+    }
+
+    @Test fun `a leftover Fish id is resolved to GPT Transcribe before it can be sent`() {
+        val stored = SettingsPreferenceStorage.secureOrNull(context)
+            ?: SettingsPreferenceStorage.legacy(context)
+        stored.edit().putString("stt_cloud_model", "fish-audio/transcribe-1").commit()
+
+        val repository = SettingsRepository(context)
+        assertEquals("openai/gpt-transcribe", repository.getSttCloudModelDirect())
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #112, separate from the mic-button polish in #113.

Fish Audio Transcribe 1 (`fish-audio/transcribe-1`) was the default dictation model. Its auto-detect often returned Chinese on short or mixed clips. This PR drops it from the curated cloud list and puts **GPT Transcribe** (`openai/gpt-transcribe`) first as the new default.

The three cloud rows are now:

1. **GPT Transcribe** — default, ~`$0.0045`/min, high-accuracy dictation
2. **Grok STT 1.0** — ~`$0.0017`/min, conversational / noisy speech
3. **Chirp 3** — ~`$0.016`/min, broad coverage (unchanged)

No language-picker page. These three labs auto-detect well enough that a 130-language setting is not worth the UI. Anyone still stored on `fish-audio/transcribe-1` falls through `SttCatalog.resolve()` to GPT.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.SttCatalogTest`
- [ ] Settings → Speech to text: first row is GPT Transcribe, selected by default on a fresh install
- [ ] Grok and Chirp still selectable
- [ ] Fish is gone from the list
- [ ] An existing install that had Fish stored now transcribes with GPT (resolve fallback)
- [ ] Dictate a short English clip with the default model

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes GPT Transcribe the curated default, cleanly migrates stale Fish selections through catalog fallback, and extracts STT payload handling for focused request and response tests. I like the product direction toward more reliable short and mixed-clip dictation; the implementation now adequately covers the previously missing request contract, and I do not see a further change that needs to be implemented.
- Replaces Fish Audio with GPT Transcribe in the cloud catalog and default selection.
- Verifies fresh-install and legacy Fish preference resolution.
- Tests model serialization and supported transcription response shapes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/SpeechToTextService.kt | Extracts request serialization and response parsing into the tested SttPayloads helper while preserving the production HTTP flow. |
| app/src/main/java/com/echoflow/data/SttCatalog.kt | Replaces Fish with GPT Transcribe as the first curated model and default fallback. |
| app/src/test/java/com/echoflow/data/SttRequestTest.kt | Adds focused coverage that the catalog default is serialized into the transcription payload and that GPT text responses are parsed. |
| app/src/test/java/com/echoflow/data/SttSettingsTest.kt | Confirms fresh installs and persisted legacy Fish selections resolve to GPT Transcribe. |

<sub>Reviews (2): Last reviewed commit: ["Cover the GPT Transcribe default on the ..."](https://github.com/adityavardhansharma/echoflow/commit/3bb081347e5db39ab0ecdf3586baf995872fbcba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52823892)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->