### PR TITLE
Let Any Talk send files to local models via anydoc

### DIFF
--- a/app/schemas/com.echoflow.data.AppDatabase/24.json
+++ b/app/schemas/com.echoflow.data.AppDatabase/24.json
@@ -1,0 +1,1377 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "2bf42fcf6596857b73f48a7e023e9cd2",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `kind` TEXT NOT NULL DEFAULT 'chat', `pinnedAt` INTEGER, `projectId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'chat'"
+          },
+          {
+            "fieldPath": "pinnedAt",
+            "columnName": "pinnedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectId",
+            "columnName": "projectId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_threads_projectId",
+            "unique": false,
+            "columnNames": [
+              "projectId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_threads_projectId` ON `${TABLE_NAME}` (`projectId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `reasoning` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `toolEventsJson` TEXT, `citationsJson` TEXT, `segmentsJson` TEXT, `replyVersionsJson` TEXT, `attachmentsJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolEventsJson",
+            "columnName": "toolEventsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "citationsJson",
+            "columnName": "citationsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyVersionsJson",
+            "columnName": "replyVersionsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachmentsJson",
+            "columnName": "attachmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `maxTokens` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "maxTokens",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "deep_research_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "research_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `topic` TEXT NOT NULL, `engineId` TEXT NOT NULL, `engineKind` TEXT NOT NULL, `engineLabel` TEXT NOT NULL, `searchProvider` TEXT, `level` TEXT, `costInfo` TEXT, `maxSearches` INTEGER NOT NULL, `maxSources` INTEGER NOT NULL, `maxCredits` INTEGER NOT NULL, `providerJobId` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `progressDone` INTEGER NOT NULL, `progressTotal` INTEGER NOT NULL, `planJson` TEXT, `stepsJson` TEXT, `sourcesJson` TEXT, `report` TEXT, `error` TEXT, `assistantMessageId` TEXT, `localAttachmentUri` TEXT, `localAttachmentMimeType` TEXT, `localAttachmentName` TEXT, `uiVersion` INTEGER NOT NULL DEFAULT 1, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineId",
+            "columnName": "engineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineKind",
+            "columnName": "engineKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engineLabel",
+            "columnName": "engineLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchProvider",
+            "columnName": "searchProvider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "costInfo",
+            "columnName": "costInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxSearches",
+            "columnName": "maxSearches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSources",
+            "columnName": "maxSources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCredits",
+            "columnName": "maxCredits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerJobId",
+            "columnName": "providerJobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressDone",
+            "columnName": "progressDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressTotal",
+            "columnName": "progressTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "planJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report",
+            "columnName": "report",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistantMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentUri",
+            "columnName": "localAttachmentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentMimeType",
+            "columnName": "localAttachmentMimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localAttachmentName",
+            "columnName": "localAttachmentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uiVersion",
+            "columnName": "uiVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_research_runs_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_research_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_research_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advisor_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelId` TEXT NOT NULL, `modelName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "fusion_panels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `modelIds` TEXT NOT NULL, `modelNames` TEXT NOT NULL, `judgeModelId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelIds",
+            "columnName": "modelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelNames",
+            "columnName": "modelNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "judgeModelId",
+            "columnName": "judgeModelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "agent_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `workerModelId` TEXT NOT NULL, `workerModelName` TEXT NOT NULL, `maxToolCalls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelId",
+            "columnName": "workerModelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workerModelName",
+            "columnName": "workerModelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxToolCalls",
+            "columnName": "maxToolCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browser_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `goal` TEXT NOT NULL, `resolvedUrl` TEXT, `scrapeId` TEXT, `liveViewUrl` TEXT, `interactiveLiveViewUrl` TEXT, `status` TEXT NOT NULL, `phase` TEXT, `pendingKind` TEXT, `pendingInstruction` TEXT, `pendingDraft` TEXT, `candidatesJson` TEXT, `lastOutput` TEXT, `error` TEXT, `openedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastActivityAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goal",
+            "columnName": "goal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedUrl",
+            "columnName": "resolvedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scrapeId",
+            "columnName": "scrapeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveViewUrl",
+            "columnName": "liveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interactiveLiveViewUrl",
+            "columnName": "interactiveLiveViewUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingKind",
+            "columnName": "pendingKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstruction",
+            "columnName": "pendingInstruction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingDraft",
+            "columnName": "pendingDraft",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "candidatesJson",
+            "columnName": "candidatesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOutput",
+            "columnName": "lastOutput",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityAt",
+            "columnName": "lastActivityAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_sessions_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_browser_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "browser_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `browser_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browser_steps_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browser_steps_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "browser_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `currentVersion` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentVersion",
+            "columnName": "currentVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifacts_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifacts_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "artifact_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artifactId` TEXT NOT NULL, `versionNumber` INTEGER NOT NULL, `content` TEXT NOT NULL, `sourcePrompt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`artifactId`) REFERENCES `artifacts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artifactId",
+            "columnName": "artifactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionNumber",
+            "columnName": "versionNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePrompt",
+            "columnName": "sourcePrompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artifact_versions_artifactId",
+            "unique": false,
+            "columnNames": [
+              "artifactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artifact_versions_artifactId` ON `${TABLE_NAME}` (`artifactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artifacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artifactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `filePath` TEXT NOT NULL, `prompt` TEXT NOT NULL, `parentId` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_images_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_images_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "video_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "generated_videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chatId` TEXT NOT NULL, `prompt` TEXT NOT NULL, `modelId` TEXT NOT NULL, `jobId` TEXT, `pollingUrl` TEXT, `status` TEXT NOT NULL, `filePath` TEXT, `aspectRatio` TEXT, `resolution` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`chatId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollingUrl",
+            "columnName": "pollingUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspectRatio",
+            "columnName": "aspectRatio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_generated_videos_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          },
+          {
+            "name": "index_generated_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_generated_videos_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "projects",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `instructions` TEXT NOT NULL, `colorIndex` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructions",
+            "columnName": "instructions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorIndex",
+            "columnName": "colorIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "project_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `projectId` TEXT NOT NULL, `name` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `extractedText` TEXT, `addedAt` INTEGER NOT NULL, `extractionStatus` TEXT, `extractionTier` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`projectId`) REFERENCES `projects`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectId",
+            "columnName": "projectId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedText",
+            "columnName": "extractedText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractionStatus",
+            "columnName": "extractionStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "extractionTier",
+            "columnName": "extractionTier",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_project_documents_projectId",
+            "unique": false,
+            "columnNames": [
+              "projectId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_project_documents_projectId` ON `${TABLE_NAME}` (`projectId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "projects",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "projectId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2bf42fcf6596857b73f48a7e023e9cd2')"
+    ]
+  }
+}

--- a/app/src/main/java/com/echoflow/data/AppDatabase.kt
+++ b/app/src/main/java/com/echoflow/data/AppDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         VideoModel::class, GeneratedVideo::class,
         Project::class, ProjectDocument::class
     ],
-    version = 23, // v23: project_documents.extractionStatus + extractionTier
+    version = 24, // v24: chat_messages.attachmentsJson (multi-file chat attachments)
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -437,6 +437,18 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Multi-file chat attachments. One additive, nullable column — no DEFAULT (matches the
+         * no-defaultValue entity policy). Existing rows keep attachmentsJson = NULL and are read
+         * through the legacy single `localAttachment*` columns by [ChatMessage.attachments], so
+         * every existing message renders exactly as before.
+         */
+        internal val MIGRATION_23_24 = object : Migration(23, 24) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN attachmentsJson TEXT")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -467,6 +479,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_20_21,
                     MIGRATION_21_22,
                     MIGRATION_22_23,
+                    MIGRATION_23_24,
                 )
                 .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -359,6 +359,10 @@ object ToolEventJson {
         Types.newParameterizedType(List::class.java, ReplyVersion::class.java)
     )
 
+    private val attachmentsAdapter: JsonAdapter<List<MessageAttachment>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, MessageAttachment::class.java)
+    )
+
     fun toolEventsToJson(events: List<ToolEvent>): String? =
         if (events.isEmpty()) null else toolEventsAdapter.toJson(events)
 
