### PR TITLE
Project files: show import errors in the Files screen, dismiss keyboard on hub open

### DIFF
--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -223,6 +223,7 @@ class ProjectManager(
         val result = runCatching {
             extractor.extract(File(document.filePath), document.mimeType, document.name)
         }.getOrElse {
+            if (it is CancellationException) throw it
             FileExtractor.Result(null, ExtractionStatus.FAILED, null)
         }
         val updated = document.copy(

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -618,10 +618,11 @@ class ChatViewModel(
      * the chat surface sitting behind the hub overlay. The project id travels with the message
      * so a late failure cannot paint a banner onto a different project's Files screen.
      */
-    data class ProjectFileError(val projectId: String, val message: String)
+    data class ProjectFileError(val projectId: String, val message: String, val importId: Long = 0L)
 
     private val _projectFileError = MutableStateFlow<ProjectFileError?>(null)
     val projectFileError: StateFlow<ProjectFileError?> = _projectFileError.asStateFlow()
+    private var nextProjectFileImportId = 0L
     fun clearProjectFileError(projectId: String) {
         if (_projectFileError.value?.projectId == projectId) _projectFileError.value = null
     }
@@ -739,27 +740,33 @@ class ChatViewModel(
     }
 
     fun addProjectDocument(projectId: String, uri: Uri) {
+        val importId = ++nextProjectFileImportId
         viewModelScope.launch {
             val added = try {
                 projectManager.addDocument(projectId, uri)
             } catch (t: CancellationException) {
                 throw t
             } catch (_: Throwable) {
-                reportProjectFileError(projectId)
+                reportProjectFileError(projectId, importId)
                 return@launch
             }
             if (added == null) {
-                reportProjectFileError(projectId)
-            } else if (_projectFileError.value?.projectId == projectId) {
-                // A later success for this project replaces a stale failure banner; leave
-                // another project's error in place.
-                _projectFileError.value = null
+                reportProjectFileError(projectId, importId)
+            } else {
+                // Only a newer success may drop this project's banner. An older import
+                // finishing later must not hide a failure that started after it.
+                val current = _projectFileError.value
+                if (current != null && current.projectId == projectId && current.importId < importId) {
+                    _projectFileError.value = null
+                }
             }
         }
     }
 
-    private fun reportProjectFileError(projectId: String) {
-        _projectFileError.value = ProjectFileError(projectId, "Couldn't add that file.")
+    private fun reportProjectFileError(projectId: String, importId: Long) {
+        val current = _projectFileError.value
+        if (current != null && current.projectId == projectId && current.importId > importId) return
+        _projectFileError.value = ProjectFileError(projectId, "Couldn't add that file.", importId)
     }
 
     fun removeProjectDocument(document: ProjectDocument) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -615,11 +615,16 @@ class ChatViewModel(
     /**
      * Errors raised while managing a project's files (e.g. an import that can't be read). Kept
      * separate from [errorMessage] so it surfaces inside the Files screen that raised it, not on
-     * the chat surface sitting behind the hub overlay.
+     * the chat surface sitting behind the hub overlay. The project id travels with the message
+     * so a late failure cannot paint a banner onto a different project's Files screen.
      */
-    private val _projectFileError = MutableStateFlow<String?>(null)
-    val projectFileError: StateFlow<String?> = _projectFileError.asStateFlow()
-    fun clearProjectFileError() { _projectFileError.value = null }
+    data class ProjectFileError(val projectId: String, val message: String)
+
+    private val _projectFileError = MutableStateFlow<ProjectFileError?>(null)
+    val projectFileError: StateFlow<ProjectFileError?> = _projectFileError.asStateFlow()
+    fun clearProjectFileError(projectId: String) {
+        if (_projectFileError.value?.projectId == projectId) _projectFileError.value = null
+    }
 
     /**
      * The project a not-yet-created chat will belong to. Starting a new chat from a project home
@@ -735,10 +740,26 @@ class ChatViewModel(
 
     fun addProjectDocument(projectId: String, uri: Uri) {
         viewModelScope.launch {
-            if (projectManager.addDocument(projectId, uri) == null) {
-                _projectFileError.value = "Couldn't add that file."
+            val added = try {
+                projectManager.addDocument(projectId, uri)
+            } catch (t: CancellationException) {
+                throw t
+            } catch (_: Throwable) {
+                reportProjectFileError(projectId)
+                return@launch
+            }
+            if (added == null) {
+                reportProjectFileError(projectId)
+            } else if (_projectFileError.value?.projectId == projectId) {
+                // A later success for this project replaces a stale failure banner; leave
+                // another project's error in place.
+                _projectFileError.value = null
             }
         }
+    }
+
+    private fun reportProjectFileError(projectId: String) {
+        _projectFileError.value = ProjectFileError(projectId, "Couldn't add that file.")
     }
 
     fun removeProjectDocument(document: ProjectDocument) {

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -613,6 +613,15 @@ class ChatViewModel(
     val openProjectId: StateFlow<String?> = _openProjectId.asStateFlow()
 
     /**
+     * Errors raised while managing a project's files (e.g. an import that can't be read). Kept
+     * separate from [errorMessage] so it surfaces inside the Files screen that raised it, not on
+     * the chat surface sitting behind the hub overlay.
+     */
+    private val _projectFileError = MutableStateFlow<String?>(null)
+    val projectFileError: StateFlow<String?> = _projectFileError.asStateFlow()
+    fun clearProjectFileError() { _projectFileError.value = null }
+
+    /**
      * The project a not-yet-created chat will belong to. Starting a new chat from a project home
      * parks the id here; the thread is created lazily on first send (like every blank chat), and
      * this is what stamps the project onto it then.
@@ -727,7 +736,7 @@ class ChatViewModel(
     fun addProjectDocument(projectId: String, uri: Uri) {
         viewModelScope.launch {
             if (projectManager.addDocument(projectId, uri) == null) {
-                _errorMessage.value = "Couldn't read that file."
+                _projectFileError.value = "Couldn't add that file."
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -354,16 +354,17 @@ private fun ProjectHomeScreen(chatViewModel: ChatViewModel, projectId: String, o
         )
         p != null && detail == ProjectDetail.Files -> {
             val modelReadsFiles by chatViewModel.modelReadsFiles.collectAsState()
-            val fileError by chatViewModel.projectFileError.collectAsState()
+            val projectFileError by chatViewModel.projectFileError.collectAsState()
+            val fileError = projectFileError?.takeIf { it.projectId == projectId }?.message
             ProjectFilesScreen(
                 project = p,
                 documents = documents,
                 modelReadsFiles = modelReadsFiles,
                 fileError = fileError,
-                onClearFileError = { chatViewModel.clearProjectFileError() },
+                onClearFileError = { chatViewModel.clearProjectFileError(projectId) },
                 onAdd = { uri -> chatViewModel.addProjectDocument(projectId, uri) },
                 onRemove = { chatViewModel.removeProjectDocument(it) },
-                onBack = { chatViewModel.clearProjectFileError(); detail = ProjectDetail.None },
+                onBack = { chatViewModel.clearProjectFileError(projectId); detail = ProjectDetail.None },
             )
         }
         else -> {
@@ -803,12 +804,16 @@ private fun ProjectFilesScreen(
             }
             // A file that couldn't be added is reported here, on the screen that raised it — not
             // on the chat surface behind the hub, where the user would never see it.
+            var bannerMessage by remember { mutableStateOf("") }
+            if (fileError != null) bannerMessage = fileError
             AnimatedVisibility(
                 visible = fileError != null,
                 enter = expandVertically() + fadeIn(),
                 exit = shrinkVertically() + fadeOut(),
             ) {
-                fileError?.let { ErrorBanner(it, onDismiss = onClearFileError) }
+                // Keep ErrorBanner composed (and its last message) through the exit
+                // transition — `fileError?.let` removed it the moment the error cleared.
+                ErrorBanner(bannerMessage, onDismiss = onClearFileError)
             }
             if (documents.isEmpty()) {
                 FilesEmptyState(onAdd = { picker.launch(arrayOf("*/*")) }, modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -7,10 +7,13 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -123,8 +126,18 @@ import com.echoflow.ui.theme.rememberReducedMotion
 fun ProjectsHubScreen(chatViewModel: ChatViewModel) {
     val openProjectId by chatViewModel.openProjectId.collectAsState()
 
+    // The hub opens over the chat, whose composer may still hold focus and keep the soft keyboard
+    // up. Nothing in the hub wants it, so dismiss it as the surface appears — otherwise it hangs
+    // over every screen inside the hub until the user taps elsewhere.
+    val keyboard = androidx.compose.ui.platform.LocalSoftwareKeyboardController.current
+    val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
+
     var appeared by remember { mutableStateOf(false) }
-    androidx.compose.runtime.LaunchedEffect(Unit) { appeared = true }
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        focusManager.clearFocus(force = true)
+        keyboard?.hide()
+        appeared = true
+    }
     val openProgress by animateFloatAsState(
         targetValue = if (appeared) 1f else 0f,
         animationSpec = tween(durationMillis = 320),
@@ -341,13 +354,16 @@ private fun ProjectHomeScreen(chatViewModel: ChatViewModel, projectId: String, o
         )
         p != null && detail == ProjectDetail.Files -> {
             val modelReadsFiles by chatViewModel.modelReadsFiles.collectAsState()
+            val fileError by chatViewModel.projectFileError.collectAsState()
             ProjectFilesScreen(
                 project = p,
                 documents = documents,
                 modelReadsFiles = modelReadsFiles,
+                fileError = fileError,
+                onClearFileError = { chatViewModel.clearProjectFileError() },
                 onAdd = { uri -> chatViewModel.addProjectDocument(projectId, uri) },
                 onRemove = { chatViewModel.removeProjectDocument(it) },
-                onBack = { detail = ProjectDetail.None },
+                onBack = { chatViewModel.clearProjectFileError(); detail = ProjectDetail.None },
             )
         }
         else -> {
@@ -763,6 +779,8 @@ private fun ProjectFilesScreen(
     project: Project,
     documents: List<ProjectDocument>,
     modelReadsFiles: Boolean,
+    fileError: String?,
+    onClearFileError: () -> Unit,
     onAdd: (android.net.Uri) -> Unit,
     onRemove: (ProjectDocument) -> Unit,
     onBack: () -> Unit,
@@ -782,6 +800,15 @@ private fun ProjectFilesScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 2.dp),
                 )
+            }
+            // A file that couldn't be added is reported here, on the screen that raised it — not
+            // on the chat surface behind the hub, where the user would never see it.
+            AnimatedVisibility(
+                visible = fileError != null,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                fileError?.let { ErrorBanner(it, onDismiss = onClearFileError) }
             }
             if (documents.isEmpty()) {
                 FilesEmptyState(onAdd = { picker.launch(arrayOf("*/*")) }, modifier = Modifier.fillMaxSize())


### PR DESCRIPTION
## What

Two fixes to the project-file flow reported from device testing.

### 1. File errors surfaced on the wrong screen
A failed file import (`addDocument` returning null — unreadable or oversized) raised the **global chat error banner**. That banner lives on the chat surface, which sits *behind* the full-screen Projects hub overlay, so the user adding a file in the Files screen never saw it.

- Added a project-scoped `projectFileError` channel to `ChatViewModel`, separate from the chat `errorMessage`.
- The Files screen now renders the error inline (reusing `ErrorBanner`) — on the screen that raised it — and clears it on dismiss / back.

### 2. Keyboard stuck open over the hub
Opening the Projects hub while the chat composer still held focus left the soft keyboard up across every screen inside the hub.

- `ProjectsHubScreen` now clears focus and hides the IME as the surface appears.

## Testing
`./gradlew :app:compileDebugKotlin` passes. Per request, no APK build / emulator run this round, so no screenshots attached — both changes are behavioural (error routing + IME dismissal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project document import errors now appear in a dedicated project file error banner instead of the general chat error area.
  * Added dismissible, animated error messages above project file content.
  * Errors are cleared when leaving project file screens.
* **Usability Improvements**
  * Opening the projects hub now clears focus and hides the software keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The product direction is good: project-file failures now appear where users can act on them, and opening the hub dismisses chat-composer focus. The error state is now project-scoped, cancellation is preserved during extraction, and the Files screen presents a dismissible animated banner, but import completion still needs operation-level ordering.

- Routes failed project imports to an inline Files-screen error instead of the obscured chat banner.
- Associates file errors with a project and clears them on dismissal, navigation, or a later success.
- Propagates coroutine cancellation from document extraction.
- Clears focus and hides the software keyboard when the Projects hub opens.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an older successful import can hide a newer failed import in the same project.

Concurrent imports are independently launched and can complete out of order, while the success path clears errors using only project identity; operation-level ordering is needed so a stale success cannot remove the current failure.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/ChatViewModel.kt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/ProjectManager.kt | Preserves structured cancellation during extraction instead of converting cancellation into an ordinary failed result. |
| app/src/main/java/com/echoflow/ui/ChatViewModel.kt | Introduces project-scoped file-import errors, but a successful concurrent import can clear a newer failure because errors have no operation identity. |
| app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt | Displays project-matched errors inline with animated dismissal and clears focus and the IME when the hub opens. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant VM as ChatViewModel
    participant PM as ProjectManager
    participant UI as Files screen
    User->>VM: Add file A
    VM->>PM: addDocument(A)
    User->>VM: Add file B
    VM->>PM: addDocument(B)
    PM-->>VM: B fails
    VM-->>UI: Show B error
    PM-->>VM: A succeeds later
    VM-->>UI: Clear project error
    Note over UI: B's current failure is hidden
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Scope project file errors to the importi..."](https://github.com/adityavardhansharma/echoflow/commit/1e40e3173f56eedc1830e4396a57d010e3c71d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54686848)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Chat conversation flow](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/chat-conversation.md)

<!-- /greptile_comment -->