### PR TITLE
Project files: long-press open actions → main

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,18 @@
             android:name=".data.DeepResearchForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Hands a project file to the user's default viewer (Open as PDF/Word/…). Files live in
+             private storage, so we grant a per-open read URI rather than exposing app storage. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
@@ -55,10 +55,10 @@ object ProjectFileOpener {
         val mime = resolveMime(document)
 
         val shared = runCatching {
-            val dir = File(context.cacheDir, SHARED_DIR).apply { mkdirs() }
-            // One file lives here at a time — clear prior copies so the cache can't grow per open.
-            dir.listFiles()?.forEach { it.delete() }
-            File(dir, safeFileName(document, mime)).also { source.copyTo(it, overwrite = true) }
+val dir = File(context.cacheDir, SHARED_DIR).apply { mkdirs() }
+// Clean up stale prior copies, but keep recent ones so external viewers don't lose their backing file.
+dir.listFiles()?.filter { it.lastModified() < System.currentTimeMillis() - 24L * 60L * 60L * 1000L }?.forEach { it.delete() }
+File(dir, safeFileName(document, mime)).also { source.copyTo(it, overwrite = true) }
         }.getOrNull() ?: return false
 
         val uri = runCatching {

--- a/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
@@ -87,11 +87,11 @@ val intent = Intent(Intent.ACTION_VIEW).apply {
 
     /** The display name, stripped of any path parts, with an extension appended if it lacks one. */
     private fun safeFileName(document: ProjectDocument, mime: String): String {
-        val raw = document.name.substringAfterLast('/').substringAfterLast('\\').trim().ifBlank { "document" }
-        val ext = raw.substringAfterLast('.', "")
-        if (ext.isNotBlank() && ext.length <= 5) return raw
-        val guessed = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
-        return if (guessed != null) "$raw.$guessed" else raw
+val raw = document.name.substringAfterLast('/').substringAfterLast('\\').trim().ifBlank { "document" }
+val ext = raw.substringAfterLast('.', "")
+if (ext.isNotBlank() && MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext.lowercase()) != null) return raw
+val guessed = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
+return if (!guessed.isNullOrBlank()) "$raw.$guessed" else raw
     }
 
     private const val SHARED_DIR = "shared_docs"

--- a/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
@@ -65,10 +65,11 @@ object ProjectFileOpener {
             FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", shared)
         }.getOrNull() ?: return false
 
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, mime)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
+val intent = Intent(Intent.ACTION_VIEW).apply {
+    setDataAndType(uri, mime)
+    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+}
         return try {
             context.startActivity(intent)
             true

--- a/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectFileOpener.kt
@@ -1,0 +1,100 @@
+package com.echoflow.data
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Hands a project file to the user's default external viewer — the "Open as PDF / Word / Excel …"
+ * long-press action on the Files screen. The in-app path (Open as Markdown) is handled separately by
+ * the document reader; this file only deals with leaving the app.
+ *
+ * Project files are copied into private storage under their doc id with no extension, which confuses
+ * external viewers (they lean on the name/extension). So each open copies the one file into
+ * `cache/shared_docs` under its real display name and shares *that* through [FileProvider], granting
+ * the target app a one-shot read permission. Nothing in app storage is exposed directly.
+ */
+object ProjectFileOpener {
+
+    /** How a project file presents to the user — drives the long-press action's label and icon. */
+    enum class Kind { PDF, WORD, SPREADSHEET, SLIDES, IMAGE, OTHER }
+
+    fun kindOf(document: ProjectDocument): Kind {
+        val ext = document.name.substringAfterLast('.', "").lowercase()
+        val mime = document.mimeType.lowercase()
+        return when {
+            ext == "pdf" || mime == "application/pdf" -> Kind.PDF
+            ext in WORD_EXTS || "word" in mime || "opendocument.text" in mime -> Kind.WORD
+            ext in SHEET_EXTS || "sheet" in mime || "excel" in mime || mime.endsWith("/csv") -> Kind.SPREADSHEET
+            ext in SLIDE_EXTS || "presentation" in mime || "powerpoint" in mime -> Kind.SLIDES
+            mime.startsWith("image/") -> Kind.IMAGE
+            else -> Kind.OTHER
+        }
+    }
+
+    /** The verb shown in the long-press menu, e.g. "Open as PDF". */
+    fun openLabel(kind: Kind): String = when (kind) {
+        Kind.PDF -> "Open as PDF"
+        Kind.WORD -> "Open as Word"
+        Kind.SPREADSHEET -> "Open as spreadsheet"
+        Kind.SLIDES -> "Open as slides"
+        Kind.IMAGE -> "Open image"
+        Kind.OTHER -> "Open file"
+    }
+
+    /**
+     * Launch the user's default viewer for [document]. Returns false when the file is gone or no
+     * installed app can open the type, so the caller can surface an honest "nothing can open this".
+     */
+    fun openExternally(context: Context, document: ProjectDocument): Boolean {
+        val source = File(document.filePath)
+        if (!source.exists()) return false
+        val mime = resolveMime(document)
+
+        val shared = runCatching {
+            val dir = File(context.cacheDir, SHARED_DIR).apply { mkdirs() }
+            // One file lives here at a time — clear prior copies so the cache can't grow per open.
+            dir.listFiles()?.forEach { it.delete() }
+            File(dir, safeFileName(document, mime)).also { source.copyTo(it, overwrite = true) }
+        }.getOrNull() ?: return false
+
+        val uri = runCatching {
+            FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", shared)
+        }.getOrNull() ?: return false
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, mime)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (e: ActivityNotFoundException) {
+            false
+        }
+    }
+
+    private fun resolveMime(document: ProjectDocument): String {
+        val declared = document.mimeType
+        if (declared.isNotBlank() && declared != "application/octet-stream" && '/' in declared) return declared
+        val ext = document.name.substringAfterLast('.', "").lowercase()
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: "application/octet-stream"
+    }
+
+    /** The display name, stripped of any path parts, with an extension appended if it lacks one. */
+    private fun safeFileName(document: ProjectDocument, mime: String): String {
+        val raw = document.name.substringAfterLast('/').substringAfterLast('\\').trim().ifBlank { "document" }
+        val ext = raw.substringAfterLast('.', "")
+        if (ext.isNotBlank() && ext.length <= 5) return raw
+        val guessed = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
+        return if (guessed != null) "$raw.$guessed" else raw
+    }
+
+    private const val SHARED_DIR = "shared_docs"
+    private val WORD_EXTS = setOf("doc", "docx", "docm", "odt", "rtf")
+    private val SHEET_EXTS = setOf("xls", "xlsx", "xlsm", "xlsb", "ods", "csv")
+    private val SLIDE_EXTS = setOf("ppt", "pptx", "odp")
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectDocumentReaderScreen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectDocumentReaderScreen.kt
@@ -1,0 +1,192 @@
+package com.echoflow.ui.screens
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.echoflow.data.ArtifactExport
+import com.echoflow.data.ExtractionTier
+import com.echoflow.data.ProjectDocument
+import com.echoflow.ui.components.RichMarkdown
+import com.echoflow.ui.theme.Spacing
+
+/**
+ * The in-app reader for "Open as Markdown" — the on-device extraction of a project file, rendered
+ * with the same native Markdown engine and slide-up chrome as the Artifact/report workspace so the
+ * two read as one family. Structured files (PDF/Word/Excel) open in the user's own viewer instead;
+ * this surface only exists for the text we produced locally.
+ *
+ * The **EchoOCR** wordmark lives here and nowhere else: it appears only when anydoc
+ * ([ExtractionTier.ANYDOC]) parsed the file. Text from ML Kit OCR or a plain-text read carries no
+ * badge — we only brand the reading we did with our own engine.
+ */
+@Composable
+fun ProjectDocumentReaderScreen(
+    document: ProjectDocument,
+    onClose: () -> Unit,
+) {
+    BackHandler { onClose() }
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val content = document.extractedText.orEmpty()
+    val showBrand = document.tier == ExtractionTier.ANYDOC
+
+    // Slide up from the bottom and fade in on first appearance, mirroring the Artifact workspace so
+    // opening a document feels like the same move the app already makes for reports.
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val openProgress by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        animationSpec = tween(durationMillis = 320),
+        label = "doc-open",
+    )
+
+    Surface(
+        Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                translationY = (1f - openProgress) * size.height
+                alpha = openProgress
+            },
+        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            ReaderTopBar(
+                title = document.name,
+                showBrand = showBrand,
+                onClose = onClose,
+                onCopy = { clipboard.setText(AnnotatedString(content)) },
+                onExport = { ArtifactExport.printArtifact(context, document.name, "markdown", content) },
+            )
+            Box(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surface),
+            ) {
+                Column(
+                    Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(Spacing.base),
+                ) {
+                    RichMarkdown(content, Modifier.fillMaxWidth())
+                    Spacer(Modifier.height(Spacing.xxl))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReaderTopBar(
+    title: String,
+    showBrand: Boolean,
+    onClose: () -> Unit,
+    onCopy: () -> Unit,
+    onExport: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = Spacing.s, vertical = Spacing.s),
+            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.KeyboardArrowDown, "Close document", Modifier.size(26.dp))
+                }
+                Text(
+                    title.ifBlank { "Document" },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onCopy) {
+                    Icon(Icons.Default.ContentCopy, "Copy text", Modifier.size(20.dp))
+                }
+                FilledTonalIconButton(onClick = onExport) {
+                    Icon(Icons.Default.PictureAsPdf, "Export PDF", Modifier.size(20.dp))
+                }
+            }
+            if (showBrand) EchoOcrBadge()
+        }
+    }
+}
+
+/**
+ * The one place the EchoOCR wordmark is shown: a small tonal pill under the title, marking that this
+ * text was read from the file by the app's own on-device parser.
+ */
+@Composable
+private fun EchoOcrBadge() {
+    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.secondaryContainer) {
+        Row(
+            Modifier.padding(horizontal = Spacing.s, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+            Icon(
+                Icons.Default.AutoAwesome,
+                null,
+                Modifier.size(13.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                "EchoOCR",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
 
 package com.echoflow.ui.screens
 
@@ -15,9 +15,11 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,9 +55,15 @@ import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notes
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material.icons.filled.Slideshow
+import androidx.compose.material.icons.filled.TableChart
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -87,6 +95,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -97,6 +108,7 @@ import androidx.compose.ui.semantics.semantics
 import com.echoflow.data.ExtractionStatus
 import com.echoflow.data.Project
 import com.echoflow.data.ProjectDocument
+import com.echoflow.data.ProjectFileOpener
 import com.echoflow.ui.ChatViewModel
 import com.echoflow.ui.components.PROJECT_ACCENT_COUNT
 import com.echoflow.ui.components.ProjectMedallion
@@ -786,7 +798,13 @@ private fun ProjectFilesScreen(
     onRemove: (ProjectDocument) -> Unit,
     onBack: () -> Unit,
 ) {
-    BackHandler { onBack() }
+    val context = LocalContext.current
+    // The file opened in the in-app Markdown reader, or null when the list is showing. Keyed by id
+    // so a Room refresh (e.g. re-extraction finishing) re-resolves to the live row.
+    var openedDocId by remember { mutableStateOf<String?>(null) }
+    val openedDoc = openedDocId?.let { id -> documents.firstOrNull { it.id == id } }
+    // The reader owns Back while it's up; the list only handles Back once it's closed.
+    BackHandler(enabled = openedDoc == null) { onBack() }
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) onAdd(uri)
     }
@@ -828,6 +846,16 @@ private fun ProjectFilesScreen(
                             document = doc,
                             shape = groupedItemShape(index, documents.size),
                             modelReadsFiles = modelReadsFiles,
+                            onOpenExternal = {
+                                if (!ProjectFileOpener.openExternally(context, doc)) {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "No app can open this file",
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    ).show()
+                                }
+                            },
+                            onOpenMarkdown = { openedDocId = doc.id },
                             onRemove = { onRemove(doc) },
                             modifier = Modifier.animateItem(),
                         )
@@ -841,6 +869,13 @@ private fun ProjectFilesScreen(
                 modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
             ) { Icon(Icons.Default.Add, "Add file") }
         }
+        // The Markdown reader slides up over the whole list when a file is opened as Markdown.
+        if (openedDoc != null) {
+            ProjectDocumentReaderScreen(
+                document = openedDoc,
+                onClose = { openedDocId = null },
+            )
+        }
     }
 }
 