@@ -382,6 +386,12 @@ object ToolEventJson {
 
     fun replyVersionsFromJson(json: String?): List<ReplyVersion> =
         json?.let { runCatching { replyVersionsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
+
+    fun attachmentsToJson(attachments: List<MessageAttachment>): String? =
+        if (attachments.isEmpty()) null else attachmentsAdapter.toJson(attachments)
+
+    fun attachmentsFromJson(json: String?): List<MessageAttachment> =
+        json?.let { runCatching { attachmentsAdapter.fromJson(it) }.getOrNull() } ?: emptyList()
 }
 
 /**

--- a/app/src/main/java/com/echoflow/data/LocalLlmPrompting.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmPrompting.kt
@@ -23,4 +23,35 @@ internal object LocalLlmPrompting {
 
     fun userTurnPrompt(content: String): String =
         "Human message:\n$content\n\nEchoFlow reply:"
+
+    /**
+     * Typed text plus parsed attachment Markdown. Local runtimes cannot take raw files.
+     * Combined attachment body is capped at [MAX_ATTACHMENT_CONTEXT_CHARS] (same ballpark as
+     * project-doc injection) so a large PDF cannot crowd out the user's question.
+     */
+    fun contentWithAttachments(message: ChatMessage): String {
+        val docs = message.attachments.filter { !it.extractedText.isNullOrBlank() }
+        if (docs.isEmpty()) return message.content
+        var budget = MAX_ATTACHMENT_CONTEXT_CHARS
+        val blocks = buildList {
+            for (attachment in docs) {
+                if (budget <= 0) {
+                    add("[Some attached files were omitted to fit the context window.]")
+                    break
+                }
+                val body = attachment.extractedText.orEmpty()
+                val slice = if (body.length > budget) body.take(budget) else body
+                budget -= slice.length
+                val truncatedMark = if (slice.length < body.length) "\n[…document truncated…]" else ""
+                add(
+                    "--- Attached file: ${attachment.name} ---\n$slice$truncatedMark\n--- End of ${attachment.name} ---"
+                )
+            }
+        }
+        val joined = blocks.joinToString("\n\n")
+        return if (message.content.isBlank()) joined else "${message.content}\n\n$joined"
+    }
+
+    /** Combined Markdown budget injected from one turn's attachments into a local prompt. */
+    internal const val MAX_ATTACHMENT_CONTEXT_CHARS = 24_000
 }

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -70,6 +70,13 @@ data class ChatMessage(
      * keeps the history so the 1/2 pager can switch between them.
      */
     val replyVersionsJson: String? = null,
+    /**
+     * All files attached to this user turn, as JSON [MessageAttachment] list (up to 3). Used by
+     * the local-model path: doc files are parsed on-device (anydoc → Markdown) into
+     * [MessageAttachment.extractedText] once, here, so the model can read them. Null on rows that
+     * predate multi-attach or that carry only a single legacy attachment (see [attachments]).
+     */
+    val attachmentsJson: String? = null,
 ) {
     /**
      * In-memory only. Extra files (project docs that still need the provider) attached to this
@@ -79,6 +86,26 @@ data class ChatMessage(
     @Ignore
     @Transient
     var extraAttachments: List<LocalFileAttachment> = emptyList()
+
+    /**
+     * The turn's attachments, coalesced across representations: the multi-file [attachmentsJson]
+     * when present, otherwise the single legacy `localAttachment*` columns wrapped as one entry.
+     * Rendering and local-model injection read this so old single-attachment rows and new
+     * multi-attach rows are handled by the same code.
+     */
+    val attachments: List<MessageAttachment>
+        get() = ToolEventJson.attachmentsFromJson(attachmentsJson).ifEmpty {
+            localAttachmentUri?.let { uri ->
+                listOf(
+                    MessageAttachment(
+                        uri = uri,
+                        mimeType = localAttachmentMimeType ?: "application/octet-stream",
+                        name = localAttachmentName ?: "Attachment",
+                    )
+                )
+            } ?: emptyList()
+        }
+
     /**
      * Rewrites a user prompt without moving its turn in the transcript. [createdAt] is the
      * stable ordering key: keeping it means a failed regeneration can restore the original
@@ -89,11 +116,13 @@ data class ChatMessage(
         attachmentUri: String?,
         attachmentMimeType: String?,
         attachmentName: String?,
+        attachmentsJson: String? = null,
     ): ChatMessage = copy(
         content = content,
         localAttachmentUri = attachmentUri,
         localAttachmentMimeType = attachmentMimeType,
         localAttachmentName = attachmentName,
+        attachmentsJson = attachmentsJson,
     )
 }
 
@@ -102,6 +131,19 @@ data class LocalFileAttachment(
     val uri: String,
     val mimeType: String,
     val name: String,
+)
+
+/**
+ * One file attached to a user turn, persisted in [ChatMessage.attachmentsJson]. Up to three per
+ * message. For the local-model path a doc file (PDF/Word/Excel/…) is parsed on-device to Markdown
+ * once and stored in [extractedText]; images carry no text ([extractedText] stays null) and are
+ * fed through the vision path instead.
+ */
+data class MessageAttachment(
+    val uri: String,
+    val mimeType: String,
+    val name: String,
+    val extractedText: String? = null,
 )
 
 @Entity(tableName = "custom_models")

--- a/app/src/main/java/com/echoflow/data/extract/ChatAttachmentExtractor.kt
+++ b/app/src/main/java/com/echoflow/data/extract/ChatAttachmentExtractor.kt
@@ -1,0 +1,101 @@
+package com.echoflow.data.extract
+
+import android.content.ContentResolver
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+
+/**
+ * On-device text extraction for a chat attachment (a `content://` URI picked in the composer).
+ *
+ * This is the local-model path: a doc file (PDF/Word/Excel/PowerPoint/ODF/RTF/EPUB/CSV) is run
+ * through the bundled [Anydoc] parser — the same one the Projects pipeline uses — and its Markdown
+ * is injected into the prompt the on-device model receives, since local models can't accept raw
+ * files. There is no OCR tier here: a scanned/image-only PDF that anydoc can't read is reported as
+ * [Result.Failed] so the composer chip offers retry/remove rather than silently attaching nothing.
+ *
+ * Never throws — every failure is a [Result.Failed]. Runs on [Dispatchers.IO].
+ */
+class ChatAttachmentExtractor(
+    private val resolver: ContentResolver,
+    private val parser: DocumentParser = Anydoc,
+) {
+    sealed interface Result {
+        data class Text(val markdown: String) : Result
+        data class Failed(val reason: String) : Result
+    }
+
+    suspend fun extract(uri: Uri, name: String): Result = withContext(Dispatchers.IO) {
+        val bytes = readCapped(uri) ?: return@withContext Result.Failed("unreadable")
+        val ext = name.substringAfterLast('.', "").lowercase()
+        val mime = resolver.getType(uri)?.lowercase().orEmpty()
+
+        if (ext in ANYDOC_EXTS || mime == "application/pdf") {
+            when (val parsed = parser.convert(bytes, name)) {
+                is Anydoc.Result.Text ->
+                    return@withContext if (parsed.markdown.isNotBlank()) {
+                        Result.Text(parsed.markdown.take(MAX_EXTRACT_CHARS))
+                    } else {
+                        Result.Failed("empty")
+                    }
+                is Anydoc.Result.Failed -> return@withContext Result.Failed(parsed.reason)
+                // Scanned / unsupported. Fall through so txt/csv that anydoc declined can
+                // still be read as UTF-8 — same split FileExtractor uses.
+                Anydoc.Result.TryOcr -> Unit
+            }
+        }
+
+        plaintextFromBytes(bytes, mime, ext)?.let { return@withContext Result.Text(it) }
+        Result.Failed("no readable text")
+    }
+
+    /** Reads the URI up to [MAX_BYTES]; returns null on an I/O error or when the file is too big. */
+    private fun readCapped(uri: Uri): ByteArray? = runCatching {
+        resolver.openInputStream(uri)?.use { input ->
+            val out = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var total = 0L
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > MAX_BYTES) return@runCatching null
+                out.write(buffer, 0, read)
+            }
+            out.toByteArray()
+        }
+    }.getOrNull()
+
+    private fun plaintextFromBytes(bytes: ByteArray, mime: String, ext: String): String? {
+        val looksTextual = mime.startsWith("text/") ||
+            mime in TEXTUAL_MIME_TYPES ||
+            ext in TEXTUAL_EXTENSIONS
+        if (!looksTextual) return null
+        return runCatching { String(bytes, Charsets.UTF_8) }.getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?.take(MAX_EXTRACT_CHARS)
+    }
+
+    companion object {
+        private const val MAX_BYTES = 25L * 1024 * 1024
+        private const val MAX_EXTRACT_CHARS = 200_000
+
+        private val ANYDOC_EXTS = setOf(
+            "doc", "docx", "docm", "ppt", "pptx", "xls", "xlsx", "xlsm", "xlsb",
+            "odt", "ods", "odp", "rtf", "epub", "csv", "pdf",
+        )
+
+        private val TEXTUAL_MIME_TYPES = setOf(
+            "application/json", "application/xml", "application/xhtml+xml",
+            "application/javascript", "application/x-yaml", "application/yaml",
+            "application/markdown", "application/x-sh", "application/csv",
+        )
+
+        private val TEXTUAL_EXTENSIONS = setOf(
+            "txt", "md", "markdown", "json", "xml", "yaml", "yml", "csv", "tsv",
+            "html", "htm", "css", "js", "ts", "kt", "java", "py", "rb", "go",
+            "rs", "c", "cpp", "h", "sh", "toml", "ini", "cfg", "log", "sql",
+        )
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -202,12 +202,20 @@ class ChatViewModel(
         val lastUser = currentMessages.value.lastOrNull { it.role == "user" } ?: return null
         if (lastUser.id != messageId) return null
         _editingUserMessageId.value = messageId
-        val uri = lastUser.localAttachmentUri?.let(Uri::parse)
-        if (uri != null) {
-            setPendingAttachment(uri, lastUser.localAttachmentMimeType, lastUser.localAttachmentName)
-        } else {
-            clearPendingAttachment()
+        cancelExtractionJobs()
+        _pendingAttachments.value = lastUser.attachments.map { att ->
+            PendingAttachment(
+                uri = att.uri,
+                mimeType = att.mimeType,
+                name = att.name,
+                kind = if (att.mimeType.startsWith("image/", ignoreCase = true)) PendingAttachment.Kind.Image
+                else PendingAttachment.Kind.Doc,
+                state = PendingAttachment.State.Ready,
+                extractedText = att.extractedText,
+            )
         }
+        // Legacy / cloud-staged docs have no Markdown yet. Parse them if this send will be local.
+        if (settingsRepository.selectedModel.value.startsWith("local/")) extractMissingDocs()
         return lastUser.content
     }
 
@@ -399,15 +407,27 @@ class ChatViewModel(
 
     private val streamJobs = mutableMapOf<String, Job>()
 
-    // Pending attachment references
-    private val _pendingAttachmentUri = MutableStateFlow<Uri?>(null)
-    val pendingAttachmentUri: StateFlow<Uri?> = _pendingAttachmentUri.asStateFlow()
+    // Pending attachments staged in the composer (up to [MAX_MESSAGE_ATTACHMENTS]). One list for
+    // every path: cloud/image sends read the first entry (they only ever stage one); the local
+    // multi-doc path stages several and parses each on-device before send.
+    private val _pendingAttachments = MutableStateFlow<List<PendingAttachment>>(emptyList())
+    val pendingAttachments: StateFlow<List<PendingAttachment>> = _pendingAttachments.asStateFlow()
 
-    private val _pendingAttachmentMimeType = MutableStateFlow<String?>(null)
-    val pendingAttachmentMimeType: StateFlow<String?> = _pendingAttachmentMimeType.asStateFlow()
+    // Single-attachment compatibility views for the Imagine surface (image reference / video first
+    // frame), which only ever stages one image. Chat consumes the full [pendingAttachments] list.
+    val pendingAttachmentUri: StateFlow<Uri?> = _pendingAttachments
+        .map { list -> list.firstOrNull()?.let { Uri.parse(it.uri) } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val pendingAttachmentName: StateFlow<String?> = _pendingAttachments
+        .map { list -> list.firstOrNull()?.name }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    private val _pendingAttachmentName = MutableStateFlow<String?>(null)
-    val pendingAttachmentName: StateFlow<String?> = _pendingAttachmentName.asStateFlow()
+    /** Per-attachment on-device extraction jobs, keyed by [PendingAttachment.id], so a removed or
+     *  retried chip can cancel its in-flight parse. */
+    private val extractionJobs = mutableMapOf<String, Job>()
+    private val chatAttachmentExtractor by lazy {
+        com.echoflow.data.extract.ChatAttachmentExtractor(getApplication<Application>().contentResolver)
+    }
 
     // Per-message capability selected by the "+" menu. Exposed as legacy boolean flows so
     // existing UI components can stay simple while illegal combinations remain unrepresentable.
@@ -1154,27 +1174,156 @@ class ChatViewModel(
         _errorMessage.value = null
     }
 
+    /**
+     * Stage a single attachment (an image, or a cloud/custom PDF), replacing whatever was staged.
+     * This is the unchanged single-file path — images and cloud files are [State.Ready] at once,
+     * never parsed on-device. The local multi-doc path is [addPendingDocs].
+     */
     fun setPendingAttachment(uri: Uri, fallbackMimeType: String? = null, overrideName: String? = null) {
         viewModelScope.launch {
-            _pendingAttachmentUri.value = uri
             val resolver = getApplication<Application>().contentResolver
             runCatching {
                 resolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             val mimeType = resolver.getType(uri) ?: fallbackMimeType ?: "image/jpeg"
-            _pendingAttachmentMimeType.value = mimeType
 
             // Get display name. An override wins outright: a file the app generated has a UUID
             // for a name, and showing that tells the user nothing about why it is attached.
-            var displayName = if (mimeType.equals("application/pdf", ignoreCase = true)) "Attached PDF" else "Attached Image"
+            val isPdf = mimeType.equals("application/pdf", ignoreCase = true)
+            var displayName = if (isPdf) "Attached PDF" else "Attached Image"
             runCatching { resolver.query(uri, null, null, null, null) }.getOrNull()?.use { cursor ->
                 val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
                 if (nameIndex != -1 && cursor.moveToFirst()) {
                     displayName = cursor.getString(nameIndex)
                 }
             }
-            _pendingAttachmentName.value = overrideName ?: displayName
+            cancelExtractionJobs()
+            _pendingAttachments.value = listOf(
+                PendingAttachment(
+                    uri = uri.toString(),
+                    mimeType = mimeType,
+                    name = overrideName ?: displayName,
+                    kind = if (mimeType.startsWith("image/", ignoreCase = true)) PendingAttachment.Kind.Image
+                    else PendingAttachment.Kind.Doc,
+                    state = PendingAttachment.State.Ready,
+                )
+            )
         }
+    }
+
+    /**
+     * Stage one or more documents for the local-model path (up to [MAX_MESSAGE_ATTACHMENTS] total),
+     * appending to whatever is already staged, and kick off on-device extraction for each. Each chip
+     * stays [State.Extracting] until anydoc yields Markdown (→ [State.Ready]) or declines
+     * (→ [State.Failed], retry/remove in the composer). Extra picks over the cap are dropped.
+     */
+    fun addPendingDocs(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+        viewModelScope.launch {
+            val resolver = getApplication<Application>().contentResolver
+            for (uri in uris) {
+                if (_pendingAttachments.value.size >= MAX_MESSAGE_ATTACHMENTS) break
+                if (_pendingAttachments.value.any { it.uri == uri.toString() }) continue
+                runCatching {
+                    resolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                val mimeType = resolver.getType(uri) ?: "application/octet-stream"
+                var displayName = uri.lastPathSegment?.substringAfterLast('/') ?: "Document"
+                runCatching { resolver.query(uri, null, null, null, null) }.getOrNull()?.use { cursor ->
+                    val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex != -1 && cursor.moveToFirst()) {
+                        displayName = cursor.getString(nameIndex)
+                    }
+                }
+                val attachment = PendingAttachment(
+                    uri = uri.toString(),
+                    mimeType = mimeType,
+                    name = displayName,
+                    kind = PendingAttachment.Kind.Doc,
+                    state = PendingAttachment.State.Extracting,
+                )
+                _pendingAttachments.value = _pendingAttachments.value + attachment
+                startExtraction(attachment)
+            }
+        }
+    }
+
+    /** Runs (or re-runs) on-device extraction for one staged doc, updating its chip in place. */
+    private fun startExtraction(attachment: PendingAttachment) {
+        extractionJobs.remove(attachment.id)?.cancel()
+        val job = viewModelScope.launch {
+            val result = chatAttachmentExtractor.extract(Uri.parse(attachment.uri), attachment.name)
+            updateAttachment(attachment.id) { current ->
+                when (result) {
+                    is com.echoflow.data.extract.ChatAttachmentExtractor.Result.Text ->
+                        current.copy(state = PendingAttachment.State.Ready, extractedText = result.markdown)
+                    is com.echoflow.data.extract.ChatAttachmentExtractor.Result.Failed ->
+                        current.copy(state = PendingAttachment.State.Failed, extractedText = null)
+                }
+            }
+        }
+        extractionJobs[attachment.id] = job
+    }
+
+    /** Retry the on-device parse for a failed doc chip (the composer's retry arrow). */
+    fun retryPendingAttachment(id: String) {
+        val target = _pendingAttachments.value.firstOrNull { it.id == id } ?: return
+        if (target.kind != PendingAttachment.Kind.Doc) return
+        updateAttachment(id) { it.copy(state = PendingAttachment.State.Extracting, extractedText = null) }
+        startExtraction(target)
+    }
+
+    /** Remove one staged attachment (the composer's ✕). */
+    fun removePendingAttachment(id: String) {
+        extractionJobs.remove(id)?.cancel()
+        _pendingAttachments.value = _pendingAttachments.value.filterNot { it.id == id }
+    }
+
+    /**
+     * Drop files this model/mode cannot send, collapse to one file off the local path, and
+     * start parsing any Ready doc that still has no Markdown (cloud PDF → local switch, or edit).
+     */
+    fun reconcilePendingAttachments(
+        imageAllowed: Boolean,
+        pdfAllowed: Boolean,
+        localFilesAllowed: Boolean,
+    ) {
+        val current = _pendingAttachments.value
+        if (current.isEmpty()) return
+        val next = PendingAttachmentPolicy.keep(
+            current,
+            imageAllowed = imageAllowed,
+            pdfAllowed = pdfAllowed,
+            localFilesAllowed = localFilesAllowed,
+            cap = MAX_MESSAGE_ATTACHMENTS,
+        )
+        if (next.map { it.id } != current.map { it.id }) {
+            val keepIds = next.map { it.id }.toSet()
+            extractionJobs.keys.filter { it !in keepIds }.forEach { extractionJobs.remove(it)?.cancel() }
+            _pendingAttachments.value = next
+            if (next.size < current.size && !localFilesAllowed && next.isNotEmpty()) {
+                _errorMessage.value = "Only one file can go with this model. Extra files were dropped."
+            }
+        }
+        if (localFilesAllowed) extractMissingDocs()
+    }
+
+    private fun extractMissingDocs() {
+        for (att in _pendingAttachments.value) {
+            if (!PendingAttachmentPolicy.needsExtraction(att)) continue
+            updateAttachment(att.id) { it.copy(state = PendingAttachment.State.Extracting, extractedText = null) }
+            val updated = _pendingAttachments.value.firstOrNull { it.id == att.id } ?: continue
+            startExtraction(updated)
+        }
+    }
+
+    private fun updateAttachment(id: String, transform: (PendingAttachment) -> PendingAttachment) {
+        _pendingAttachments.value = _pendingAttachments.value.map { if (it.id == id) transform(it) else it }
+    }
+
+    private fun cancelExtractionJobs() {
+        extractionJobs.values.forEach { it.cancel() }
+        extractionJobs.clear()
     }
 
     fun setPendingPastedImage(uri: Uri, fallbackMimeType: String? = null) {
@@ -1232,9 +1381,8 @@ class ChatViewModel(
         }
 
     fun clearPendingAttachment() {
-        _pendingAttachmentUri.value = null
-        _pendingAttachmentMimeType.value = null
-        _pendingAttachmentName.value = null
+        cancelExtractionJobs()
+        _pendingAttachments.value = emptyList()
     }
 
     fun startNewChat() {
@@ -1327,9 +1475,22 @@ class ChatViewModel(
     fun sendMessage(content: String) {
         val prompt = content.trim()
         val editingUserId = _editingUserMessageId.value
-        val attachmentUri = _pendingAttachmentUri.value?.toString()
-        val attachmentMime = _pendingAttachmentMimeType.value
-        val attachmentName = _pendingAttachmentName.value
+        val stagedAttachments = _pendingAttachments.value
+        // The representative single attachment drives the legacy columns and the unchanged
+        // cloud/image/deep-research paths (image first so a vision model / video frame still
+        // resolves). The full list — with each doc's on-device Markdown — rides on attachmentsJson.
+        val representative = stagedAttachments.firstOrNull { it.isImage } ?: stagedAttachments.firstOrNull()
+        val attachmentUri = representative?.uri
+        val attachmentMime = representative?.mimeType
+        val attachmentName = representative?.name
+        val messageAttachments = stagedAttachments.map {
+            MessageAttachment(uri = it.uri, mimeType = it.mimeType, name = it.name, extractedText = it.extractedText)
+        }
+        // Only persist the multi-attachment JSON when it carries more than the legacy columns can:
+        // a second file, or parsed doc text. A lone cloud PDF/image stays on the legacy columns.
+        val attachmentsJson = if (stagedAttachments.size > 1 || stagedAttachments.any { it.extractedText != null }) {
+            ToolEventJson.attachmentsToJson(messageAttachments)
+        } else null
 
         if (prompt.isEmpty() && attachmentUri == null) return
 
@@ -1381,8 +1542,6 @@ class ChatViewModel(
                     return@launch
                 }
             }
-
-            clearPendingAttachment()
 
             val apiKey = settingsRepository.getApiKeyDirect()
             val selectedModel = settingsRepository.getSelectedModelDirect()
@@ -1451,8 +1610,12 @@ class ChatViewModel(
                 return@launch
             }
 
-            if (isLocal && attachmentMime.equals("application/pdf", ignoreCase = true)) {
-                _errorMessage.value = "PDF files work with OpenRouter models only. Pick a cloud model to attach this PDF."
+            if (stagedAttachments.any { it.isProcessing || it.isFailed }) {
+                _errorMessage.value = "Wait for files to finish reading, or remove ones that couldn't be read."
+                return@launch
+            }
+            if (isLocal && stagedAttachments.any { !it.isImage && it.extractedText.isNullOrBlank() }) {
+                _errorMessage.value = "That file has no readable text for the on-device model. Wait for it to finish, or remove it."
                 return@launch
             }
 
@@ -1654,6 +1817,7 @@ class ChatViewModel(
             var replacedAssistant: ChatMessage? = null
 
             if (editingUserId == null) {
+                clearPendingAttachment()
                 // Insert User Message
                 val userMsg = ChatMessage(
                     id = UUID.randomUUID().toString(),
@@ -1663,7 +1827,8 @@ class ChatViewModel(
                     createdAt = System.currentTimeMillis(),
                     localAttachmentUri = attachmentUri,
                     localAttachmentMimeType = attachmentMime,
-                    localAttachmentName = attachmentName
+                    localAttachmentName = attachmentName,
+                    attachmentsJson = attachmentsJson,
                 )
                 chatRepository.insertMessage(userMsg)
 
@@ -1709,6 +1874,7 @@ class ChatViewModel(
                         isLocal = isLocal,
                     ),
                 )
+                clearPendingAttachment()
                 val editResult = withContext(NonCancellable) {
                     commitEditTurn(
                         userMessageId = editingUserId,
@@ -1716,6 +1882,7 @@ class ChatViewModel(
                         attachmentUri = attachmentUri,
                         attachmentMime = attachmentMime,
                         attachmentName = attachmentName,
+                        attachmentsJson = attachmentsJson,
                     )
                 }
                 if (editResult == null) {
@@ -1744,6 +1911,14 @@ class ChatViewModel(
                     }
                 fullHistory.lastOrNull { it.role == "user" }?.extraAttachments = extras
             }
+
+            // On-device history: fold each turn's parsed-doc Markdown into the content the local
+            // engine sees (it can't take raw files). The displayed message keeps only its typed
+            // text — this augmented copy exists only for the prompt. Cloud/custom paths use
+            // fullHistory unchanged.
+            val localHistory = if (isLocal) {
+                fullHistory.map { it.copy(content = LocalLlmPrompting.contentWithAttachments(it)) }
+            } else fullHistory
 
             // Resolve the user's global sampler settings for whichever model is about to run,
             // clamped to that model's limits (so a budget set for a big model can't break a
@@ -1856,7 +2031,7 @@ class ChatViewModel(
                         LlmStreamRequest(
                             model = selectedModel,
                             chatId = chatId,
-                            history = fullHistory,
+                            history = localHistory,
                             systemPrompt = systemPrompt,
                             params = inferenceParams,
                             localModel = localModel,
@@ -1887,14 +2062,14 @@ class ChatViewModel(
                         params = inferenceParams,
                     )
                 isLocal && clientSearchReady ->
-                    localPromptProtocolFlow(localModel!!, chatId, fullHistory, systemPrompt, provider, searchKey, inferenceParams)
+                    localPromptProtocolFlow(localModel!!, chatId, localHistory, systemPrompt, provider, searchKey, inferenceParams)
                         .withLocalInferenceGate("a chat reply")
                 isLocal ->
                     localGateway.stream(
                         LlmStreamRequest(
                             model = selectedModel,
                             chatId = chatId,
-                            history = fullHistory,
+                            history = localHistory,
                             systemPrompt = systemPrompt,
                             params = inferenceParams,
                             localModel = localModel,
@@ -2438,6 +2613,7 @@ class ChatViewModel(
         attachmentUri: String?,
         attachmentMime: String?,
         attachmentName: String?,
+        attachmentsJson: String?,
     ): EditTurnResult? {
         val chatId = _currentChatThreadId.value ?: return null
         val messages = chatRepository.history(chatId)
@@ -2459,6 +2635,7 @@ class ChatViewModel(
                 attachmentUri = attachmentUri,
                 attachmentMimeType = attachmentMime,
                 attachmentName = attachmentName,
+                attachmentsJson = attachmentsJson,
             ),
             oldAssistantId = assistant?.id,
         )
@@ -2635,6 +2812,9 @@ class ChatViewModel(
 
         /** Bound how many unread project files ride on one send (each is already ≤ 25 MB). */
         private const val MAX_PROVIDER_DOCS = 3
+
+        /** Files a single chat turn may carry (the local multi-doc path). */
+        const val MAX_MESSAGE_ATTACHMENTS = 3
 
         fun provideFactory(
             application: Application,

--- a/app/src/main/java/com/echoflow/ui/PendingAttachment.kt
+++ b/app/src/main/java/com/echoflow/ui/PendingAttachment.kt
@@ -1,0 +1,62 @@
+package com.echoflow.ui
+
+import java.util.UUID
+
+/**
+ * A file staged in the composer, before the turn is sent. The composer renders one chip per
+ * entry with a state-driven leading slot (loader / tick / retry) and a remove button.
+ *
+ * Doc files on the local-model path are parsed on-device (anydoc → Markdown) between attach and
+ * send; the chip stays [State.Extracting] until [extractedText] lands or it [State.Failed]s. Images
+ * and files bound for a cloud/custom model are [State.Ready] immediately (no local parse).
+ */
+data class PendingAttachment(
+    val id: String = UUID.randomUUID().toString(),
+    val uri: String,
+    val mimeType: String,
+    val name: String,
+    val kind: Kind,
+    val state: State,
+    /** On-device Markdown for a parsed doc; null for images and unparsed (cloud) files. */
+    val extractedText: String? = null,
+) {
+    enum class Kind { Image, Doc }
+    enum class State { Extracting, Ready, Failed }
+
+    val isImage: Boolean get() = kind == Kind.Image
+    val isProcessing: Boolean get() = state == State.Extracting
+    val isFailed: Boolean get() = state == State.Failed
+    val isPdf: Boolean get() = mimeType.equals("application/pdf", ignoreCase = true)
+}
+
+/** What to keep when the model or mode changes, and which chips still need an on-device parse. */
+internal object PendingAttachmentPolicy {
+    fun keep(
+        current: List<PendingAttachment>,
+        imageAllowed: Boolean,
+        pdfAllowed: Boolean,
+        localFilesAllowed: Boolean,
+        cap: Int = 3,
+    ): List<PendingAttachment> {
+        val legal = current.filter { att ->
+            when {
+                att.isImage -> imageAllowed
+                att.isPdf -> pdfAllowed || localFilesAllowed
+                else -> localFilesAllowed
+            }
+        }
+        if (legal.isEmpty()) return emptyList()
+        return if (localFilesAllowed) {
+            legal.take(cap)
+        } else {
+            // Cloud/custom/Imagine still send a single localAttachmentUri.
+            listOf(legal.firstOrNull { it.isImage } ?: legal.first())
+        }
+    }
+
+    /** Ready doc with no Markdown — a cloud-staged PDF or a legacy edit. Kick off anydoc. */
+    fun needsExtraction(att: PendingAttachment): Boolean =
+        att.kind == PendingAttachment.Kind.Doc &&
+            att.extractedText.isNullOrBlank() &&
+            att.state == PendingAttachment.State.Ready
+}

--- a/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatComposer.kt
@@ -139,15 +139,16 @@ import kotlinx.coroutines.launch
 internal fun InputToolbar(
     text: String,
     onText: (String) -> Unit,
-    pendingUri: String?,
-    pendingMime: String?,
-    pendingName: String?,
-    onClearAttachment: () -> Unit,
+    attachments: List<com.echoflow.ui.PendingAttachment>,
+    attachmentLimit: Int,
+    onRemoveAttachment: (String) -> Unit,
+    onRetryAttachment: (String) -> Unit,
     onAttach: () -> Unit,
     onAttachPdf: () -> Unit,
     onReceiveImage: (Uri) -> Unit,
     imageAttachEnabled: Boolean,
     pdfAttachEnabled: Boolean,
+    requireExtractedDocs: Boolean = false,
     isStreaming: Boolean,
     deepResearchActive: Boolean,
     webSearchChipOn: Boolean,
@@ -239,30 +240,13 @@ internal fun InputToolbar(
             )
         }
 
-        AnimatedVisibility(visible = pendingUri != null) {
-            pendingUri?.let { uri ->
-                Surface(
-                    shape = MaterialTheme.shapes.large,
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    modifier = Modifier.padding(bottom = Spacing.s),
-                ) {
-                    Row(Modifier.padding(Spacing.s), verticalAlignment = Alignment.CenterVertically) {
-                        if (pendingMime.equals("application/pdf", ignoreCase = true)) {
-                            Icon(
-                                Icons.Default.PictureAsPdf,
-                                null,
-                                Modifier.size(40.dp),
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                        } else {
-                            AsyncImage(uri, null, Modifier.size(40.dp).clip(MaterialTheme.shapes.medium), contentScale = ContentScale.Crop)
-                        }
-                        Spacer(Modifier.width(Spacing.m))
-                        Text(pendingName ?: "Attachment", maxLines = 1, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSecondaryContainer, modifier = Modifier.weight(1f))
-                        IconButton(onClick = onClearAttachment, modifier = Modifier.size(28.dp)) { Icon(Icons.Default.Close, "Remove", Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSecondaryContainer) }
-                    }
-                }
-            }
+        AnimatedVisibility(visible = attachments.isNotEmpty()) {
+            AttachmentChips(
+                attachments = attachments,
+                onRemove = onRemoveAttachment,
+                onRetry = onRetryAttachment,
+                modifier = Modifier.padding(bottom = Spacing.s),
+            )
         }
 
         // What this next message will be sent with: the model first, then whatever
@@ -416,9 +400,15 @@ internal fun InputToolbar(
                 val showStop = isStreaming || researchInProgress
                 val transcribing = voicePhase == VoicePhase.Transcribing
                 val hasText = text.trim().isNotEmpty()
-                val hasContent = hasText || (pendingUri != null && !researchMode)
+                val hasContent = hasText || (attachments.isNotEmpty() && !researchMode)
+                // Local path: a Ready chip with no Markdown is an unparsed cloud PDF / legacy
+                // attachment — hold send until extract finishes (or the user removes it).
+                val attachmentsSettled = attachments.all { att ->
+                    att.state == com.echoflow.ui.PendingAttachment.State.Ready &&
+                        (!requireExtractedDocs || att.isImage || !att.extractedText.isNullOrBlank())
+                }
                 // Inert while capturing/transcribing — the mic owns that phase, not send.
-                val canSend = hasContent && !showStop && blockedReason == null && voicePhase == VoicePhase.Idle
+                val canSend = hasContent && attachmentsSettled && !showStop && blockedReason == null && voicePhase == VoicePhase.Idle
                 SendButton(
                     enabled = canSend,
                     isStreaming = showStop,
@@ -429,6 +419,98 @@ internal fun InputToolbar(
                 ) {
                     if (canSend) onSend()
                 }
+            }
+        }
+    }
+}
+
+/**
+ * The staged attachments, one pill each (up to the message limit). A pill narrates its own state:
+ * a morphing [LoadingIndicator] while its doc is parsed on-device, a tick once ready, a tap-to-retry
+ * arrow if the parse failed. Every pill carries a ✕ to drop that file from the turn. Images show a
+ * thumbnail and are ready at once (no local parse).
+ */
+@Composable
+private fun AttachmentChips(
+    attachments: List<com.echoflow.ui.PendingAttachment>,
+    onRemove: (String) -> Unit,
+    onRetry: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        attachments.forEach { attachment ->
+            key(attachment.id) {
+                AttachmentChip(
+                    attachment = attachment,
+                    onRemove = { onRemove(attachment.id) },
+                    onRetry = { onRetry(attachment.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AttachmentChip(
+    attachment: com.echoflow.ui.PendingAttachment,
+    onRemove: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    val failed = attachment.isFailed
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color = if (failed) MaterialTheme.colorScheme.errorContainer
+        else MaterialTheme.colorScheme.secondaryContainer,
+    ) {
+        Row(
+            Modifier.padding(horizontal = Spacing.s, vertical = Spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val onContainer = if (failed) MaterialTheme.colorScheme.onErrorContainer
+            else MaterialTheme.colorScheme.onSecondaryContainer
+            // Leading slot: image thumbnail, or a state glyph for a doc (loader → tick → retry).
+            Box(Modifier.size(26.dp), contentAlignment = Alignment.Center) {
+                when {
+                    attachment.isImage ->
+                        AsyncImage(
+                            attachment.uri,
+                            null,
+                            Modifier.size(26.dp).clip(MaterialTheme.shapes.small),
+                            contentScale = ContentScale.Crop,
+                        )
+                    attachment.isProcessing ->
+                        LoadingIndicator(modifier = Modifier.size(20.dp), color = onContainer)
+                    failed ->
+                        Icon(
+                            Icons.Default.Refresh,
+                            "Retry",
+                            Modifier
+                                .size(22.dp)
+                                .clip(CircleShape)
+                                .clickable(onClick = onRetry)
+                                .semantics { contentDescription = "Retry reading ${attachment.name}" },
+                            tint = onContainer,
+                        )
+                    else ->
+                        Icon(Icons.Default.CheckCircle, "Ready", Modifier.size(20.dp), tint = onContainer)
+                }
+            }
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                attachment.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyMedium,
+                color = onContainer,
+                modifier = Modifier.widthIn(max = 160.dp),
+            )
+            Spacer(Modifier.width(Spacing.xs))
+            IconButton(onClick = onRemove, modifier = Modifier.size(26.dp)) {
+                Icon(Icons.Default.Close, "Remove ${attachment.name}", Modifier.size(16.dp), tint = onContainer)
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -489,14 +489,18 @@ internal fun MessageBubble(
             onCopy = { onCopy(message.content) },
             onEdit = { onEditUserMessage(message.id) },
             modifier = modifier,
-            attachment = message.localAttachmentUri?.let { uri ->
+            attachment = message.attachments.takeIf { it.isNotEmpty() }?.let { list ->
                 {
-                    MessageAttachmentPreview(
-                        uri = uri,
-                        mimeType = message.localAttachmentMimeType,
-                        name = message.localAttachmentName,
-                        modifier = Modifier.padding(bottom = Spacing.s),
-                    )
+                    Column {
+                        list.forEach { att ->
+                            MessageAttachmentPreview(
+                                uri = att.uri,
+                                mimeType = att.mimeType,
+                                name = att.name,
+                                modifier = Modifier.padding(bottom = Spacing.s),
+                            )
+                        }
+                    }
                 }
             },
         )
@@ -589,11 +593,11 @@ private fun AssistantAnswerBody(
         onCopy(timelineText.ifBlank { message.content })
     }
 
-    message.localAttachmentUri?.let { uri ->
+    message.attachments.forEach { att ->
         MessageAttachmentPreview(
-            uri = uri,
-            mimeType = message.localAttachmentMimeType,
-            name = message.localAttachmentName,
+            uri = att.uri,
+            mimeType = att.mimeType,
+            name = att.name,
             modifier = Modifier.padding(bottom = Spacing.s),
         )
     }
@@ -1031,36 +1035,38 @@ internal fun MessageAttachmentPreview(
     name: String?,
     modifier: Modifier = Modifier,
 ) {
-    if (mimeType.equals("application/pdf", ignoreCase = true)) {
-        Surface(
-            shape = MaterialTheme.shapes.large,
-            color = MaterialTheme.colorScheme.secondaryContainer,
-            modifier = modifier.widthIn(max = 280.dp),
-        ) {
-            Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    Icons.Default.PictureAsPdf,
-                    null,
-                    Modifier.size(28.dp),
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Spacer(Modifier.width(Spacing.s))
-                Text(
-                    name ?: "PDF file",
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.weight(1f),
-                )
-            }
-        }
-    } else {
+    val isImage = mimeType?.startsWith("image/", ignoreCase = true) == true
+    if (isImage) {
         AsyncImage(
             uri,
             null,
             modifier.size(200.dp).clip(MaterialTheme.shapes.large),
             contentScale = ContentScale.Crop,
         )
+        return
+    }
+    val isPdf = mimeType.equals("application/pdf", ignoreCase = true)
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = modifier.widthIn(max = 280.dp),
+    ) {
+        Row(Modifier.padding(Spacing.base), verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                if (isPdf) Icons.Default.PictureAsPdf else Icons.Default.Description,
+                null,
+                Modifier.size(28.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.width(Spacing.s))
+            Text(
+                name ?: if (isPdf) "PDF file" else "Document",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -113,6 +113,29 @@ import kotlinx.coroutines.launch
 private val DEFAULT_MODEL = "google/gemini-2.0-flash" to "Gemini 2.0 Flash"
 
 /**
+ * Doc types the local-model "Files" picker offers — everything the bundled anydoc parser reads.
+ * Extra/unknown picks that anydoc can't handle simply fail their chip (retry/remove), so this list
+ * only needs to be broad enough to surface the common formats in the system picker.
+ */
+private val DOC_ATTACH_MIME_TYPES = arrayOf(
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.oasis.opendocument.text",
+    "application/vnd.oasis.opendocument.spreadsheet",
+    "application/vnd.oasis.opendocument.presentation",
+    "application/rtf",
+    "application/epub+zip",
+    "text/plain",
+    "text/csv",
+    "text/markdown",
+)
+
+/**
  * The Chat surface: turn-taking conversation and every capability that makes an answer
  * better — search, research, artifacts, the browser, the Echo modes.
  *
@@ -137,9 +160,7 @@ internal fun ChatSurface(
     val localModelLoading by chatViewModel.localModelLoading.collectAsState()
     val anyLocalStreamActive by chatViewModel.anyLocalStreamActive.collectAsState()
 
-    val pendingUri by chatViewModel.pendingAttachmentUri.collectAsState()
-    val pendingMime by chatViewModel.pendingAttachmentMimeType.collectAsState()
-    val pendingName by chatViewModel.pendingAttachmentName.collectAsState()
+    val pendingAttachments by chatViewModel.pendingAttachments.collectAsState()
     val selectedModelID by settingsViewModel.selectedModel.collectAsState()
     val customProviderConfig by settingsViewModel.customProviderConfig.collectAsState()
     val customModelsList by settingsViewModel.customModels.collectAsState()
@@ -310,13 +331,24 @@ internal fun ChatSurface(
             else -> selectedModelIsOpenRouter || selectedModelIsCustomPdfCapable
         }
     }
-    LaunchedEffect(pendingUri, pendingMime, imageAttachAvailable, pdfAttachAllowed) {
-        if (pendingUri != null) {
-            val pendingIsPdf = pendingMime.equals("application/pdf", ignoreCase = true)
-            if ((pendingIsPdf && !pdfAttachAllowed) || (!pendingIsPdf && !imageAttachAvailable)) {
-                chatViewModel.clearPendingAttachment()
-            }
-        }
+    // On-device models parse doc files locally (PDF/Word/Excel/…). Fusion/Adviser/Agent/Browser
+    // do not consume that Markdown, so they stay on the single raw-PDF path (or none).
+    val isLocalModel = remember(selectedModelID) { selectedModelID.startsWith("local/") }
+    val filesAttachAllowed = isLocalModel &&
+        !deepResearchActive &&
+        !dataAgentActive &&
+        !echoFusionActive &&
+        !echoAdviserActive &&
+        !echoAgentActive &&
+        !browserFlowActive
+    val fileMenuEnabled = pdfAttachAllowed || filesAttachAllowed
+
+    LaunchedEffect(pendingAttachments, imageAttachAvailable, pdfAttachAllowed, filesAttachAllowed) {
+        chatViewModel.reconcilePendingAttachments(
+            imageAllowed = imageAttachAvailable,
+            pdfAllowed = pdfAttachAllowed,
+            localFilesAllowed = filesAttachAllowed,
+        )
     }
 
     val activeModelList = remember(customModelsList, customProviderModels) {
@@ -372,6 +404,11 @@ internal fun ChatSurface(
     val pdfPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
         onResult = { uri -> if (uri != null) chatViewModel.setPendingAttachment(uri, "application/pdf") },
+    )
+    // Local-model doc path: pick several files at once; each is parsed on-device (anydoc).
+    val docPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenMultipleDocuments(),
+        onResult = { uris -> if (uris.isNotEmpty()) chatViewModel.addPendingDocs(uris) },
     )
 
     // Measure the floating input's height so the message list always pads exactly enough to clear
@@ -475,15 +512,20 @@ internal fun ChatSurface(
             modifier = Modifier,
             text = textInput,
             onText = { textInput = it },
-            pendingUri = pendingUri?.toString(),
-            pendingMime = pendingMime,
-            pendingName = pendingName,
-            onClearAttachment = { chatViewModel.clearPendingAttachment() },
+            attachments = pendingAttachments,
+            attachmentLimit = com.echoflow.ui.ChatViewModel.MAX_MESSAGE_ATTACHMENTS,
+            onRemoveAttachment = { id -> chatViewModel.removePendingAttachment(id) },
+            onRetryAttachment = { id -> chatViewModel.retryPendingAttachment(id) },
             onAttach = { imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
-            onAttachPdf = { pdfPicker.launch(arrayOf("application/pdf")) },
+            onAttachPdf = {
+                if (filesAttachAllowed) docPicker.launch(DOC_ATTACH_MIME_TYPES)
+                else pdfPicker.launch(arrayOf("application/pdf"))
+            },
             onReceiveImage = { uri -> chatViewModel.setPendingPastedImage(uri) },
             imageAttachEnabled = imageAttachAvailable,
-            pdfAttachEnabled = pdfAttachAllowed,
+            pdfAttachEnabled = fileMenuEnabled &&
+                (!filesAttachAllowed || pendingAttachments.size < com.echoflow.ui.ChatViewModel.MAX_MESSAGE_ATTACHMENTS),
+            requireExtractedDocs = filesAttachAllowed,
             isStreaming = isStreaming,
             deepResearchActive = deepResearchActive,
             webSearchChipOn = webSearchChipOn,

--- a/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
+++ b/app/src/test/java/com/echoflow/DatabaseUpgradeTest.kt
@@ -119,5 +119,10 @@ class DatabaseUpgradeTest {
         database.openHelper.readableDatabase.query(
             "SELECT extractionStatus, extractionTier FROM project_documents LIMIT 0"
         ).use { /* columns are queryable after the chained migration */ }
+
+        // v24: multi-file chat attachments column exists after the chained migration.
+        database.openHelper.readableDatabase.query(
+            "SELECT attachmentsJson FROM chat_messages LIMIT 0"
+        ).use { /* queryable => the additive column landed */ }
     }
 }

--- a/app/src/test/java/com/echoflow/data/ChatMessageAttachmentsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ChatMessageAttachmentsTest.kt
@@ -1,0 +1,47 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** [ChatMessage.attachments] coalesces the new JSON list with the legacy single columns. */
+class ChatMessageAttachmentsTest {
+    private fun message(
+        localUri: String? = null,
+        localMime: String? = null,
+        localName: String? = null,
+        attachmentsJson: String? = null,
+    ) = ChatMessage(
+        id = "m", chatId = "c", role = "user", content = "", createdAt = 0L,
+        localAttachmentUri = localUri, localAttachmentMimeType = localMime, localAttachmentName = localName,
+        attachmentsJson = attachmentsJson,
+    )
+
+    @Test fun `no attachments yields an empty list`() {
+        assertTrue(message().attachments.isEmpty())
+    }
+
+    @Test fun `a legacy single attachment is wrapped as one entry`() {
+        val list = message(localUri = "u", localMime = "application/pdf", localName = "old.pdf").attachments
+        assertEquals(1, list.size)
+        assertEquals("u", list[0].uri)
+        assertEquals("application/pdf", list[0].mimeType)
+        assertEquals("old.pdf", list[0].name)
+        assertNull(list[0].extractedText)
+    }
+
+    @Test fun `the json list wins when present`() {
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(
+                MessageAttachment("u1", "application/pdf", "a.pdf", "alpha"),
+                MessageAttachment("u2", "text/csv", "b.csv", "beta"),
+            )
+        )
+        // Even with legacy columns also set, the richer JSON list is what reads back.
+        val list = message(localUri = "u1", localMime = "application/pdf", localName = "a.pdf", attachmentsJson = json).attachments
+        assertEquals(2, list.size)
+        assertEquals("alpha", list[0].extractedText)
+        assertEquals("beta", list[1].extractedText)
+    }
+}

--- a/app/src/test/java/com/echoflow/data/LocalLlmPromptingAttachmentsTest.kt
+++ b/app/src/test/java/com/echoflow/data/LocalLlmPromptingAttachmentsTest.kt
@@ -1,0 +1,92 @@
+package com.echoflow.data
+
+import com.echoflow.data.LocalLlmPrompting.MAX_ATTACHMENT_CONTEXT_CHARS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** [LocalLlmPrompting.contentWithAttachments] — how parsed docs reach an on-device model. */
+class LocalLlmPromptingAttachmentsTest {
+    private fun userMessage(content: String, attachmentsJson: String?): ChatMessage = ChatMessage(
+        id = "m1",
+        chatId = "c1",
+        role = "user",
+        content = content,
+        createdAt = 0L,
+        attachmentsJson = attachmentsJson,
+    )
+
+    @Test fun `a message with no attachments is returned unchanged`() {
+        val message = userMessage("what is 2+2", null)
+        assertEquals("what is 2+2", LocalLlmPrompting.contentWithAttachments(message))
+    }
+
+    @Test fun `a parsed doc is appended below the typed text`() {
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(MessageAttachment(uri = "u1", mimeType = "application/pdf", name = "report.pdf", extractedText = "# Q3\n\nRevenue up"))
+        )
+        val message = userMessage("summarize this", json)
+        val out = LocalLlmPrompting.contentWithAttachments(message)
+        assertTrue(out.startsWith("summarize this"))
+        assertTrue(out.contains("Attached file: report.pdf"))
+        assertTrue(out.contains("Revenue up"))
+    }
+
+    @Test fun `several docs are all injected`() {
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(
+                MessageAttachment(uri = "u1", mimeType = "application/pdf", name = "a.pdf", extractedText = "alpha body"),
+                MessageAttachment(uri = "u2", mimeType = "text/csv", name = "b.csv", extractedText = "beta body"),
+            )
+        )
+        val out = LocalLlmPrompting.contentWithAttachments(userMessage("compare", json))
+        assertTrue(out.contains("a.pdf"))
+        assertTrue(out.contains("alpha body"))
+        assertTrue(out.contains("b.csv"))
+        assertTrue(out.contains("beta body"))
+    }
+
+    @Test fun `images and text-less attachments contribute nothing`() {
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(MessageAttachment(uri = "u1", mimeType = "image/png", name = "photo.png", extractedText = null))
+        )
+        val out = LocalLlmPrompting.contentWithAttachments(userMessage("look", json))
+        assertEquals("look", out)
+        assertFalse(out.contains("Attached file"))
+    }
+
+    @Test fun `an empty prompt still delivers the doc text`() {
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(MessageAttachment(uri = "u1", mimeType = "application/pdf", name = "only.pdf", extractedText = "the whole thing"))
+        )
+        val out = LocalLlmPrompting.contentWithAttachments(userMessage("", json))
+        assertTrue(out.contains("only.pdf"))
+        assertTrue(out.contains("the whole thing"))
+    }
+
+    @Test fun `a long doc is truncated to the context budget`() {
+        val body = "x".repeat(MAX_ATTACHMENT_CONTEXT_CHARS + 80)
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(MessageAttachment(uri = "u1", mimeType = "application/pdf", name = "big.pdf", extractedText = body))
+        )
+        val out = LocalLlmPrompting.contentWithAttachments(userMessage("summarize", json))
+        assertTrue(out.startsWith("summarize"))
+        assertTrue(out.contains("[…document truncated…]"))
+        assertFalse(out.contains("x".repeat(MAX_ATTACHMENT_CONTEXT_CHARS + 1)))
+    }
+
+    @Test fun `a second doc is omitted once the budget is spent`() {
+        val huge = "a".repeat(MAX_ATTACHMENT_CONTEXT_CHARS)
+        val json = ToolEventJson.attachmentsToJson(
+            listOf(
+                MessageAttachment(uri = "u1", mimeType = "application/pdf", name = "a.pdf", extractedText = huge),
+                MessageAttachment(uri = "u2", mimeType = "text/csv", name = "b.csv", extractedText = "beta body"),
+            )
+        )
+        val out = LocalLlmPrompting.contentWithAttachments(userMessage("compare", json))
+        assertTrue(out.contains("a.pdf"))
+        assertTrue(out.contains("omitted"))
+        assertFalse(out.contains("beta body"))
+    }
+}

--- a/app/src/test/java/com/echoflow/data/extract/ChatAttachmentExtractorTest.kt
+++ b/app/src/test/java/com/echoflow/data/extract/ChatAttachmentExtractorTest.kt
@@ -1,0 +1,88 @@
+package com.echoflow.data.extract
+
+import android.net.Uri
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import java.io.ByteArrayInputStream
+
+@RunWith(RobolectricTestRunner::class)
+class ChatAttachmentExtractorTest {
+    private val resolver get() = RuntimeEnvironment.getApplication().contentResolver
+
+    private fun extractorReturning(result: Anydoc.Result) = ChatAttachmentExtractor(
+        resolver,
+        object : DocumentParser {
+            override val available = true
+            override fun convert(bytes: ByteArray, filename: String) = result
+        },
+    )
+
+    private fun stagedUri(bytes: ByteArray = byteArrayOf(1, 2, 3)): Uri {
+        val uri = Uri.parse("content://docs/report")
+        Shadows.shadowOf(resolver).registerInputStream(uri, ByteArrayInputStream(bytes))
+        return uri
+    }
+
+    @Test fun `parsed markdown comes back as text`() = runBlocking {
+        val result = extractorReturning(Anydoc.Result.Text("# Heading\n\nBody"))
+            .extract(stagedUri(), "report.pdf")
+        assertTrue(result is ChatAttachmentExtractor.Result.Text)
+        assertTrue((result as ChatAttachmentExtractor.Result.Text).markdown.contains("Heading"))
+    }
+
+    @Test fun `a doc anydoc declines fails (no OCR tier in chat)`() = runBlocking {
+        val result = extractorReturning(Anydoc.Result.TryOcr).extract(stagedUri(), "scan.pdf")
+        assertTrue(result is ChatAttachmentExtractor.Result.Failed)
+    }
+
+    @Test fun `an encrypted doc fails`() = runBlocking {
+        val result = extractorReturning(Anydoc.Result.Failed("encrypted")).extract(stagedUri(), "locked.pdf")
+        assertEquals("encrypted", (result as ChatAttachmentExtractor.Result.Failed).reason)
+    }
+
+    @Test fun `blank markdown is treated as a failure`() = runBlocking {
+        val result = extractorReturning(Anydoc.Result.Text("   ")).extract(stagedUri(), "empty.docx")
+        assertTrue(result is ChatAttachmentExtractor.Result.Failed)
+    }
+
+    @Test fun `an unreadable uri fails without throwing`() = runBlocking {
+        // Nothing registered for this URI → the read returns null → Failed, never an exception.
+        val result = extractorReturning(Anydoc.Result.Text("unused"))
+            .extract(Uri.parse("content://docs/missing"), "gone.pdf")
+        assertTrue(result is ChatAttachmentExtractor.Result.Failed)
+    }
+
+    @Test fun `a text file is read even when anydoc is not used`() = runBlocking {
+        val uri = Uri.parse("content://docs/notes")
+        Shadows.shadowOf(resolver).registerInputStream(
+            uri,
+            ByteArrayInputStream("hello from notes".toByteArray()),
+        )
+        // anydoc is never called for .txt; even a failing parser must not block plaintext.
+        val result = extractorReturning(Anydoc.Result.Failed("unused")).extract(uri, "notes.txt")
+        assertTrue(result is ChatAttachmentExtractor.Result.Text)
+        assertEquals("hello from notes", (result as ChatAttachmentExtractor.Result.Text).markdown)
+    }
+
+    @Test fun `markdown is read as plaintext`() = runBlocking {
+        val uri = Uri.parse("content://docs/readme")
+        Shadows.shadowOf(resolver).registerInputStream(
+            uri,
+            ByteArrayInputStream("# Title\n\nBody".toByteArray()),
+        )
+        val result = extractorReturning(Anydoc.Result.TryOcr).extract(uri, "readme.md")
+        assertTrue(result is ChatAttachmentExtractor.Result.Text)
+        assertTrue((result as ChatAttachmentExtractor.Result.Text).markdown.contains("Title"))
+    }
+
+    @Test fun `a scanned pdf still fails (no OCR, no plaintext fallback)`() = runBlocking {
+        val result = extractorReturning(Anydoc.Result.TryOcr).extract(stagedUri(), "scan.pdf")
+        assertTrue(result is ChatAttachmentExtractor.Result.Failed)
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/PendingAttachmentPolicyTest.kt
+++ b/app/src/test/java/com/echoflow/ui/PendingAttachmentPolicyTest.kt
@@ -1,0 +1,89 @@
+package com.echoflow.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PendingAttachmentPolicyTest {
+    private fun doc(
+        id: String,
+        pdf: Boolean = true,
+        text: String? = null,
+        state: PendingAttachment.State = PendingAttachment.State.Ready,
+    ) = PendingAttachment(
+        id = id,
+        uri = "content://$id",
+        mimeType = if (pdf) "application/pdf" else "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        name = if (pdf) "$id.pdf" else "$id.docx",
+        kind = PendingAttachment.Kind.Doc,
+        state = state,
+        extractedText = text,
+    )
+
+    private fun image(id: String) = PendingAttachment(
+        id = id,
+        uri = "content://$id",
+        mimeType = "image/png",
+        name = "$id.png",
+        kind = PendingAttachment.Kind.Image,
+        state = PendingAttachment.State.Ready,
+    )
+
+    @Test fun `local keeps several docs up to the cap`() {
+        val kept = PendingAttachmentPolicy.keep(
+            listOf(doc("a"), doc("b"), doc("c"), doc("d")),
+            imageAllowed = false,
+            pdfAllowed = false,
+            localFilesAllowed = true,
+            cap = 3,
+        )
+        assertEquals(listOf("a", "b", "c"), kept.map { it.id })
+    }
+
+    @Test fun `cloud collapses several PDFs to the first`() {
+        val kept = PendingAttachmentPolicy.keep(
+            listOf(doc("a"), doc("b"), doc("c")),
+            imageAllowed = true,
+            pdfAllowed = true,
+            localFilesAllowed = false,
+        )
+        assertEquals(listOf("a"), kept.map { it.id })
+    }
+
+    @Test fun `cloud prefers a staged image over extra PDFs`() {
+        val kept = PendingAttachmentPolicy.keep(
+            listOf(doc("a"), image("pic"), doc("b")),
+            imageAllowed = true,
+            pdfAllowed = true,
+            localFilesAllowed = false,
+        )
+        assertEquals(listOf("pic"), kept.map { it.id })
+    }
+
+    @Test fun `docx is dropped when leaving the local files path`() {
+        val kept = PendingAttachmentPolicy.keep(
+            listOf(doc("word", pdf = false, text = "body")),
+            imageAllowed = true,
+            pdfAllowed = true,
+            localFilesAllowed = false,
+        )
+        assertTrue(kept.isEmpty())
+    }
+
+    @Test fun `a ready doc with no text still needs extraction`() {
+        assertTrue(PendingAttachmentPolicy.needsExtraction(doc("a", text = null)))
+        assertFalse(PendingAttachmentPolicy.needsExtraction(doc("a", text = "# hi")))
+        assertFalse(
+            PendingAttachmentPolicy.needsExtraction(
+                doc("a", text = null, state = PendingAttachment.State.Extracting),
+            ),
+        )
+        assertFalse(
+            PendingAttachmentPolicy.needsExtraction(
+                doc("a", text = null, state = PendingAttachment.State.Failed),
+            ),
+        )
+        assertFalse(PendingAttachmentPolicy.needsExtraction(image("pic")))
+    }
+}


### PR DESCRIPTION
## Why

On-device models cannot accept raw files. Project Files already parse documents with anydoc and inject Markdown into the system prompt. Chat still only had the cloud single-PDF / image path, so attaching a PDF (or Word, Excel, …) while a local model was selected either failed or sent nothing the model could read.

## What

- **+ → Files** on a local model is a multi-select (up to 3). Each chip extracts on-device (anydoc → Markdown; `.txt` / `.md` fall back to UTF-8). Failed chips retry or remove. Send stays disabled until every doc has text.
- Extracted Markdown is stored on `chat_messages.attachmentsJson` (Room v24, additive) and folded into the local prompt. Combined body is capped at **24k chars**, same ballpark as project-doc injection.
- Cloud/custom keep the single raw-PDF path. Switching off local collapses extra files to the one URI those backends still send.
- Transcript bubbles show a file chip for non-image MIME types (Word/Excel/CSV used to render as a broken `AsyncImage`).
- `sendMessage` refuses Ready-without-text docs (cloud PDF staged then switched to local, or a legacy edit) instead of answering as if nothing was attached. Chips are no longer cleared before validation failures.

## Tests

- `ChatMessageAttachmentsTest` — JSON list vs legacy single columns
- `ChatAttachmentExtractorTest` — anydoc text, encrypted, blank, scanned PDF, txt/md plaintext
- `LocalLlmPromptingAttachmentsTest` — inject, skip images, truncate, omit once the budget is spent
- `PendingAttachmentPolicyTest` — cap, collapse to one file on cloud, drop docx off local, needsExtraction
- `DatabaseUpgradeTest` — v1 through v24, `attachmentsJson` is queryable

No emulator run. Screenshots not included for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching up to three files to chat messages.
  * Added previews, processing indicators, retry, and removal controls for attachments.
  * Added local extraction of text from supported documents for on-device models.
  * Added support for multiple document types alongside images and PDFs.
  * Preserved and upgraded existing chats with attachment data.

* **Bug Fixes**
  * Improved handling of failed, unreadable, encrypted, and empty documents.
  * Ensured attachment content is safely limited before being included in prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->