### PR TITLE
Rename Cloud to OpenRouter in Models settings labels

### DIFF
--- a/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
+++ b/app/src/main/java/com/echoflow/data/DeepResearchEngine.kt
@@ -825,7 +825,7 @@ class DeepResearchEngine(
         attachment: OpenRouterService.LocalAttachment?,
     ) {
         if (openRouterKey.isBlank()) {
-            emit(ResearchEvent.Failed("OpenRouter API key is missing — add it in Settings → Cloud models."))
+            emit(ResearchEvent.Failed("OpenRouter API key is missing — add it in Settings → Models → OpenRouter."))
             return
         }
         val searchProvider = config.searchProvider

--- a/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt
@@ -87,7 +87,7 @@ class OpenRouterVideoService {
     ): VideoJobHandle = withContext(Dispatchers.IO) {
         if (apiKey.isBlank()) {
             throw VideoGenerationException.MissingApiKey(
-                "Video generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                "Video generation uses OpenRouter. Add your API key in Settings → Models → OpenRouter."
             )
         }
         val payload = buildMap<String, Any> {
@@ -206,7 +206,7 @@ class OpenRouterVideoService {
         400 -> ProviderHttpSupport.errorMessage("OpenRouter", code, body)
             .takeIf { !it.endsWith("HTTP $code.") }
             ?: "$model rejected these settings. Try a different aspect ratio or resolution."
-        401 -> "OpenRouter rejected your API key. Check it in Settings → Cloud models."
+        401 -> "OpenRouter rejected your API key. Check it in Settings → Models → OpenRouter."
         402, 403 -> "OpenRouter refused the request — your credit may be depleted."
         404 -> "$model is not available for video generation."
         else -> ProviderHttpSupport.errorMessage("OpenRouter", code, body)

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -1116,7 +1116,7 @@ class ChatViewModel(
                     return@launch
                 }
                 if (apiKey.isBlank()) {
-                    _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                    _errorMessage.value = "Image generation uses OpenRouter. Add your API key in Settings → Models → OpenRouter."
                     return@launch
                 }
             }
@@ -1127,7 +1127,7 @@ class ChatViewModel(
                     return@launch
                 }
                 if (apiKey.isBlank()) {
-                    _errorMessage.value = "Video generation uses OpenRouter. Add your API key in Settings → Cloud models."
+                    _errorMessage.value = "Video generation uses OpenRouter. Add your API key in Settings → Models → OpenRouter."
                     return@launch
                 }
                 if (attachmentMime.equals("application/pdf", ignoreCase = true)) {
@@ -1873,7 +1873,7 @@ class ChatViewModel(
                 }
             } else {
                 if (settingsRepository.getApiKeyDirect().isBlank()) {
-                    _errorMessage.value = "OpenRouter API key is missing. Add it in Settings → Cloud models."
+                    _errorMessage.value = "OpenRouter API key is missing. Add it in Settings → Models → OpenRouter."
                     return@launch
                 }
                 val chosen = settingsRepository.getDeepResearchSearchProviderDirect()

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -129,7 +129,7 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
     var keyVisible by remember { mutableStateOf(false) }
     var showModelDirectory by remember { mutableStateOf(false) }
 
-    SettingsPageBody(embedded, title = "Cloud models", subtitle = "OpenRouter key & model list", onBack = onBack) {
+    SettingsPageBody(embedded, title = "OpenRouter models", subtitle = "API key & model list", onBack = onBack) {
         PageSection("API key", "One key from openrouter.ai unlocks every cloud model")
         FormCard {
             OutlinedTextField(

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsEchoLabs.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsEchoLabs.kt
@@ -366,7 +366,7 @@ internal fun EchoAdviserPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
         if (apiKey.isBlank()) {
             Spacer(Modifier.height(Spacing.m))
-            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Adviser.", error = true)
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key under Models → OpenRouter to use Echo Adviser.", error = true)
         }
 
         Spacer(Modifier.height(Spacing.xl))
@@ -459,7 +459,7 @@ internal fun EchoFusionPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
         if (apiKey.isBlank()) {
             Spacer(Modifier.height(Spacing.m))
-            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Fusion.", error = true)
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key under Models → OpenRouter to use Echo Fusion.", error = true)
         }
 
         Spacer(Modifier.height(Spacing.xl))
@@ -690,7 +690,7 @@ internal fun EchoAgentPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 
         if (apiKey.isBlank()) {
             Spacer(Modifier.height(Spacing.m))
-            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key in Cloud models to use Echo Agents.", error = true)
+            EchoNoticeCard(Icons.Default.Key, "Add your OpenRouter key under Models → OpenRouter to use Echo Agents.", error = true)
         }
 
         Spacer(Modifier.height(Spacing.xl))

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt
@@ -277,10 +277,10 @@ internal fun ModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
     var tab by rememberSaveable { mutableStateOf(PageCloudModels) }
     val effects = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
 
-    SettingsPageScaffold(title = "Models", subtitle = "Cloud & on-device", onBack = onBack) {
+    SettingsPageScaffold(title = "Models", subtitle = "OpenRouter & on-device", onBack = onBack) {
         ConnectedToggleRow(
             options = listOf(
-                PageCloudModels to "Cloud",
+                PageCloudModels to "OpenRouter",
                 PageLocalModels to "On-device",
             ),
             selected = tab,
@@ -422,7 +422,7 @@ internal fun SettingsHomePage(
                 icon = Icons.Default.Hub,
                 polygon = MaterialShapes.Gem,
                 title = "Models",
-                subtitle = "Cloud & on-device",
+                subtitle = "OpenRouter & on-device",
                 container = MaterialTheme.colorScheme.secondaryContainer,
                 onContainer = MaterialTheme.colorScheme.onSecondaryContainer,
                 index = 1, count = 8,
@@ -432,7 +432,7 @@ internal fun SettingsHomePage(
                 icon = Icons.Default.Key,
                 polygon = BrandShapes.avatarStart, // Cookie9Sided
                 title = "Custom",
-                subtitle = "Bring your own API keys",
+                subtitle = "OpenAI · Claude · Gemini · Cerebras · xAI · Ollama · LM Studio",
                 container = MaterialTheme.colorScheme.primaryContainer,
                 onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
                 index = 2, count = 8,

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsSpeechToText.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsSpeechToText.kt
@@ -222,13 +222,13 @@ private fun SttKeyStatusCard(hasKey: Boolean, onOpenCloudModels: () -> Unit) {
                 Column(Modifier.weight(1f)) {
                     Text("OpenRouter key needed", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onTertiaryContainer)
                     Text(
-                        "Add it under Cloud models to turn on the chat mic.",
+                        "Add it under OpenRouter in Models to turn on the chat mic.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                     )
                 }
                 Spacer(Modifier.width(Spacing.s))
-                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Open Cloud models", tint = MaterialTheme.colorScheme.onTertiaryContainer)
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Open OpenRouter in Models", tint = MaterialTheme.colorScheme.onTertiaryContainer)
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Models page toggle label: **Cloud** → **OpenRouter**
- Models page and hub subtitles: **Cloud & on-device** → **OpenRouter & on-device**
- Custom hub row subtitle now lists what's inside: **OpenAI · Claude · Gemini · Cerebras · xAI · Ollama · LM Studio**
- Updated cross-references (STT, Echo Labs, error messages) to point to **Settings → Models → OpenRouter**

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.echoflow.ui.screens.SettingsNavigationTest"` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e93960-bc35-4530-9d16-e6cd2b742a30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e93960-bc35-4530-9d16-e6cd2b742a30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The rename makes OpenRouter’s role much clearer across the product, especially by aligning missing-key guidance with the current Models hierarchy. I like this direction because it replaces the vague “Cloud” terminology with the provider users actually configure; the main implementation improvement would be summarizing the Custom row more compactly so its newly informative subtitle remains visible.
- Renames the Models toggle and OpenRouter model-page labels.
- Updates OpenRouter-key guidance across research, media generation, chat, Echo Labs, and speech-to-text surfaces.
- Expands the Custom settings-row subtitle to identify its supported providers, although the one-line row truncates the complete list on constrained layouts.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking UI-copy issue where the expanded Custom subtitle is truncated on constrained layouts.

The OpenRouter terminology changes accurately match the settings hierarchy and do not alter runtime behavior; only the new provider-list subtitle conflicts with the existing single-line ellipsis constraint.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/screens/SettingsScreen.kt | Clarifies OpenRouter naming throughout the Models hub, but the expanded Custom subtitle exceeds the row’s single-line presentation. |
| app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt | Renames the detail page and subtitle consistently without changing settings behavior. |
| app/src/main/java/com/echoflow/ui/screens/SettingsSpeechToText.kt | Updates missing-key guidance and accessibility copy to identify the correct OpenRouter settings destination. |
| app/src/main/java/com/echoflow/ui/screens/SettingsEchoLabs.kt | Consistently updates three informational notices to use the new Models → OpenRouter terminology. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Updates user-facing missing-key errors to match the renamed settings hierarchy without altering orchestration. |
| app/src/main/java/com/echoflow/data/DeepResearchEngine.kt | Updates the deep-research missing-key message to point users to the renamed OpenRouter settings. |
| app/src/main/java/com/echoflow/data/OpenRouterVideoService.kt | Aligns video-generation key errors with the new OpenRouter settings terminology. |

<sub>Reviews (1): Last reviewed commit: ["Rename Cloud to OpenRouter in Models set..."](https://github.com/adityavardhansharma/echoflow/commit/1dd0c1eff01c55fb8dbe7ab0a706a43ebc4e7b1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53613271)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Settings, providers, and profiles](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/settings-and-profiles.md)
- Knowledge Base — [Speech input: microphone to composer text](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/speech-input.md)
- Knowledge Base — [EchoFlow UI design system](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/ui-design-system.md)
</details>

<!-- /greptile_comment -->