### PR TITLE
Tint project file row on press instead of a square ripple

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -21,6 +22,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -896,18 +898,28 @@ internal fun DocumentRow(
         (document.status == ExtractionStatus.NEEDS_PROVIDER && !modelReadsFiles)
     val haptics = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
     var menuOpen by remember { mutableStateOf(false) }
     // "Open as Markdown" only when we actually have readable on-device text; a file that goes
     // straight to the model (NEEDS_PROVIDER) or failed extraction has none, so the option is hidden.
     val canOpenMarkdown = document.hasText
     val kind = ProjectFileOpener.kindOf(document)
-    // Long-press (or tap) surfaces the open options anchored to the row. Clip to the grouped
-    // shape and skip the default ripple — that indication is a square drawn around the chip,
-    // not a shadow that follows the container.
+    // Long-press (or tap) surfaces the open options anchored to the row. A bounded ripple painted a
+    // square around the rounded chip, so instead we tint the surface fill on press — that feedback
+    // is the container's own colour, so it always follows the grouped rounded shape.
+    val pressColor by animateColorAsState(
+        targetValue = if (pressed) {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        animationSpec = tween(durationMillis = if (pressed) 90 else 220),
+        label = "docPress",
+    )
     Box {
         Surface(
             shape = shape,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            color = pressColor,
             modifier = modifier
                 .fillMaxWidth()
                 .clip(shape)

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -907,13 +908,14 @@ internal fun DocumentRow(
     // Long-press (or tap) surfaces the open options anchored to the row. A bounded ripple painted a
     // square around the rounded chip, so instead we tint the surface fill on press — that feedback
     // is the container's own colour, so it always follows the grouped rounded shape.
+    val reducedMotion = rememberReducedMotion()
     val pressColor by animateColorAsState(
         targetValue = if (pressed) {
             MaterialTheme.colorScheme.surfaceContainerHighest
         } else {
             MaterialTheme.colorScheme.surfaceContainerHigh
         },
-        animationSpec = tween(durationMillis = if (pressed) 90 else 220),
+        animationSpec = if (reducedMotion) snap() else tween(durationMillis = if (pressed) 90 else 220),
         label = "docPress",
     )
     Box {


### PR DESCRIPTION
## What

Tapping a project file row gave **no press feedback** — the previous fix set `indication = null` to kill a bounded ripple that painted a square around the rounded file chip. That removed the square, but left the row feeling bland/dead on tap.

This restores feedback without the square: on press, the row's `Surface` fill animates from `surfaceContainerHigh` → `surfaceContainerHighest` (90 ms in, 220 ms out). Because the feedback *is* the container's own colour, it's inherently clipped to the grouped rounded `shape` and covers only the file body — there's no separate overlay to leak past the corners.

## Why this over a ripple

A bounded ripple is hosted on the clickable's rectangular bounds, so on a rounded/grouped chip it reads as a square. Tinting the surface fill sidesteps that entirely and stays theme-safe — it uses `MaterialTheme.colorScheme` roles, so it reads correctly across every palette in light and dark.

## Notes

- No screenshots: this is a press-state colour animation; per the request it's shipped without emulator capture.
- Build: `:app:compileDebugKotlin` passes (pre-existing deprecation warnings only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a visual pressed-state animation to document rows for clearer touch feedback.
  * Preserved existing click, long-press, menu, and file actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->