### PR TITLE
Enable web search for cloud artifact mode

### DIFF
--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -342,18 +342,28 @@ object SystemPrompts {
         isLocalModel: Boolean,
         offline: Boolean,
         priorArtifact: String? = null,
+        searchProvider: String = "off",
         currentDate: String = currentDate(),
     ): String {
         val sections = mutableListOf<String>()
         sections += identity(isLocalModel)
         sections += "Current date: $currentDate."
         sections += artifactContract()
+        if (!isLocalModel && searchProvider != "off") sections += artifactSearchGuidance()
         sections += artifactTypeGuidance()
         sections += htmlDesignGuidance(isLocalModel, offline)
         sections += reportGuidance()
         priorArtifact?.takeIf { it.isNotBlank() }?.let { sections += artifactIterationGuidance(it) }
         return sections.joinToString("\n\n")
     }
+
+    private fun artifactSearchGuidance(): String =
+        """
+        ## Web search
+        web_search is available. Use it when you lack facts or the request is time-bound. Finish
+        searching before you write the artifact; put verified facts inside it. The output contract
+        still applies.
+        """.trimIndent()
 
     private fun artifactContract(): String =
         """

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1528,6 +1528,8 @@ class ChatViewModel(
                         val withSearch = systemPrompt + "\n\nUse these web search results when relevant:\n$searchContext"
                         emitAll(customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, withSearch, inferenceParams))
                     }
+                artifactMode && customProviderActive ->
+                    customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 artifactMode && provider == "openrouter" ->
                     openRouterGateway.stream(
                         LlmStreamRequest(
@@ -1544,8 +1546,6 @@ class ChatViewModel(
                     openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
                         webSearchService.search(provider, searchKey, query)
                     }
-                artifactMode && customProviderActive ->
-                    customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 artifactMode ->
                     openRouterGateway.stream(
                         LlmStreamRequest(

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1282,7 +1282,8 @@ class ChatViewModel(
             val artifactSystemPrompt = if (artifactMode) {
                 val prior = _currentChatThreadId.value?.let { artifactManager.getLatestVersionContent(it) }
                 val offline = settingsRepository.getArtifactsOfflineDirect() || isLocal
-                SystemPrompts.buildArtifact(isLocal, offline, prior)
+                val artifactSearch = if (!isLocal && effectiveProvider != "off") effectiveProvider else "off"
+                SystemPrompts.buildArtifact(isLocal, offline, prior, artifactSearch)
             } else null
 
             val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: when {
@@ -1498,8 +1499,8 @@ class ChatViewModel(
                         agent = agentReq,
                         params = inferenceParams,
                     )
-                // Artifact mode runs the plain streaming path (no search); the parser extracts the
-                // <echo:artifact> block from the content stream.
+                // Artifact mode: on-device stays search-free; cloud uses the same search paths as
+                // normal chat. The parser extracts the <echo:artifact> block from the content stream.
                 artifactMode && isLocal ->
                     localGateway.stream(
                         LlmStreamRequest(
@@ -1511,6 +1512,38 @@ class ChatViewModel(
                             localModel = localModel,
                         )
                     ).withLocalInferenceGate("a chat reply")
+                artifactMode && customToolCallingActive ->
+                    customProviderToolFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams) { query ->
+                        webSearchService.search(provider, searchKey, query)
+                    }
+                artifactMode && customProviderActive && clientSearchReady ->
+                    flow {
+                        val query = prompt
+                        emit(StreamChunk.SearchStarted(query))
+                        val sources = webSearchService.search(provider, searchKey, query)
+                        emit(StreamChunk.SearchSources(query, sources))
+                        val searchContext = sources.joinToString("\n\n") { source ->
+                            "[${source.title}](${source.url})\n${source.snippet.orEmpty()}"
+                        }
+                        val withSearch = systemPrompt + "\n\nUse these web search results when relevant:\n$searchContext"
+                        emitAll(customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, withSearch, inferenceParams))
+                    }
+                artifactMode && provider == "openrouter" ->
+                    openRouterGateway.stream(
+                        LlmStreamRequest(
+                            apiKey = apiKey,
+                            model = selectedModel,
+                            chatId = chatId,
+                            history = fullHistory,
+                            systemPrompt = systemPrompt,
+                            params = inferenceParams,
+                            serverWebSearch = true,
+                        )
+                    )
+                artifactMode && clientSearchReady ->
+                    openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
+                        webSearchService.search(provider, searchKey, query)
+                    }
                 artifactMode && customProviderActive ->
                     customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
                 artifactMode ->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud models in artifact mode can now use web search before building an artifact. Local on-device artifact mode is unchanged (no search).

## Changes

### `SystemPrompts.buildArtifact`
- Added optional `searchProvider` parameter (defaults to `"off"`).
- When cloud + search is configured, appends a minimal 4-line search section after the artifact contract.

### `ChatViewModel` routing
Artifact mode mirrors normal chat search paths for cloud models, with **custom-provider branches checked before OpenRouter search branches** (fixes misrouting when search provider is OpenRouter but the model is custom).

- **Custom provider + tool calling** → `customProviderToolFlow`
- **Custom provider + client search** → pre-injected search, then `customProviderFlow`
- **Custom provider (plain)** → `customProviderFlow`
- **OpenRouter provider** → `serverWebSearch = true`
- **Exa / Parallel / Firecrawl** → `sendWithClientSearch` tool loop
- **Local models** → plain stream (no search)

## Prompt added (cloud only, when search configured)

```
## Web search
web_search is available. Use it when you lack facts or the request is time-bound. Finish
searching before you write the artifact; put verified facts inside it. The output contract
still applies.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abacd9ff-da66-4f9b-bd85-831924dda8bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abacd9ff-da66-4f9b-bd85-831924dda8bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artifact generation now supports web search for cloud-based models.
  * Search automatically uses the configured provider, including native tools, client-side results, or server-side search.
  * AI-generated artifacts can incorporate verified, current information when needed.
  * Search guidance helps ensure research is completed before artifact writing.

* **Improvements**
  * Local and offline artifact generation remains search-free.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR advances the product in a useful direction by letting cloud artifact generation use current web information while preserving search-free local behavior. The implementation improves the previously reported routing by prioritizing custom-provider paths before OpenRouter; no further implementation change is required from this follow-up.

- Adds search-aware artifact prompt guidance for eligible cloud models.
- Routes custom-provider artifacts through their configured custom endpoints before considering OpenRouter.
- Supports tool-based, pre-injected client, and server-side search paths while leaving local artifacts unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported custom-provider misrouting is resolved, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/SystemPrompts.kt | Adds cloud-only web-search guidance to artifact prompts when an eligible search provider is configured. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Extends artifact routing across custom and OpenRouter search flows while correctly prioritizing custom-provider branches. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Artifact request] --> B{Local model?}
    B -- Yes --> C[Local stream without search]
    B -- No --> D{Custom provider with tool calling?}
    D -- Yes --> E[Custom provider tool flow]
    D -- No --> F{Custom provider with client search?}
    F -- Yes --> G[Inject search results into custom provider flow]
    F -- No --> H{Custom provider?}
    H -- Yes --> I[Plain custom provider flow]
    H -- No --> J{OpenRouter search provider?}
    J -- Yes --> K[OpenRouter server web search]
    J -- No --> L{Client search ready?}
    L -- Yes --> M[OpenRouter client-search loop]
    L -- No --> N[Plain OpenRouter stream]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix artifact routing: custom providers b..."](https://github.com/adityavardhansharma/echoflow/commit/e89f500c41544d08ababaa76a19150afdcbbbc23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52926594)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->