### PR TITLE
Fix OpenAI Responses stream compile under coroutines

### DIFF
--- a/app/src/main/java/com/echoflow/data/OpenAiResponses.kt
+++ b/app/src/main/java/com/echoflow/data/OpenAiResponses.kt
@@ -132,7 +132,7 @@ internal object OpenAiResponses {
 
     suspend fun consumeStream(source: BufferedSource, onEvent: suspend (Event) -> Unit) {
         val decoder = SseDecoder()
-        fun dispatch(frame: SseEvent) {
+        suspend fun dispatch(frame: SseEvent) {
             when (val event = parseData(frame.data)) {
                 null -> Unit
                 is Event.Failed -> throw Exception(event.message)
@@ -141,9 +141,9 @@ internal object OpenAiResponses {
         }
         while (!source.exhausted()) {
             val line = source.readUtf8Line() ?: break
-            decoder.accept(line)?.let(::dispatch)
+            decoder.accept(line)?.let { dispatch(it) }
         }
-        decoder.flush()?.let(::dispatch)
+        decoder.flush()?.let { dispatch(it) }
     }
 
     private fun inputImage(dataUrl: String): Map<String, Any> = mapOf(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #143. The merged Responses client called a suspend `onEvent` from a non-suspend local `dispatch`, so `:app:compileDebugKotlin` failed with “Suspension functions can only be called within coroutine body.”

This makes `dispatch` a suspend function so streaming can `emit` from the Responses SSE loop.

Verified with `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.OpenAiResponsesTest` — 9 tests, 0 failures.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce6fa267-40d2-4da6-9ea3-f2660d6aa27a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce6fa267-40d2-4da6-9ea3-f2660d6aa27a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

