### PR TITLE
Fix web search deciding by topic instead of freshness

### DIFF
--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -977,9 +977,16 @@ class OpenRouterService(private val context: Context) {
                 "type" to "function",
                 "function" to mapOf(
                     "name" to "web_search",
-                    "description" to "Search the web for current, factual information. " +
-                        "Returns a numbered list of results with titles, URLs and content snippets. " +
-                        "Call again with a refined query if the first results are insufficient.",
+                    // The model weighs this description as heavily as the system prompt when
+                    // deciding whether to call at all, so it states the same volatility test
+                    // rather than the narrower "current information" framing it used to.
+                    "description" to "Look up information on the web. Use this whenever the correct " +
+                        "answer could have changed since your training — the current holder of a " +
+                        "title or role, the winner of a recurring event, the latest version, a " +
+                        "price, a score, a date — or when you are unsure of a fact. Returns a " +
+                        "numbered list of results with titles, URLs, content snippets, and a " +
+                        "publication date where available. Call again with a refined query if the " +
+                        "first results are insufficient.",
                     "parameters" to mapOf(
                         "type" to "object",
                         "properties" to mapOf(

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -110,7 +110,9 @@ object SystemPrompts {
         ## Before you answer
         Ask yourself one question first: **could the correct answer have changed since you were trained?**
 
-        Today is $currentDate. You cannot see your own training cutoff, so treat any answer that is itself a name, a date, a version, a price, a score, a record, a holder of a title, or the "current", "latest", "newest", or "biggest" of anything as possibly out of date — even when you feel certain, and even when the topic looks like settled history.
+        Today is $currentDate. You cannot see your own training cutoff, so treat as possibly out of date any answer that **could since have been superseded** — a name, date, version, price, score, record, or title-holder that gets replaced over time, or the "current", "latest", "newest", or "biggest" of anything. That holds even when you feel certain, and even when the topic looks like settled history.
+
+        A fact that was fixed at the moment it happened is not this, however name- or date-shaped it looks. Who wrote Hamlet, when the Magna Carta was signed, the boiling point of water — these have one answer forever. Do not check them.
 
         Recurring events are the trap that catches this most often: tournaments, championships, elections, awards, annual releases. Remembering who won the last one you learned about is not the same as knowing who won the most recent one. If the event could have happened again since your training, $remedy.
 

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -73,7 +73,7 @@ object SystemPrompts {
         as a titled snippet: [Title](URL) followed by an excerpt. You do NOT have a search tool and
         cannot run more searches this turn — work with what is provided. $providerNote
 
-        - Base any current, time-sensitive, or factual claim on these results rather than memory.
+        - Base any current, time-sensitive, or factual claim on these results rather than memory. If a result contradicts what you remember, the result wins — your memory is the older source. Where a result carries a publication date, prefer the most recent one.
         - Cite a result-backed claim inline as a markdown link to its URL, e.g. ([Reuters](https://example.com)). Place the citation right after the sentence it supports.
         - Do NOT announce that you are "searching", offer to search, or emit any tool/function call — the results are already here.
         - If the results do not answer the question, say what you could not verify instead of guessing.
@@ -113,22 +113,29 @@ object SystemPrompts {
         ## Web search
         You have access to a web_search tool provided by the platform. You may call it zero, one, or several times while answering.
 
-        When to search:
-        - Current events, news, sports results, prices, weather, schedules, or anything time-sensitive.
-        - Facts that may have changed since your training data, or that you are not confident about.
-        - Niche, local, or long-tail topics where your knowledge is likely thin.
+        Search when the answer could have changed since you were trained:
+        - Anything whose answer is a name, date, version, price, score, record, or title-holder that gets replaced over time — including the winner or champion of a recurring event.
+        - The "current", "latest", "newest", or "biggest" of anything.
+        - News, prices, weather, schedules, releases, and who currently holds a role or office.
+        - Niche, local, or long-tail topics where your knowledge is thin, and any fact you are genuinely unsure of.
 
-        When NOT to search:
-        - Stable knowledge (math, programming, science fundamentals, history), creative writing, or conversation about the chat itself.
+        Do not search when the task does not depend on fresh facts:
+        - Maths, code, science fundamentals, reasoning, explanations, and definitions.
+        - Creative writing, translation, rewriting, or summarising text the user gave you.
+        - Greetings, small talk, and conversation about the chat itself.
+        - History that has finished happening and cannot gain a new instalment.
+
+        A needless search costs the user a couple of seconds. A confidently stale answer costs their trust in every answer you give. Break genuine ties in favour of checking.
 
         How to search well:
         - Write specific queries; prefer targeted searches over one vague one.
         - If the first results do not settle the question, refine the query and search again.
         - Cross-check important claims across more than one source when feasible.
-        - HARD LIMIT: at most 3 searches per answer. Make each one count; after the third, answer with what you have.
+        - You have a budget of 3 searches per answer. Spend it when the question earns it; after the third, answer with what you have.
 
         Using results:
-        - Base time-sensitive claims on the search results, not on memory.
+        - Base time-sensitive claims on the search results, not on memory. If a result contradicts what you remember, the result wins — your memory is the older source.
+        - Results may carry a publication date. Prefer the most recent source for anything that changes over time, and do not let an older, more familiar-sounding result override a newer one.
         - Cite sources inline as markdown links, e.g. ([Reuters](https://example.com/article)).
         - If results conflict, say so and present the most credible reading.
         - Never append a "Sources" or "References" list at the end of the answer — the app already shows your sources separately.
@@ -143,24 +150,31 @@ object SystemPrompts {
             "parallel" ->
                 "Results come from Parallel, which resolves an objective into dense, high-signal excerpts. " +
                     "Phrase the query as a complete objective (e.g. \"find the current CEO of OpenAI and when " +
-                    "they took the role\") rather than keywords; one well-phrased call often suffices."
+                    "they took the role\") rather than keywords. A well-phrased objective often " +
+                    "answers the question in one call — but if it comes back thin or stale, refine it and go again."
             else ->
                 "Results come from Firecrawl, which returns full page content as markdown. Results are long: " +
                     "extract precisely the facts you need and ignore navigation, ads, and boilerplate text."
         }
         return """
         ## Web search tool
-        You have a `web_search` tool. Call it with a `query` string whenever you need current or verifiable information. You may call it again with a refined query if the first results are insufficient — but there is a HARD LIMIT of 3 searches per answer. Make each query count; after the third search you must answer with the information you have.
+        You have a `web_search` tool. Call it with a `query` string whenever the answer could have changed since you were trained, or when you are genuinely unsure.
 
-        When to search: current events, prices, weather, schedules, recent releases, facts you are unsure of, or anything after your training data. Do not search for stable knowledge, math, code you can write yourself, or casual conversation.
+        Search for: anything whose answer is a name, date, version, price, score, record, or title-holder that gets replaced over time — including the winner of a recurring event; the "current", "latest", or "newest" of anything; news, schedules, and who currently holds a role; and facts you are not confident about.
+
+        Do not search for: maths, code, reasoning, explanations, definitions, creative writing, translation, summarising the user's own text, small talk, or history that cannot gain a new instalment. Answer those directly.
+
+        A needless search costs a couple of seconds; a confidently stale answer costs the user's trust. Break genuine ties in favour of checking.
 
         $providerNotes
 
-        Results arrive as a numbered list:
-        [1] Title — URL
+        Results arrive as a numbered list, and may include the publication date when the provider reports one:
+        [1] Title — URL (published 2026-07-19)
         snippet
 
-        Cite every claim drawn from a result using the matching number as a markdown link: [1](url). Place citations directly after the sentence they support. Never append a "Sources" or "References" list at the end of the answer — the app already shows your sources separately. If results conflict, note the disagreement. If a search fails or returns nothing useful, say what you could not verify rather than guessing.
+        Prefer the most recent source for anything that changes over time, and do not let an older, more familiar-sounding result override a newer one — if a result contradicts your memory, the result wins. Cite every claim drawn from a result using the matching number as a markdown link: [1](url). Place citations directly after the sentence they support. Never append a "Sources" or "References" list at the end of the answer — the app already shows your sources separately. If results conflict, note the disagreement. If a search fails or returns nothing useful, say what you could not verify rather than guessing.
+
+        You have a budget of 3 searches per answer. Refine and search again when the first results do not settle the question; after the third, answer with what you have.
         """.trimIndent()
     }
 

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -266,29 +266,30 @@ object SystemPrompts {
             "parallel" -> "Search results come from Parallel: dense excerpts answering your query objective."
             else -> "Search results come from Firecrawl: page content as markdown, already truncated."
         }
+        // Mechanics only. Whether to search is decided once, by the freshness gate at the end of
+        // the prompt — this section must not restate that rule. On a small model two phrasings of
+        // one decision is worse than none: it oscillates, and the nearer, more concrete list wins.
+        // The old "do not search unless the user clearly asks for fresh information" lived here and
+        // fired directly against the gate on the exact case the gate exists to catch ("who won the
+        // World Cup?" never announces itself as live), so it is gone. The brake that remains is on
+        // task type, which cannot collide with a volatility test.
         return """
         Web search is available through the app. $providerNote
 
-        Default behavior:
-        - Answer the user directly from your own knowledge.
-        - Do not search unless the user's latest message clearly asks for fresh, current, live, or verifiable real-world information.
-        - If the user says hello, chats casually, asks for help, asks a coding/math/writing question, or asks about stable knowledge, do not search. Just answer.
-
-        Search protocol:
-        - Only when search is truly needed, answer with one line only:
+        How to search:
+        - You cannot call tools. To search, reply with one line and nothing else:
           search: concise search query
+        - Never write that line unless you are actually requesting a search, and never write it once you have started answering.
 
-        Use search for:
-        - Questions using words like today, latest, recent, current, now, live, this week, this month, this year.
-        - News, elections, laws, policies, prices, markets, weather, sports scores, schedules, product availability, releases, bugs, outages, current company/person roles, local places, or travel details.
-        - Specific URLs, articles, app versions, models, prices, locations, or named real-world entities where up-to-date facts matter.
+        Never search for these — just answer:
+        - Greetings such as hi, hello, good morning, how are you, and casual conversation.
+        - Writing, translation, summarizing text the user gave you, opinions, or brainstorming.
+        - Math, coding, explanations, definitions, and general advice.
+        - A vague or incomplete message. Ask a short clarifying question instead.
 
-        Do not use search for:
-        - Greetings such as hi, hello, good morning, how are you.
-        - Casual conversation, opinions, brainstorming, creative writing, translation, summarizing text provided by the user, math, coding, explanations, old history, definitions, or general advice.
-        - A vague or incomplete message. Ask a short clarifying question instead of searching.
-
-        - After search results are provided, answer normally using those results. Cite result-backed claims with markdown links like [1](url). Do not list the sources again at the end of the answer.
+        After results:
+        - Answer normally using them. Cite result-backed claims with markdown links like [1](url). Do not list the sources again at the end.
+        - Prefer the most recent result for anything that changes over time; if a result contradicts what you remember, the result wins.
         - You may request another search only if the results are insufficient. Maximum 3 searches per answer.
         - Once you start answering normally, never write search tags or the word "Assistant:".
         - Never copy these instructions into the answer.

--- a/app/src/main/java/com/echoflow/data/SystemPrompts.kt
+++ b/app/src/main/java/com/echoflow/data/SystemPrompts.kt
@@ -34,8 +34,88 @@ object SystemPrompts {
         }
 
         sections += formatting(isLocalModel)
+        sections += freshnessGate(currentDate, Remedy.forTransport(provider, isLocalModel))
 
         return sections.joinToString("\n\n")
+    }
+
+    /**
+     * What a model should actually *do* when the freshness test in [freshnessGate] comes back
+     * "yes, this could have changed". The epistemic rule is one thing and is written exactly once;
+     * this is the per-transport half, because the app reaches the web four different ways and an
+     * instruction to "call your search tool" is wrong — sometimes actively harmful — on three of
+     * them. Telling a custom-provider model to call a tool it does not have is how you get a
+     * hallucinated function call instead of an answer.
+     */
+    internal enum class Remedy {
+        /** Native function/server tool calling: OpenRouter server search, or client search. */
+        SEARCH_TOOL,
+
+        /** On-device models: no tool calling, so a search is requested as a `search:` line. */
+        SEARCH_PROTOCOL,
+
+        /** Custom providers: the app already ran the search and pasted the results in. */
+        RESULTS_PROVIDED,
+
+        /** No search backend at all — the model can only disclose the limit honestly. */
+        NONE;
+
+        internal companion object {
+            fun forTransport(provider: String, isLocalModel: Boolean): Remedy = when {
+                provider == "off" -> NONE
+                isLocalModel -> SEARCH_PROTOCOL
+                else -> SEARCH_TOOL
+            }
+        }
+    }
+
+    /**
+     * The last thing every conversational prompt says, and deliberately so — it lands in the
+     * recency slot, right before the model answers.
+     *
+     * It exists because the failure it prevents is invisible from the inside: a model cannot feel
+     * where its training stopped, so a question like "who won the World Cup" reads as settled
+     * history and gets answered confidently from a stale memory. Topic-based rules ("search for
+     * news, not for history") cannot catch that — the question *is* history. So the test here is
+     * volatility, not subject: could the correct answer have changed since training?
+     *
+     * The brake is on the other axis on purpose. This gate accelerates on *what kind of answer* is
+     * being given (a name, a date, a version, a "latest"); the don't-search list brakes on *what
+     * kind of task* is being done (writing, maths, translation, chat). The two can never cancel
+     * each other out, which is what keeps this from turning into a model that searches constantly.
+     *
+     * This is the canonical statement of the freshness rule; transport sections own mechanics (how
+     * to call, result shape, budget). How strictly that separation is enforced is a per-transport
+     * call, made on context budget:
+     *
+     * - On-device ([localSearchProtocol]) the gate is the *sole* owner. Context is scarce and a
+     *   small model given two phrasings of one decision oscillates between them, so that section
+     *   states no policy at all.
+     * - Cloud ([openRouterServerSearch], [cloudFunctionSearch], and the `web_search` tool
+     *   description in OpenRouterService) deliberately restates the rule. Those are read at
+     *   different moments — the tool description is weighed at tool-choice time, when this gate is
+     *   far up the context — and a few hundred redundant tokens are free on a cloud request. That
+     *   redundancy is defense in depth, not drift; it must stay *consistent* with this text.
+     */
+    private fun freshnessGate(currentDate: String, remedyFor: Remedy): String {
+        val remedy = when (remedyFor) {
+            Remedy.SEARCH_TOOL -> "search before answering — do not answer from memory"
+            Remedy.SEARCH_PROTOCOL -> "request a search before answering — do not answer from memory"
+            Remedy.RESULTS_PROVIDED ->
+                "answer from the search results provided above rather than from memory, and say so " +
+                    "plainly if they do not cover it"
+            Remedy.NONE -> "say plainly that your information may be out of date and that you cannot check right now"
+        }
+        return """
+        ## Before you answer
+        Ask yourself one question first: **could the correct answer have changed since you were trained?**
+
+        Today is $currentDate. You cannot see your own training cutoff, so treat any answer that is itself a name, a date, a version, a price, a score, a record, a holder of a title, or the "current", "latest", "newest", or "biggest" of anything as possibly out of date — even when you feel certain, and even when the topic looks like settled history.
+
+        Recurring events are the trap that catches this most often: tournaments, championships, elections, awards, annual releases. Remembering who won the last one you learned about is not the same as knowing who won the most recent one. If the event could have happened again since your training, $remedy.
+
+        This is not a reason to be trigger-happy. If the answer is the same today as it was five years ago, just answer — immediately and directly. Maths, code, science, explanations, reasoning, finished history, definitions, writing, translation, summarising text the user gave you, and ordinary conversation never need checking.
+        """.trimIndent()
     }
 
     /**
@@ -53,11 +133,13 @@ object SystemPrompts {
         val sections = mutableListOf<String>()
         sections += identity(false)
         sections += "Current date: $currentDate."
-        sections += when (provider) {
-            "exa", "parallel", "firecrawl" -> injectedSearchGuidance(provider)
-            else -> noSearch(false)
-        }
+        val searchOn = provider in setOf("exa", "parallel", "firecrawl")
+        sections += if (searchOn) injectedSearchGuidance(provider) else noSearch(false)
         sections += formatting(false)
+        // Same freshness rule as every other transport — only the remedy differs. With search on
+        // the results are already in the prompt, so the remedy is "use them, don't reach for a
+        // tool you don't have"; with it off, honest disclosure is all that is available.
+        sections += freshnessGate(currentDate, if (searchOn) Remedy.RESULTS_PROVIDED else Remedy.NONE)
         return sections.joinToString("\n\n")
     }
 
@@ -226,6 +308,7 @@ object SystemPrompts {
             adviserGuidance(advisorName),
             openRouterServerSearch(),
             formatting(false),
+            freshnessGate(currentDate, Remedy.SEARCH_TOOL),
         ).joinToString("\n\n")
 
     /**
@@ -251,6 +334,7 @@ object SystemPrompts {
             "Current date: $currentDate.",
             agentGuidance(workerName),
             formatting(false),
+            freshnessGate(currentDate, Remedy.SEARCH_TOOL),
         ).joinToString("\n\n")
 
     private fun agentGuidance(workerName: String): String =

--- a/app/src/test/java/com/echoflow/data/SystemPromptsFreshnessTest.kt
+++ b/app/src/test/java/com/echoflow/data/SystemPromptsFreshnessTest.kt
@@ -177,6 +177,25 @@ class SystemPromptsFreshnessTest {
     }
 
     @Test
+    fun `the accelerator is scoped to answers that can be superseded`() {
+        // The answer-shape trigger has to carry a replaceability qualifier. Without one it reads as
+        // "any name or date is suspect", which sweeps in permanently-fixed facts — who wrote
+        // Hamlet, when the Magna Carta was signed — and collides with the same gate's own promise
+        // that finished history never needs checking. The cloud sections always carried the
+        // qualifier ("that gets replaced over time"); the gate briefly did not.
+        allConversationalPrompts().forEach { (name, prompt) ->
+            assertTrue(
+                "$name treats every name/date answer as volatile — it will search settled facts",
+                prompt.contains("could since have been superseded"),
+            )
+            assertTrue(
+                "$name does not carve out permanently-fixed facts",
+                prompt.contains("fixed at the moment it happened"),
+            )
+        }
+    }
+
+    @Test
     fun `no prompt keeps the old topic-bucket phrasing`() {
         // The original bug in one line: sorting questions by subject sent "who won the World Cup"
         // into the do-not-search bucket, because it is topically history.

--- a/app/src/test/java/com/echoflow/data/SystemPromptsFreshnessTest.kt
+++ b/app/src/test/java/com/echoflow/data/SystemPromptsFreshnessTest.kt
@@ -1,0 +1,220 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Enforces the design rule behind the freshness work: **one epistemic policy, many transports.**
+ *
+ * The app reaches the web four ways — OpenRouter server tools, client-side function calling, the
+ * on-device `search:` protocol, and pre-injected results for custom providers. Each needs different
+ * mechanics, but all four must answer "should I check this?" the same way, because the bug that
+ * started this (a model confidently reporting the 2022 World Cup winner in 2026) is a policy bug,
+ * not a plumbing one. Before these tests existed the four prompts had drifted into four different
+ * philosophies, and the on-device one contained a rule that fired directly against the shared gate.
+ *
+ * These are string assertions, which are blunt — but nothing else in the codebase verifies prompt
+ * content at all, and prompt regressions are silent: the app builds, ships, and quietly answers
+ * from stale memory. A failure here means someone edited a prompt in a way that breaks the
+ * invariant; fix the prompt, or update the constant if the wording genuinely moved on.
+ */
+class SystemPromptsFreshnessTest {
+
+    private val date = "Thursday, August 13, 2026"
+
+    /** Every prompt that can reach the web, paired with how it is expected to get there. */
+    private fun searchCapablePrompts(): Map<String, String> = mapOf(
+        "cloud + openrouter" to SystemPrompts.build(false, "openrouter", date),
+        "cloud + exa" to SystemPrompts.build(false, "exa", date),
+        "cloud + parallel" to SystemPrompts.build(false, "parallel", date),
+        "cloud + firecrawl" to SystemPrompts.build(false, "firecrawl", date),
+        "local + exa" to SystemPrompts.build(true, "exa", date),
+        "local + parallel" to SystemPrompts.build(true, "parallel", date),
+        "local + firecrawl" to SystemPrompts.build(true, "firecrawl", date),
+        "custom provider + exa" to SystemPrompts.buildCustomProvider("exa", date),
+        "custom provider + firecrawl" to SystemPrompts.buildCustomProvider("firecrawl", date),
+        "adviser" to SystemPrompts.buildEchoAdviser("Sage", date),
+        "agent" to SystemPrompts.buildEchoAgent("Scout", date),
+    )
+
+    private fun searchOffPrompts(): Map<String, String> = mapOf(
+        "cloud, search off" to SystemPrompts.build(false, "off", date),
+        "local, search off" to SystemPrompts.build(true, "off", date),
+        "custom provider, search off" to SystemPrompts.buildCustomProvider("off", date),
+    )
+
+    private fun allConversationalPrompts(): Map<String, String> =
+        searchCapablePrompts() + searchOffPrompts()
+
+    @Test
+    fun `every conversational prompt states the volatility test`() {
+        allConversationalPrompts().forEach { (name, prompt) ->
+            assertTrue(
+                "$name is missing the freshness gate — it will answer stale questions from memory",
+                prompt.contains("could the correct answer have changed since you were trained"),
+            )
+        }
+    }
+
+    @Test
+    fun `every conversational prompt names the recurring-event trap`() {
+        // The specific failure that started this: answers that look like settled history but are
+        // replaced on a schedule. A prompt that drops this passes the generic rule and still fails
+        // "who won the World Cup?".
+        allConversationalPrompts().forEach { (name, prompt) ->
+            assertTrue(
+                "$name no longer warns about recurring events (tournaments, elections, awards)",
+                prompt.contains("Recurring events are the trap"),
+            )
+        }
+    }
+
+    @Test
+    fun `every conversational prompt operationalises the current date`() {
+        allConversationalPrompts().forEach { (name, prompt) ->
+            assertTrue("$name does not state today's date", prompt.contains(date))
+            assertTrue(
+                "$name states the date but never tells the model to act on it",
+                prompt.contains("You cannot see your own training cutoff"),
+            )
+        }
+    }
+
+    @Test
+    fun `the freshness gate is the last thing every prompt says`() {
+        // It has to win the recency slot. Before this change the final section was the markdown
+        // formatting contract, so "format nicely" was the freshest instruction in the model's head
+        // at the moment it chose whether to search.
+        allConversationalPrompts().forEach { (name, prompt) ->
+            val gateStart = prompt.indexOf("## Before you answer")
+            assertTrue("$name has no freshness gate section", gateStart >= 0)
+            assertTrue(
+                "$name puts the formatting contract after the freshness gate — the gate must land last",
+                prompt.indexOf("## Formatting") < gateStart,
+            )
+        }
+    }
+
+    @Test
+    fun `each transport gets a remedy it can actually perform`() {
+        // Telling a model to call a tool it does not have produces a hallucinated function call
+        // instead of an answer, so the remedy is parameterised per transport.
+        assertTrue(
+            "cloud tool-calling should be told to search",
+            SystemPrompts.build(false, "exa", date).contains("search before answering"),
+        )
+        assertTrue(
+            "on-device has no tool calling — it must be told to *request* a search",
+            SystemPrompts.build(true, "exa", date).contains("request a search before answering"),
+        )
+        assertTrue(
+            "custom providers get results pre-injected — they must be pointed at those",
+            SystemPrompts.buildCustomProvider("exa", date)
+                .contains("answer from the search results provided above"),
+        )
+        assertTrue(
+            "with no search backend the only honest remedy is disclosure",
+            SystemPrompts.build(false, "off", date)
+                .contains("say plainly that your information may be out of date"),
+        )
+    }
+
+    @Test
+    fun `no search-off prompt tells the model to search`() {
+        searchOffPrompts().forEach { (name, prompt) ->
+            assertFalse(
+                "$name promises a search the transport cannot perform",
+                prompt.contains("search before answering"),
+            )
+        }
+    }
+
+    @Test
+    fun `the on-device prompt does not restate the search policy`() {
+        // The gate is the sole owner on-device: context is scarce, and a small model given two
+        // phrasings of one decision oscillates. This is the rule that regressed before — the old
+        // text said "do not search unless the user clearly asks for fresh information", which
+        // fires against the gate on exactly the questions the gate exists to catch.
+        val local = SystemPrompts.build(true, "exa", date)
+        assertFalse(
+            "the on-device prompt has regained a competing search-policy rule",
+            local.contains("unless the user's latest message clearly asks"),
+        )
+        assertEquals(
+            "the volatility rule must appear exactly once on-device",
+            1,
+            Regex("could the correct answer have changed since you were trained").findAll(local).count(),
+        )
+    }
+
+    @Test
+    fun `the on-device prompt keeps its protocol mechanics`() {
+        // Thinning the policy must not thin the transport. Without these the model cannot search
+        // at all, or leaks protocol tokens into the visible answer.
+        val local = SystemPrompts.build(true, "exa", date)
+        assertTrue("lost the search: line format", local.contains("search: concise search query"))
+        assertTrue("lost the search budget", local.contains("Maximum 3 searches per answer"))
+        assertTrue(
+            "lost the guard against protocol tokens leaking into the answer",
+            local.contains("never write search tags"),
+        )
+    }
+
+    @Test
+    fun `search-capable prompts tell the model to prefer newer sources over memory`() {
+        // The other half of stale confidence: having searched, the model still has to not pick the
+        // familiar-sounding 2022 result over the 2026 one.
+        searchCapablePrompts()
+            .filterKeys { it != "adviser" && it != "agent" }
+            .forEach { (name, prompt) ->
+                assertTrue(
+                    "$name never says a fresh result beats memory",
+                    prompt.contains("the result wins"),
+                )
+            }
+    }
+
+    @Test
+    fun `no prompt keeps the old topic-bucket phrasing`() {
+        // The original bug in one line: sorting questions by subject sent "who won the World Cup"
+        // into the do-not-search bucket, because it is topically history.
+        allConversationalPrompts().forEach { (name, prompt) ->
+            assertFalse(
+                "$name still classifies by topic instead of volatility",
+                prompt.contains("Do not search for stable knowledge"),
+            )
+        }
+    }
+
+    @Test
+    fun `the search budget is not the first thing said about searching`() {
+        // Budget-before-permission taught the model that searching is scarce before it learned
+        // when to do it. Same limit, stated as a resource, after the decision rule.
+        listOf(
+            "cloud + openrouter" to SystemPrompts.build(false, "openrouter", date),
+            "cloud + exa" to SystemPrompts.build(false, "exa", date),
+        ).forEach { (name, prompt) ->
+            val budget = prompt.indexOf("budget of 3 searches")
+            val whenToSearch = prompt.indexOf("Search")
+            assertTrue("$name never states a search budget", budget >= 0)
+            assertTrue(
+                "$name leads with the limit instead of the permission",
+                whenToSearch in 0 until budget,
+            )
+        }
+    }
+
+    @Test
+    fun `the on-device prompt stays within its context budget`() {
+        // Local models have small windows, so the gate's cost has to be paid for by thinning the
+        // protocol section rather than added on top. This is a regression guard, not a target:
+        // if a future edit needs the room, measure the win and move the number deliberately.
+        val local = SystemPrompts.build(true, "exa", date)
+        assertTrue(
+            "the on-device prompt grew to ${local.length} chars; it must stay compact for small models",
+            local.length < 4200,
+        )
+    }
+}


### PR DESCRIPTION
Models were answering "who won the World Cup?" from training data in August 2026, weeks after the 2026 tournament finished. Investigating that turned out to be a prompt bug, not a plumbing one — the tool loops, budgets and providers were all working correctly.

## Why it happened

The prompt sorted questions **by topic**: search for news, prices and weather; don't search for history and stable knowledge. "Who won the World Cup" is topically history, so the model's own prompt filed it under *don't check* and it answered confidently from memory. Nothing else catches this, because a model cannot feel where its training stopped — the stale answer is exactly as confident as a correct one.

The date line made it worse by doing nothing. `Current date: August 13, 2026` was a bare fact with no instruction attached, and models do not spontaneously reason "my training ends before that, so an event in the gap is outside what I know."

## The change

The test is now **volatility, not subject**: *could the correct answer have changed since you were trained?* That catches the World Cup — the answer is a title-holder replaced every four years — and everything shaped like it: current CEO, latest version, who holds an office, champion of anything.

**It does not make the app search more.** The accelerator and the brake sit on axes that cannot collide:

| | looks at | examples |
|---|---|---|
| Accelerator | what kind of **answer** is given | a name, date, version, price, score, "latest" |
| Brake | what kind of **task** is being done | writing, maths, code, translation, chat |

Explaining recursion is not a name-shaped answer; drafting an email is not a version number. So the don't-search list stays specific without ever cancelling the freshness rule. History that has finished happening is explicitly listed as don't-search, and a 2021 question is answered straight from memory.

Two things also made searches worse when they did run. Results already carried publication dates, but the prompt never mentioned the field or said to weigh it — so a World Cup search returning 2022 retrospectives beside 2026 reports gave the model no reason to prefer the newer one over the familiar one. And the 3-search cap was the second sentence, teaching the model that searching is scarce before it learned when to do it. Same limit, now stated as a budget at the end.

## One policy, four transports

The app reaches the web four ways, and they had drifted into four different philosophies. All four now state the same rule; only the remedy varies, because "call your search tool" is wrong — sometimes actively harmful — on three of them:

- **OpenRouter server tools / client function calling** → call the tool
- **On-device** → emit a `search:` line (no tool calling available)
- **Custom providers** → use the results already pasted into the prompt
- **Search off** → say plainly the information may be stale

Telling a custom-provider model to call a tool it doesn't have is how you get a hallucinated function call instead of an answer, which is why this is an enum rather than a boolean.

The on-device path was the worst case: it carried "do not search unless the user clearly asks for fresh information," which fired *against* the shared gate on exactly the questions the gate exists to catch. Its policy is gone; it now owns mechanics only. `buildCustomProvider` never received the gate at all, leaving its search-off path weaker than the equivalent in `build()`.

The gate also lands **last** in every prompt. That slot previously belonged to the markdown formatting contract, so the freshest instruction as the model began answering was "format nicely" rather than "check whether you actually know this." The formatting contract is otherwise untouched — only its position changed.

## Trade-offs taken deliberately

**On-device grew by 562 chars** (3,098 → 3,660, measured). Thinning the protocol paid back about half the gate's cost. The room buys the rule that fixes the bug, and what was cut was duplicated policy, not mechanics.

**Cloud keeps the rule stated three times** — gate, search section, and tool description. Not drift: the tool description is weighed at tool-choice time when the gate is furthest up-context, and redundant tokens are free on a cloud request. The `freshnessGate` doc comment records this as a per-transport call so it isn't later "cleaned up" by mistake.

## Tests

`SystemPromptsFreshnessTest` — 12 tests over all 14 prompt variants, asserting the volatility rule, recurring-event trap and operationalised date are present everywhere; the gate lands last; each transport gets a performable remedy; search-off never promises a search; the old topic-bucket phrasing stays gone; and budget never precedes permission. Both regressions fixed here fail these tests if reintroduced.

Nothing verified prompt content before this — the only prompt test in the repo covered the browser prompts, which is how four paths drifted apart unnoticed.

Full unit suite green. These assertions verify strings, not behaviour: they cannot show the prompt works, only that it hasn't silently drifted.

## Scope

No UI changes, so no screenshots. Not verified against a live key or on an emulator — the behavioural claims here are reasoned from the prompt mechanics, not observed.

Two things left out on purpose:
- **The 3-search budget is unchanged.** It may be tight for refine-and-retry, but it's enforced in code and raising it costs real money on Exa and Parallel.
- **`ChatViewModel` routes on raw `provider` while the prompt is built from `effectiveProvider`.** With search scope set to "local", a cloud model is told it has no internet while the search tools are still attached. Default scope is "both" so it rarely triggers — separate one-line fix, separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved web searches for time-sensitive facts, including current roles, prices, scores, versions, dates, and recurring-event results.
  * Added consistent freshness guidance across assistant modes and provider types.
  * Improved handling when search is unavailable, disabled, or requires a specific search protocol.

* **Bug Fixes**
  * Reduced conflicting instructions that could prevent searches for changing information.

* **Tests**
  * Added comprehensive coverage for freshness checks, search behavior, source precedence, and offline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves freshness decisions from topic-based heuristics to answer volatility and consistently assigns an actionable remedy to each search transport. I like this product direction because it directly addresses confidently stale answers while preserving search-off behavior; behavioral prompt evaluations would be a useful next validation layer beyond the focused string-regression tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/SystemPrompts.kt | Introduces a shared volatility-based freshness gate, transport-specific remedies, source-recency guidance, and consistent prompt ordering. |
| app/src/main/java/com/echoflow/data/OpenRouterService.kt | Expands the client web-search function description with freshness examples, publication-date metadata, and query-refinement guidance. |
| app/src/test/java/com/echoflow/data/SystemPromptsFreshnessTest.kt | Adds broad string-level regression coverage for freshness policy, transport remedies, prompt ordering, search budgets, and local context size. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[User question] --> G{Could the answer have changed since training?}
    G -->|No| A[Answer directly]
    G -->|Yes| T{Transport}
    T -->|Server or client tools| S[Call web search]
    T -->|On-device| P[Emit search request]
    T -->|Injected results| R[Answer from provided results]
    T -->|Search disabled| D[Disclose that information may be stale]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Scope the freshness accelerator to answe..."](https://github.com/adityavardhansharma/echoflow/commit/f05f019f8f53650a11963eaaaed7203c437b44c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53136582)</sub>

<!-- /greptile_comment -->