### PR TITLE
Migrate direct OpenAI to the v1 Responses API

### DIFF
--- a/app/src/main/java/com/echoflow/data/CustomProviderService.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderService.kt
@@ -131,6 +131,7 @@ class CustomProviderService(private val context: Context? = null) {
             client = client,
             dynamicAdapter = dynamicAdapter,
             openAiMessages = ::buildOpenAiMessages,
+            openAiResponsesInput = { history, _ -> OpenAiResponses.inputItems(history, ::getBase64FromUri) },
             simpleMessages = ::buildSimpleMessages,
             urlJoiner = ::joinUrl,
             baseUrlValidator = ::validateBaseUrl,
@@ -183,8 +184,35 @@ class CustomProviderService(private val context: Context? = null) {
         history: List<ChatMessage>,
         systemPrompt: String,
         params: InferenceParams,
-    ): Flow<StreamChunk> =
-        streamOpenAiCompatible("https://api.openai.com/v1", apiKey, model, history, systemPrompt, params)
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("OpenAI API key is missing.")
+        if (model.isBlank()) throw Exception("Enter an OpenAI model name.")
+        val payload = OpenAiResponses.request(
+            model = model,
+            input = OpenAiResponses.inputItems(history, ::getBase64FromUri),
+            instructions = systemPrompt,
+            params = params,
+        )
+        val request = Request.Builder()
+            .url(joinUrl(OpenAiResponses.DEFAULT_BASE_URL, OpenAiResponses.PATH))
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", "Bearer ${apiKey.trim()}")
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception(customError("OpenAI", response.code, response.body?.string().orEmpty()))
+            val body = response.body ?: throw Exception("Empty stream body received.")
+            body.source().use { source ->
+                OpenAiResponses.consumeStream(source) { event ->
+                    when (event) {
+                        is OpenAiResponses.Event.Content -> emit(StreamChunk.Content(event.text))
+                        is OpenAiResponses.Event.Reasoning -> emit(StreamChunk.Reasoning(event.text))
+                        else -> Unit
+                    }
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
 
     fun streamClaude(
         apiKey: String,
@@ -389,6 +417,9 @@ class CustomProviderService(private val context: Context? = null) {
 
     fun streamOpenAiTools(baseUrl: String, apiKey: String, model: String, history: List<ChatMessage>, systemPrompt: String, params: InferenceParams, search: suspend (String) -> List<SearchSource>): Flow<StreamChunk> =
         toolStreamer.streamOpenAiTools(baseUrl, apiKey, model, history, systemPrompt, params, search)
+
+    fun streamOpenAiResponsesTools(apiKey: String, model: String, history: List<ChatMessage>, systemPrompt: String, params: InferenceParams, search: suspend (String) -> List<SearchSource>): Flow<StreamChunk> =
+        toolStreamer.streamOpenAiResponsesTools(apiKey, model, history, systemPrompt, params, search)
 
     fun streamOllamaTools(baseUrl: String, model: String, history: List<ChatMessage>, systemPrompt: String, params: InferenceParams, search: suspend (String) -> List<SearchSource>): Flow<StreamChunk> =
         toolStreamer.streamOllamaTools(baseUrl, model, history, systemPrompt, params, search)

--- a/app/src/main/java/com/echoflow/data/CustomProviderToolStreamer.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderToolStreamer.kt
@@ -15,12 +15,14 @@ internal class CustomProviderToolStreamer(
     private val client: OkHttpClient,
     private val dynamicAdapter: JsonAdapter<Any>,
     private val openAiMessages: (List<ChatMessage>, String) -> List<Map<String, Any>>,
+    private val openAiResponsesInput: (List<ChatMessage>, String) -> List<Map<String, Any>>,
     private val simpleMessages: (List<ChatMessage>, String) -> List<Map<String, String>>,
     private val urlJoiner: (String, String) -> String,
     private val baseUrlValidator: (String) -> ProviderValidationResult,
     private val errorDecoder: (String, Int, String) -> String,
 ) {
     private fun buildOpenAiMessages(history: List<ChatMessage>, prompt: String) = openAiMessages(history, prompt)
+    private fun buildOpenAiResponsesInput(history: List<ChatMessage>, prompt: String) = openAiResponsesInput(history, prompt)
     private fun buildSimpleMessages(history: List<ChatMessage>, prompt: String) = simpleMessages(history, prompt)
     private fun joinUrl(base: String, path: String) = urlJoiner(base, path)
     private fun validateBaseUrl(base: String) = baseUrlValidator(base)
@@ -192,6 +194,108 @@ internal class CustomProviderToolStreamer(
                 )
                 messages.add(mapOf("role" to "tool", "tool_call_id" to callId, "content" to toolContent))
             }
+            round++
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /** Official OpenAI `/v1/responses` tool loop — flat function tools + `function_call_output`. */
+    fun streamOpenAiResponsesTools(
+        apiKey: String,
+        model: String,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        params: InferenceParams,
+        search: suspend (String) -> List<SearchSource>,
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) throw Exception("OpenAI API key is missing.")
+        if (model.isBlank()) throw Exception("Enter a model name.")
+        var previousResponseId: String? = null
+        var pendingOutputs: List<Map<String, Any>> = buildOpenAiResponsesInput(history, systemPrompt)
+        var searchCount = 0
+        var round = 0
+        while (true) {
+            val payload = OpenAiResponses.request(
+                model = model,
+                input = pendingOutputs,
+                instructions = systemPrompt,
+                params = params,
+                tools = if (searchCount < maxToolSearches) listOf(OpenAiResponses.webSearchTool) else null,
+                previousResponseId = previousResponseId,
+            )
+            val request = Request.Builder()
+                .url(joinUrl(OpenAiResponses.DEFAULT_BASE_URL, OpenAiResponses.PATH))
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer ${apiKey.trim()}")
+                .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val pending = linkedMapOf<String, OpenAiPendingCall>()
+            fun slot(itemId: String): OpenAiPendingCall {
+                val key = itemId.ifBlank { "call_$round" }
+                return pending.getOrPut(key) { OpenAiPendingCall() }
+            }
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception(customError("OpenAI", response.code, response.body?.string().orEmpty()))
+                val body = response.body ?: throw Exception("Empty stream body received.")
+                body.source().use { source ->
+                    OpenAiResponses.consumeStream(source) { event ->
+                        when (event) {
+                            is OpenAiResponses.Event.Content -> emit(StreamChunk.Content(event.text))
+                            is OpenAiResponses.Event.Reasoning -> emit(StreamChunk.Reasoning(event.text))
+                            is OpenAiResponses.Event.ResponseId -> previousResponseId = event.id
+                            is OpenAiResponses.Event.FunctionCallMeta -> {
+                                val call = slot(event.itemId)
+                                if (event.callId.isNotEmpty()) call.id = event.callId
+                                if (event.name.isNotEmpty()) call.name = event.name
+                            }
+                            is OpenAiResponses.Event.FunctionCallArgsDelta -> slot(event.itemId).args.append(event.delta)
+                            is OpenAiResponses.Event.FunctionCallArgsDone -> {
+                                val call = slot(event.itemId)
+                                if (event.callId.isNotEmpty()) call.id = event.callId
+                                if (event.name.isNotEmpty()) call.name = event.name
+                                if (event.arguments.isNotEmpty()) {
+                                    call.args.clear()
+                                    call.args.append(event.arguments)
+                                }
+                            }
+                            is OpenAiResponses.Event.Failed -> throw Exception(event.message)
+                        }
+                    }
+                }
+            }
+
+            if (pending.values.none { it.name == "web_search" }) break
+
+            val outputs = mutableListOf<Map<String, Any>>()
+            for (call in pending.values) {
+                val callId = call.id.ifBlank { "call_${call.name}" }
+                if (call.name != "web_search") {
+                    outputs.add(OpenAiResponses.functionCallOutput(callId, "Unknown tool."))
+                    continue
+                }
+                val query = extractQuery(call.args.toString())
+                if (searchCount >= maxToolSearches) {
+                    emit(StreamChunk.StatusNote("Search limit reached ($maxToolSearches per answer)"))
+                    outputs.add(OpenAiResponses.functionCallOutput(callId, "Search limit reached. Answer now using the results already available."))
+                    continue
+                }
+                searchCount++
+                emit(StreamChunk.SearchStarted(query))
+                val searchResult = runCatching { search(query) }
+                val toolContent = searchResult.fold(
+                    onSuccess = { sources ->
+                        emit(StreamChunk.SearchSources(query, sources))
+                        formatSearchResultsForModel(sources)
+                    },
+                    onFailure = {
+                        emit(StreamChunk.SearchSources(query, emptyList()))
+                        emit(StreamChunk.StatusNote("Search failed: ${it.message}"))
+                        "Search failed: ${it.message ?: "Unknown error"}"
+                    },
+                )
+                outputs.add(OpenAiResponses.functionCallOutput(callId, toolContent))
+            }
+            pendingOutputs = outputs
             round++
         }
     }.flowOn(Dispatchers.IO)

--- a/app/src/main/java/com/echoflow/data/OpenAiResponses.kt
+++ b/app/src/main/java/com/echoflow/data/OpenAiResponses.kt
@@ -1,0 +1,190 @@
+package com.echoflow.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okio.BufferedSource
+
+/**
+ * Direct OpenAI [POST /v1/responses] payload + SSE helpers.
+ *
+ * Official OpenAI chat has moved off Chat Completions for newer models; OpenAI-compatible
+ * hosts (Cerebras, xAI, local servers) stay on `/v1/chat/completions`.
+ */
+internal object OpenAiResponses {
+    const val DEFAULT_BASE_URL = "https://api.openai.com/v1"
+    const val PATH = "responses"
+
+    private val json = Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(Any::class.java)
+
+    val webSearchTool: Map<String, Any> = mapOf(
+        "type" to "function",
+        "name" to "web_search",
+        "description" to "Search the web for current, recent, niche, or factual information. Returns a numbered list of results.",
+        "parameters" to mapOf(
+            "type" to "object",
+            "properties" to mapOf(
+                "query" to mapOf("type" to "string", "description" to "A focused, self-contained search query."),
+            ),
+            "required" to listOf("query"),
+        ),
+    )
+
+    fun request(
+        model: String,
+        input: List<Any>,
+        instructions: String,
+        params: InferenceParams,
+        tools: List<Map<String, Any>>? = null,
+        previousResponseId: String? = null,
+    ): MutableMap<String, Any> {
+        val payload = mutableMapOf<String, Any>(
+            "model" to model.trim(),
+            "input" to input,
+            "stream" to true,
+        )
+        if (instructions.isNotBlank()) payload["instructions"] = instructions
+        payload["temperature"] = params.temperature
+        payload["top_p"] = params.topP
+        if (params.maxTokens > 0) payload["max_output_tokens"] = params.maxTokens
+        if (!tools.isNullOrEmpty()) payload["tools"] = tools
+        previousResponseId?.trim()?.takeIf { it.isNotEmpty() }?.let { payload["previous_response_id"] = it }
+        return payload
+    }
+
+    fun inputItems(history: List<ChatMessage>, encode: (String?) -> String?): List<Map<String, Any>> {
+        return history.map { msg ->
+            val extraImages = if (msg.role == "user") {
+                msg.extraAttachments.mapNotNull { extra ->
+                    if (extra.mimeType.equals("application/pdf", ignoreCase = true)) return@mapNotNull null
+                    val encoded = encode(extra.uri) ?: return@mapNotNull null
+                    inputImage("data:${extra.mimeType};base64,$encoded")
+                }
+            } else {
+                emptyList()
+            }
+            val primaryImage = if (msg.role == "user" && !msg.localAttachmentMimeType.equals("application/pdf", ignoreCase = true)) {
+                encode(msg.localAttachmentUri)?.let { bytes ->
+                    val mime = msg.localAttachmentMimeType ?: "image/jpeg"
+                    inputImage("data:$mime;base64,$bytes")
+                }
+            } else {
+                null
+            }
+            val parts = buildList {
+                add(mapOf("type" to "input_text", "text" to msg.content))
+                if (primaryImage != null) add(primaryImage)
+                addAll(extraImages)
+            }
+            if (parts.size == 1 && extraImages.isEmpty() && primaryImage == null) {
+                mapOf("role" to msg.role, "content" to msg.content)
+            } else {
+                mapOf("role" to msg.role, "content" to parts)
+            }
+        }
+    }
+
+    fun functionCallOutput(callId: String, output: String): Map<String, Any> = mapOf(
+        "type" to "function_call_output",
+        "call_id" to callId,
+        "output" to output,
+    )
+
+    sealed class Event {
+        data class Content(val text: String) : Event()
+        data class Reasoning(val text: String) : Event()
+        data class ResponseId(val id: String) : Event()
+        data class FunctionCallMeta(val itemId: String, val callId: String, val name: String) : Event()
+        data class FunctionCallArgsDelta(val itemId: String, val delta: String) : Event()
+        data class FunctionCallArgsDone(val itemId: String, val callId: String, val name: String, val arguments: String) : Event()
+        data class Failed(val message: String) : Event()
+    }
+
+    fun parseData(data: String): Event? {
+        if (data.isBlank() || data == "[DONE]") return null
+        val map = runCatching { json.fromJson(data) as? Map<*, *> }.getOrNull() ?: return null
+        val type = map["type"] as? String ?: return null
+        return when (type) {
+            "response.output_text.delta" -> deltaText(map)?.let { Event.Content(it) }
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+            -> deltaText(map)?.let { Event.Reasoning(it) }
+            "response.created",
+            "response.in_progress",
+            "response.completed",
+            -> responseId(map)?.let { Event.ResponseId(it) }
+            "response.output_item.added",
+            "response.output_item.done",
+            -> functionCallMeta(map)
+            "response.function_call_arguments.delta" -> {
+                val delta = deltaText(map) ?: return null
+                Event.FunctionCallArgsDelta(itemId = stringField(map, "item_id"), delta = delta)
+            }
+            "response.function_call_arguments.done" -> Event.FunctionCallArgsDone(
+                itemId = stringField(map, "item_id"),
+                callId = stringField(map, "call_id"),
+                name = stringField(map, "name"),
+                arguments = (map["arguments"] as? String).orEmpty(),
+            )
+            "error", "response.failed" -> Event.Failed(errorMessage(map))
+            else -> null
+        }
+    }
+
+    suspend fun consumeStream(source: BufferedSource, onEvent: suspend (Event) -> Unit) {
+        val decoder = SseDecoder()
+        fun dispatch(frame: SseEvent) {
+            when (val event = parseData(frame.data)) {
+                null -> Unit
+                is Event.Failed -> throw Exception(event.message)
+                else -> onEvent(event)
+            }
+        }
+        while (!source.exhausted()) {
+            val line = source.readUtf8Line() ?: break
+            decoder.accept(line)?.let(::dispatch)
+        }
+        decoder.flush()?.let(::dispatch)
+    }
+
+    private fun inputImage(dataUrl: String): Map<String, Any> = mapOf(
+        "type" to "input_image",
+        "image_url" to dataUrl,
+    )
+
+    private fun deltaText(map: Map<*, *>): String? {
+        val raw = map["delta"] ?: map["text"]
+        val text = when (raw) {
+            is String -> raw
+            is Map<*, *> -> (raw["text"] as? String) ?: (raw["delta"] as? String)
+            else -> null
+        }
+        return text?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun responseId(map: Map<*, *>): String? {
+        val response = map["response"] as? Map<*, *>
+        return (response?.get("id") as? String)?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun functionCallMeta(map: Map<*, *>): Event.FunctionCallMeta? {
+        val item = map["item"] as? Map<*, *> ?: return null
+        if (item["type"] as? String != "function_call") return null
+        return Event.FunctionCallMeta(
+            itemId = (item["id"] as? String).orEmpty(),
+            callId = (item["call_id"] as? String).orEmpty(),
+            name = (item["name"] as? String).orEmpty(),
+        )
+    }
+
+    private fun stringField(map: Map<*, *>, key: String): String = (map[key] as? String).orEmpty()
+
+    private fun errorMessage(map: Map<*, *>): String {
+        val nested = when (val error = map["error"]) {
+            is String -> error
+            is Map<*, *> -> error["message"] as? String
+            else -> null
+        }
+        val fromResponse = ((map["response"] as? Map<*, *>)?.get("error") as? Map<*, *>)?.get("message") as? String
+        return nested ?: fromResponse ?: map["message"] as? String ?: "OpenAI request failed."
+    }
+}

--- a/app/src/main/java/com/echoflow/ui/CustomProviderFlowRouter.kt
+++ b/app/src/main/java/com/echoflow/ui/CustomProviderFlowRouter.kt
@@ -17,7 +17,7 @@ internal class CustomProviderFlowRouter(private val service: CustomProviderServi
     }
 
     fun streamWithTools(provider: String?, config: CustomProviderConfig, model: String, history: List<ChatMessage>, prompt: String, params: InferenceParams, search: suspend (String) -> List<SearchSource>): Flow<StreamChunk> = when (provider) {
-        "openai" -> service.streamOpenAiTools("https://api.openai.com/v1", config.openAiApiKey, model, history, prompt, params, search)
+        "openai" -> service.streamOpenAiResponsesTools(config.openAiApiKey, model, history, prompt, params, search)
         "cerebras" -> service.streamOpenAiTools("https://api.cerebras.ai/v1", config.cerebrasApiKey, model, history, prompt, params, search)
         "xai" -> service.streamOpenAiTools("https://api.x.ai/v1", config.xAiApiKey, model, history, prompt, params, search)
         "openai-compatible" -> service.streamOpenAiTools(config.openAiBaseUrl, config.openAiCompatibleApiKey, model, history, prompt, params, search)

--- a/app/src/test/java/com/echoflow/data/OpenAiResponsesTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenAiResponsesTest.kt
@@ -1,0 +1,184 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.runBlocking
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OpenAiResponsesTest {
+    private val params = InferenceParams(temperature = 0.4f, topK = 0, topP = 0.9f, maxTokens = 512)
+
+    @Test fun `request uses responses fields not chat completions`() {
+        val payload = OpenAiResponses.request(
+            model = "gpt-5.4",
+            input = listOf(mapOf("role" to "user", "content" to "hi")),
+            instructions = "be brief",
+            params = params,
+            tools = listOf(OpenAiResponses.webSearchTool),
+        )
+        assertEquals("gpt-5.4", payload["model"])
+        assertEquals(true, payload["stream"])
+        assertEquals("be brief", payload["instructions"])
+        assertEquals(512, payload["max_output_tokens"])
+        assertFalse(payload.containsKey("messages"))
+        assertFalse(payload.containsKey("max_tokens"))
+        val tool = (payload["tools"] as List<*>).single() as Map<*, *>
+        assertEquals("function", tool["type"])
+        assertEquals("web_search", tool["name"])
+        assertFalse(tool.containsKey("function"))
+    }
+
+    @Test fun `omits optional fields when unset`() {
+        val payload = OpenAiResponses.request(
+            model = "gpt-4.1-mini",
+            input = emptyList(),
+            instructions = "  ",
+            params = InferenceParams(temperature = 0.7f, topK = 0, topP = 1f, maxTokens = 0),
+        )
+        assertFalse(payload.containsKey("instructions"))
+        assertFalse(payload.containsKey("max_output_tokens"))
+        assertFalse(payload.containsKey("tools"))
+        assertFalse(payload.containsKey("previous_response_id"))
+    }
+
+    @Test fun `carries previous_response_id for the tool follow-up turn`() {
+        val payload = OpenAiResponses.request(
+            model = "gpt-5.4",
+            input = listOf(OpenAiResponses.functionCallOutput("call_1", "results")),
+            instructions = "stay on topic",
+            params = params,
+            previousResponseId = "resp_abc",
+        )
+        assertEquals("resp_abc", payload["previous_response_id"])
+        assertEquals("function_call_output", (payload["input"] as List<*>).let { (it.single() as Map<*, *>)["type"] })
+    }
+
+    @Test fun `builds scalar text input and image parts`() {
+        val history = listOf(
+            message(role = "user", content = "hello"),
+            message(role = "assistant", content = "hi"),
+            message(role = "user", content = "what is this", uri = "content://photo", mime = "image/png"),
+        )
+        val items = OpenAiResponses.inputItems(history) { if (it == null) null else "cGhvdG8=" }
+        assertEquals("hello", items[0]["content"])
+        assertEquals("hi", items[1]["content"])
+        val parts = items[2]["content"] as List<*>
+        assertEquals("input_text", (parts[0] as Map<*, *>)["type"])
+        assertEquals("input_image", (parts[1] as Map<*, *>)["type"])
+        assertEquals("data:image/png;base64,cGhvdG8=", (parts[1] as Map<*, *>)["image_url"])
+    }
+
+    @Test fun `skips PDFs and attaches extra images`() {
+        val history = listOf(message(role = "user", content = "use these"))
+        history.single().extraAttachments = listOf(
+            LocalFileAttachment("file:///tmp/scan.pdf", "application/pdf", "scan.pdf"),
+            LocalFileAttachment("file:///tmp/photo.png", "image/png", "photo.png"),
+        )
+        val items = OpenAiResponses.inputItems(history) { uri ->
+            when {
+                uri == null -> null
+                uri.endsWith(".pdf") -> "cGRm"
+                else -> "cG5n"
+            }
+        }
+        val parts = items.single()["content"] as List<*>
+        assertEquals(2, parts.size)
+        assertEquals("input_image", (parts[1] as Map<*, *>)["type"])
+        assertEquals("data:image/png;base64,cG5n", (parts[1] as Map<*, *>)["image_url"])
+    }
+
+    @Test fun `parses output text and reasoning deltas`() {
+        assertEquals(
+            OpenAiResponses.Event.Content("Hello"),
+            OpenAiResponses.parseData("""{"type":"response.output_text.delta","delta":"Hello"}"""),
+        )
+        assertEquals(
+            OpenAiResponses.Event.Reasoning("think"),
+            OpenAiResponses.parseData("""{"type":"response.reasoning_summary_text.delta","delta":"think"}"""),
+        )
+        assertNull(OpenAiResponses.parseData("[DONE]"))
+        assertNull(OpenAiResponses.parseData("""{"type":"response.output_text.done"}"""))
+    }
+
+    @Test fun `parses function-call stream events and failures`() {
+        val added = OpenAiResponses.parseData(
+            """{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_9","name":"web_search"}}""",
+        )
+        assertEquals(OpenAiResponses.Event.FunctionCallMeta("fc_1", "call_9", "web_search"), added)
+
+        val delta = OpenAiResponses.parseData(
+            """{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"q"}""",
+        )
+        assertEquals(OpenAiResponses.Event.FunctionCallArgsDelta("fc_1", "{\"q"), delta)
+
+        val done = OpenAiResponses.parseData(
+            """{"type":"response.function_call_arguments.done","item_id":"fc_1","call_id":"call_9","name":"web_search","arguments":"{\"query\":\"news\"}"}""",
+        )
+        assertEquals(
+            OpenAiResponses.Event.FunctionCallArgsDone("fc_1", "call_9", "web_search", """{"query":"news"}"""),
+            done,
+        )
+
+        val failed = OpenAiResponses.parseData(
+            """{"type":"response.failed","response":{"error":{"message":"model_not_found"}}}""",
+        )
+        assertEquals(OpenAiResponses.Event.Failed("model_not_found"), failed)
+    }
+
+    @Test fun `consumes a named SSE transcript into content`() {
+        val wire = """
+            event: response.created
+            data: {"type":"response.created","response":{"id":"resp_1"}}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","delta":"Hi"}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","delta":" there"}
+
+            event: response.completed
+            data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+        """.trimIndent()
+        val source = Buffer().writeUtf8(wire)
+        val chunks = mutableListOf<String>()
+        var responseId: String? = null
+        runBlocking {
+            OpenAiResponses.consumeStream(source) { event ->
+                when (event) {
+                    is OpenAiResponses.Event.Content -> chunks.add(event.text)
+                    is OpenAiResponses.Event.ResponseId -> responseId = event.id
+                    else -> Unit
+                }
+            }
+        }
+        assertEquals(listOf("Hi", " there"), chunks)
+        assertEquals("resp_1", responseId)
+    }
+
+    @Test fun `joinApiUrl points official OpenAI at v1 responses`() {
+        assertEquals(
+            "https://api.openai.com/v1/responses",
+            ProviderHttpSupport.joinApiUrl(OpenAiResponses.DEFAULT_BASE_URL, OpenAiResponses.PATH),
+        )
+    }
+
+    private fun message(
+        role: String,
+        content: String,
+        uri: String? = null,
+        mime: String? = null,
+    ) = ChatMessage(
+        id = "message-$role-$content",
+        chatId = "chat",
+        role = role,
+        content = content,
+        createdAt = 1L,
+        localAttachmentUri = uri,
+        localAttachmentMimeType = mime,
+        localAttachmentName = mime,
+    )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Direct OpenAI chat was still calling `/v1/chat/completions`, which newer models no longer support.

This switches the official OpenAI provider (plain stream and web-search tool loop) to `POST /v1/responses`:

- Request body uses `input` + `instructions` + `max_output_tokens` instead of `messages` / `max_tokens`.
- Streaming parses Responses SSE (`response.output_text.delta`, reasoning deltas, function-call events).
- Tool follow-ups send `function_call_output` items with `previous_response_id`.
- Function tools use the flat Responses schema (`type`/`name`/`parameters`), not the Chat Completions nested `function` object.

Cerebras, xAI, and OpenAI-compatible endpoints stay on `/v1/chat/completions`.

No UI change. Cloud VMs cannot run the arm64 OpenAI path on an emulator; verification is `OpenAiResponsesTest` (9 tests, all passing).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce6fa267-40d2-4da6-9ea3-f2660d6aa27a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce6fa267-40d2-4da6-9ea3-f2660d6aa27a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAI’s Responses API for streaming conversations.
  - Improved handling of streamed text and reasoning content.
  - Added support for image attachments in Responses-based requests.
  - Enabled web search and tool calling during OpenAI Responses conversations.
  - Added support for continuing multi-step tool interactions.

- **Bug Fixes**
  - Improved validation and error reporting for missing API keys, models, and failed requests.
  - Enhanced handling of streamed response events and function-call results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->