### PR TITLE
Revert "Enable web search for cloud artifact mode" (#115)

### DIFF
--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -342,28 +342,18 @@ object SystemPrompts {
         isLocalModel: Boolean,
         offline: Boolean,
         priorArtifact: String? = null,
-        searchProvider: String = "off",
         currentDate: String = currentDate(),
     ): String {
         val sections = mutableListOf<String>()
         sections += identity(isLocalModel)
         sections += "Current date: $currentDate."
         sections += artifactContract()
-        if (!isLocalModel && searchProvider != "off") sections += artifactSearchGuidance()
         sections += artifactTypeGuidance()
         sections += htmlDesignGuidance(isLocalModel, offline)
         sections += reportGuidance()
         priorArtifact?.takeIf { it.isNotBlank() }?.let { sections += artifactIterationGuidance(it) }
         return sections.joinToString("\n\n")
     }
-
-    private fun artifactSearchGuidance(): String =
-        """
-        ## Web search
-        web_search is available. Use it when you lack facts or the request is time-bound. Finish
-        searching before you write the artifact; put verified facts inside it. The output contract
-        still applies.
-        """.trimIndent()
 
     private fun artifactContract(): String =
         """

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1282,8 +1282,7 @@ class ChatViewModel(
             val artifactSystemPrompt = if (artifactMode) {
                 val prior = _currentChatThreadId.value?.let { artifactManager.getLatestVersionContent(it) }
                 val offline = settingsRepository.getArtifactsOfflineDirect() || isLocal
-                val artifactSearch = if (!isLocal && effectiveProvider != "off") effectiveProvider else "off"
-                SystemPrompts.buildArtifact(isLocal, offline, prior, artifactSearch)
+                SystemPrompts.buildArtifact(isLocal, offline, prior)
             } else null
 
             val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: when {
@@ -1499,8 +1498,8 @@ class ChatViewModel(
                         agent = agentReq,
                         params = inferenceParams,
                     )
-                // Artifact mode: on-device stays search-free; cloud uses the same search paths as
-                // normal chat. The parser extracts the <echo:artifact> block from the content stream.
+                // Artifact mode runs the plain streaming path (no search); the parser extracts the
+                // <echo:artifact> block from the content stream.
                 artifactMode && isLocal ->
                     localGateway.stream(
                         LlmStreamRequest(
@@ -1512,40 +1511,8 @@ class ChatViewModel(
                             localModel = localModel,
                         )
                     ).withLocalInferenceGate("a chat reply")
-                artifactMode && customToolCallingActive ->
-                    customProviderToolFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams) { query ->
-                        webSearchService.search(provider, searchKey, query)
-                    }
-                artifactMode && customProviderActive && clientSearchReady ->
-                    flow {
-                        val query = prompt
-                        emit(StreamChunk.SearchStarted(query))
-                        val sources = webSearchService.search(provider, searchKey, query)
-                        emit(StreamChunk.SearchSources(query, sources))
-                        val searchContext = sources.joinToString("\n\n") { source ->
-                            "[${source.title}](${source.url})\n${source.snippet.orEmpty()}"
-                        }
-                        val withSearch = systemPrompt + "\n\nUse these web search results when relevant:\n$searchContext"
-                        emitAll(customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, withSearch, inferenceParams))
-                    }
                 artifactMode && customProviderActive ->
                     customProviderFlow(customProvider, customProviderConfig, requestModel, fullHistory, systemPrompt, inferenceParams)
-                artifactMode && provider == "openrouter" ->
-                    openRouterGateway.stream(
-                        LlmStreamRequest(
-                            apiKey = apiKey,
-                            model = selectedModel,
-                            chatId = chatId,
-                            history = fullHistory,
-                            systemPrompt = systemPrompt,
-                            params = inferenceParams,
-                            serverWebSearch = true,
-                        )
-                    )
-                artifactMode && clientSearchReady ->
-                    openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
-                        webSearchService.search(provider, searchKey, query)
-                    }
                 artifactMode ->
                     openRouterGateway.stream(
                         LlmStreamRequest(


### PR DESCRIPTION
Reverts #115.

The artifact-mode cloud search change should not stay on main. This undoes the merge commit (31af577) and restores the previous artifact routing and prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified Artifact mode by removing web-search provider selection and search-specific behavior.
  * Artifact generation now follows a consistent streaming process across supported providers.
  * Existing local and custom-provider routing remains available.
  * Artifact prompts continue to include formatting, report, date, and iteration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR cleanly restores artifact mode to its previous search-free behavior. I like the product decision to keep artifact generation on a predictable plain-streaming path while the cloud-search design is reconsidered; a future implementation could better isolate artifact search behind an explicit capability or feature flag and add routing tests before enabling it.
- Removes web-search guidance and the search-provider argument from the artifact system prompt.
- Routes local, custom-provider, and OpenRouter artifact requests through their plain streaming paths.
- Leaves normal-chat web-search routing unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the prompt contract and artifact routing consistently restored to search-free behavior.

The removed prompt parameter has no stale callers, all artifact configurations retain valid plain-streaming fallbacks, and normal-chat search behavior remains unchanged.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/SystemPrompts.kt | Removes artifact-specific web-search guidance and keeps the prompt builder synchronized with its sole caller. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Restores search-free artifact routing while preserving the existing search-enabled paths for normal chat. |

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Enable web search for cloud arti..."](https://github.com/adityavardhansharma/echoflow/commit/740245f7103d9a7734aa2463613f099e6df15a41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53116233)</sub>

**Context used:**

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->