### PR TITLE
Projects & Artifacts gallery

### DIFF
--- a/app/schemas/com.echoflow.data.AppDatabase/22.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/22.json
@@ -1,0 +1,1362 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "25018ca5fc399fa20a79187d4930e290",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `kind` TEXT NOT NULL DEFAULT 'chat', `pinnedAt` INTEGER, `projectId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'chat'"
+          },
+          {
+            "fieldPath": "pinnedAt",
+            "columnName": "pinnedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectId",
+            "columnName": "projectId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_threads_projectId",
+            "unique": false,
+            "columnNames": [
+              "projectId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_threads_projectId` ON `${TABLE_NAME}` (`projectId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, `replyVersionsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyVersionsJson",
+            "columnName": "replyVersionsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `stepsJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `uiVersion` INTEGER NOT NULL DEFAULT 1, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uiVersion",
+            "columnName": "uiVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "projects",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `instructions` TEXT NOT NULL, `colorIndex` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructions",
+            "columnName": "instructions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorIndex",
+            "columnName": "colorIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "project_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `projectId` TEXT NOT NULL, `name` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `extractedText` TEXT, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`projectId`) REFERENCES `projects`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectId",
+            "columnName": "projectId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedText",
+            "columnName": "extractedText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_project_documents_projectId",
+            "unique": false,
+            "columnNames": [
+              "projectId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_project_documents_projectId` ON `${TABLE_NAME}` (`projectId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "projects",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "projectId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '25018ca5fc399fa20a79187d4930e290')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -68,6 +68,8 @@ class EchoFlowAppGraph(application: Application) {
             database.artifactVersionDao(),
             database.generatedImageDao(),
             database.generatedVideoDao(),
+            database.projectDao(),
+            database.projectDocumentDao(),
             localInferenceGate,
         )
     }

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -395,12 +395,15 @@ abstract class AppDatabase : RoomDatabase() {
          */
         internal val MIGRATION_21_22 = object : Migration(21, 22) {
             override fun migrate(db: SupportSQLiteDatabase) {
+                // No DEFAULT clauses: the entity fields carry no @ColumnInfo(defaultValue), so a
+                // fresh Room install creates these columns without SQL defaults — the migrated
+                // table must match that exactly. Every insert supplies all columns anyway.
                 db.execSQL(
                     "CREATE TABLE IF NOT EXISTS projects (" +
                         "id TEXT NOT NULL PRIMARY KEY, " +
                         "name TEXT NOT NULL, " +
-                        "instructions TEXT NOT NULL DEFAULT '', " +
-                        "colorIndex INTEGER NOT NULL DEFAULT 0, " +
+                        "instructions TEXT NOT NULL, " +
+                        "colorIndex INTEGER NOT NULL, " +
                         "createdAt INTEGER NOT NULL, " +
                         "updatedAt INTEGER NOT NULL)"
                 )

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -14,9 +14,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AgentProfile::class, BrowserSession::class, BrowserStep::class,
         Artifact::class, ArtifactVersion::class,
         ImageModel::class, GeneratedImage::class,
-        VideoModel::class, GeneratedVideo::class
+        VideoModel::class, GeneratedVideo::class,
+        Project::class, ProjectDocument::class
     ],
-    version = 21, // v21: Deep Research step timeline (research_runs.stepsJson/uiVersion)
+    version = 22, // v22: Projects (projects, project_documents, chat_threads.projectId)
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -37,6 +38,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun generatedImageDao(): GeneratedImageDao
     abstract fun videoModelDao(): VideoModelDao
     abstract fun generatedVideoDao(): GeneratedVideoDao
+    abstract fun projectDao(): ProjectDao
+    abstract fun projectDocumentDao(): ProjectDocumentDao
 
     companion object {
         @Volatile
@@ -383,6 +386,42 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Projects. Two new tables plus an additive nullable column on chat_threads — no data
+         * movement, so every existing conversation is untouched and simply starts life with a
+         * null projectId (a loose chat). The projectId column is deliberately *not* a foreign
+         * key: a project delete returns its chats to the drawer rather than cascading them away,
+         * which the app does in code. The index matches ChatThread's declared Index("projectId").
+         */
+        internal val MIGRATION_21_22 = object : Migration(21, 22) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS projects (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "instructions TEXT NOT NULL DEFAULT '', " +
+                        "colorIndex INTEGER NOT NULL DEFAULT 0, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS project_documents (" +
+                        "id TEXT NOT NULL PRIMARY KEY, " +
+                        "projectId TEXT NOT NULL, " +
+                        "name TEXT NOT NULL, " +
+                        "mimeType TEXT NOT NULL, " +
+                        "sizeBytes INTEGER NOT NULL, " +
+                        "filePath TEXT NOT NULL, " +
+                        "extractedText TEXT, " +
+                        "addedAt INTEGER NOT NULL, " +
+                        "FOREIGN KEY(projectId) REFERENCES projects(id) ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_project_documents_projectId ON project_documents (projectId)")
+                db.execSQL("ALTER TABLE chat_threads ADD COLUMN projectId TEXT")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_chat_threads_projectId ON chat_threads (projectId)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -411,6 +450,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_18_19,
                     MIGRATION_19_20,
                     MIGRATION_20_21,
+                    MIGRATION_21_22,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ArtifactDaos.kt
+++ b/app/src/main/java/com/echoflow/data/ArtifactDaos.kt
@@ -10,6 +10,13 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ArtifactDao {
+    /**
+     * Every artifact lineage, newest activity first — one row per chat by the one-lineage-per-chat
+     * rule, so this is exactly "the latest artifact of each chat". Backs the Artifacts gallery.
+     */
+    @Query("SELECT * FROM artifacts ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<Artifact>>
+
     /** The most-recent artifact for one chat — used when iterating the chat's current lineage. */
     @Query("SELECT * FROM artifacts WHERE chatId = :chatId ORDER BY updatedAt DESC LIMIT 1")
     fun observeLatestForChat(chatId: String): Flow<Artifact?>

--- a/app/src/main/java/com/echoflow/data/ChatRepository.kt
+++ b/app/src/main/java/com/echoflow/data/ChatRepository.kt
@@ -37,6 +37,7 @@ class ChatRepository(
         mode: AppMode = AppMode.Chat,
         title: String = defaultTitleFor(mode),
         now: Long = System.currentTimeMillis(),
+        projectId: String? = null,
     ): ChatThread {
         val thread = ChatThread(
             id = UUID.randomUUID().toString(),
@@ -44,6 +45,7 @@ class ChatRepository(
             createdAt = now,
             updatedAt = now,
             kind = mode.storageKey,
+            projectId = projectId,
         )
         chatDao.insertThread(thread)
         return thread

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -69,6 +69,10 @@ interface ChatDao {
 
     @Query("SELECT * FROM chat_threads WHERE id = :id LIMIT 1")
     suspend fun getThreadById(id: String): ChatThread?
+
+    /** The project a conversation belongs to (or null), observed for the in-chat project pill. */
+    @Query("SELECT projectId FROM chat_threads WHERE id = :id LIMIT 1")
+    fun observeProjectId(id: String): Flow<String?>
 }
 
 @Dao

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -47,14 +47,18 @@ interface ChatDao {
     @Query("UPDATE chat_threads SET pinnedAt = :pinnedAt WHERE id = :id")
     suspend fun setPinnedAt(id: String, pinnedAt: Long?)
 
-    /** Conversations belonging to one project, newest activity first (pins still float to the top). */
+    /**
+     * Conversations belonging to one project, newest activity first (pins still float to the top).
+     * Scoped to Chat threads: projects are a Chat concept, so an Imagine thread that somehow
+     * carries a projectId never surfaces in a project.
+     */
     @Query(
-        "SELECT * FROM chat_threads WHERE projectId = :projectId ORDER BY " +
+        "SELECT * FROM chat_threads WHERE projectId = :projectId AND kind = 'chat' ORDER BY " +
             "CASE WHEN pinnedAt IS NULL THEN 1 ELSE 0 END, pinnedAt DESC, updatedAt DESC"
     )
     fun getThreadsByProject(projectId: String): Flow<List<ChatThread>>
 
-    @Query("SELECT COUNT(*) FROM chat_threads WHERE projectId = :projectId")
+    @Query("SELECT COUNT(*) FROM chat_threads WHERE projectId = :projectId AND kind = 'chat'")
     fun countThreadsInProject(projectId: String): Flow<Int>
 
     @Query("UPDATE chat_threads SET projectId = :projectId WHERE id = :id")

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -47,6 +47,23 @@ interface ChatDao {
     @Query("UPDATE chat_threads SET pinnedAt = :pinnedAt WHERE id = :id")
     suspend fun setPinnedAt(id: String, pinnedAt: Long?)
 
+    /** Conversations belonging to one project, newest activity first (pins still float to the top). */
+    @Query(
+        "SELECT * FROM chat_threads WHERE projectId = :projectId ORDER BY " +
+            "CASE WHEN pinnedAt IS NULL THEN 1 ELSE 0 END, pinnedAt DESC, updatedAt DESC"
+    )
+    fun getThreadsByProject(projectId: String): Flow<List<ChatThread>>
+
+    @Query("SELECT COUNT(*) FROM chat_threads WHERE projectId = :projectId")
+    fun countThreadsInProject(projectId: String): Flow<Int>
+
+    @Query("UPDATE chat_threads SET projectId = :projectId WHERE id = :id")
+    suspend fun setProjectId(id: String, projectId: String?)
+
+    /** Return a project's chats to the drawer — used when a project is deleted (no FK cascade). */
+    @Query("UPDATE chat_threads SET projectId = NULL WHERE projectId = :projectId")
+    suspend fun clearProjectAssignments(projectId: String)
+
     @Delete
     suspend fun deleteThread(thread: ChatThread)
 

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -6,7 +6,10 @@ import androidx.room.PrimaryKey
 import androidx.room.ForeignKey
 import androidx.room.Index
 
-@Entity(tableName = "chat_threads")
+@Entity(
+    tableName = "chat_threads",
+    indices = [Index("projectId")],
+)
 data class ChatThread(
     @PrimaryKey val id: String,
     val title: String,
@@ -24,6 +27,12 @@ data class ChatThread(
     @ColumnInfo(defaultValue = "'chat'") val kind: String = AppMode.Chat.storageKey,
     /** When set, the conversation stays at the top of the drawer until unpinned. */
     val pinnedAt: Long? = null,
+    /**
+     * The [Project] this conversation belongs to, or null for a loose chat. Deliberately not a
+     * DB foreign key: deleting a project must return its chats to the drawer, not cascade them
+     * away, so the "set null on project delete" is done in code (see ProjectManager).
+     */
+    val projectId: String? = null,
 ) {
     val mode: AppMode get() = AppMode.fromStorage(kind)
     val isPinned: Boolean get() = pinnedAt != null

--- a/app/src/main/java/com/echoflow/data/ProjectDaos.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectDaos.kt
@@ -1,0 +1,60 @@
+package com.echoflow.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ProjectDao {
+    /** The Projects hub list — most-recently-touched first. */
+    @Query("SELECT * FROM projects ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<Project>>
+
+    @Query("SELECT * FROM projects WHERE id = :id LIMIT 1")
+    fun observeById(id: String): Flow<Project?>
+
+    @Query("SELECT * FROM projects WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): Project?
+
+    @Upsert
+    suspend fun upsert(project: Project)
+
+    @Query("UPDATE projects SET name = :name, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun rename(id: String, name: String, updatedAt: Long)
+
+    @Query("UPDATE projects SET instructions = :instructions, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun setInstructions(id: String, instructions: String, updatedAt: Long)
+
+    @Query("UPDATE projects SET colorIndex = :colorIndex, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun setColor(id: String, colorIndex: Int, updatedAt: Long)
+
+    @Query("UPDATE projects SET updatedAt = :updatedAt WHERE id = :id")
+    suspend fun touch(id: String, updatedAt: Long)
+
+    @Query("DELETE FROM projects WHERE id = :id")
+    suspend fun delete(id: String)
+}
+
+@Dao
+interface ProjectDocumentDao {
+    @Query("SELECT * FROM project_documents WHERE projectId = :projectId ORDER BY addedAt ASC")
+    fun observeForProject(projectId: String): Flow<List<ProjectDocument>>
+
+    @Query("SELECT * FROM project_documents WHERE projectId = :projectId ORDER BY addedAt ASC")
+    suspend fun getForProjectSync(projectId: String): List<ProjectDocument>
+
+    @Query("SELECT COUNT(*) FROM project_documents WHERE projectId = :projectId")
+    fun countForProject(projectId: String): Flow<Int>
+
+    @Query("SELECT * FROM project_documents WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): ProjectDocument?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(document: ProjectDocument)
+
+    @Query("DELETE FROM project_documents WHERE id = :id")
+    suspend fun delete(id: String)
+}

--- a/app/src/main/java/com/echoflow/data/ProjectDocument.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectDocument.kt
@@ -1,0 +1,33 @@
+package com.echoflow.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/** A file copied into a project's folder; extractedText is injected as chat context when present. */
+@Entity(
+    tableName = "project_documents",
+    foreignKeys = [
+        ForeignKey(
+            entity = Project::class,
+            parentColumns = ["id"],
+            childColumns = ["projectId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("projectId")],
+)
+data class ProjectDocument(
+    @PrimaryKey val id: String,
+    val projectId: String,
+    val name: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val filePath: String,
+    val extractedText: String? = null,
+    val addedAt: Long,
+) {
+    /** Whether this document actually contributes text to the project's context. */
+    val hasText: Boolean get() = !extractedText.isNullOrBlank()
+}

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -66,11 +66,16 @@ class ProjectManager(
     /**
      * Delete a project. Its chats are returned to the drawer (projectId set null) rather than
      * deleted, its documents' files are swept, and the row delete cascades away the document rows.
+     *
+     * The Room parent is removed *before* the folder: a concurrent [addDocument] that recreates
+     * the directory then cannot insert (FK) and falls into its dest-delete path. Sweeping first
+     * let an import mkdir, register a row, then lose that row to this cascade with no exception
+     * and a file the files UI cannot see.
      */
     suspend fun deleteProject(id: String) = withContext(Dispatchers.IO) {
         chatDao.clearProjectAssignments(id)
-        runCatching { projectDir(id).deleteRecursively() }
         projectDao.delete(id)
+        runCatching { projectDir(id).deleteRecursively() }
     }
 
     suspend fun assignChat(chatId: String, projectId: String?) {
@@ -101,6 +106,7 @@ class ProjectManager(
         // SIZE when it can, and that check is free. The stream-time cap below still applies
         // when SIZE is missing or understated.
         if (size > MAX_IMPORT_BYTES) return@withContext null
+        if (projectDao.getById(projectId) == null) return@withContext null
 
         val docId = UUID.randomUUID().toString()
         val dir = projectDir(projectId).apply { mkdirs() }
@@ -142,11 +148,18 @@ class ProjectManager(
             addedAt = System.currentTimeMillis(),
         )
         // Copy succeeded; the file is only reachable through a project_documents row. If
-        // insert or touch throws (project deleted mid-import, disk-full, cancellation) the
-        // dest must go with it — otherwise it sits unreferenced until the whole project
-        // folder is swept, and the files UI cannot remove it.
+        // insert or touch throws, or the parent was deleted between copy and now (cascade
+        // removes the row without throwing), dest must go with it — otherwise it sits
+        // unreferenced and the files UI cannot remove it.
         try {
             projectDocumentDao.insert(document)
+            if (projectDao.getById(projectId) == null ||
+                projectDocumentDao.getById(document.id) == null
+            ) {
+                runCatching { projectDocumentDao.delete(document.id) }
+                runCatching { dest.delete() }
+                return@withContext null
+            }
             touch(projectId)
         } catch (t: Throwable) {
             runCatching { projectDocumentDao.delete(document.id) }

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -41,7 +41,7 @@ class ProjectManager(
         projectDao.upsert(
             Project(
                 id = id,
-                name = name.trim().ifBlank { "Untitled project" },
+                name = name.trim().ifBlank { UNTITLED_PROJECT },
                 instructions = "",
                 colorIndex = colorIndex,
                 createdAt = now,
@@ -52,7 +52,7 @@ class ProjectManager(
     }
 
     suspend fun rename(id: String, name: String) =
-        projectDao.rename(id, name.trim().ifBlank { "Untitled project" }, System.currentTimeMillis())
+        projectDao.rename(id, name.trim().ifBlank { UNTITLED_PROJECT }, System.currentTimeMillis())
 
     suspend fun setInstructions(id: String, instructions: String) =
         projectDao.setInstructions(id, instructions, System.currentTimeMillis())
@@ -96,16 +96,37 @@ class ProjectManager(
             }
         }
 
+        // Reject oversized selections before we open a stream or allocate dest. SAF reports
+        // SIZE when it can, and that check is free. The stream-time cap below still applies
+        // when SIZE is missing or understated.
+        if (size > MAX_IMPORT_BYTES) return@withContext null
+
         val docId = UUID.randomUUID().toString()
         val dir = projectDir(projectId).apply { mkdirs() }
         val dest = File(dir, docId)
+        // Bounded copy: stop (and delete) once the source exceeds the import cap, so a huge or
+        // hostile file can't fill app storage. Any failure mid-write also sweeps the partial file
+        // — otherwise it would linger unreferenced until the whole project is deleted.
         val copied = runCatching {
             resolver.openInputStream(uri)?.use { input ->
-                dest.outputStream().use { output -> input.copyTo(output) }
+                dest.outputStream().use { output ->
+                    val buffer = ByteArray(64 * 1024)
+                    var total = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > MAX_IMPORT_BYTES) throw java.io.IOException("File exceeds import cap")
+                        output.write(buffer, 0, read)
+                    }
+                }
             } ?: return@runCatching false
             true
         }.getOrDefault(false)
-        if (!copied) return@withContext null
+        if (!copied) {
+            runCatching { dest.delete() }
+            return@withContext null
+        }
         if (size <= 0L) size = dest.length()
 
         val extracted = extractText(dest, mimeType, displayName)
@@ -173,8 +194,8 @@ class ProjectManager(
         File(File(context.filesDir, "project_documents"), projectId)
 
     /**
-     * Extract text for context injection. v1 reads text-shaped formats only (text/*, and a few
-     * textual application/* types); binary formats like PDF keep a null body — they still list in
+     * Extract text for context injection. v1 reads text-shaped formats only (text MIME types, and a
+     * few textual application types); binary formats like PDF keep a null body — they still list in
      * the project, they just contribute no context, and the UI says so. Extraction is capped per
      * document so one huge file can't dominate later assembly.
      */
@@ -185,14 +206,31 @@ class ProjectManager(
             lower in TEXTUAL_MIME_TYPES ||
             ext in TEXTUAL_EXTENSIONS
         if (!looksTextual) return null
+        // Read at most MAX_EXTRACT_CHARS characters so peak allocation is capped regardless of file
+        // size — readText() would materialize the whole (possibly hundreds of MB) file first, then
+        // truncate, risking OutOfMemoryError on large log/csv/sql files selected through SAF.
         return runCatching {
-            val text = file.readText(Charsets.UTF_8)
-            if (text.length > MAX_EXTRACT_CHARS) text.take(MAX_EXTRACT_CHARS) else text
+            file.bufferedReader(Charsets.UTF_8).use { reader ->
+                val buffer = CharArray(MAX_EXTRACT_CHARS)
+                var filled = 0
+                while (filled < buffer.size) {
+                    val read = reader.read(buffer, filled, buffer.size - filled)
+                    if (read < 0) break
+                    filled += read
+                }
+                if (filled <= 0) null else String(buffer, 0, filled)
+            }
         }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 
     companion object {
-        /** Per-document extraction cap on import. */
+        /** Fallback when the user supplies a blank project name. */
+        const val UNTITLED_PROJECT = "Untitled project"
+
+        /** Hard cap on an imported file's size (bytes) — larger selections are rejected. */
+        private const val MAX_IMPORT_BYTES = 25L * 1024 * 1024
+
+        /** Per-document extraction cap on import (characters read into memory). */
         private const val MAX_EXTRACT_CHARS = 200_000
 
         /** Combined document budget injected into any single system prompt. */

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -3,6 +3,7 @@ package com.echoflow.data
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -140,8 +141,19 @@ class ProjectManager(
             extractedText = extracted,
             addedAt = System.currentTimeMillis(),
         )
-        projectDocumentDao.insert(document)
-        touch(projectId)
+        // Copy succeeded; the file is only reachable through a project_documents row. If
+        // insert or touch throws (project deleted mid-import, disk-full, cancellation) the
+        // dest must go with it — otherwise it sits unreferenced until the whole project
+        // folder is swept, and the files UI cannot remove it.
+        try {
+            projectDocumentDao.insert(document)
+            touch(projectId)
+        } catch (t: Throwable) {
+            runCatching { projectDocumentDao.delete(document.id) }
+            runCatching { dest.delete() }
+            if (t is CancellationException) throw t
+            return@withContext null
+        }
         document
     }
 

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -1,0 +1,213 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.UUID
+
+/**
+ * Owns the Projects store. Mirrors how [ArtifactManager] fronts the artifact tables: the UI observes
+ * the rows this writes. A project bundles a custom instruction and a set of reference documents; the
+ * documents' extracted text and the instruction are assembled by [buildSystemContext] into the
+ * addendum a project's chats prepend to their system prompt.
+ *
+ * Imported files are copied into app storage so they outlive the source Uri; on removal (and on
+ * project delete) those files are swept here, since Room can't touch the filesystem.
+ */
+class ProjectManager(
+    private val context: Context,
+    private val projectDao: ProjectDao,
+    private val projectDocumentDao: ProjectDocumentDao,
+    private val chatDao: ChatDao,
+) {
+    fun observeProjects(): Flow<List<Project>> = projectDao.observeAll()
+    fun observeProject(id: String): Flow<Project?> = projectDao.observeById(id)
+    fun observeDocuments(projectId: String): Flow<List<ProjectDocument>> =
+        projectDocumentDao.observeForProject(projectId)
+    fun observeDocumentCount(projectId: String): Flow<Int> =
+        projectDocumentDao.countForProject(projectId)
+    fun observeChats(projectId: String): Flow<List<ChatThread>> =
+        chatDao.getThreadsByProject(projectId)
+
+    suspend fun getProject(id: String): Project? = projectDao.getById(id)
+
+    suspend fun createProject(name: String, colorIndex: Int = 0): String {
+        val now = System.currentTimeMillis()
+        val id = UUID.randomUUID().toString()
+        projectDao.upsert(
+            Project(
+                id = id,
+                name = name.trim().ifBlank { "Untitled project" },
+                instructions = "",
+                colorIndex = colorIndex,
+                createdAt = now,
+                updatedAt = now,
+            )
+        )
+        return id
+    }
+
+    suspend fun rename(id: String, name: String) =
+        projectDao.rename(id, name.trim().ifBlank { "Untitled project" }, System.currentTimeMillis())
+
+    suspend fun setInstructions(id: String, instructions: String) =
+        projectDao.setInstructions(id, instructions, System.currentTimeMillis())
+
+    suspend fun setColor(id: String, colorIndex: Int) =
+        projectDao.setColor(id, colorIndex, System.currentTimeMillis())
+
+    suspend fun touch(id: String) = projectDao.touch(id, System.currentTimeMillis())
+
+    /**
+     * Delete a project. Its chats are returned to the drawer (projectId set null) rather than
+     * deleted, its documents' files are swept, and the row delete cascades away the document rows.
+     */
+    suspend fun deleteProject(id: String) = withContext(Dispatchers.IO) {
+        chatDao.clearProjectAssignments(id)
+        runCatching { projectDir(id).deleteRecursively() }
+        projectDao.delete(id)
+    }
+
+    suspend fun assignChat(chatId: String, projectId: String?) {
+        chatDao.setProjectId(chatId, projectId)
+        if (projectId != null) touch(projectId)
+    }
+
+    /**
+     * Import [uri] as a reference document: copy it into the project's folder and, for text
+     * formats, extract its text for context injection. Returns the stored row, or null if the
+     * file couldn't be read at all.
+     */
+    suspend fun addDocument(projectId: String, uri: Uri): ProjectDocument? = withContext(Dispatchers.IO) {
+        val resolver = context.contentResolver
+        val mimeType = resolver.getType(uri) ?: "application/octet-stream"
+        var displayName = "Document"
+        var size = 0L
+        runCatching { resolver.query(uri, null, null, null, null) }.getOrNull()?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+            if (cursor.moveToFirst()) {
+                if (nameIndex != -1) cursor.getString(nameIndex)?.let { displayName = it }
+                if (sizeIndex != -1 && !cursor.isNull(sizeIndex)) size = cursor.getLong(sizeIndex)
+            }
+        }
+
+        val docId = UUID.randomUUID().toString()
+        val dir = projectDir(projectId).apply { mkdirs() }
+        val dest = File(dir, docId)
+        val copied = runCatching {
+            resolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { output -> input.copyTo(output) }
+            } ?: return@runCatching false
+            true
+        }.getOrDefault(false)
+        if (!copied) return@withContext null
+        if (size <= 0L) size = dest.length()
+
+        val extracted = extractText(dest, mimeType, displayName)
+        val document = ProjectDocument(
+            id = docId,
+            projectId = projectId,
+            name = displayName,
+            mimeType = mimeType,
+            sizeBytes = size,
+            filePath = dest.absolutePath,
+            extractedText = extracted,
+            addedAt = System.currentTimeMillis(),
+        )
+        projectDocumentDao.insert(document)
+        touch(projectId)
+        document
+    }
+
+    suspend fun removeDocument(document: ProjectDocument) = withContext(Dispatchers.IO) {
+        runCatching { File(document.filePath).delete() }
+        projectDocumentDao.delete(document.id)
+        touch(document.projectId)
+    }
+
+    /**
+     * The project's standing context, appended to the system prompt of every chat in it. Empty
+     * when the project has neither an instruction nor any readable document, so a bare "folder"
+     * project adds nothing to the prompt. Document text is budget-capped so a large corpus can't
+     * blow the context window — the model is told when a document was truncated.
+     */
+    suspend fun buildSystemContext(projectId: String): String {
+        val project = projectDao.getById(projectId) ?: return ""
+        val docs = projectDocumentDao.getForProjectSync(projectId).filter { it.hasText }
+        val instructions = project.instructions.trim()
+        if (instructions.isBlank() && docs.isEmpty()) return ""
+
+        val sb = StringBuilder()
+        sb.append("\n\n---\n")
+        sb.append("The user is working inside a project called \"").append(project.name).append("\".")
+        if (instructions.isNotBlank()) {
+            sb.append("\n\nProject instructions (follow these for every message in this project):\n")
+            sb.append(instructions)
+        }
+        if (docs.isNotEmpty()) {
+            sb.append("\n\nReference documents attached to this project. Use them as background ")
+            sb.append("knowledge when relevant, and cite them by name:\n")
+            var budget = MAX_DOC_CONTEXT_CHARS
+            for (doc in docs) {
+                if (budget <= 0) {
+                    sb.append("\n[Some documents were omitted to fit the context window.]")
+                    break
+                }
+                val body = doc.extractedText.orEmpty()
+                val slice = if (body.length > budget) body.take(budget) else body
+                budget -= slice.length
+                sb.append("\n### ").append(doc.name).append('\n').append(slice)
+                if (slice.length < body.length) sb.append("\n[…document truncated…]")
+                sb.append('\n')
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun projectDir(projectId: String): File =
+        File(File(context.filesDir, "project_documents"), projectId)
+
+    /**
+     * Extract text for context injection. v1 reads text-shaped formats only (text/*, and a few
+     * textual application/* types); binary formats like PDF keep a null body — they still list in
+     * the project, they just contribute no context, and the UI says so. Extraction is capped per
+     * document so one huge file can't dominate later assembly.
+     */
+    private fun extractText(file: File, mimeType: String, name: String): String? {
+        val lower = mimeType.lowercase()
+        val ext = name.substringAfterLast('.', "").lowercase()
+        val looksTextual = lower.startsWith("text/") ||
+            lower in TEXTUAL_MIME_TYPES ||
+            ext in TEXTUAL_EXTENSIONS
+        if (!looksTextual) return null
+        return runCatching {
+            val text = file.readText(Charsets.UTF_8)
+            if (text.length > MAX_EXTRACT_CHARS) text.take(MAX_EXTRACT_CHARS) else text
+        }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    companion object {
+        /** Per-document extraction cap on import. */
+        private const val MAX_EXTRACT_CHARS = 200_000
+
+        /** Combined document budget injected into any single system prompt. */
+        private const val MAX_DOC_CONTEXT_CHARS = 24_000
+
+        private val TEXTUAL_MIME_TYPES = setOf(
+            "application/json", "application/xml", "application/xhtml+xml",
+            "application/javascript", "application/x-yaml", "application/yaml",
+            "application/markdown", "application/x-sh", "application/csv",
+        )
+
+        private val TEXTUAL_EXTENSIONS = setOf(
+            "txt", "md", "markdown", "json", "xml", "yaml", "yml", "csv", "tsv",
+            "html", "htm", "css", "js", "ts", "kt", "java", "py", "rb", "go",
+            "rs", "c", "cpp", "h", "sh", "toml", "ini", "cfg", "log", "sql",
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/data/ProjectModels.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectModels.kt
@@ -1,8 +1,6 @@
 package com.echoflow.data
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -27,36 +25,3 @@ data class Project(
     val createdAt: Long,
     val updatedAt: Long,
 )
-
-/**
- * One reference document attached to a [Project]. The imported file is copied into app storage
- * ([filePath], under filesDir/project_documents/) so it survives the source Uri being revoked, and
- * its extracted plain text ([extractedText]) is what gets injected into chats as background
- * knowledge. Binary formats we can't read as text (for v1, anything but text/*) keep a null
- * [extractedText]; they still list in the project but contribute no context, and the UI says so.
- */
-@Entity(
-    tableName = "project_documents",
-    foreignKeys = [
-        ForeignKey(
-            entity = Project::class,
-            parentColumns = ["id"],
-            childColumns = ["projectId"],
-            onDelete = ForeignKey.CASCADE,
-        )
-    ],
-    indices = [Index("projectId")],
-)
-data class ProjectDocument(
-    @PrimaryKey val id: String,
-    val projectId: String,
-    val name: String,
-    val mimeType: String,
-    val sizeBytes: Long,
-    val filePath: String,
-    val extractedText: String? = null,
-    val addedAt: Long,
-) {
-    /** Whether this document actually contributes text to the project's context. */
-    val hasText: Boolean get() = !extractedText.isNullOrBlank()
-}

--- a/app/src/main/java/com/echoflow/data/ProjectModels.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectModels.kt
@@ -1,0 +1,62 @@
+package com.echoflow.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * A Project: a durable workspace that groups conversations and gives them shared standing context.
+ * Two things turn "a folder of chats" into a project — a custom instruction the model is told to
+ * follow for every chat in the project, and a set of reference [ProjectDocument]s whose text is
+ * handed to the model as background knowledge. Both are optional; an empty project is just a folder
+ * until the user fills them in.
+ *
+ * A chat is linked to a project by [ChatThread.projectId]. The link is nullable and set-null on
+ * delete (handled in code, not by a DB foreign key) so deleting a project never takes its
+ * conversations with it — they simply return to the ordinary drawer list.
+ */
+@Entity(tableName = "projects")
+data class Project(
+    @PrimaryKey val id: String,
+    val name: String,
+    /** The custom instruction prepended to the system prompt for every chat in this project. */
+    val instructions: String = "",
+    /** Index into the UI accent palette (see ProjectAccents) — the project's colour identity. */
+    val colorIndex: Int = 0,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+/**
+ * One reference document attached to a [Project]. The imported file is copied into app storage
+ * ([filePath], under filesDir/project_documents/) so it survives the source Uri being revoked, and
+ * its extracted plain text ([extractedText]) is what gets injected into chats as background
+ * knowledge. Binary formats we can't read as text (for v1, anything but text/*) keep a null
+ * [extractedText]; they still list in the project but contribute no context, and the UI says so.
+ */
+@Entity(
+    tableName = "project_documents",
+    foreignKeys = [
+        ForeignKey(
+            entity = Project::class,
+            parentColumns = ["id"],
+            childColumns = ["projectId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("projectId")],
+)
+data class ProjectDocument(
+    @PrimaryKey val id: String,
+    val projectId: String,
+    val name: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val filePath: String,
+    val extractedText: String? = null,
+    val addedAt: Long,
+) {
+    /** Whether this document actually contributes text to the project's context. */
+    val hasText: Boolean get() = !extractedText.isNullOrBlank()
+}

--- a/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
@@ -22,6 +22,7 @@ fun MainNavigationHub(chatViewModel: ChatViewModel, settingsViewModel: SettingsV
     val artifactWorkspaceOpen by chatViewModel.artifactWorkspaceOpen.collectAsState()
     val researchWorkspace by chatViewModel.researchWorkspace.collectAsState()
     val artifactsGalleryOpen by chatViewModel.artifactsGalleryOpen.collectAsState()
+    val projectsHubOpen by chatViewModel.projectsHubOpen.collectAsState()
 
     Box(Modifier.fillMaxSize()) {
         if (activeTab == "settings") {
@@ -64,6 +65,10 @@ fun MainNavigationHub(chatViewModel: ChatViewModel, settingsViewModel: SettingsV
                 chatViewModel = chatViewModel,
                 onClose = { chatViewModel.closeArtifactsGallery() },
             )
+        }
+        if (projectsHubOpen) {
+            // The hub owns its own back stepping: home → list → closed (see ProjectsHubScreen).
+            com.echoflow.ui.screens.ProjectsHubScreen(chatViewModel = chatViewModel)
         }
     }
 }

--- a/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/echoflow/navigation/MainNavigation.kt
@@ -21,6 +21,7 @@ fun MainNavigationHub(chatViewModel: ChatViewModel, settingsViewModel: SettingsV
     val browserWorkspaceChatId by chatViewModel.browserWorkspaceChatId.collectAsState()
     val artifactWorkspaceOpen by chatViewModel.artifactWorkspaceOpen.collectAsState()
     val researchWorkspace by chatViewModel.researchWorkspace.collectAsState()
+    val artifactsGalleryOpen by chatViewModel.artifactsGalleryOpen.collectAsState()
 
     Box(Modifier.fillMaxSize()) {
         if (activeTab == "settings") {
@@ -57,6 +58,13 @@ fun MainNavigationHub(chatViewModel: ChatViewModel, settingsViewModel: SettingsV
                 onClose = { chatViewModel.closeResearchWorkspace() },
             )
         }
+        if (artifactsGalleryOpen) {
+            BackHandler { chatViewModel.closeArtifactsGallery() }
+            com.echoflow.ui.screens.ArtifactsGalleryScreen(
+                chatViewModel = chatViewModel,
+                onClose = { chatViewModel.closeArtifactsGallery() },
+            )
+        }
     }
 }
 
@@ -90,6 +98,8 @@ fun AdaptiveChatWorkspace(
                         onPinThread = chatViewModel::pinThread,
                         onUnpinThread = chatViewModel::unpinThread,
                         onSettingsClicked = onSettingsClicked,
+                        onProjectsClicked = chatViewModel::openProjectsHub,
+                        onArtifactsClicked = chatViewModel::openArtifactsGallery,
                         searchQuery = query,
                         onSearchQueryChange = chatViewModel::setDrawerSearchQuery,
                     )
@@ -120,6 +130,8 @@ fun AdaptiveChatWorkspace(
                         onPinThread = chatViewModel::pinThread,
                         onUnpinThread = chatViewModel::unpinThread,
                         onSettingsClicked = onSettingsClicked,
+                        onProjectsClicked = chatViewModel::openProjectsHub,
+                        onArtifactsClicked = chatViewModel::openArtifactsGallery,
                         onCloseDrawer = { scope.launch { drawerState.close() } },
                         searchQuery = query,
                         onSearchQueryChange = chatViewModel::setDrawerSearchQuery,

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -708,6 +708,12 @@ class ChatViewModel(
         dismissProjectSurfaces()
     }
 
+    /** From the in-chat pill: open the current chat's project home over the conversation. */
+    fun openProjectFromChat(projectId: String) {
+        _projectsHubOpen.value = true
+        _openProjectId.value = projectId
+    }
+
     /**
      * The Deep Research report currently open fullscreen, or null.
      *

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -674,7 +674,37 @@ class ChatViewModel(
         viewModelScope.launch {
             projectManager.deleteProject(projectId)
             if (_openProjectId.value == projectId) _openProjectId.value = null
+            // Drop a pending assignment to the now-deleted project so the next blank-chat send
+            // can't stamp a thread with a dangling project id.
+            if (_pendingProjectId.value == projectId) _pendingProjectId.value = null
         }
+    }
+
+    /**
+     * Pending project for a not-yet-created thread, or null if none / it no longer exists.
+     * Does not consume the pending slot — callers clear it after a successful insert so a
+     * failed create can retry with the same assignment.
+     */
+    private suspend fun pendingProjectIfStillExists(): String? {
+        val pendingProjectId = _pendingProjectId.value ?: return null
+        if (projectManager.getProject(pendingProjectId) == null) {
+            _pendingProjectId.value = null
+            return null
+        }
+        return pendingProjectId
+    }
+
+    /**
+     * Stamp a freshly-created blank thread with the pending project (if any) and clear the pending
+     * slot. The normal send path applies the id at insert time; the specialized starters (Deep
+     * Research, Browser, Data Agent) route their new-thread creation through here so a chat begun
+     * from a project home lands in that project no matter which action creates its thread.
+     */
+    private suspend fun consumePendingProjectForNewThread(chatId: String) {
+        val pendingProjectId = pendingProjectIfStillExists() ?: return
+        chatDao.setProjectId(chatId, pendingProjectId)
+        projectManager.touch(pendingProjectId)
+        _pendingProjectId.value = null
     }
 
     fun addProjectDocument(projectId: String, uri: Uri) {
@@ -1462,7 +1492,7 @@ class ChatViewModel(
             // project chat) contributes its instructions + reference documents to the prompt.
             val activeProjectId =
                 _currentChatThreadId.value?.let { chatRepository.thread(it)?.projectId }
-                    ?: _pendingProjectId.value
+                    ?: pendingProjectIfStillExists()
             val systemPrompt = baseSystemPrompt + (activeProjectId?.let { projectManager.buildSystemContext(it) } ?: "")
 
             var isFirstMsgInChat = false
@@ -1470,7 +1500,12 @@ class ChatViewModel(
 
             if (chatId == null) {
                 isFirstMsgInChat = true
-                chatId = chatRepository.createThread(mode = appMode.value, projectId = activeProjectId).id
+                // Project chats are always Chat threads — projects are a Chat concept, so a thread
+                // that carries a projectId is stamped 'chat' regardless of the active surface.
+                chatId = chatRepository.createThread(
+                    mode = if (activeProjectId != null) AppMode.Chat else appMode.value,
+                    projectId = activeProjectId,
+                ).id
                 openThread(chatId)
                 // The blank thread is real now, so this mode returns here rather than to
                 // whatever came before it.
@@ -2068,6 +2103,7 @@ class ChatViewModel(
             if (chatId == null) {
                 chatId = chatRepository.createThread(now = now).id
                 openThread(chatId)
+                consumePendingProjectForNewThread(chatId)
                 val fallbackTitle = fallbackThreadTitle(topic)
                 chatRepository.renameThread(chatId, fallbackTitle)
             }
@@ -2145,6 +2181,7 @@ class ChatViewModel(
                 chatId = UUID.randomUUID().toString()
                 chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
                 openThread(chatId)
+                consumePendingProjectForNewThread(chatId)
             } else {
                 openThread(chatId)
             }
@@ -2184,6 +2221,7 @@ class ChatViewModel(
                 chatId = UUID.randomUUID().toString()
                 chatDao.insertThread(ChatThread(id = chatId, title = "New Conversation", createdAt = now, updatedAt = now))
                 openThread(chatId)
+                consumePendingProjectForNewThread(chatId)
                 val fallbackTitle = fallbackThreadTitle(topic)
                 chatDao.setTitle(chatId, fallbackTitle)
             }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -42,11 +42,16 @@ class ChatViewModel(
     private val artifactVersionDao: ArtifactVersionDao,
     private val generatedImageDao: GeneratedImageDao,
     private val generatedVideoDao: GeneratedVideoDao,
+    private val projectDao: ProjectDao,
+    private val projectDocumentDao: ProjectDocumentDao,
     private val localInferenceGate: LocalInferenceGate
 ) : AndroidViewModel(application) {
 
     // Artifacts: model-built, rendered content (web page / document / report) with version history.
     private val artifactManager = ArtifactManager(artifactDao, artifactVersionDao)
+
+    // Projects: durable workspaces that group chats and give them shared instructions + documents.
+    private val projectManager = ProjectManager(application, projectDao, projectDocumentDao, chatDao)
 
     // Image generation: decoded PNGs on disk, version chain in Room (see GeneratedImageStore).
     private val generatedImageStore = GeneratedImageStore(application, generatedImageDao)
@@ -565,6 +570,144 @@ class ChatViewModel(
         _artifactInitialVersion.value = null
     }
 
+    // ── Artifacts gallery ────────────────────────────────────────────────────────────────
+    // A read-only shelf of every chat's latest artifact, opened from the drawer. Tapping a tile
+    // opens the existing fullscreen workspace (which owns version switching), so the gallery adds
+    // a browse surface without duplicating the viewer.
+
+    private val _artifactsGalleryOpen = MutableStateFlow(false)
+    val artifactsGalleryOpen: StateFlow<Boolean> = _artifactsGalleryOpen.asStateFlow()
+
+    /** Every artifact lineage, newest first — one per chat by the one-lineage-per-chat rule. */
+    val galleryArtifacts: StateFlow<List<Artifact>> = artifactDao.observeAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun openArtifactsGallery() { _artifactsGalleryOpen.value = true }
+    fun closeArtifactsGallery() { _artifactsGalleryOpen.value = false }
+
+    /** From a gallery tile: open the workspace on that lineage (optionally at a chosen version). */
+    fun openArtifactFromGallery(artifactId: String, targetVersion: Int? = null) {
+        _artifactsGalleryOpen.value = false
+        openArtifactWorkspace(artifactId, targetVersion)
+    }
+
+    // ── Projects ─────────────────────────────────────────────────────────────────────────
+    // The Projects hub (list + create) and a project home (chats + instructions + documents) are
+    // fullscreen surfaces opened from the drawer, mirroring the workspace overlay pattern. Home
+    // stacks on top of the hub, so back steps home → hub → closed.
+
+    private val _projectsHubOpen = MutableStateFlow(false)
+    val projectsHubOpen: StateFlow<Boolean> = _projectsHubOpen.asStateFlow()
+
+    /** The project whose home is open, layered above the hub list; null = showing the list. */
+    private val _openProjectId = MutableStateFlow<String?>(null)
+    val openProjectId: StateFlow<String?> = _openProjectId.asStateFlow()
+
+    /**
+     * The project a not-yet-created chat will belong to. Starting a new chat from a project home
+     * parks the id here; the thread is created lazily on first send (like every blank chat), and
+     * this is what stamps the project onto it then.
+     */
+    private val _pendingProjectId = MutableStateFlow<String?>(null)
+
+    val projects: StateFlow<List<Project>> = projectManager.observeProjects()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun projectFlow(id: String): Flow<Project?> = projectManager.observeProject(id)
+    fun projectDocumentsFlow(id: String): Flow<List<ProjectDocument>> = projectManager.observeDocuments(id)
+    fun projectDocumentCountFlow(id: String): Flow<Int> = projectManager.observeDocumentCount(id)
+    fun projectChatsFlow(id: String): Flow<List<ChatThread>> = projectManager.observeChats(id)
+
+    /** The open chat's project (or its pending project before the thread exists) — the in-chat pill. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentThreadProject: StateFlow<Project?> =
+        combine(
+            _currentChatThreadId.flatMapLatest { id ->
+                if (id == null) flowOf(null) else chatDao.observeProjectId(id)
+            },
+            _pendingProjectId,
+        ) { threadProjectId, pendingProjectId -> threadProjectId ?: pendingProjectId }
+            .flatMapLatest { projectId ->
+                if (projectId == null) flowOf(null) else projectManager.observeProject(projectId)
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    fun openProjectsHub() {
+        _projectsHubOpen.value = true
+        _openProjectId.value = null
+    }
+
+    fun openProjectHome(projectId: String) { _openProjectId.value = projectId }
+    fun closeProjectHome() { _openProjectId.value = null }
+
+    fun closeProjectsHub() {
+        _projectsHubOpen.value = false
+        _openProjectId.value = null
+    }
+
+    private fun dismissProjectSurfaces() {
+        _projectsHubOpen.value = false
+        _openProjectId.value = null
+        _artifactsGalleryOpen.value = false
+    }
+
+    fun createProject(name: String, onCreated: ((String) -> Unit)? = null) {
+        viewModelScope.launch {
+            val id = projectManager.createProject(name)
+            onCreated?.invoke(id)
+        }
+    }
+
+    fun renameProject(projectId: String, name: String) {
+        viewModelScope.launch { projectManager.rename(projectId, name) }
+    }
+
+    fun setProjectInstructions(projectId: String, instructions: String) {
+        viewModelScope.launch { projectManager.setInstructions(projectId, instructions) }
+    }
+
+    fun setProjectColor(projectId: String, colorIndex: Int) {
+        viewModelScope.launch { projectManager.setColor(projectId, colorIndex) }
+    }
+
+    fun deleteProject(projectId: String) {
+        viewModelScope.launch {
+            projectManager.deleteProject(projectId)
+            if (_openProjectId.value == projectId) _openProjectId.value = null
+        }
+    }
+
+    fun addProjectDocument(projectId: String, uri: Uri) {
+        viewModelScope.launch {
+            if (projectManager.addDocument(projectId, uri) == null) {
+                _errorMessage.value = "Couldn't read that file."
+            }
+        }
+    }
+
+    fun removeProjectDocument(document: ProjectDocument) {
+        viewModelScope.launch { projectManager.removeDocument(document) }
+    }
+
+    /** Move the open conversation into a project (or out of one when [projectId] is null). */
+    fun assignCurrentChatToProject(projectId: String?) {
+        val chatId = _currentChatThreadId.value ?: return
+        viewModelScope.launch { projectManager.assignChat(chatId, projectId) }
+    }
+
+    /** Start a fresh conversation that will belong to [projectId], and leave the projects surfaces. */
+    fun startNewChatInProject(projectId: String) {
+        selectThread(null)
+        _pendingProjectId.value = projectId
+        dismissProjectSurfaces()
+    }
+
+    /** Open an existing conversation from a project home, leaving the projects surfaces. */
+    fun openChatFromProject(chatId: String) {
+        selectThread(chatId)
+        dismissProjectSurfaces()
+    }
+
     /**
      * The Deep Research report currently open fullscreen, or null.
      *
@@ -837,6 +980,10 @@ class ChatViewModel(
             if (chatId == null) ModePosition.Blank else ModePosition.Thread(chatId),
         )
         clearPendingAttachment()
+        // A pending project only survives until the next explicit navigation. Selecting an
+        // existing thread means that thread's own projectId governs; a plain new chat is loose.
+        // startNewChatInProject re-arms this immediately after calling here.
+        _pendingProjectId.value = null
         clearError()
     }
 
@@ -1295,7 +1442,7 @@ class ChatViewModel(
                 SystemPrompts.buildArtifact(isLocal, offline, prior)
             } else null
 
-            val systemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: when {
+            val baseSystemPrompt = echoSystemPrompt ?: artifactSystemPrompt ?: when {
                 // Tool-calling custom providers behave like cloud models: they call web_search
                 // themselves, so they get the standard "you have a web_search tool" prompt.
                 customToolCallingActive -> SystemPrompts.build(false, effectiveProvider)
@@ -1305,16 +1452,27 @@ class ChatViewModel(
                 else -> SystemPrompts.build(isLocal, effectiveProvider)
             }
 
+            // Project context: the open thread's project (or the pending one for a brand-new
+            // project chat) contributes its instructions + reference documents to the prompt.
+            val activeProjectId =
+                _currentChatThreadId.value?.let { chatRepository.thread(it)?.projectId }
+                    ?: _pendingProjectId.value
+            val systemPrompt = baseSystemPrompt + (activeProjectId?.let { projectManager.buildSystemContext(it) } ?: "")
+
             var isFirstMsgInChat = false
             var chatId = _currentChatThreadId.value
 
             if (chatId == null) {
                 isFirstMsgInChat = true
-                chatId = chatRepository.createThread(mode = appMode.value).id
+                chatId = chatRepository.createThread(mode = appMode.value, projectId = activeProjectId).id
                 openThread(chatId)
                 // The blank thread is real now, so this mode returns here rather than to
                 // whatever came before it.
                 settingsRepository.saveLastPosition(appMode.value, ModePosition.Thread(chatId))
+                if (activeProjectId != null) {
+                    projectManager.touch(activeProjectId)
+                    _pendingProjectId.value = null
+                }
             }
 
             if (streamJobs[chatId]?.isActive == true) return@launch
@@ -2306,6 +2464,8 @@ class ChatViewModel(
             artifactVersionDao: ArtifactVersionDao,
             generatedImageDao: GeneratedImageDao,
             generatedVideoDao: GeneratedVideoDao,
+            projectDao: ProjectDao,
+            projectDocumentDao: ProjectDocumentDao,
             localInferenceGate: LocalInferenceGate
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
@@ -2315,6 +2475,7 @@ class ChatViewModel(
                     researchRunDao, deepResearchModelDao, advisorProfileDao, fusionPanelDao,
                     agentProfileDao, browserSessionDao, browserStepDao, artifactDao, artifactVersionDao,
                     generatedImageDao, generatedVideoDao,
+                    projectDao, projectDocumentDao,
                     localInferenceGate
                 ) as T
             }

--- a/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ChatDrawer.kt
@@ -21,8 +21,10 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
@@ -72,6 +74,8 @@ fun ChatDrawerContent(
     onPinThread: (ChatThread) -> Unit,
     onUnpinThread: (ChatThread) -> Unit,
     onSettingsClicked: () -> Unit,
+    onProjectsClicked: () -> Unit = {},
+    onArtifactsClicked: () -> Unit = {},
     onCloseDrawer: (() -> Unit)? = null,
     searchQuery: String = "",
     onSearchQueryChange: ((String) -> Unit)? = null,
@@ -136,6 +140,26 @@ fun ChatDrawerContent(
                 query = searchQuery,
                 onQueryChange = onSearchQueryChange,
                 placeholder = if (imagine) "Search creations" else "Search conversations",
+            )
+        }
+
+        // Two standing destinations under the search, sharing the drawer's own surface (no card,
+        // no accent) and split by a hairline — deliberately quieter than the conversation list so
+        // they read as "places", not entries. Hidden while searching, which is a list operation.
+        if (searchQuery.isBlank()) {
+            Spacer(Modifier.height(Spacing.s))
+            DrawerDestinationRow(
+                icon = Icons.Default.FolderOpen,
+                label = "Projects",
+                onClick = { onProjectsClicked(); onCloseDrawer?.invoke() },
+                modifier = Modifier.testTag("drawer_projects_entry"),
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+            DrawerDestinationRow(
+                icon = Icons.Default.Dashboard,
+                label = "Artifacts",
+                onClick = { onArtifactsClicked(); onCloseDrawer?.invoke() },
+                modifier = Modifier.testTag("drawer_artifacts_entry"),
             )
         }
 
@@ -407,6 +431,44 @@ private fun pressScale(
         ),
         label = "press-scale",
     )
+}
+
+/**
+ * A standing drawer destination (Projects / Artifacts): icon + label on the drawer's own surface,
+ * with press feedback but no container fill, so it sits a notch below the conversation list in
+ * visual weight while still reading as tappable.
+ */
+@Composable
+private fun DrawerDestinationRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val scale by pressScale(interaction)
+    Surface(
+        onClick = onClick,
+        color = androidx.compose.ui.graphics.Color.Transparent,
+        shape = RoundedCornerShape(16.dp),
+        interactionSource = interaction,
+        modifier = modifier
+            .fillMaxWidth()
+            .graphicsLayer { scaleX = scale; scaleY = scale },
+    ) {
+        Row(
+            Modifier.heightIn(min = 48.dp).padding(horizontal = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(Spacing.m))
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
 }
 
 /** Shared empty/no-results state for the drawer list. */

--- a/app/src/main/java/com/echoflow/ui/components/ProjectAccents.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ProjectAccents.kt
@@ -1,0 +1,31 @@
+package com.echoflow.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * A project's colour identity, resolved from the active [MaterialTheme.colorScheme] rather than
+ * hardcoded hex — so every accent adapts to light/dark and to each palette (and dynamic colour)
+ * exactly like the rest of the app. [colorIndex] is stored on the project and mapped here.
+ */
+data class ProjectAccentColors(
+    val container: Color,
+    val onContainer: Color,
+    val solid: Color,
+)
+
+/** How many distinct accents [projectAccent] cycles through — the colour picker offers these. */
+const val PROJECT_ACCENT_COUNT = 5
+
+@Composable
+fun projectAccent(colorIndex: Int): ProjectAccentColors {
+    val cs = MaterialTheme.colorScheme
+    return when (((colorIndex % PROJECT_ACCENT_COUNT) + PROJECT_ACCENT_COUNT) % PROJECT_ACCENT_COUNT) {
+        0 -> ProjectAccentColors(cs.primaryContainer, cs.onPrimaryContainer, cs.primary)
+        1 -> ProjectAccentColors(cs.secondaryContainer, cs.onSecondaryContainer, cs.secondary)
+        2 -> ProjectAccentColors(cs.tertiaryContainer, cs.onTertiaryContainer, cs.tertiary)
+        3 -> ProjectAccentColors(cs.errorContainer, cs.onErrorContainer, cs.error)
+        else -> ProjectAccentColors(cs.surfaceVariant, cs.onSurfaceVariant, cs.outline)
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/components/ProjectChip.kt
+++ b/app/src/main/java/com/echoflow/ui/components/ProjectChip.kt
@@ -1,0 +1,54 @@
+package com.echoflow.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+/**
+ * The in-chat project pill: a quiet, tinted chip shown under the top bar when the open conversation
+ * belongs to a project. It signals "this chat is running with extra context" without nagging, and
+ * taps through to the project home. Colour comes from the project's accent so it matches the hub.
+ */
+@Composable
+fun ProjectChip(
+    name: String,
+    colorIndex: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = projectAccent(colorIndex)
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(50),
+        color = accent.container,
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Icon(Icons.Default.FolderOpen, null, Modifier.size(15.dp), tint = accent.onContainer)
+            Text(
+                name,
+                style = MaterialTheme.typography.labelMedium,
+                color = accent.onContainer,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ArtifactsGalleryScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ArtifactsGalleryScreen.kt
@@ -1,0 +1,266 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.Artifact
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The Artifacts gallery — a shelf of every chat's latest artifact, opened from the drawer. It is a
+ * browse surface, not a second viewer: a tile opens the existing fullscreen workspace (which owns
+ * preview/code and version history). The one-lineage-per-chat rule means each tile is a chat's
+ * current artifact; the version chip lets you drop straight into an earlier version if you want one.
+ */
+@Composable
+fun ArtifactsGalleryScreen(
+    chatViewModel: ChatViewModel,
+    onClose: () -> Unit,
+) {
+    val artifacts by chatViewModel.galleryArtifacts.collectAsState()
+
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val openProgress by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        animationSpec = tween(durationMillis = 320),
+        label = "gallery-open",
+    )
+
+    Surface(
+        Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                translationY = (1f - openProgress) * size.height
+                alpha = openProgress
+            },
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            GalleryTopBar(count = artifacts.size, onClose = onClose)
+            if (artifacts.isEmpty()) {
+                GalleryEmptyState(Modifier.fillMaxSize())
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 168.dp),
+                    contentPadding = PaddingValues(Spacing.base),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.m),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.m),
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(artifacts, key = { it.id }) { artifact ->
+                        ArtifactTile(
+                            artifact = artifact,
+                            onOpen = { chatViewModel.openArtifactFromGallery(artifact.id) },
+                            onOpenVersion = { v -> chatViewModel.openArtifactFromGallery(artifact.id, v) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryTopBar(count: Int, onClose: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.KeyboardArrowDown, "Close artifacts", Modifier.size(26.dp))
+            }
+            Column(Modifier.weight(1f)) {
+                Text("Artifacts", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                if (count > 0) {
+                    Text(
+                        if (count == 1) "1 artifact" else "$count artifacts",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtifactTile(
+    artifact: Artifact,
+    onOpen: () -> Unit,
+    onOpenVersion: (Int) -> Unit,
+) {
+    val (glyph, typeLabel) = galleryGlyph(artifact.type)
+    Surface(
+        onClick = onOpen,
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column {
+            // Type-tinted header band with the glyph — a quick, scannable identity per tile.
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(84.dp)
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    glyph, null, Modifier.size(34.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Column(Modifier.padding(Spacing.m)) {
+                Text(
+                    artifact.title.ifBlank { typeLabel },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    Modifier.fillMaxWidth().padding(top = Spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                ) {
+                    Text(
+                        typeLabel,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (artifact.currentVersion > 1) {
+                        VersionChip(artifact.currentVersion, onOpenVersion)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** A "v{n}" chip that opens a menu to drop straight into any earlier version of the lineage. */
+@Composable
+private fun VersionChip(currentVersion: Int, onOpenVersion: (Int) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    Box {
+        Surface(
+            onClick = { open = true },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ) {
+            Row(
+                Modifier.padding(horizontal = Spacing.s, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text("v$currentVersion", style = MaterialTheme.typography.labelMedium)
+                Icon(Icons.Default.UnfoldMore, "Pick version", Modifier.size(14.dp))
+            }
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            (currentVersion downTo 1).forEach { v ->
+                DropdownMenuItem(
+                    text = { Text(if (v == currentVersion) "Version $v (latest)" else "Version $v") },
+                    trailingIcon = {
+                        if (v == currentVersion) {
+                            Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.primary)
+                        }
+                    },
+                    onClick = { open = false; onOpenVersion(v) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier.padding(Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            Modifier.size(72.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(Icons.Default.Dashboard, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Text(
+            "No artifacts yet",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = Spacing.base),
+        )
+        Text(
+            "Web pages, documents and reports you build in Artifact mode collect here.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.xs, start = Spacing.base, end = Spacing.base),
+        )
+    }
+}
+
+private fun galleryGlyph(type: String): Pair<ImageVector, String> = when (type) {
+    Artifact.TYPE_MARKDOWN -> Icons.AutoMirrored.Filled.Article to "Document"
+    Artifact.TYPE_LATEX -> Icons.Default.PictureAsPdf to "Report"
+    else -> Icons.Default.Code to "Web page"
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatScreen.kt
@@ -51,6 +51,7 @@ fun ChatScreen(
     val mode by chatViewModel.appMode.collectAsState()
     val renderingModes by chatViewModel.renderingModes.collectAsState()
     val errorMessage by chatViewModel.errorMessage.collectAsState()
+    val currentProject by chatViewModel.currentThreadProject.collectAsState()
 
     // Top inset so content scrolls behind the floating bar without hiding its first item.
     val topBarInset = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 64.dp
@@ -99,6 +100,23 @@ fun ChatScreen(
                 onMenu = onMenuClicked,
                 onNewChat = { chatViewModel.startNewChat() },
             )
+
+            // In-chat project pill: sits just under the top bar when the open conversation belongs
+            // to a project, and yields to an error banner (which claims the same slot).
+            AnimatedVisibility(
+                visible = currentProject != null && errorMessage == null,
+                modifier = Modifier.align(Alignment.TopCenter).padding(top = topBarInset),
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                currentProject?.let { project ->
+                    com.echoflow.ui.components.ProjectChip(
+                        name = project.name,
+                        colorIndex = project.colorIndex,
+                        onClick = { chatViewModel.openProjectFromChat(project.id) },
+                    )
+                }
+            }
 
             // Errors belong to the app, not to a surface: a failure raised in one mode should
             // still be readable if the user has already switched away from it.

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -58,6 +59,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -468,7 +470,9 @@ private fun ProjectChatRow(thread: com.echoflow.data.ChatThread, onClick: () -> 
 
 @Composable
 private fun ProjectInstructionsScreen(project: Project, onSave: (String) -> Unit, onBack: () -> Unit) {
-    var text by remember(project.id) { mutableStateOf(project.instructions) }
+    // rememberSaveable, not remember: autosave only fires on leave, so a config change or process
+    // death mid-edit must not discard the in-progress text and snap back to the persisted value.
+    var text by rememberSaveable(project.id) { mutableStateOf(project.instructions) }
     // Autosave on leave: the editor is a place you visit and step back from, not a form you submit.
     val leave = { onSave(text.trim()); onBack() }
     BackHandler { leave() }

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -1,0 +1,702 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.echoflow.ui.screens
+
+import android.text.format.DateUtils
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.Project
+import com.echoflow.data.ProjectDocument
+import com.echoflow.ui.ChatViewModel
+import com.echoflow.ui.components.PROJECT_ACCENT_COUNT
+import com.echoflow.ui.components.projectAccent
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The Projects hub — a fullscreen surface opened from the drawer. It hosts two levels: the list of
+ * projects, and one project's home (its chats, instructions and documents). Which is shown is driven
+ * by [ChatViewModel.openProjectId], so back steps home → list → closed. This is Option B ("a
+ * launchpad, not a container"): a project home surfaces its chats, and points to instructions and
+ * documents as focused sub-screens rather than cramming everything onto one page.
+ */
+@Composable
+fun ProjectsHubScreen(chatViewModel: ChatViewModel) {
+    val openProjectId by chatViewModel.openProjectId.collectAsState()
+
+    var appeared by remember { mutableStateOf(false) }
+    androidx.compose.runtime.LaunchedEffect(Unit) { appeared = true }
+    val openProgress by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        animationSpec = tween(durationMillis = 320),
+        label = "projects-open",
+    )
+
+    Surface(
+        Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                translationY = (1f - openProgress) * size.height
+                alpha = openProgress
+            },
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        val projectId = openProjectId
+        if (projectId == null) {
+            BackHandler { chatViewModel.closeProjectsHub() }
+            ProjectsListContent(chatViewModel)
+        } else {
+            ProjectHomeScreen(chatViewModel, projectId, onBack = { chatViewModel.closeProjectHome() })
+        }
+    }
+}
+
+@Composable
+private fun ProjectsListContent(chatViewModel: ChatViewModel) {
+    val projects by chatViewModel.projects.collectAsState()
+    var showCreate by remember { mutableStateOf(false) }
+
+    if (showCreate) {
+        ProjectNameDialog(
+            title = "New project",
+            initial = "",
+            confirmLabel = "Create",
+            onDismiss = { showCreate = false },
+            onConfirm = { name ->
+                showCreate = false
+                chatViewModel.createProject(name) { id -> chatViewModel.openProjectHome(id) }
+            },
+        )
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            HubTopBar(
+                title = "Projects",
+                subtitle = projects.size.takeIf { it > 0 }?.let { if (it == 1) "1 project" else "$it projects" },
+                onClose = { chatViewModel.closeProjectsHub() },
+            )
+            if (projects.isEmpty()) {
+                ProjectsEmptyState(Modifier.fillMaxSize())
+            } else {
+                LazyColumn(
+                    Modifier.fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.base, Spacing.s, Spacing.base, 96.dp),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.m),
+                ) {
+                    items(projects, key = { it.id }) { project ->
+                        ProjectListCard(project) { chatViewModel.openProjectHome(project.id) }
+                    }
+                }
+            }
+        }
+        FloatingActionButton(
+            onClick = { showCreate = true },
+            modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
+        ) { Icon(Icons.Default.Add, "New project") }
+    }
+}
+
+@Composable
+private fun ProjectListCard(project: Project, onClick: () -> Unit) {
+    val accent = projectAccent(project.colorIndex)
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(Spacing.base),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier.size(44.dp).clip(RoundedCornerShape(14.dp)).background(accent.container),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(Icons.Default.CreateNewFolder, null, Modifier.size(22.dp), tint = accent.onContainer)
+            }
+            Spacer(Modifier.width(Spacing.m))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    project.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                val hint = project.instructions.trim().ifBlank { "Tap to open" }
+                Text(
+                    hint,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+// ── Project home ───────────────────────────────────────────────────────────────────────
+
+private enum class ProjectDetail { None, Instructions, Files }
+
+@Composable
+private fun ProjectHomeScreen(chatViewModel: ChatViewModel, projectId: String, onBack: () -> Unit) {
+    val project by remember(projectId) { chatViewModel.projectFlow(projectId) }.collectAsState(null)
+    val documents by remember(projectId) { chatViewModel.projectDocumentsFlow(projectId) }.collectAsState(emptyList())
+    val chats by remember(projectId) { chatViewModel.projectChatsFlow(projectId) }.collectAsState(emptyList())
+    var detail by remember(projectId) { mutableStateOf(ProjectDetail.None) }
+
+    val p = project
+    when {
+        p != null && detail == ProjectDetail.Instructions -> ProjectInstructionsScreen(
+            project = p,
+            onSave = { chatViewModel.setProjectInstructions(projectId, it) },
+            onBack = { detail = ProjectDetail.None },
+        )
+        p != null && detail == ProjectDetail.Files -> ProjectFilesScreen(
+            documents = documents,
+            onAdd = { uri -> chatViewModel.addProjectDocument(projectId, uri) },
+            onRemove = { chatViewModel.removeProjectDocument(it) },
+            onBack = { detail = ProjectDetail.None },
+        )
+        else -> {
+            BackHandler { onBack() }
+            ProjectHomeContent(
+                chatViewModel = chatViewModel,
+                project = p,
+                projectId = projectId,
+                documents = documents,
+                chats = chats,
+                onBack = onBack,
+                onOpenInstructions = { detail = ProjectDetail.Instructions },
+                onOpenFiles = { detail = ProjectDetail.Files },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProjectHomeContent(
+    chatViewModel: ChatViewModel,
+    project: Project?,
+    projectId: String,
+    documents: List<ProjectDocument>,
+    chats: List<com.echoflow.data.ChatThread>,
+    onBack: () -> Unit,
+    onOpenInstructions: () -> Unit,
+    onOpenFiles: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    var showRename by remember { mutableStateOf(false) }
+    var showDelete by remember { mutableStateOf(false) }
+    var showColor by remember { mutableStateOf(false) }
+    val accent = projectAccent(project?.colorIndex ?: 0)
+
+    if (showRename && project != null) {
+        ProjectNameDialog(
+            title = "Rename project",
+            initial = project.name,
+            confirmLabel = "Save",
+            onDismiss = { showRename = false },
+            onConfirm = { showRename = false; chatViewModel.renameProject(projectId, it) },
+        )
+    }
+    if (showDelete && project != null) {
+        AlertDialog(
+            onDismissRequest = { showDelete = false },
+            icon = { Icon(Icons.Default.DeleteOutline, null) },
+            title = { Text("Delete project?") },
+            text = { Text("“${project.name}” will be deleted. Its conversations are kept and return to your chat list.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDelete = false
+                    chatViewModel.deleteProject(projectId)
+                    onBack()
+                }) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = { TextButton(onClick = { showDelete = false }) { Text("Cancel") } },
+        )
+    }
+    if (showColor && project != null) {
+        ProjectColorDialog(
+            selected = project.colorIndex,
+            onDismiss = { showColor = false },
+            onPick = { showColor = false; chatViewModel.setProjectColor(projectId, it) },
+        )
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        // Top bar
+        Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .padding(horizontal = Spacing.s, vertical = Spacing.s),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Default.KeyboardArrowDown, "Back to projects", Modifier.size(26.dp)) }
+                Box(
+                    Modifier.size(28.dp).clip(RoundedCornerShape(9.dp)).background(accent.container),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(Icons.Default.CreateNewFolder, null, Modifier.size(16.dp), tint = accent.onContainer) }
+                Spacer(Modifier.width(Spacing.s))
+                Text(
+                    project?.name ?: "Project",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Box {
+                    IconButton(onClick = { menuOpen = true }) { Icon(Icons.Default.MoreVert, "Project options") }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(text = { Text("Rename") }, leadingIcon = { Icon(Icons.Default.Edit, null) }, onClick = { menuOpen = false; showRename = true })
+                        DropdownMenuItem(text = { Text("Colour") }, leadingIcon = { Icon(Icons.Default.Palette, null) }, onClick = { menuOpen = false; showColor = true })
+                        DropdownMenuItem(text = { Text("Delete") }, leadingIcon = { Icon(Icons.Default.Delete, null) }, onClick = { menuOpen = false; showDelete = true })
+                    }
+                }
+            }
+        }
+
+        LazyColumn(
+            Modifier.fillMaxSize(),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.base, Spacing.base, Spacing.base, 32.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.m),
+        ) {
+            // Context strip: two compact summary cards that point to focused sub-screens. This is
+            // the whole "launchpad not container" idea — setup is glanceable, never in the way.
+            item {
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.m)) {
+                    ContextCard(
+                        icon = Icons.Default.Description,
+                        title = "Instructions",
+                        subtitle = project?.instructions?.trim().orEmpty().ifBlank { "Add instructions" },
+                        onClick = onOpenInstructions,
+                        modifier = Modifier.weight(1f),
+                    )
+                    ContextCard(
+                        icon = Icons.Default.Description,
+                        title = "Files",
+                        subtitle = when (documents.size) {
+                            0 -> "Add files"
+                            1 -> "1 file"
+                            else -> "${documents.size} files"
+                        },
+                        onClick = onOpenFiles,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            item {
+                Surface(
+                    onClick = { chatViewModel.startNewChatInProject(projectId) },
+                    shape = RoundedCornerShape(18.dp),
+                    color = accent.container,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        Modifier.padding(Spacing.base),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                    ) {
+                        Icon(Icons.Default.Add, null, tint = accent.onContainer)
+                        Text(
+                            "New chat in this project",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = accent.onContainer,
+                        )
+                    }
+                }
+            }
+
+            item {
+                Text(
+                    "Conversations",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = Spacing.xs, top = Spacing.xs),
+                )
+            }
+
+            if (chats.isEmpty()) {
+                item {
+                    Text(
+                        "No conversations yet. Start one above and it will live in this project.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = Spacing.s, horizontal = Spacing.xs),
+                    )
+                }
+            } else {
+                items(chats, key = { it.id }) { thread ->
+                    ProjectChatRow(thread) { chatViewModel.openChatFromProject(thread.id) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContextCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier,
+    ) {
+        Column(Modifier.padding(Spacing.base)) {
+            Icon(icon, null, Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(Spacing.s))
+            Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProjectChatRow(thread: com.echoflow.data.ChatThread, onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.AutoMirrored.Filled.Chat, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(Spacing.m))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    thread.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    DateUtils.getRelativeTimeSpanString(thread.updatedAt).toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+// ── Instructions editor ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProjectInstructionsScreen(project: Project, onSave: (String) -> Unit, onBack: () -> Unit) {
+    var text by remember(project.id) { mutableStateOf(project.instructions) }
+    // Autosave on leave: the editor is a place you visit and step back from, not a form you submit.
+    val leave = { onSave(text.trim()); onBack() }
+    BackHandler { leave() }
+
+    Column(Modifier.fillMaxSize()) {
+        DetailTopBar(title = "Instructions", onBack = leave, action = "Save" to { leave() })
+        Text(
+            "Told to the model on every message in this project.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.base, vertical = Spacing.s),
+        )
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            placeholder = { Text("e.g. You are helping me write a mystery novel. Keep a wry, noir tone and remember the characters in the attached files.") },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = Spacing.base)
+                .padding(bottom = Spacing.base)
+                .imePadding(),
+        )
+    }
+}
+
+// ── Files ──────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProjectFilesScreen(
+    documents: List<ProjectDocument>,
+    onAdd: (android.net.Uri) -> Unit,
+    onRemove: (ProjectDocument) -> Unit,
+    onBack: () -> Unit,
+) {
+    BackHandler { onBack() }
+    val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri != null) onAdd(uri)
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            DetailTopBar(title = "Files", onBack = onBack, action = null)
+            Text(
+                "Text files are read and used as background knowledge in this project's chats.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = Spacing.base, vertical = Spacing.s),
+            )
+            if (documents.isEmpty()) {
+                Column(
+                    Modifier.fillMaxSize().padding(Spacing.xl),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Icon(Icons.Default.Description, null, Modifier.size(40.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("No files yet", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = Spacing.m))
+                }
+            } else {
+                LazyColumn(
+                    Modifier.fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.base, Spacing.s, Spacing.base, 96.dp),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                ) {
+                    items(documents, key = { it.id }) { doc -> DocumentRow(doc) { onRemove(doc) } }
+                }
+            }
+        }
+        FloatingActionButton(
+            onClick = { picker.launch(arrayOf("*/*")) },
+            modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
+        ) { Icon(Icons.Default.Add, "Add file") }
+    }
+}
+
+@Composable
+private fun DocumentRow(document: ProjectDocument, onRemove: () -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.base, vertical = Spacing.m),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Default.Description, null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(Spacing.m))
+            Column(Modifier.weight(1f)) {
+                Text(document.name, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    buildString {
+                        append(formatBytes(document.sizeBytes))
+                        if (!document.hasText) append(" · not read as text")
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (document.hasText) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.error,
+                )
+            }
+            IconButton(onClick = onRemove) { Icon(Icons.Default.DeleteOutline, "Remove file", tint = MaterialTheme.colorScheme.onSurfaceVariant) }
+        }
+    }
+}
+
+// ── Shared bits ────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun HubTopBar(title: String, subtitle: String?, onClose: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onClose) { Icon(Icons.Default.KeyboardArrowDown, "Close", Modifier.size(26.dp)) }
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                if (subtitle != null) {
+                    Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailTopBar(title: String, onBack: () -> Unit, action: Pair<String, () -> Unit>?) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) { Icon(Icons.Default.KeyboardArrowDown, "Back", Modifier.size(26.dp)) }
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+            if (action != null) TextButton(onClick = action.second) { Text(action.first) }
+        }
+    }
+}
+
+@Composable
+private fun ProjectNameDialog(
+    title: String,
+    initial: String,
+    confirmLabel: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var name by remember { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                singleLine = true,
+                placeholder = { Text("Project name") },
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(name.trim().ifBlank { "Untitled project" }) }) { Text(confirmLabel) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun ProjectColorDialog(selected: Int, onDismiss: () -> Unit, onPick: (Int) -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Project colour") },
+        text = {
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.m)) {
+                (0 until PROJECT_ACCENT_COUNT).forEach { index ->
+                    val accent = projectAccent(index)
+                    Box(
+                        Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(accent.solid)
+                            .then(
+                                if (index == selected) {
+                                    Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                } else Modifier
+                            )
+                            .clickable { onPick(index) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (index == selected) Icon(Icons.Default.Check, null, Modifier.size(20.dp), tint = accent.onContainer)
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
+    )
+}
+
+@Composable
+private fun ProjectsEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier.padding(Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            Modifier.size(72.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(Icons.Default.CreateNewFolder, null, Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Text("No projects yet", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = Spacing.base))
+        Text(
+            "Group related chats, give them a shared instruction, and attach reference files. Tap + to start one.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.xs, start = Spacing.base, end = Spacing.base),
+        )
+    }
+}
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes < 1024 -> "$bytes B"
+    bytes < 1024 * 1024 -> "${bytes / 1024} KB"
+    else -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+}

--- a/app/src/test/java/com/echoflow/data/ProjectsMigrationTest.kt
+++ b/app/src/test/java/com/echoflow/data/ProjectsMigrationTest.kt
@@ -119,15 +119,34 @@ class ProjectsMigrationTest {
         )
         db.execSQL("UPDATE chat_threads SET projectId = 'proj-1' WHERE id = 'thread-1'")
 
-        // The app clears assignments in code before deleting (no FK on chat_threads.projectId).
-        db.execSQL("UPDATE chat_threads SET projectId = NULL WHERE projectId = 'proj-1'")
+        // Delete while the chat is still linked: chat_threads.projectId carries no FK, so the
+        // row must survive. The app clears the assignment in code (see ProjectManager).
         db.execSQL("DELETE FROM projects WHERE id = 'proj-1'")
 
         db.query("SELECT COUNT(*) FROM project_documents").use { c ->
             assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0)) // cascaded away
         }
         db.query("SELECT COUNT(*) FROM chat_threads").use { c ->
-            assertTrue(c.moveToFirst()); assertEquals(1, c.getInt(0)) // chat kept
+            assertTrue(c.moveToFirst()); assertEquals(1, c.getInt(0)) // chat kept, no cascade
         }
+
+        // And the in-code sweep returns it to the drawer.
+        db.execSQL("UPDATE chat_threads SET projectId = NULL WHERE projectId = 'proj-1'")
+        db.query("SELECT projectId FROM chat_threads WHERE id = 'thread-1'").use { c ->
+            assertTrue(c.moveToFirst()); assertNull(c.getString(0))
+        }
+    }
+
+    @Test fun `migration creates the expected indexes`() {
+        insertThread("thread-1")
+
+        AppDatabase.MIGRATION_21_22.migrate(db)
+
+        val names = mutableSetOf<String>()
+        db.query("SELECT name FROM sqlite_master WHERE type = 'index'").use { c ->
+            while (c.moveToNext()) names += c.getString(0)
+        }
+        assertTrue(names.contains("index_chat_threads_projectId"))
+        assertTrue(names.contains("index_project_documents_projectId"))
     }
 }

--- a/app/src/test/java/com/echoflow/data/ProjectsMigrationTest.kt
+++ b/app/src/test/java/com/echoflow/data/ProjectsMigrationTest.kt
@@ -1,0 +1,133 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Projects ship behind a schema bump (v22). The promise is that the change is purely additive:
+ * every existing conversation survives untouched and simply starts life as a loose chat (null
+ * projectId). These tests build a v21 `chat_threads` table by hand, run
+ * [AppDatabase.MIGRATION_21_22] against it, and assert the new tables/column exist and that a
+ * pre-existing thread is preserved with a null project.
+ *
+ * The risk here is entirely in the three statements of MIGRATION_21_22 (one ALTER, two CREATEs),
+ * so we exercise those directly rather than through Room's device-only MigrationTestHelper.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ProjectsMigrationTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private lateinit var helper: SupportSQLiteOpenHelper
+    private lateinit var db: SupportSQLiteDatabase
+
+    /** `chat_threads` as of v21 — name-equivalent (assertions select by name). */
+    private val createV21 = """
+        CREATE TABLE IF NOT EXISTS chat_threads (
+            id TEXT NOT NULL PRIMARY KEY,
+            title TEXT NOT NULL,
+            createdAt INTEGER NOT NULL,
+            updatedAt INTEGER NOT NULL,
+            kind TEXT NOT NULL DEFAULT 'chat',
+            pinnedAt INTEGER
+        )
+    """.trimIndent()
+
+    @Before fun setUp() {
+        helper = FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(null) // in-memory
+                .callback(object : SupportSQLiteOpenHelper.Callback(21) {
+                    override fun onCreate(db: SupportSQLiteDatabase) = db.execSQL(createV21)
+                    override fun onUpgrade(db: SupportSQLiteDatabase, old: Int, new: Int) = Unit
+                })
+                .build()
+        )
+        db = helper.writableDatabase
+    }
+
+    @After fun tearDown() = helper.close()
+
+    private fun insertThread(id: String) {
+        db.execSQL(
+            "INSERT INTO chat_threads (id, title, createdAt, updatedAt, kind) VALUES (?, ?, ?, ?, ?)",
+            arrayOf(id, "Existing chat", 1_000L, 2_000L, "chat"),
+        )
+    }
+
+    @Test fun `existing threads survive and become loose chats`() {
+        insertThread("thread-1")
+
+        AppDatabase.MIGRATION_21_22.migrate(db)
+
+        db.query("SELECT id, title, projectId FROM chat_threads WHERE id = 'thread-1'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("thread-1", c.getString(0))
+            assertEquals("Existing chat", c.getString(1))
+            assertNull(c.getString(2)) // null projectId — a loose chat
+        }
+    }
+
+    @Test fun `projects and documents can be created and a chat linked`() {
+        insertThread("thread-1")
+        AppDatabase.MIGRATION_21_22.migrate(db)
+
+        db.execSQL(
+            "INSERT INTO projects (id, name, instructions, colorIndex, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?)",
+            arrayOf("proj-1", "Novel", "Keep a noir tone.", 2, 10L, 20L),
+        )
+        db.execSQL(
+            "INSERT INTO project_documents (id, projectId, name, mimeType, sizeBytes, filePath, extractedText, addedAt) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            arrayOf("doc-1", "proj-1", "notes.txt", "text/plain", 12L, "/tmp/doc-1", "hello", 30L),
+        )
+        db.execSQL("UPDATE chat_threads SET projectId = 'proj-1' WHERE id = 'thread-1'")
+
+        db.query(
+            "SELECT t.projectId, p.name, d.extractedText FROM chat_threads t " +
+                "JOIN projects p ON p.id = t.projectId " +
+                "JOIN project_documents d ON d.projectId = p.id WHERE t.id = 'thread-1'"
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("proj-1", c.getString(0))
+            assertEquals("Novel", c.getString(1))
+            assertEquals("hello", c.getString(2))
+        }
+    }
+
+    @Test fun `deleting a project cascades documents but not chats`() {
+        insertThread("thread-1")
+        AppDatabase.MIGRATION_21_22.migrate(db)
+        db.execSQL("PRAGMA foreign_keys=ON")
+        db.execSQL(
+            "INSERT INTO projects (id, name, instructions, colorIndex, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?)",
+            arrayOf("proj-1", "Novel", "", 0, 10L, 20L),
+        )
+        db.execSQL(
+            "INSERT INTO project_documents (id, projectId, name, mimeType, sizeBytes, filePath, extractedText, addedAt) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            arrayOf("doc-1", "proj-1", "notes.txt", "text/plain", 12L, "/tmp/doc-1", "hello", 30L),
+        )
+        db.execSQL("UPDATE chat_threads SET projectId = 'proj-1' WHERE id = 'thread-1'")
+
+        // The app clears assignments in code before deleting (no FK on chat_threads.projectId).
+        db.execSQL("UPDATE chat_threads SET projectId = NULL WHERE projectId = 'proj-1'")
+        db.execSQL("DELETE FROM projects WHERE id = 'proj-1'")
+
+        db.query("SELECT COUNT(*) FROM project_documents").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0)) // cascaded away
+        }
+        db.query("SELECT COUNT(*) FROM chat_threads").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(1, c.getInt(0)) // chat kept
+        }
+    }
+}


### PR DESCRIPTION
## Projects & Artifacts gallery

Adds two standing destinations to the drawer, under the search — **Projects** and **Artifacts** — each on the drawer's own surface (no card, no accent), split by a hairline so they read as *places*, quieter than the conversation list.

### Artifacts
A fullscreen gallery of **every chat's latest artifact** (one per chat by the one-lineage-per-chat rule) in an adaptive grid. Each tile is type-tinted; a **version chip** drops straight into any earlier version. Tiles open the existing artifact **workspace**, so the gallery is a browse surface rather than a second viewer.

### Projects (Option B — "a launchpad, not a container")
- **Hub**: list + create.
- **Project home**: chats-first, with a two-card **context strip** that points to focused sub-screens — it never crams setup onto one page.
  - **Instructions**: a full-screen autosaving editor. Injected into the system prompt for every chat in the project.
  - **Files**: SAF import, copied into app storage; text formats are extracted and handed to the model as background knowledge. Per-file size + a clear *"not read as text"* state for binary formats. (v1 extracts text-shaped formats only — see caveats.)
- **New chat in this project** stamps the project onto the thread it lazily creates.
- Rename, theme-derived **colour**, and **delete** (delete returns the project's chats to the drawer — it never cascades conversations away).
- **In-chat pill**: a quiet, accent-tinted chip under the top bar when the open chat belongs to a project; taps through to the home.

### Data (Room v22)
`projects` + `project_documents` tables and a nullable, indexed `chat_threads.projectId` (no FK — so a project delete sets null in code rather than cascading). Migration is purely additive; a Robolectric test exercises `MIGRATION_21_22` directly.

### Commits
1. Data layer (Room v22, entities, DAOs, migration)
2. `ProjectManager` + ViewModel wiring + system-prompt injection
3. Drawer destinations + Artifacts gallery
4. Projects hub, home, instructions editor, files
5. In-chat project pill + migration test

### ⚠️ Caveats — please read before merge
- **Not compiled here.** This branch was written without a local build (per request). Please run `./gradlew :app:assembleDebug` once — expect to resolve any minor signature drift, and Room/KSP will **generate `app/schemas/com.echoflow.data.AppDatabase/22.json`** on first build; commit it.
- **Screenshots pending.** The `CLAUDE.md` on-device-screenshot rule couldn't be met (emulator/build were out of scope this session). New surfaces to capture: drawer destinations, Artifacts gallery (+ version chip), projects list, project home, instructions editor, files screen, and the in-chat pill.
- **Document extraction is v1** — text-shaped formats only (`text/*`, common code/markdown). PDFs and other binaries list in the project but contribute no context (surfaced in the UI). Wiring PDF text extraction is a clean follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Projects for organizing chats with custom instructions, colors, and reference documents.
  - Added project-specific chat views, chat assignment, document management, and contextual prompts.
  - Added an Artifacts gallery for browsing saved artifacts and versions.
  - Added project and artifact destinations to the chat drawer.
  - Added project indicators to conversations and support for opening related projects.
- **Bug Fixes**
  - Preserved existing chats during the database upgrade and ensured project deletion handles related content safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Projects as a chat launchpad and Artifacts as a gallery while integrating project context, files, navigation, and Room persistence. I like that these are treated as focused destinations rather than overloading the drawer or chat screen; the follow-up’s bounded import cleanup and saveable instruction state are better implementations of the affected lifecycle boundaries.
- Adds project creation, customization, document import, context injection, and chat assignment.
- Adds an adaptive artifact gallery that opens the existing version-aware workspace.
- Extends Room to version 22 with project tables and nullable chat ownership.
- Integrates project and artifact destinations with the drawer and fullscreen navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the current follow-up scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/ProjectManager.kt | Adds project lifecycle, bounded document import and cleanup, and capped prompt-context assembly; the previously reported cleanup paths are addressed. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Integrates project and gallery state, routes specialized thread creation through project assignment, and exposes the new UI actions. |
| app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt | Implements the project hub and focused detail screens, with instruction drafts now surviving recreation. |
| app/src/main/java/com/echoflow/navigation/MainNavigation.kt | Adds explicit fullscreen routing and back transitions for project and artifact destinations. |
| app/src/main/java/com/echoflow/data/AppDatabase.kt | Registers the version 22 project schema, DAO boundaries, and additive migration. |
| app/src/main/java/com/echoflow/ui/screens/ArtifactsGalleryScreen.kt | Adds the adaptive artifact browse surface while reusing the established artifact workspace. |
| app/src/test/java/com/echoflow/data/ProjectsMigrationTest.kt | Exercises the direct version 21-to-22 migration and its project schema additions. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Drawer[Drawer destinations] --> Projects[Projects hub]
    Drawer --> Gallery[Artifacts gallery]
    Projects --> Home[Project home]
    Home --> Chats[Project chats]
    Home --> Instructions[Instructions editor]
    Home --> Files[Reference files]
    Chats --> Chat[Chat workspace]
    Instructions --> Context[Project system context]
    Files --> Context
    Context --> Chat
    Gallery --> Artifact[Artifact workspace]
    DB[(Room v22)] --> Projects
    DB --> Gallery
    DB --> Chat
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Delete the project row before sweeping i..."](https://github.com/adityavardhansharma/echoflow/commit/24af7e5c4c765dd87bac6e54eb9153455a52ac5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53829739)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Context used - always add what you liked in the pr for the produc... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Android app shell and top-level navigation](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/app-shell-navigation.md)
- Knowledge Base — [Chat conversation flow](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/chat-conversation.md)
- Knowledge Base — [Persistence and Room database](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/persistence-database.md)
- Knowledge Base — [EchoFlow UI design system](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/ui-design-system.md)
</details>

<!-- /greptile_comment -->