### PR TITLE
Let project Files add several documents in batches of four

### DIFF
--- a/app/src/main/java/com/echoflow/data/ProjectDocument.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectDocument.kt
@@ -49,7 +49,13 @@ enum class ExtractionStatus {
     FAILED,
     UNKNOWN;
 
-    val isBusy: Boolean get() = this == PENDING || this == EXTRACTING
+    /** Copy finished, anydoc/OCR not started yet — waiting for a batch slot. */
+    val isQueued: Boolean get() = this == PENDING
+
+    /** anydoc or OCR is running on this row. */
+    val isExtracting: Boolean get() = this == EXTRACTING
+
+    val isBusy: Boolean get() = isQueued || isExtracting
 
     companion object {
         fun from(s: String?) = entries.firstOrNull { it.name == s } ?: UNKNOWN

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -110,8 +110,16 @@ class ProjectManager(
      * PENDING row immediately, then extract on this IO dispatcher. The Files UI observes the
      * Room flow so the row settles in place. Returns the stored row, or null if the file
      * couldn't be copied at all.
+     *
+     * [onAdmitted] fires once the row is in Room, *before* extraction waits on a batch
+     * slot, so the Files header can drop this pick from the "queued" count without
+     * waiting for anydoc.
      */
-    suspend fun addDocument(projectId: String, uri: Uri): ProjectDocument? = withContext(Dispatchers.IO) {
+    suspend fun addDocument(
+        projectId: String,
+        uri: Uri,
+        onAdmitted: (() -> Unit)? = null,
+    ): ProjectDocument? = withContext(Dispatchers.IO) {
         val resolver = context.contentResolver
         val mimeType = resolver.getType(uri) ?: "application/octet-stream"
         var displayName = "Document"
@@ -200,6 +208,7 @@ class ProjectManager(
             if (t is CancellationException) throw t
             return@withContext null
         }
+        onAdmitted?.invoke()
         claimAndExtract(pending)
     }
 

--- a/app/src/main/java/com/echoflow/data/ProjectManager.kt
+++ b/app/src/main/java/com/echoflow/data/ProjectManager.kt
@@ -1,15 +1,20 @@
 package com.echoflow.data
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
 import com.echoflow.data.extract.FileExtractor
 import com.echoflow.data.extract.OcrExtractor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
@@ -30,9 +35,17 @@ class ProjectManager(
     private val chatDao: ChatDao,
     private val extractor: FileExtractor = FileExtractor(ocr = OcrExtractor(context)),
 ) {
-    private val backfillLocks = mutableMapOf<String, Mutex>()
-    private fun backfillLock(projectId: String): Mutex = synchronized(backfillLocks) {
-        backfillLocks.getOrPut(projectId) { Mutex() }
+    /**
+     * Copy and parse at most [EXTRACT_BATCH_SIZE] files at once. anydoc loads the whole
+     * file (up to 25 MB) into a ByteArray, so four in flight is ~100 MB peak — enough to
+     * ingest a handful of large docs quickly, not enough to OOM a mid-range phone if the
+     * user dumps a folder of twenty.
+     */
+    private val copySlots = Semaphore(EXTRACT_BATCH_SIZE)
+    private val extractSlots = Semaphore(EXTRACT_BATCH_SIZE)
+    private val rowLocks = mutableMapOf<String, Mutex>()
+    private fun rowLock(documentId: String): Mutex = synchronized(rowLocks) {
+        rowLocks.getOrPut(documentId) { Mutex() }
     }
     fun observeProjects(): Flow<List<Project>> = projectDao.observeAll()
     fun observeProject(id: String): Flow<Project?> = projectDao.observeById(id)
@@ -118,28 +131,37 @@ class ProjectManager(
         if (size > MAX_IMPORT_BYTES) return@withContext null
         if (projectDao.getById(projectId) == null) return@withContext null
 
+        // Keep the picker grant alive if the copy waits on a batch slot — OpenMultipleDocuments
+        // URIs otherwise die with the activity result.
+        runCatching {
+            resolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
         val docId = UUID.randomUUID().toString()
         val dir = projectDir(projectId).apply { mkdirs() }
         val dest = File(dir, docId)
         // Bounded copy: stop (and delete) once the source exceeds the import cap, so a huge or
         // hostile file can't fill app storage. Any failure mid-write also sweeps the partial file
         // — otherwise it would linger unreferenced until the whole project is deleted.
-        val copied = runCatching {
-            resolver.openInputStream(uri)?.use { input ->
-                dest.outputStream().use { output ->
-                    val buffer = ByteArray(64 * 1024)
-                    var total = 0L
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        total += read
-                        if (total > MAX_IMPORT_BYTES) throw java.io.IOException("File exceeds import cap")
-                        output.write(buffer, 0, read)
+        // Copy shares the same batch size as extract so twenty 25 MB picks don't all stream at once.
+        val copied = copySlots.withPermit {
+            runCatching {
+                resolver.openInputStream(uri)?.use { input ->
+                    dest.outputStream().use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        var total = 0L
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            total += read
+                            if (total > MAX_IMPORT_BYTES) throw java.io.IOException("File exceeds import cap")
+                            output.write(buffer, 0, read)
+                        }
                     }
-                }
-            } ?: return@runCatching false
-            true
-        }.getOrDefault(false)
+                } ?: return@runCatching false
+                true
+            }.getOrDefault(false)
+        }
         if (!copied) {
             runCatching { dest.delete() }
             return@withContext null
@@ -178,42 +200,54 @@ class ProjectManager(
             if (t is CancellationException) throw t
             return@withContext null
         }
-        backfillLock(projectId).withLock {
-            val current = projectDocumentDao.getById(pending.id) ?: return@withLock null
-            if (current.status.isBusy || current.status == ExtractionStatus.UNKNOWN) {
-                extractAndStore(current)
-            } else {
-                current
-            }
-        }
+        claimAndExtract(pending)
     }
 
     /**
      * Re-run extraction for legacy (`UNKNOWN`) rows and for imports interrupted mid-extract
      * (`PENDING` / `EXTRACTING`). Existing text files are stamped EXTRACTED / LEGACY_TEXT.
-     * Shares [backfillLock] with [addDocument] so the two cannot extract the same row.
+     * Shares [rowLock] with [addDocument] so the two cannot extract the same row, and
+     * [extractSlots] so a backfill of many files still batches through anydoc.
      */
     suspend fun backfillProject(projectId: String) = withContext(Dispatchers.IO) {
-        backfillLock(projectId).withLock {
-            val docs = projectDocumentDao.getForProjectSync(projectId)
+        val docs = projectDocumentDao.getForProjectSync(projectId)
+        coroutineScope {
             for (doc in docs) {
-                val current = projectDocumentDao.getById(doc.id) ?: continue
-                when (current.status) {
-                    ExtractionStatus.UNKNOWN -> {
-                        if (current.hasText) {
-                            projectDocumentDao.update(
-                                current.copy(
-                                    extractionStatus = ExtractionStatus.EXTRACTED.name,
-                                    extractionTier = ExtractionTier.LEGACY_TEXT.name,
+                launch {
+                    val current = projectDocumentDao.getById(doc.id) ?: return@launch
+                    when (current.status) {
+                        ExtractionStatus.UNKNOWN -> {
+                            if (current.hasText) {
+                                projectDocumentDao.update(
+                                    current.copy(
+                                        extractionStatus = ExtractionStatus.EXTRACTED.name,
+                                        extractionTier = ExtractionTier.LEGACY_TEXT.name,
+                                    )
                                 )
-                            )
-                        } else {
-                            extractAndStore(current)
+                            } else {
+                                claimAndExtract(current)
+                            }
                         }
+                        ExtractionStatus.PENDING, ExtractionStatus.EXTRACTING -> claimAndExtract(current)
+                        else -> Unit
                     }
-                    ExtractionStatus.PENDING, ExtractionStatus.EXTRACTING -> extractAndStore(current)
-                    else -> Unit
                 }
+            }
+        }
+    }
+
+    /**
+     * Take a parse slot (at most [EXTRACT_BATCH_SIZE] at once) and run [extractAndStore].
+     * The per-row mutex is the claim: add and backfill both go through here, so a
+     * PENDING row cannot be parsed twice.
+     */
+    private suspend fun claimAndExtract(document: ProjectDocument): ProjectDocument? {
+        return rowLock(document.id).withLock {
+            val current = projectDocumentDao.getById(document.id) ?: return@withLock null
+            if (current.status.isBusy || current.status == ExtractionStatus.UNKNOWN) {
+                extractSlots.withPermit { extractAndStore(current) }
+            } else {
+                current
             }
         }
     }
@@ -295,6 +329,13 @@ class ProjectManager(
 
         /** Hard cap on an imported file's size (bytes) — larger selections are rejected. */
         private const val MAX_IMPORT_BYTES = 25L * 1024 * 1024
+
+        /**
+         * How many files copy or parse at once. Four is the memory bound: each anydoc
+         * conversion holds the whole file (≤ 25 MB) as bytes. Picks above this wait in
+         * PENDING until a slot frees.
+         */
+        const val EXTRACT_BATCH_SIZE = 4
 
         /** Combined document budget injected into any single system prompt. */
         private const val MAX_DOC_CONTEXT_CHARS = 24_000

--- a/app/src/main/java/com/echoflow/data/extract/FileExtractor.kt
+++ b/app/src/main/java/com/echoflow/data/extract/FileExtractor.kt
@@ -11,7 +11,7 @@ import java.io.File
  * provider). Called from [com.echoflow.data.ProjectManager] after a file is copied and from
  * the lazy backfill sweep.
  */
-class FileExtractor(
+open class FileExtractor(
     private val parser: DocumentParser = Anydoc,
     private val ocr: ImageTextRecognizer? = null,
 ) {
@@ -21,7 +21,7 @@ class FileExtractor(
         val tier: ExtractionTier?,
     )
 
-    suspend fun extract(file: File, mime: String, name: String): Result = withContext(Dispatchers.IO) {
+    open suspend fun extract(file: File, mime: String, name: String): Result = withContext(Dispatchers.IO) {
         val ext = name.substringAfterLast('.', "").lowercase()
         val lowerMime = mime.lowercase()
 

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.coroutineContext
 
 class ChatViewModel(
@@ -623,6 +624,7 @@ class ChatViewModel(
     /**
      * Files the user picked that have not been copied into the project yet. Used so the
      * Files header can say "8 waiting" while the first batch of four occupies copy slots.
+     * Keyed by project so two open imports cannot overwrite each other.
      */
     data class ProjectImportProgress(
         val projectId: String,
@@ -637,8 +639,9 @@ class ChatViewModel(
     val projectFileError: StateFlow<ProjectFileError?> = _projectFileError.asStateFlow()
     private var nextProjectFileImportId = 0L
     private val importProgressLock = Any()
-    private val _projectImportProgress = MutableStateFlow<ProjectImportProgress?>(null)
-    val projectImportProgress: StateFlow<ProjectImportProgress?> = _projectImportProgress.asStateFlow()
+    private val _projectImportProgress = MutableStateFlow<Map<String, ProjectImportProgress>>(emptyMap())
+    val projectImportProgress: StateFlow<Map<String, ProjectImportProgress>> =
+        _projectImportProgress.asStateFlow()
     fun clearProjectFileError(projectId: String) {
         if (_projectFileError.value?.projectId == projectId) _projectFileError.value = null
     }
@@ -765,21 +768,29 @@ class ChatViewModel(
         for (uri in uris) {
             val importId = ++nextProjectFileImportId
             viewModelScope.launch {
+                val admitted = AtomicBoolean(false)
                 val added = try {
-                    projectManager.addDocument(projectId, uri)
+                    projectManager.addDocument(projectId, uri) {
+                        if (admitted.compareAndSet(false, true)) {
+                            noteImportFinished(projectId, admitted = true)
+                        }
+                    }
                 } catch (t: CancellationException) {
-                    noteImportFinished(projectId, admitted = false)
+                    if (!admitted.get()) noteImportFinished(projectId, admitted = false)
                     throw t
                 } catch (_: Throwable) {
-                    val failed = noteImportFinished(projectId, admitted = false)
-                    reportProjectFileError(projectId, importId, failed)
+                    if (!admitted.get()) {
+                        val failed = noteImportFinished(projectId, admitted = false)
+                        reportProjectFileError(projectId, importId, failed)
+                    }
                     return@launch
                 }
                 if (added == null) {
-                    val failed = noteImportFinished(projectId, admitted = false)
-                    reportProjectFileError(projectId, importId, failed)
+                    if (!admitted.get()) {
+                        val failed = noteImportFinished(projectId, admitted = false)
+                        reportProjectFileError(projectId, importId, failed)
+                    }
                 } else {
-                    noteImportFinished(projectId, admitted = true)
                     // Only a newer success may drop this project's banner. An older import
                     // finishing later must not hide a failure that started after it.
                     val current = _projectFileError.value
@@ -793,27 +804,33 @@ class ChatViewModel(
 
     private fun beginImport(projectId: String, count: Int) {
         synchronized(importProgressLock) {
-            val current = _projectImportProgress.value
-            _projectImportProgress.value = if (current != null && current.projectId == projectId) {
+            val map = _projectImportProgress.value.toMutableMap()
+            val current = map[projectId]
+            map[projectId] = if (current != null) {
                 current.copy(selected = current.selected + count)
             } else {
                 ProjectImportProgress(projectId = projectId, selected = count)
             }
+            _projectImportProgress.value = map
         }
     }
 
     /** Returns the running failure count for [projectId] after applying this result. */
     private fun noteImportFinished(projectId: String, admitted: Boolean): Int {
         synchronized(importProgressLock) {
-            val current = _projectImportProgress.value
-            if (current == null || current.projectId != projectId) return if (admitted) 0 else 1
+            val map = _projectImportProgress.value.toMutableMap()
+            val current = map[projectId] ?: return if (admitted) 0 else 1
             val next = if (admitted) {
                 current.copy(admitted = current.admitted + 1)
             } else {
                 current.copy(failed = current.failed + 1)
             }
-            _projectImportProgress.value =
-                if (next.admitted + next.failed >= next.selected) null else next
+            if (next.admitted + next.failed >= next.selected) {
+                map.remove(projectId)
+            } else {
+                map[projectId] = next
+            }
+            _projectImportProgress.value = map
             return next.failed
         }
     }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -620,9 +620,25 @@ class ChatViewModel(
      */
     data class ProjectFileError(val projectId: String, val message: String, val importId: Long = 0L)
 
+    /**
+     * Files the user picked that have not been copied into the project yet. Used so the
+     * Files header can say "8 waiting" while the first batch of four occupies copy slots.
+     */
+    data class ProjectImportProgress(
+        val projectId: String,
+        val selected: Int,
+        val admitted: Int = 0,
+        val failed: Int = 0,
+    ) {
+        val queued: Int get() = (selected - admitted - failed).coerceAtLeast(0)
+    }
+
     private val _projectFileError = MutableStateFlow<ProjectFileError?>(null)
     val projectFileError: StateFlow<ProjectFileError?> = _projectFileError.asStateFlow()
     private var nextProjectFileImportId = 0L
+    private val importProgressLock = Any()
+    private val _projectImportProgress = MutableStateFlow<ProjectImportProgress?>(null)
+    val projectImportProgress: StateFlow<ProjectImportProgress?> = _projectImportProgress.asStateFlow()
     fun clearProjectFileError(projectId: String) {
         if (_projectFileError.value?.projectId == projectId) _projectFileError.value = null
     }
@@ -740,33 +756,73 @@ class ChatViewModel(
     }
 
     fun addProjectDocument(projectId: String, uri: Uri) {
-        val importId = ++nextProjectFileImportId
-        viewModelScope.launch {
-            val added = try {
-                projectManager.addDocument(projectId, uri)
-            } catch (t: CancellationException) {
-                throw t
-            } catch (_: Throwable) {
-                reportProjectFileError(projectId, importId)
-                return@launch
-            }
-            if (added == null) {
-                reportProjectFileError(projectId, importId)
-            } else {
-                // Only a newer success may drop this project's banner. An older import
-                // finishing later must not hide a failure that started after it.
-                val current = _projectFileError.value
-                if (current != null && current.projectId == projectId && current.importId < importId) {
-                    _projectFileError.value = null
+        addProjectDocuments(projectId, listOf(uri))
+    }
+
+    fun addProjectDocuments(projectId: String, uris: List<Uri>) {
+        if (uris.isEmpty()) return
+        beginImport(projectId, uris.size)
+        for (uri in uris) {
+            val importId = ++nextProjectFileImportId
+            viewModelScope.launch {
+                val added = try {
+                    projectManager.addDocument(projectId, uri)
+                } catch (t: CancellationException) {
+                    noteImportFinished(projectId, admitted = false)
+                    throw t
+                } catch (_: Throwable) {
+                    val failed = noteImportFinished(projectId, admitted = false)
+                    reportProjectFileError(projectId, importId, failed)
+                    return@launch
+                }
+                if (added == null) {
+                    val failed = noteImportFinished(projectId, admitted = false)
+                    reportProjectFileError(projectId, importId, failed)
+                } else {
+                    noteImportFinished(projectId, admitted = true)
+                    // Only a newer success may drop this project's banner. An older import
+                    // finishing later must not hide a failure that started after it.
+                    val current = _projectFileError.value
+                    if (current != null && current.projectId == projectId && current.importId < importId) {
+                        _projectFileError.value = null
+                    }
                 }
             }
         }
     }
 
-    private fun reportProjectFileError(projectId: String, importId: Long) {
+    private fun beginImport(projectId: String, count: Int) {
+        synchronized(importProgressLock) {
+            val current = _projectImportProgress.value
+            _projectImportProgress.value = if (current != null && current.projectId == projectId) {
+                current.copy(selected = current.selected + count)
+            } else {
+                ProjectImportProgress(projectId = projectId, selected = count)
+            }
+        }
+    }
+
+    /** Returns the running failure count for [projectId] after applying this result. */
+    private fun noteImportFinished(projectId: String, admitted: Boolean): Int {
+        synchronized(importProgressLock) {
+            val current = _projectImportProgress.value
+            if (current == null || current.projectId != projectId) return if (admitted) 0 else 1
+            val next = if (admitted) {
+                current.copy(admitted = current.admitted + 1)
+            } else {
+                current.copy(failed = current.failed + 1)
+            }
+            _projectImportProgress.value =
+                if (next.admitted + next.failed >= next.selected) null else next
+            return next.failed
+        }
+    }
+
+    private fun reportProjectFileError(projectId: String, importId: Long, failedCount: Int = 1) {
         val current = _projectFileError.value
         if (current != null && current.projectId == projectId && current.importId > importId) return
-        _projectFileError.value = ProjectFileError(projectId, "Couldn't add that file.", importId)
+        val message = if (failedCount <= 1) "Couldn't add that file." else "Couldn't add $failedCount files."
+        _projectFileError.value = ProjectFileError(projectId, message, importId)
     }
 
     fun removeProjectDocument(document: ProjectDocument) {

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -372,14 +372,17 @@ private fun ProjectHomeScreen(chatViewModel: ChatViewModel, projectId: String, o
         p != null && detail == ProjectDetail.Files -> {
             val modelReadsFiles by chatViewModel.modelReadsFiles.collectAsState()
             val projectFileError by chatViewModel.projectFileError.collectAsState()
+            val importProgress by chatViewModel.projectImportProgress.collectAsState()
             val fileError = projectFileError?.takeIf { it.projectId == projectId }?.message
+            val queued = importProgress?.takeIf { it.projectId == projectId }?.queued ?: 0
             ProjectFilesScreen(
                 project = p,
                 documents = documents,
+                queued = queued,
                 modelReadsFiles = modelReadsFiles,
                 fileError = fileError,
                 onClearFileError = { chatViewModel.clearProjectFileError(projectId) },
-                onAdd = { uri -> chatViewModel.addProjectDocument(projectId, uri) },
+                onAdd = { uris -> chatViewModel.addProjectDocuments(projectId, uris) },
                 onRemove = { chatViewModel.removeProjectDocument(it) },
                 onBack = { chatViewModel.clearProjectFileError(projectId); detail = ProjectDetail.None },
             )
@@ -796,10 +799,11 @@ private fun ProjectInstructionsScreen(project: Project, onSave: (String) -> Unit
 private fun ProjectFilesScreen(
     project: Project,
     documents: List<ProjectDocument>,
+    queued: Int,
     modelReadsFiles: Boolean,
     fileError: String?,
     onClearFileError: () -> Unit,
-    onAdd: (android.net.Uri) -> Unit,
+    onAdd: (List<android.net.Uri>) -> Unit,
     onRemove: (ProjectDocument) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -810,8 +814,8 @@ private fun ProjectFilesScreen(
     val openedDoc = openedDocId?.let { id -> documents.firstOrNull { it.id == id } }
     // The reader owns Back while it's up; the list only handles Back once it's closed.
     BackHandler(enabled = openedDoc == null) { onBack() }
-    val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-        if (uri != null) onAdd(uri)
+    val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        if (uris.isNotEmpty()) onAdd(uris)
     }
 
     Box(Modifier.fillMaxSize()) {
@@ -819,7 +823,7 @@ private fun ProjectFilesScreen(
             ProjectHeader(onBack = onBack) {
                 Text("Files", style = MaterialTheme.typography.headlineMedium)
                 Text(
-                    filesHeaderSubtitle(documents),
+                    filesHeaderSubtitle(documents, queued),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 2.dp),
@@ -838,7 +842,7 @@ private fun ProjectFilesScreen(
                 // transition — `fileError?.let` removed it the moment the error cleared.
                 ErrorBanner(bannerMessage, onDismiss = onClearFileError)
             }
-            if (documents.isEmpty()) {
+            if (documents.isEmpty() && queued == 0) {
                 FilesEmptyState(onAdd = { picker.launch(arrayOf("*/*")) }, modifier = Modifier.fillMaxSize())
             } else {
                 LazyColumn(
@@ -846,6 +850,14 @@ private fun ProjectFilesScreen(
                     contentPadding = PaddingValues(Spacing.base, Spacing.l, Spacing.base, 104.dp),
                     verticalArrangement = Arrangement.spacedBy(3.dp),
                 ) {
+                    if (queued > 0) {
+                        item(key = "queued-batch") {
+                            QueuedFilesRow(
+                                count = queued,
+                                modifier = Modifier.padding(bottom = if (documents.isEmpty()) 0.dp else Spacing.s),
+                            )
+                        }
+                    }
                     itemsIndexed(documents, key = { _, it -> it.id }) { index, doc ->
                         DocumentRow(
                             document = doc,
@@ -868,11 +880,11 @@ private fun ProjectFilesScreen(
                 }
             }
         }
-        if (documents.isNotEmpty()) {
+        if (documents.isNotEmpty() || queued > 0) {
             FloatingActionButton(
                 onClick = { picker.launch(arrayOf("*/*")) },
                 modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.base),
-            ) { Icon(Icons.Default.Add, "Add file") }
+            ) { Icon(Icons.Default.Add, "Add files") }
         }
         // The Markdown reader slides up over the whole list when a file is opened as Markdown.
         if (openedDoc != null) {
@@ -945,16 +957,18 @@ internal fun DocumentRow(
                         .clip(RoundedCornerShape(11.dp))
                         .background(MaterialTheme.colorScheme.secondaryContainer)
                         .then(
-                            if (document.status.isBusy) {
-                                Modifier.semantics { contentDescription = "Reading ${document.name}" }
-                            } else {
-                                Modifier
+                            when (document.status) {
+                                ExtractionStatus.EXTRACTING ->
+                                    Modifier.semantics { contentDescription = "Reading ${document.name}" }
+                                ExtractionStatus.PENDING ->
+                                    Modifier.semantics { contentDescription = "Waiting to read ${document.name}" }
+                                else -> Modifier
                             },
                         ),
                     contentAlignment = Alignment.Center,
                 ) {
                     AnimatedContent(
-                        targetState = document.status.isBusy,
+                        targetState = document.status.isExtracting,
                         transitionSpec = { fadeIn(tween(180)) togetherWith fadeOut(tween(120)) },
                         label = "docLeading",
                     ) { busy ->
@@ -1030,6 +1044,53 @@ internal fun DocumentRow(
     }
 }
 
+@Composable
+private fun QueuedFilesRow(count: Int, modifier: Modifier = Modifier) {
+    Surface(
+        shape = groupedItemShape(0, 1),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = if (count == 1) "1 file queued" else "$count files queued"
+            },
+    ) {
+        Row(
+            Modifier.padding(start = Spacing.base, end = Spacing.xs, top = Spacing.s, bottom = Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier
+                    .size(34.dp)
+                    .clip(RoundedCornerShape(11.dp))
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Description,
+                    null,
+                    Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Spacer(Modifier.width(Spacing.m))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    if (count == 1) "1 file queued" else "$count files queued",
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    "Waiting…",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
 private fun kindIcon(kind: ProjectFileOpener.Kind): ImageVector = when (kind) {
     ProjectFileOpener.Kind.PDF -> Icons.Default.PictureAsPdf
     ProjectFileOpener.Kind.WORD -> Icons.Default.Description
@@ -1039,8 +1100,9 @@ private fun kindIcon(kind: ProjectFileOpener.Kind): ImageVector = when (kind) {
     ProjectFileOpener.Kind.OTHER -> Icons.Default.InsertDriveFile
 }
 
-private fun documentStatusHint(status: ExtractionStatus, modelReadsFiles: Boolean): String? = when (status) {
-    ExtractionStatus.PENDING, ExtractionStatus.EXTRACTING -> "Reading…"
+internal fun documentStatusHint(status: ExtractionStatus, modelReadsFiles: Boolean): String? = when (status) {
+    ExtractionStatus.PENDING -> "Waiting…"
+    ExtractionStatus.EXTRACTING -> "Reading…"
     ExtractionStatus.EXTRACTED -> null
     ExtractionStatus.NEEDS_PROVIDER ->
         if (modelReadsFiles) "Sent to the model as a file" else "This model can't read this file"
@@ -1048,18 +1110,21 @@ private fun documentStatusHint(status: ExtractionStatus, modelReadsFiles: Boolea
     ExtractionStatus.UNKNOWN -> null
 }
 
-private fun filesHeaderSubtitle(documents: List<ProjectDocument>): String {
-    val count = when (documents.size) {
+internal fun filesHeaderSubtitle(documents: List<ProjectDocument>, queued: Int = 0): String {
+    val total = documents.size + queued
+    val count = when (total) {
         0 -> "Background knowledge for this project"
         1 -> "1 file"
-        else -> "${documents.size} files"
+        else -> "$total files"
     }
-    val reading = documents.count { it.status.isBusy }
-    return if (reading > 0 && documents.isNotEmpty()) {
-        "$count · reading $reading"
-    } else {
-        count
-    }
+    if (total == 0) return count
+    val reading = documents.count { it.status.isExtracting }
+    val waiting = documents.count { it.status.isQueued } + queued
+    return buildList {
+        add(count)
+        if (reading > 0) add("reading $reading")
+        if (waiting > 0) add("$waiting waiting")
+    }.joinToString(" · ")
 }
 
 // ── Empty states & dialogs ───────────────────────────────────────────────────────────────
@@ -1082,7 +1147,7 @@ private fun FilesEmptyState(onAdd: () -> Unit, modifier: Modifier = Modifier) {
         glyph = Icons.Default.Description,
         title = "No files yet",
         body = "Add PDFs, Word or Excel files, slides or notes — EchoFlow reads them on your device and makes them background knowledge for this project.",
-        actionLabel = "Add file",
+        actionLabel = "Add files",
         onAction = onAdd,
         modifier = modifier,
     )

--- a/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ProjectsScreens.kt
@@ -374,7 +374,7 @@ private fun ProjectHomeScreen(chatViewModel: ChatViewModel, projectId: String, o
             val projectFileError by chatViewModel.projectFileError.collectAsState()
             val importProgress by chatViewModel.projectImportProgress.collectAsState()
             val fileError = projectFileError?.takeIf { it.projectId == projectId }?.message
-            val queued = importProgress?.takeIf { it.projectId == projectId }?.queued ?: 0
+            val queued = importProgress[projectId]?.queued ?: 0
             ProjectFilesScreen(
                 project = p,
                 documents = documents,

--- a/app/src/test/java/com/echoflow/data/ProjectManagerImportBatchTest.kt
+++ b/app/src/test/java/com/echoflow/data/ProjectManagerImportBatchTest.kt
@@ -1,0 +1,106 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.net.Uri
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.echoflow.data.extract.FileExtractor
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * anydoc holds a full file in memory (up to 25 MB). The manager must therefore parse
+ * at most [ProjectManager.EXTRACT_BATCH_SIZE] files at once; the rest sit PENDING.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ProjectManagerImportBatchTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var database: AppDatabase
+    private lateinit var hold: CompletableDeferred<Unit>
+    private lateinit var extractor: CountingExtractor
+    private lateinit var manager: ProjectManager
+
+    @Before fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        hold = CompletableDeferred()
+        extractor = CountingExtractor(hold)
+        manager = ProjectManager(
+            context = context,
+            projectDao = database.projectDao(),
+            projectDocumentDao = database.projectDocumentDao(),
+            chatDao = database.chatDao(),
+            extractor = extractor,
+        )
+    }
+
+    @After fun tearDown() {
+        hold.complete(Unit)
+        database.close()
+        File(context.filesDir, "project_documents").deleteRecursively()
+    }
+
+    @Test fun `extracts four files at a time and queues the rest`() = runBlocking {
+        assertEquals(4, ProjectManager.EXTRACT_BATCH_SIZE)
+        val projectId = manager.createProject("Batch")
+        val jobs = (1..6).map { i ->
+            async(Dispatchers.IO) {
+                val file = File(context.cacheDir, "batch-$i.docx").apply { writeText("doc $i") }
+                manager.addDocument(projectId, Uri.fromFile(file))
+            }
+        }
+
+        withTimeout(5_000) {
+            while (true) {
+                val rows = database.projectDocumentDao().getForProjectSync(projectId)
+                if (rows.size == 6 &&
+                    rows.count { it.status == ExtractionStatus.EXTRACTING } == 4 &&
+                    rows.count { it.status == ExtractionStatus.PENDING } == 2
+                ) break
+                delay(10)
+            }
+        }
+        assertEquals(4, extractor.maxInFlight.get())
+
+        hold.complete(Unit)
+        val added = jobs.awaitAll()
+        assertTrue(added.all { it != null })
+        val done = database.projectDocumentDao().getForProjectSync(projectId)
+        assertEquals(6, done.size)
+        assertTrue(done.all { it.status == ExtractionStatus.EXTRACTED })
+        assertEquals(4, extractor.maxInFlight.get())
+    }
+
+    private class CountingExtractor(
+        private val hold: CompletableDeferred<Unit>,
+    ) : FileExtractor() {
+        val inFlight = AtomicInteger(0)
+        val maxInFlight = AtomicInteger(0)
+
+        override suspend fun extract(file: File, mime: String, name: String): Result {
+            val n = inFlight.incrementAndGet()
+            maxInFlight.accumulateAndGet(n) { a, b -> maxOf(a, b) }
+            try {
+                hold.await()
+                return Result("ok", ExtractionStatus.EXTRACTED, ExtractionTier.ANYDOC)
+            } finally {
+                inFlight.decrementAndGet()
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/echoflow/data/ProjectManagerImportBatchTest.kt
+++ b/app/src/test/java/com/echoflow/data/ProjectManagerImportBatchTest.kt
@@ -58,10 +58,11 @@ class ProjectManagerImportBatchTest {
     @Test fun `extracts four files at a time and queues the rest`() = runBlocking {
         assertEquals(4, ProjectManager.EXTRACT_BATCH_SIZE)
         val projectId = manager.createProject("Batch")
+        val admitted = AtomicInteger(0)
         val jobs = (1..6).map { i ->
             async(Dispatchers.IO) {
                 val file = File(context.cacheDir, "batch-$i.docx").apply { writeText("doc $i") }
-                manager.addDocument(projectId, Uri.fromFile(file))
+                manager.addDocument(projectId, Uri.fromFile(file), onAdmitted = { admitted.incrementAndGet() })
             }
         }
 
@@ -69,6 +70,7 @@ class ProjectManagerImportBatchTest {
             while (true) {
                 val rows = database.projectDocumentDao().getForProjectSync(projectId)
                 if (rows.size == 6 &&
+                    admitted.get() == 6 &&
                     rows.count { it.status == ExtractionStatus.EXTRACTING } == 4 &&
                     rows.count { it.status == ExtractionStatus.PENDING } == 2
                 ) break
@@ -76,6 +78,8 @@ class ProjectManagerImportBatchTest {
             }
         }
         assertEquals(4, extractor.maxInFlight.get())
+        // Admission is the Room insert, not extract finishing — all six are in before anydoc resumes.
+        assertEquals(6, admitted.get())
 
         hold.complete(Unit)
         val added = jobs.awaitAll()

--- a/app/src/test/java/com/echoflow/ui/screens/ProjectFileImportUiTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/ProjectFileImportUiTest.kt
@@ -6,7 +6,10 @@ import com.echoflow.ui.ChatViewModel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ProjectFileImportUiTest {
 
     @Test fun `queued files say waiting, active parse says reading`() {

--- a/app/src/test/java/com/echoflow/ui/screens/ProjectFileImportUiTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/ProjectFileImportUiTest.kt
@@ -1,0 +1,56 @@
+package com.echoflow.ui.screens
+
+import com.echoflow.data.ExtractionStatus
+import com.echoflow.data.ProjectDocument
+import com.echoflow.ui.ChatViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProjectFileImportUiTest {
+
+    @Test fun `queued files say waiting, active parse says reading`() {
+        assertEquals("Waiting…", documentStatusHint(ExtractionStatus.PENDING, modelReadsFiles = true))
+        assertEquals("Reading…", documentStatusHint(ExtractionStatus.EXTRACTING, modelReadsFiles = true))
+        assertNull(documentStatusHint(ExtractionStatus.EXTRACTED, modelReadsFiles = true))
+    }
+
+    @Test fun `header names reading and waiting without changing the file count`() {
+        val docs = listOf(
+            doc("a", ExtractionStatus.EXTRACTING),
+            doc("b", ExtractionStatus.EXTRACTING),
+            doc("c", ExtractionStatus.PENDING),
+            doc("d", ExtractionStatus.EXTRACTED),
+        )
+        assertEquals("4 files · reading 2 · 1 waiting", filesHeaderSubtitle(docs))
+        assertEquals(
+            "8 files · reading 2 · 5 waiting",
+            filesHeaderSubtitle(docs, queued = 4),
+        )
+        assertEquals("Background knowledge for this project", filesHeaderSubtitle(emptyList()))
+        assertEquals("3 files · 3 waiting", filesHeaderSubtitle(emptyList(), queued = 3))
+    }
+
+    @Test fun `import progress queued is selected minus admitted and failed`() {
+        val progress = ChatViewModel.ProjectImportProgress(
+            projectId = "p",
+            selected = 10,
+            admitted = 4,
+            failed = 1,
+        )
+        assertEquals(5, progress.queued)
+        assertEquals(0, progress.copy(admitted = 9, failed = 1).queued)
+    }
+
+    private fun doc(id: String, status: ExtractionStatus) = ProjectDocument(
+        id = id,
+        projectId = "p",
+        name = "$id.pdf",
+        mimeType = "application/pdf",
+        sizeBytes = 1_024,
+        filePath = "/tmp/$id.pdf",
+        extractedText = if (status == ExtractionStatus.EXTRACTED) "text" else null,
+        addedAt = 1L,
+        extractionStatus = status.name,
+    )
+}


### PR DESCRIPTION
## Why

The project Files picker used `OpenDocument`, so the user could only add one file at a time. That was a picker limit, not an anydoc limit. The native converter already handles a 25 MB file in about a second or two, but it loads the whole file into a `ByteArray`. Four concurrent parses is ~100 MB peak, which is the right bound; twenty of them is not.

## What

- Files picker is now `OpenMultipleDocuments`.
- Copy and extract each run at most **4 files at a time**. Extra picks wait their turn.
- Row stages:
  - **Queued** — picked, not copied yet (`N files queued · Waiting…`)
  - **Waiting** — copied, waiting for an anydoc/OCR slot (`12.4 MB · Waiting…`, file glyph)
  - **Reading** — parse in flight (`12.4 MB · Reading…`, loading indicator)
- Header: `8 files · reading 4 · 4 waiting`
- Failures aggregate: `Couldn't add N files.`

## Why 4, not unlimited

anydoc is `toMarkdownBytes(bytes)` — the whole file is in RAM. A 25 MB PDF is fine. Four of those is fine. A folder dump is not. The batch size is the memory cap; the UI is the queue.

## Tests

- `ProjectManagerImportBatchTest` — 6 files in, 4 extract, 2 stay PENDING, then all settle.
- `ProjectFileImportUiTest` — waiting/reading copy and header counts.

No emulator run (requested). Screenshots not included for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select and import multiple project documents at once.
  * View import progress, including admitted, failed, and queued files.
  * See clearer file statuses for waiting and actively reading documents.
  * File counts and accessibility labels now reflect queued items.
  * The empty-state action is now labeled “Add files.”

* **Performance**
  * Document imports and extraction are processed concurrently with controlled limits for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->