### PR TITLE
Ship GPT 5.6 Luna and Echo Lumen as default chat models

### DIFF
--- a/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
+++ b/app/src/main/java/com/echoflow/EchoFlowAppGraph.kt
@@ -2,6 +2,7 @@ package com.echoflow
 
 import android.app.Application
 import com.echoflow.data.AppDatabase
+import com.echoflow.data.DefaultChatModelsSeed
 import com.echoflow.data.LegacyImageModelCleanup
 import com.echoflow.data.LocalInferenceGate
 import com.echoflow.data.ModelDownloadManager
@@ -11,6 +12,7 @@ import com.echoflow.ui.SettingsViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Application-scoped composition root.
@@ -20,7 +22,13 @@ import kotlinx.coroutines.launch
  */
 class EchoFlowAppGraph(application: Application) {
     val database: AppDatabase = AppDatabase.getDatabase(application)
-    val settingsRepository = SettingsRepository(application.applicationContext)
+
+    val settingsRepository: SettingsRepository = run {
+        // Must run before SettingsRepository reads selected_model so upgrades preserve legacy picks.
+        runBlocking { DefaultChatModelsSeed.run(application.applicationContext, database) }
+        SettingsRepository(application.applicationContext)
+    }
+
     private val modelDownloadManager =
         ModelDownloadManager(application.applicationContext, database.localModelDao())
     // One gate app-wide: only one on-device LLM generation runs at a time.

--- a/app/src/main/java/com/echoflow/data/Daos.kt
+++ b/app/src/main/java/com/echoflow/data/Daos.kt
@@ -61,6 +61,9 @@ interface ChatDao {
     @Query("SELECT COUNT(*) FROM chat_threads WHERE projectId = :projectId AND kind = 'chat'")
     fun countThreadsInProject(projectId: String): Flow<Int>
 
+    @Query("SELECT EXISTS(SELECT 1 FROM chat_threads LIMIT 1)")
+    suspend fun hasAnyThreads(): Boolean
+
     @Query("UPDATE chat_threads SET projectId = :projectId WHERE id = :id")
     suspend fun setProjectId(id: String, projectId: String?)
 

--- a/app/src/main/java/com/echoflow/data/DefaultChatModels.kt
+++ b/app/src/main/java/com/echoflow/data/DefaultChatModels.kt
@@ -30,4 +30,8 @@ object DefaultChatModels {
     fun displayName(modelId: String): String? =
         SHIPPED.firstOrNull { it.first == modelId }?.second
             ?: if (modelId == LEGACY_DEFAULT_MODEL_ID) LEGACY_DEFAULT_MODEL_NAME else null
+
+    /** Picker-only label; the composer pill keeps [displayName] without the free badge. */
+    fun pickerDisplayName(modelId: String, name: String): String =
+        if (modelId == ECHO_LUMEN_MODEL_ID) "(Free) $name" else name
 }

--- a/app/src/main/java/com/echoflow/data/DefaultChatModels.kt
+++ b/app/src/main/java/com/echoflow/data/DefaultChatModels.kt
@@ -1,0 +1,33 @@
+package com.echoflow.data
+
+/**
+ * Built-in OpenRouter chat models EchoFlow ships with out of the box.
+ *
+ * [BUILT_IN] entries always appear in the in-chat picker even before Room seeding finishes.
+ * [SHIPPED] is written into `custom_models` once so Settings → Models shows them too.
+ */
+object DefaultChatModels {
+    const val DEFAULT_MODEL_ID = "openai/gpt-5.6-luna"
+    const val DEFAULT_MODEL_NAME = "GPT 5.6 Luna"
+
+    /** OpenRouter's free-model router, presented in EchoFlow as a first-party model. */
+    const val ECHO_LUMEN_MODEL_ID = "openrouter/free"
+    const val ECHO_LUMEN_MODEL_NAME = "Echo Lumen"
+
+    /** Previous built-in default; preserved for upgrades that never persisted a selection. */
+    const val LEGACY_DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
+    const val LEGACY_DEFAULT_MODEL_NAME = "Gemini 2.0 Flash"
+
+    val BUILT_IN: List<Pair<String, String>> = listOf(
+        DEFAULT_MODEL_ID to DEFAULT_MODEL_NAME,
+        ECHO_LUMEN_MODEL_ID to ECHO_LUMEN_MODEL_NAME,
+    )
+
+    val SHIPPED: List<Pair<String, String>> = BUILT_IN
+
+    val BUILT_IN_IDS: Set<String> = SHIPPED.map { it.first }.toSet()
+
+    fun displayName(modelId: String): String? =
+        SHIPPED.firstOrNull { it.first == modelId }?.second
+            ?: if (modelId == LEGACY_DEFAULT_MODEL_ID) LEGACY_DEFAULT_MODEL_NAME else null
+}

--- a/app/src/main/java/com/echoflow/data/DefaultChatModelsSeed.kt
+++ b/app/src/main/java/com/echoflow/data/DefaultChatModelsSeed.kt
@@ -1,0 +1,79 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * One-time upgrade that adds the shipped chat models to `custom_models` without disturbing
+ * existing selections.
+ *
+ * - **New installs** keep the implicit [DefaultChatModels.DEFAULT_MODEL_ID] default.
+ * - **Existing installs** that never persisted `selected_model` but already have chat history
+ *   stay on the legacy Gemini default so an app update does not silently switch models mid-thread.
+ * - **Everyone else** keeps whatever model they had selected; Luna and Echo Lumen are merely added
+ *   to the picker and Settings list when missing.
+ */
+object DefaultChatModelsSeed {
+    private const val KEY_DONE = "default_chat_models_seeded_v1"
+    private const val SELECTED_MODEL_KEY = "selected_model"
+
+    suspend fun run(context: Context, database: AppDatabase) = withContext(Dispatchers.IO) {
+        val legacyPrefs = SettingsPreferenceStorage.legacy(context)
+        val securePrefs = SettingsPreferenceStorage.secureOrNull(context)
+        val prefs = securePrefs ?: legacyPrefs
+        if (prefs.getBoolean(KEY_DONE, false)) return@withContext
+
+        val customModelDao = database.customModelDao()
+        DefaultChatModels.SHIPPED.forEach { (id, name) ->
+            ensureCustomModel(customModelDao, id, name)
+        }
+
+        val selectedModel = readSelectedModel(legacyPrefs, securePrefs)
+        when {
+            selectedModel == DefaultChatModels.LEGACY_DEFAULT_MODEL_ID ->
+                ensureCustomModel(
+                    customModelDao,
+                    DefaultChatModels.LEGACY_DEFAULT_MODEL_ID,
+                    DefaultChatModels.LEGACY_DEFAULT_MODEL_NAME,
+                )
+            selectedModel == null && database.chatDao().hasAnyThreads() -> {
+                ensureCustomModel(
+                    customModelDao,
+                    DefaultChatModels.LEGACY_DEFAULT_MODEL_ID,
+                    DefaultChatModels.LEGACY_DEFAULT_MODEL_NAME,
+                )
+                writeSelectedModel(legacyPrefs, securePrefs, DefaultChatModels.LEGACY_DEFAULT_MODEL_ID)
+            }
+        }
+
+        prefs.edit().putBoolean(KEY_DONE, true).apply()
+    }
+
+    private fun readSelectedModel(
+        legacyPrefs: SharedPreferences,
+        securePrefs: SharedPreferences?,
+    ): String? = when {
+        legacyPrefs.contains(SELECTED_MODEL_KEY) ->
+            legacyPrefs.getString(SELECTED_MODEL_KEY, null)
+        securePrefs?.contains(SELECTED_MODEL_KEY) == true ->
+            securePrefs.getString(SELECTED_MODEL_KEY, null)
+        else -> null
+    }
+
+    private suspend fun ensureCustomModel(dao: CustomModelDao, id: String, name: String) {
+        if (dao.getCustomModelById(id) == null) {
+            dao.insertCustomModel(CustomModel(id, name))
+        }
+    }
+
+    private fun writeSelectedModel(
+        legacyPrefs: SharedPreferences,
+        securePrefs: SharedPreferences?,
+        modelId: String,
+    ) {
+        legacyPrefs.edit().putString(SELECTED_MODEL_KEY, modelId).apply()
+        securePrefs?.edit()?.putString(SELECTED_MODEL_KEY, modelId)?.apply()
+    }
+}

--- a/app/src/main/java/com/echoflow/data/LocalLlmPrompting.kt
+++ b/app/src/main/java/com/echoflow/data/LocalLlmPrompting.kt
@@ -52,6 +52,23 @@ internal object LocalLlmPrompting {
         return if (message.content.isBlank()) joined else "${message.content}\n\n$joined"
     }
 
+    /**
+     * Request-only history for cloud models that read attachments via anydoc text injection
+     * (Echo Lumen). Strips raw attachment URIs so OpenRouter never receives Tier-3 file parts.
+     */
+    fun historyWithInjectedDocs(history: List<ChatMessage>): List<ChatMessage> =
+        history.map { message ->
+            val cleared = message.also { it.extraAttachments = emptyList() }
+            if (cleared.attachments.none { !it.extractedText.isNullOrBlank() }) cleared
+            else cleared.copy(
+                content = contentWithAttachments(cleared),
+                localAttachmentUri = null,
+                localAttachmentMimeType = null,
+                localAttachmentName = null,
+                attachmentsJson = null,
+            ).also { it.extraAttachments = emptyList() }
+        }
+
     /** Combined Markdown budget injected from one turn's attachments into a local prompt. */
     internal const val MAX_ATTACHMENT_CONTEXT_CHARS = 24_000
 }

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -173,8 +173,7 @@ class SettingsRepository(context: Context) {
     }
 
     fun getSelectedModelDirect(): String {
-        // Defaulting to "google/gemini-2.0-flash" which is standard and rapid
-        return prefs.getString("selected_model", "google/gemini-2.0-flash").orEmpty()
+        return prefs.getString("selected_model", DefaultChatModels.DEFAULT_MODEL_ID).orEmpty()
     }
 
     fun saveSelectedModel(modelId: String) {
@@ -756,7 +755,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_SEARCH_PROVIDER = "web_search_provider"
         private const val KEY_SEARCH_SCOPE = "web_search_scope"
         private const val KEY_LAST_SEARCH_PROVIDER = "last_search_provider"
-        const val DEFAULT_MODEL_ID = "google/gemini-2.0-flash"
+        const val DEFAULT_MODEL_ID = DefaultChatModels.DEFAULT_MODEL_ID
         const val DEFAULT_IMAGE_MODEL_ID = "google/gemini-2.5-flash-image"
 
         /** Veo 3.1 Fast: good quality without the flagship's per-second price. */

--- a/app/src/main/java/com/echoflow/data/extract/ModelFileCapability.kt
+++ b/app/src/main/java/com/echoflow/data/extract/ModelFileCapability.kt
@@ -1,5 +1,7 @@
 package com.echoflow.data.extract
 
+import com.echoflow.data.DefaultChatModels
+
 /**
  * Whether the active model can accept raw files/images on a chat turn (Tier 3).
  *
@@ -7,10 +9,21 @@ package com.echoflow.data.extract
  * custom/direct-cloud (`custom/`) send paths drop PDFs or all extra parts, so
  * they must not be advertised as file-capable — the Files row would otherwise
  * say the file was sent when it was not.
+ *
+ * [DefaultChatModels.ECHO_LUMEN_MODEL_ID] uses on-device anydoc (Tier 1) instead — see
+ * [extractsDocsLocally].
  */
 object ModelFileCapability {
     fun readsFiles(modelId: String): Boolean =
         modelId.isNotBlank() &&
             !modelId.startsWith("local/") &&
-            !modelId.startsWith("custom/")
+            !modelId.startsWith("custom/") &&
+            modelId != DefaultChatModels.ECHO_LUMEN_MODEL_ID
+
+    /**
+     * Tier 1: parse supported doc files on-device (anydoc → Markdown) before send.
+     * Images are not supported on this path.
+     */
+    fun extractsDocsLocally(modelId: String): Boolean =
+        modelId.startsWith("local/") || modelId == DefaultChatModels.ECHO_LUMEN_MODEL_ID
 }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.echoflow.data.*
+import com.echoflow.data.extract.ModelFileCapability
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.CoroutineStart
@@ -214,8 +215,10 @@ class ChatViewModel(
                 extractedText = att.extractedText,
             )
         }
-        // Legacy / cloud-staged docs have no Markdown yet. Parse them if this send will be local.
-        if (settingsRepository.selectedModel.value.startsWith("local/")) extractMissingDocs()
+        // Legacy / cloud-staged docs have no Markdown yet. Parse them if this send uses anydoc.
+        if (com.echoflow.data.extract.ModelFileCapability.extractsDocsLocally(settingsRepository.selectedModel.value)) {
+            extractMissingDocs()
+        }
         return lastUser.content
     }
 