@@ -849,85 +884,127 @@ private fun DocumentRow(
     document: ProjectDocument,
     shape: Shape,
     modelReadsFiles: Boolean,
+    onOpenExternal: () -> Unit,
+    onOpenMarkdown: () -> Unit,
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val hint = documentStatusHint(document.status, modelReadsFiles)
     val hintIsError = document.status == ExtractionStatus.FAILED ||
         (document.status == ExtractionStatus.NEEDS_PROVIDER && !modelReadsFiles)
-    Surface(
-        shape = shape,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        Row(
-            Modifier.padding(start = Spacing.base, end = Spacing.xs, top = Spacing.s, bottom = Spacing.s),
-            verticalAlignment = Alignment.CenterVertically,
+    val haptics = LocalHapticFeedback.current
+    var menuOpen by remember { mutableStateOf(false) }
+    // "Open as Markdown" only when we actually have readable on-device text; a file that goes
+    // straight to the model (NEEDS_PROVIDER) or failed extraction has none, so the option is hidden.
+    val canOpenMarkdown = document.hasText
+    val kind = ProjectFileOpener.kindOf(document)
+    // Long-press (or tap) surfaces the open options anchored to the row.
+    Box {
+        Surface(
+            shape = shape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onClick = { menuOpen = true },
+                    onLongClick = {
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                        menuOpen = true
+                    },
+                ),
         ) {
-            Box(
-                Modifier
-                    .size(34.dp)
-                    .clip(RoundedCornerShape(11.dp))
-                    .background(MaterialTheme.colorScheme.secondaryContainer)
-                    .then(
-                        if (document.status.isBusy) {
-                            Modifier.semantics { contentDescription = "Reading ${document.name}" }
-                        } else {
-                            Modifier
-                        },
-                    ),
-                contentAlignment = Alignment.Center,
+            Row(
+                Modifier.padding(start = Spacing.base, end = Spacing.xs, top = Spacing.s, bottom = Spacing.s),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                AnimatedContent(
-                    targetState = document.status.isBusy,
-                    transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(120)) },
-                    label = "docLeading",
-                ) { busy ->
-                    if (busy) {
-                        LoadingIndicator(
-                            modifier = Modifier.size(18.dp),
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        )
-                    } else {
-                        Icon(
-                            Icons.Default.Description,
-                            null,
-                            Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                Box(
+                    Modifier
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(11.dp))
+                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                        .then(
+                            if (document.status.isBusy) {
+                                Modifier.semantics { contentDescription = "Reading ${document.name}" }
+                            } else {
+                                Modifier
+                            },
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AnimatedContent(
+                        targetState = document.status.isBusy,
+                        transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(120)) },
+                        label = "docLeading",
+                    ) { busy ->
+                        if (busy) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        } else {
+                            Icon(
+                                Icons.Default.Description,
+                                null,
+                                Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.width(Spacing.m))
+                Column(Modifier.weight(1f)) {
+                    Text(document.name, style = MaterialTheme.typography.titleSmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    AnimatedContent(
+                        targetState = hint,
+                        transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(120)) },
+                        label = "docHint",
+                    ) { currentHint ->
+                        Text(
+                            buildString {
+                                append(formatBytes(document.sizeBytes))
+                                if (currentHint != null) {
+                                    append(" · ")
+                                    append(currentHint)
+                                }
+                            },
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (hintIsError) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
                         )
                     }
                 }
-            }
-            Spacer(Modifier.width(Spacing.m))
-            Column(Modifier.weight(1f)) {
-                Text(document.name, style = MaterialTheme.typography.titleSmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                AnimatedContent(
-                    targetState = hint,
-                    transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(120)) },
-                    label = "docHint",
-                ) { currentHint ->
-                    Text(
-                        buildString {
-                            append(formatBytes(document.sizeBytes))
-                            if (currentHint != null) {
-                                append(" · ")
-                                append(currentHint)
-                            }
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (hintIsError) {
-                            MaterialTheme.colorScheme.error
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
+                IconButton(onClick = onRemove, modifier = Modifier.size(40.dp)) {
+                    Icon(Icons.Default.DeleteOutline, "Remove file", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
-            IconButton(onClick = onRemove, modifier = Modifier.size(40.dp)) {
-                Icon(Icons.Default.DeleteOutline, "Remove file", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text(ProjectFileOpener.openLabel(kind)) },
+                leadingIcon = { Icon(kindIcon(kind), null) },
+                onClick = { menuOpen = false; onOpenExternal() },
+            )
+            if (canOpenMarkdown) {
+                DropdownMenuItem(
+                    text = { Text("Open as Markdown") },
+                    leadingIcon = { Icon(Icons.Default.Notes, null) },
+                    onClick = { menuOpen = false; onOpenMarkdown() },
+                )
             }
         }
     }
+}
+
+private fun kindIcon(kind: ProjectFileOpener.Kind): ImageVector = when (kind) {
+    ProjectFileOpener.Kind.PDF -> Icons.Default.PictureAsPdf
+    ProjectFileOpener.Kind.WORD -> Icons.Default.Description
+    ProjectFileOpener.Kind.SPREADSHEET -> Icons.Default.TableChart
+    ProjectFileOpener.Kind.SLIDES -> Icons.Default.Slideshow
+    ProjectFileOpener.Kind.IMAGE -> Icons.Default.Image
+    ProjectFileOpener.Kind.OTHER -> Icons.Default.InsertDriveFile
 }
 
 private fun documentStatusHint(status: ExtractionStatus, modelReadsFiles: Boolean): String? = when (status) {

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -70,6 +70,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
@@ -976,8 +977,10 @@ private fun DocumentRow(
                         )
                     }
                 }
-                IconButton(onClick = onRemove, modifier = Modifier.size(40.dp)) {
-                    Icon(Icons.Default.DeleteOutline, "Remove file", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                // The three-dot affordance opens the same menu as a long-press, so the actions are
+                // discoverable without knowing the gesture.
+                IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(40.dp)) {
+                    Icon(Icons.Default.MoreVert, "File options", Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
@@ -994,6 +997,14 @@ private fun DocumentRow(
                     onClick = { menuOpen = false; onOpenMarkdown() },
                 )
             }
+            HorizontalDivider(Modifier.padding(vertical = Spacing.xs))
+            DropdownMenuItem(
+                text = { Text("Remove", color = MaterialTheme.colorScheme.error) },
+                leadingIcon = {
+                    Icon(Icons.Default.DeleteOutline, null, tint = MaterialTheme.colorScheme.error)
+                },
+                onClick = { menuOpen = false; onRemove() },
+            )
         }
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Paths the app is allowed to hand to other apps through FileProvider. Project files are stored
+  without an extension (their name is the doc id), so we never share them in place; instead we copy
+  the one being opened into cache/shared_docs under its real display name and share that. Only that
+  cache subfolder is exposed here.
+-->
+<paths>
+    <cache-path name="shared_docs" path="shared_docs/" />
+</paths>


### PR DESCRIPTION
Brings the **project file open actions** to `main`. The extraction pipeline this built on is already on `main` (PR #134); this adds the UI on top of it.

## What
Long-press (or tap the three-dot) a file in a project's **Files** screen to open a menu:
- **Open as PDF / Word / spreadsheet / slides / image** — hands the file to the user's default external viewer via a per-open FileProvider grant.
- **Open as Markdown** — opens the on-device extraction in an in-app reader (Artifact/report-style chrome, native Markdown, copy, export-to-PDF). Shown only when extraction produced readable text.
- **Remove** — moved into the menu, in the error role, below a divider.

The **EchoOCR** wordmark shows only inside the Markdown reader, and only for text parsed by anydoc (`ExtractionTier.ANYDOC`); ML Kit OCR / plain-text reads carry no badge. Files sent straight to the model (`NEEDS_PROVIDER`) or that failed extraction offer no Markdown option.

## Database
**No migration** — reuses the existing `extractedText` / `extractionStatus` / `extractionTier` columns.

## Note
Not built or run on an emulator per the task request, so the repo's screenshot rule is still owed before/after this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an in-app document reader with Markdown rendering, scrolling, text copying, PDF export, and navigation controls.
  - Added options to open supported project files in external apps.
  - Added file-type icons, document actions, and improved tap/long-press menus.
  - Added visual feedback for automatically extracted documents.

- **Bug Fixes**
  - Improved secure file sharing when opening project documents externally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->