### PR TITLE
Use Ocean as dynamic accent fallback on pre-Android 12

### DIFF
--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -183,8 +183,8 @@ class SettingsRepository(context: Context) {
     }
 
     fun getThemeColorDirect(): String {
-        // Default to Material You wallpaper-sampled dynamic color; Theme.kt falls back to the
-        // monochrome palette automatically on devices older than Android 12.
+        // Default to Material You wallpaper-sampled dynamic color; Theme.kt falls back to Ocean
+        // on devices older than Android 12.
         return prefs.getString("theme_color", "dynamic").orEmpty()
     }
 

--- a/app/src/main/java/com/echoflow/ui/theme/Theme.kt
+++ b/app/src/main/java/com/echoflow/ui/theme/Theme.kt
@@ -31,12 +31,14 @@ fun EchoFlowTheme(
     val colorScheme = when {
         themeName == "dynamic" && supportsDynamic ->
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        themeName == "dynamic" ->
+            if (darkTheme) OceanDark else OceanLight // pre-Android 12: no Material You sampling
         themeName == "ocean" -> if (darkTheme) OceanDark else OceanLight
         themeName == "forest" -> if (darkTheme) ForestDark else ForestLight
         themeName == "sunset" -> if (darkTheme) SunsetDark else SunsetLight
         themeName == "lavender" -> if (darkTheme) LavenderDark else LavenderLight
         themeName == "rose" -> if (darkTheme) RoseDark else RoseLight
-        else -> if (darkTheme) MonochromeDark else MonochromeLight // monochrome is the default
+        else -> if (darkTheme) MonochromeDark else MonochromeLight // unknown theme names
     }
 
     MaterialExpressiveTheme(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fresh installs still default to the **Wallpaper** accent (`theme_color = dynamic`), but on Android 11 and below Material You sampling is unavailable. Previously those devices silently fell through to **Monochrome**; they now use the **Ocean** palette instead.

## Changes

- `Theme.kt`: when `themeName == "dynamic"` and `supportsDynamic` is false, apply `OceanLight` / `OceanDark`.
- `SettingsRepository.kt`: update the comment documenting the fallback.

Monochrome remains the fallback for unknown theme names and the default parameter on `EchoFlowTheme` when no preference is wired.

## Testing

- `./gradlew :app:testDebugUnitTest --tests 'com.echoflow.SettingsRepositoryCharacterizationTest'` — passed.
- Logic-only change; pre-Android 12 palette swap is not exercised in Robolectric (API 31+ host).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc1555fd-b8f9-4191-80d8-6023e45801fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc1555fd-b8f9-4191-80d8-6023e45801fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the pre-Android 12 fallback explicit and consistent with the intended product direction; using the established Ocean palette gives fresh installs a more distinctive default than Monochrome. The implementation is appropriately narrow, though a focused pre-Android 12 theme-selection test would better protect the new fallback behavior.
- Selects `OceanLight` or `OceanDark` when the saved theme is `dynamic` but the platform predates Android 12.
- Preserves Material You colors on supported devices and Monochrome for unknown theme names.
- Updates the settings documentation to match the runtime fallback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new fallback limited to platforms where Material You sampling is unavailable.

The API-level condition exclusively routes pre-Android 12 dynamic-theme selections to complete, platform-independent Ocean color schemes, while supported devices and all other theme names retain their existing behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/theme/Theme.kt | Adds a correctly API-gated Ocean fallback for dynamic themes while preserving existing named-palette and unknown-theme behavior. |
| app/src/main/java/com/echoflow/data/SettingsRepository.kt | Updates the preference-default comment so it accurately documents the new pre-Android 12 fallback. |

<sub>Reviews (1): Last reviewed commit: ["Use Ocean as dynamic-color fallback on p..."](https://github.com/adityavardhansharma/echoflow/commit/1077144566c5a6cf86ab8492ae89ecab6e39a8f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53314374)</sub>

<!-- /greptile_comment -->