@@ -1614,8 +1617,10 @@ class ChatViewModel(
                 _errorMessage.value = "Wait for files to finish reading, or remove ones that couldn't be read."
                 return@launch
             }
-            if (isLocal && stagedAttachments.any { !it.isImage && it.extractedText.isNullOrBlank() }) {
-                _errorMessage.value = "That file has no readable text for the on-device model. Wait for it to finish, or remove it."
+            if (ModelFileCapability.extractsDocsLocally(selectedModel) &&
+                stagedAttachments.any { !it.isImage && it.extractedText.isNullOrBlank() }
+            ) {
+                _errorMessage.value = "That file has no readable text for this model. Wait for it to finish, or remove it."
                 return@launch
             }
 
@@ -1919,6 +1924,11 @@ class ChatViewModel(
             val localHistory = if (isLocal) {
                 fullHistory.map { it.copy(content = LocalLlmPrompting.contentWithAttachments(it)) }
             } else fullHistory
+            val openRouterHistory = if (ModelFileCapability.extractsDocsLocally(selectedModel) && !isLocal) {
+                LocalLlmPrompting.historyWithInjectedDocs(fullHistory)
+            } else {
+                fullHistory
+            }
 
             // Resolve the user's global sampler settings for whichever model is about to run,
             // clamped to that model's limits (so a budget set for a big model can't break a
@@ -2045,7 +2055,7 @@ class ChatViewModel(
                             apiKey = apiKey,
                             model = selectedModel,
                             chatId = chatId,
-                            history = fullHistory,
+                            history = openRouterHistory,
                             systemPrompt = systemPrompt,
                             params = inferenceParams,
                             serverWebSearch = false,
@@ -2099,14 +2109,14 @@ class ChatViewModel(
                             apiKey = apiKey,
                             model = selectedModel,
                             chatId = chatId,
-                            history = fullHistory,
+                            history = openRouterHistory,
                             systemPrompt = systemPrompt,
                             params = inferenceParams,
                             serverWebSearch = true,
                         )
                     )
                 clientSearchReady ->
-                    openRouterService.sendWithClientSearch(apiKey, selectedModel, fullHistory, systemPrompt, inferenceParams) { query ->
+                    openRouterService.sendWithClientSearch(apiKey, selectedModel, openRouterHistory, systemPrompt, inferenceParams) { query ->
                         webSearchService.search(provider, searchKey, query)
                     }
                 else ->
@@ -2115,7 +2125,7 @@ class ChatViewModel(
                             apiKey = apiKey,
                             model = selectedModel,
                             chatId = chatId,
-                            history = fullHistory,
+                            history = openRouterHistory,
                             systemPrompt = systemPrompt,
                             params = inferenceParams,
                             serverWebSearch = false,

--- a/app/src/main/java/com/echoflow/ui/screens/ChatPickerSheets.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatPickerSheets.kt
@@ -72,6 +72,7 @@ import com.echoflow.data.AgentProfile
 import com.echoflow.data.ChatMessage
 import com.echoflow.data.CustomProviderCapabilities
 import com.echoflow.data.DataAgentCatalog
+import com.echoflow.data.DefaultChatModels
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
@@ -457,7 +458,9 @@ internal fun DrEngineRow(name: String, description: String, selected: Boolean, o
 
 @Composable
 internal fun ModelRow(name: String, modelId: String, selected: Boolean, isLocal: Boolean = false, onClick: () -> Unit) {
-    val displayName = remember(name, isLocal) { modelPickerDisplayName(name, isLocal) }
+    val displayName = remember(name, modelId, isLocal) {
+        modelPickerDisplayName(DefaultChatModels.pickerDisplayName(modelId, name), isLocal)
+    }
     val provider = when {
         modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) -> "Direct OpenAI API"
         modelId.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_CLAUDE) -> "Direct Claude API"

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -278,6 +278,7 @@ internal fun ChatSurface(
     // support vision); .task models are text-only, so the Image option is hidden for them.
     val imageAttachAllowed = remember(selectedModelID, localModelsList, customProviderConfig) {
         when {
+            selectedModelID == DefaultChatModels.ECHO_LUMEN_MODEL_ID -> false
             selectedModelID.startsWith("local/") ->
                 localModelsList.firstOrNull { it.id == selectedModelID }
                     ?.fileName?.endsWith(".litertlm", ignoreCase = true) == true
@@ -293,6 +294,9 @@ internal fun ChatSurface(
     val imageAttachAvailable = imageAttachAllowed && !deepResearchActive && !dataAgentActive
     val selectedModelIsOpenRouter = remember(selectedModelID) {
         !selectedModelID.startsWith("local/") && !selectedModelID.startsWith("custom/")
+    }
+    val selectedModelUsesAnydocExtraction = remember(selectedModelID) {
+        com.echoflow.data.extract.ModelFileCapability.extractsDocsLocally(selectedModelID)
     }
     val selectedModelIsDirectCloudPdfCapable = remember(selectedModelID) {
         selectedModelID.startsWith(com.echoflow.data.CustomProviderConfig.PREFIX_OPENAI) ||
@@ -325,15 +329,18 @@ internal fun ChatSurface(
             dataAgentActive -> false
             deepResearchActive -> deepResearchUsesOpenRouter
             echoFusionActive -> true
-            echoAdviserActive -> selectedModelIsOpenRouter
-            echoAgentActive -> selectedModelIsOpenRouter
-            else -> selectedModelIsOpenRouter || selectedModelIsCustomPdfCapable
+            echoAdviserActive -> selectedModelIsOpenRouter &&
+                selectedModelID != DefaultChatModels.ECHO_LUMEN_MODEL_ID
+            echoAgentActive -> selectedModelIsOpenRouter &&
+                selectedModelID != DefaultChatModels.ECHO_LUMEN_MODEL_ID
+            else -> (selectedModelIsOpenRouter &&
+                selectedModelID != DefaultChatModels.ECHO_LUMEN_MODEL_ID) ||
+                selectedModelIsCustomPdfCapable
         }
     }
-    // On-device models parse doc files locally (PDF/Word/Excel/…). Fusion/Adviser/Agent/Browser
-    // do not consume that Markdown, so they stay on the single raw-PDF path (or none).
-    val isLocalModel = remember(selectedModelID) { selectedModelID.startsWith("local/") }
-    val filesAttachAllowed = isLocalModel &&
+    // On-device models and Echo Lumen parse doc files locally (anydoc → Markdown). Fusion/Adviser/
+    // Agent/Browser do not consume that Markdown, so they stay on the single raw-PDF path (or none).
+    val filesAttachAllowed = selectedModelUsesAnydocExtraction &&
         !deepResearchActive &&
         !dataAgentActive &&
         !echoFusionActive &&

--- a/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatSurface.kt
@@ -80,6 +80,7 @@ import com.echoflow.data.AgentProfile
 import com.echoflow.data.ChatMessage
 import com.echoflow.data.CustomProviderCapabilities
 import com.echoflow.data.DataAgentCatalog
+import com.echoflow.data.DefaultChatModels
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DeepResearchModel
 import com.echoflow.data.DrEngine
@@ -109,8 +110,6 @@ import com.echoflow.ui.theme.rememberMorphProgress
 import com.echoflow.ui.theme.rememberReducedMotion
 import kotlinx.coroutines.launch
 
-/** Single built-in model. Everything else the user adds in Settings. */
-private val DEFAULT_MODEL = "google/gemini-2.0-flash" to "Gemini 2.0 Flash"
 
 /**
  * Doc types the local-model "Files" picker offers — everything the bundled anydoc parser reads.
@@ -352,7 +351,7 @@ internal fun ChatSurface(
     }
 
     val activeModelList = remember(customModelsList, customProviderModels) {
-        val list = mutableListOf(DEFAULT_MODEL)
+        val list = DefaultChatModels.BUILT_IN.toMutableList()
         customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
         customProviderModels.filter { !it.isLocalLike }.forEach { model ->
             if (list.none { it.first == model.id }) list.add(model.id to "${model.group}: ${model.name}")
@@ -360,7 +359,7 @@ internal fun ChatSurface(
         list
     }
     val openRouterOnlyModelList = remember(customModelsList) {
-        val list = mutableListOf(DEFAULT_MODEL)
+        val list = DefaultChatModels.BUILT_IN.toMutableList()
         customModelsList.forEach { custom -> if (list.none { it.first == custom.id }) list.add(custom.id to custom.name) }
         list
     }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -95,6 +95,7 @@ import com.echoflow.data.CatalogEntry
 import com.echoflow.data.CustomModelProvider
 import com.echoflow.data.CustomProviderConfig
 import com.echoflow.data.DataAgentCatalog
+import com.echoflow.data.DefaultChatModels
 import com.echoflow.data.FusionPanel
 import com.echoflow.data.DeepResearchCatalog
 import com.echoflow.data.DownloadState
@@ -244,7 +245,7 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
             results = orResults,
             loading = orLoading,
             error = orError,
-            addedIds = customModels.map { it.id }.toSet(),
+            addedIds = (customModels.map { it.id } + DefaultChatModels.BUILT_IN_IDS).toSet(),
             onQueryChange = viewModel::updateOrModelQuery,
             onRetry = viewModel::loadOpenRouterDirectory,
             onAdd = { info -> viewModel.addCustomModel(info.id, info.name.substringAfter(": ")) },

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -245,7 +245,8 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
             results = orResults,
             loading = orLoading,
             error = orError,
-            addedIds = (customModels.map { it.id } + DefaultChatModels.BUILT_IN_IDS).toSet(),
+            addedIds = customModels.map { it.id }.toSet(),
+            builtInIds = DefaultChatModels.BUILT_IN_IDS,
             onQueryChange = viewModel::updateOrModelQuery,
             onRetry = viewModel::loadOpenRouterDirectory,
             onAdd = { info -> viewModel.addCustomModel(info.id, info.name.substringAfter(": ")) },
@@ -263,6 +264,7 @@ internal fun OpenRouterDirectorySheet(
     loading: Boolean,
     error: String?,
     addedIds: Set<String>,
+    builtInIds: Set<String> = emptySet(),
     onQueryChange: (String) -> Unit,
     onRetry: () -> Unit,
     onAdd: (OpenRouterModelInfo) -> Unit,
@@ -362,7 +364,8 @@ internal fun OpenRouterDirectorySheet(
                                 info = info,
                                 index = index,
                                 count = results.size,
-                                added = info.id in addedIds,
+                                added = info.id in addedIds || info.id in builtInIds,
+                                removable = info.id in addedIds && info.id !in builtInIds,
                                 onAdd = { onAdd(info) },
                                 onRemove = { onRemove(info.id) },
                             )
@@ -381,11 +384,17 @@ internal fun OrModelRow(
     index: Int,
     count: Int,
     added: Boolean,
+    removable: Boolean = added,
     onAdd: () -> Unit,
     onRemove: () -> Unit,
 ) {
     Surface(
-        onClick = { if (added) onRemove() else onAdd() },
+        onClick = {
+            when {
+                added && removable -> onRemove()
+                !added -> onAdd()
+            }
+        },
         shape = groupedItemShape(index, count),
         color = if (added) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/test/java/com/echoflow/data/DefaultChatModelsSeedTest.kt
+++ b/app/src/test/java/com/echoflow/data/DefaultChatModelsSeedTest.kt
@@ -1,0 +1,113 @@
+package com.echoflow.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.echoflow.data.SettingsPreferenceStorage.LEGACY_FILE
+import com.echoflow.data.SettingsPreferenceStorage.SECURE_FILE
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultChatModelsSeedTest {
+    private lateinit var context: Context
+    private lateinit var database: AppDatabase
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences(LEGACY_FILE, Context.MODE_PRIVATE).edit().clear().commit()
+        context.getSharedPreferences(SECURE_FILE, Context.MODE_PRIVATE).edit().clear().commit()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test fun `fresh install seeds shipped models and keeps Luna as the implicit default`() = runBlocking {
+        DefaultChatModelsSeed.run(context, database)
+
+        val models = database.customModelDao().getAllCustomModelsSync()
+        assertTrue(models.any { it.id == DefaultChatModels.DEFAULT_MODEL_ID })
+        assertTrue(models.any { it.id == DefaultChatModels.ECHO_LUMEN_MODEL_ID })
+        assertFalse(models.any { it.id == DefaultChatModels.LEGACY_DEFAULT_MODEL_ID })
+
+        val repository = SettingsRepository(context)
+        assertEquals(DefaultChatModels.DEFAULT_MODEL_ID, repository.getSelectedModelDirect())
+    }
+
+    @Test fun `existing chats without a saved selection stay on legacy Gemini`() = runBlocking {
+        database.chatDao().insertThread(
+            ChatThread(
+                id = "thread-1",
+                title = "Existing chat",
+                createdAt = 1L,
+                updatedAt = 1L,
+            ),
+        )
+
+        DefaultChatModelsSeed.run(context, database)
+
+        val models = database.customModelDao().getAllCustomModelsSync()
+        assertTrue(models.any { it.id == DefaultChatModels.LEGACY_DEFAULT_MODEL_ID })
+        assertTrue(models.any { it.id == DefaultChatModels.DEFAULT_MODEL_ID })
+        assertTrue(models.any { it.id == DefaultChatModels.ECHO_LUMEN_MODEL_ID })
+
+        val repository = SettingsRepository(context)
+        assertEquals(DefaultChatModels.LEGACY_DEFAULT_MODEL_ID, repository.getSelectedModelDirect())
+    }
+
+    @Test fun `explicit legacy selection keeps Gemini without rewriting other models`() = runBlocking {
+        context.getSharedPreferences(LEGACY_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString("selected_model", DefaultChatModels.LEGACY_DEFAULT_MODEL_ID)
+            .commit()
+
+        DefaultChatModelsSeed.run(context, database)
+
+        val models = database.customModelDao().getAllCustomModelsSync()
+        assertTrue(models.any { it.id == DefaultChatModels.LEGACY_DEFAULT_MODEL_ID })
+
+        val repository = SettingsRepository(context)
+        assertEquals(DefaultChatModels.LEGACY_DEFAULT_MODEL_ID, repository.getSelectedModelDirect())
+    }
+
+    @Test fun `existing custom selection is left untouched while shipped models are added`() = runBlocking {
+        database.customModelDao().insertCustomModel(CustomModel("anthropic/claude-sonnet-4.5", "Claude Sonnet 4.5"))
+        context.getSharedPreferences(LEGACY_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString("selected_model", "anthropic/claude-sonnet-4.5")
+            .commit()
+
+        DefaultChatModelsSeed.run(context, database)
+
+        val models = database.customModelDao().getAllCustomModelsSync()
+        assertTrue(models.any { it.id == "anthropic/claude-sonnet-4.5" })
+        assertTrue(models.any { it.id == DefaultChatModels.DEFAULT_MODEL_ID })
+        assertTrue(models.any { it.id == DefaultChatModels.ECHO_LUMEN_MODEL_ID })
+        assertFalse(models.any { it.id == DefaultChatModels.LEGACY_DEFAULT_MODEL_ID })
+
+        val repository = SettingsRepository(context)
+        assertEquals("anthropic/claude-sonnet-4.5", repository.getSelectedModelDirect())
+    }
+
+    @Test fun `seed runs only once`() = runBlocking {
+        DefaultChatModelsSeed.run(context, database)
+        database.customModelDao().deleteCustomModel(DefaultChatModels.DEFAULT_MODEL_ID)
+
+        DefaultChatModelsSeed.run(context, database)
+
+        assertEquals(null, database.customModelDao().getCustomModelById(DefaultChatModels.DEFAULT_MODEL_ID))
+    }
+}

--- a/app/src/test/java/com/echoflow/data/DefaultChatModelsTest.kt
+++ b/app/src/test/java/com/echoflow/data/DefaultChatModelsTest.kt
@@ -27,4 +27,22 @@ class DefaultChatModelsTest {
         assertEquals("Gemini 2.0 Flash", DefaultChatModels.displayName(DefaultChatModels.LEGACY_DEFAULT_MODEL_ID))
         assertNull(DefaultChatModels.displayName("anthropic/claude-sonnet-4.5"))
     }
+
+    @Test fun `pickerDisplayName adds a free badge only for Echo Lumen`() {
+        assertEquals(
+            "(Free) Echo Lumen",
+            DefaultChatModels.pickerDisplayName(
+                DefaultChatModels.ECHO_LUMEN_MODEL_ID,
+                DefaultChatModels.ECHO_LUMEN_MODEL_NAME,
+            ),
+        )
+        assertEquals(
+            "GPT 5.6 Luna",
+            DefaultChatModels.pickerDisplayName(
+                DefaultChatModels.DEFAULT_MODEL_ID,
+                DefaultChatModels.DEFAULT_MODEL_NAME,
+            ),
+        )
+        assertEquals("Echo Lumen", DefaultChatModels.displayName(DefaultChatModels.ECHO_LUMEN_MODEL_ID))
+    }
 }

--- a/app/src/test/java/com/echoflow/data/DefaultChatModelsTest.kt
+++ b/app/src/test/java/com/echoflow/data/DefaultChatModelsTest.kt
@@ -1,0 +1,30 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultChatModelsTest {
+    @Test fun `ships Luna as the primary default and Echo Lumen as the free router`() {
+        assertEquals("openai/gpt-5.6-luna", DefaultChatModels.DEFAULT_MODEL_ID)
+        assertEquals("GPT 5.6 Luna", DefaultChatModels.DEFAULT_MODEL_NAME)
+        assertEquals("openrouter/free", DefaultChatModels.ECHO_LUMEN_MODEL_ID)
+        assertEquals("Echo Lumen", DefaultChatModels.ECHO_LUMEN_MODEL_NAME)
+    }
+
+    @Test fun `built in picker entries match shipped models`() {
+        assertEquals(DefaultChatModels.SHIPPED, DefaultChatModels.BUILT_IN)
+        assertTrue(DefaultChatModels.BUILT_IN_IDS.contains(DefaultChatModels.DEFAULT_MODEL_ID))
+        assertTrue(DefaultChatModels.BUILT_IN_IDS.contains(DefaultChatModels.ECHO_LUMEN_MODEL_ID))
+    }
+
+    @Test fun `displayName resolves shipped and legacy ids`() {
+        assertEquals("GPT 5.6 Luna", DefaultChatModels.displayName(DefaultChatModels.DEFAULT_MODEL_ID))
+        assertEquals("Echo Lumen", DefaultChatModels.displayName(DefaultChatModels.ECHO_LUMEN_MODEL_ID))
+        assertEquals("Gemini 2.0 Flash", DefaultChatModels.displayName(DefaultChatModels.LEGACY_DEFAULT_MODEL_ID))
+        assertNull(DefaultChatModels.displayName("anthropic/claude-sonnet-4.5"))
+    }
+}

--- a/app/src/test/java/com/echoflow/data/extract/ModelFileCapabilityTest.kt
+++ b/app/src/test/java/com/echoflow/data/extract/ModelFileCapabilityTest.kt
@@ -1,11 +1,13 @@
 package com.echoflow.data.extract
 
+import com.echoflow.data.DefaultChatModels
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ModelFileCapabilityTest {
     @Test fun `openrouter models can take files`() {
+        assertTrue(ModelFileCapability.readsFiles(DefaultChatModels.DEFAULT_MODEL_ID))
         assertTrue(ModelFileCapability.readsFiles("google/gemini-2.0-flash"))
         assertTrue(ModelFileCapability.readsFiles("anthropic/claude-sonnet-4.6"))
     }

--- a/app/src/test/java/com/echoflow/data/extract/ModelFileCapabilityTest.kt
+++ b/app/src/test/java/com/echoflow/data/extract/ModelFileCapabilityTest.kt
@@ -1,21 +1,65 @@
 package com.echoflow.data.extract
 
+import com.echoflow.data.ChatMessage
 import com.echoflow.data.DefaultChatModels
+import com.echoflow.data.LocalLlmPrompting
+import com.echoflow.data.MessageAttachment
+import com.echoflow.data.ToolEventJson
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ModelFileCapabilityTest {
-    @Test fun `openrouter models can take files`() {
+    @Test fun `openrouter models can take provider file uploads`() {
         assertTrue(ModelFileCapability.readsFiles(DefaultChatModels.DEFAULT_MODEL_ID))
         assertTrue(ModelFileCapability.readsFiles("google/gemini-2.0-flash"))
         assertTrue(ModelFileCapability.readsFiles("anthropic/claude-sonnet-4.6"))
     }
 
-    @Test fun `local and custom models cannot take files`() {
+    @Test fun `echo lumen uses anydoc instead of provider file uploads`() {
+        assertFalse(ModelFileCapability.readsFiles(DefaultChatModels.ECHO_LUMEN_MODEL_ID))
+        assertTrue(ModelFileCapability.extractsDocsLocally(DefaultChatModels.ECHO_LUMEN_MODEL_ID))
+    }
+
+    @Test fun `local models use anydoc and never provider uploads`() {
         assertFalse(ModelFileCapability.readsFiles("local/gemma-3-1b"))
+        assertTrue(ModelFileCapability.extractsDocsLocally("local/gemma-3-1b"))
+    }
+
+    @Test fun `custom models cannot take files`() {
         assertFalse(ModelFileCapability.readsFiles("custom/openai/gpt-4o"))
         assertFalse(ModelFileCapability.readsFiles("custom/ollama/llama3"))
+        assertFalse(ModelFileCapability.extractsDocsLocally("custom/openai/gpt-4o"))
         assertFalse(ModelFileCapability.readsFiles(""))
+    }
+}
+
+class LocalLlmPromptingAttachmentHistoryTest {
+    @Test fun `historyWithInjectedDocs folds markdown and strips upload URIs`() {
+        val attachments = listOf(
+            MessageAttachment(
+                uri = "content://doc",
+                mimeType = "application/pdf",
+                name = "notes.pdf",
+                extractedText = "Quarterly revenue rose.",
+            ),
+        )
+        val history = listOf(
+            ChatMessage(
+                id = "u1",
+                chatId = "c1",
+                role = "user",
+                content = "Summarize this",
+                createdAt = 1L,
+                attachmentsJson = ToolEventJson.attachmentsToJson(attachments),
+            ),
+        )
+
+        val prepared = LocalLlmPrompting.historyWithInjectedDocs(history).single()
+
+        assertTrue(prepared.content.contains("Quarterly revenue rose."))
+        assertTrue(prepared.content.contains("notes.pdf"))
+        assertTrue(prepared.localAttachmentUri == null)
+        assertTrue(prepared.attachmentsJson == null)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates EchoFlow's out-of-the-box chat models from a single built-in **Gemini 2.0 Flash** entry to two OpenRouter defaults:

| Display name | OpenRouter ID | Role |
|---|---|---|
| **GPT 5.6 Luna** | `openai/gpt-5.6-luna` | Primary default on fresh installs |
| **(Free) Echo Lumen** in picker / **Echo Lumen** in composer | `openrouter/free` | Free-model router, branded as a first-party Echo model |

Echo Lumen shows `(Free)` only inside the model picker rows; the composer pill keeps the plain **Echo Lumen** label after selection.

### Echo Lumen file handling (CodeRabbit fix)

`openrouter/free` does not support Tier-3 provider file uploads. Echo Lumen now follows the same **Tier-1 anydoc** path as local models and projects:

- Supported document types only (PDF/Word/Excel/PowerPoint/ODF/RTF/EPUB/CSV/text) — **no images**
- Files are parsed on-device via anydoc before send
- Extracted Markdown is injected into the OpenRouter prompt instead of uploading raw attachments
- Other cloud models keep the existing provider upload behavior

### Settings directory fix (CodeRabbit fix)

Built-in shipped models are tracked separately from removable custom models in the OpenRouter directory, so Luna/Lumen show as added but cannot be "removed" into a dead-end state.

## Upgrade safety

A one-time seed (`DefaultChatModelsSeed`) runs before `SettingsRepository` loads:

- **New installs** — Luna is selected by default; Luna and Echo Lumen appear in the picker and Settings → Models.
- **Existing users with chat history but no saved `selected_model`** — stay on legacy Gemini 2.0 Flash.
- **Existing users with any other saved selection** — selection is untouched; Luna and Echo Lumen are added when missing.
- **Existing users still on Gemini** — Gemini is added to `custom_models` so it remains in the picker.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.echoflow.data.extract.ModelFileCapabilityTest" --tests "com.echoflow.data.DefaultChatModelsTest" --tests "com.echoflow.data.DefaultChatModelsSeedTest"` — passed

## Notes

This touches the chat model picker and attachment UI. Emulator screenshots should be captured on an arm64 device/emulator before marking ready for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a71a74c-44e5-49d3-a102-0e252b5f6a24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a71a74c-44e5-49d3-a102-0e252b5f6a24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multiple built-in chat models to the model picker.
  - Added clearer model names and a free-model label where applicable.
  - Built-in models now appear consistently across chat and cloud model settings.
  - Added improved support for local document extraction and attachment handling.

- **Bug Fixes**
  - Existing model selections and chat history are preserved when upgrading.
  - Legacy default model choices continue to display correctly.
  - Default models are available automatically for new installations.
  - Document content is handled correctly when sending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->