### PR TITLE
Omit deprecated temperature on Claude 4.7+ custom API

### DIFF
--- a/app/src/main/java/com/echoflow/data/CustomProviderService.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderService.kt
@@ -104,6 +104,41 @@ object CustomProviderCapabilities {
     }
 
     fun xAiSupportsPdfs(model: String): Boolean = false
+
+    /**
+     * Anthropic rejects `temperature` / `top_p` / `top_k` on Claude Opus 4.7 and later
+     * (including Sonnet 5, Fable 5, Mythos). Sending them returns HTTP 400:
+     * "temperature is deprecated for this model." Older Claude 4.6 / 4.5 / 3.x IDs
+     * still accept temperature, so keep sending it there.
+     */
+    fun claudeSupportsSamplingParams(model: String): Boolean {
+        val id = model.trim().lowercase().substringAfterLast('/')
+        if (id.contains("mythos") || id.contains("glasswing")) return false
+        val version = claudeModelVersion(id) ?: return true
+        return version < ClaudeVersion(4, 7)
+    }
+
+    fun putClaudeSampling(payload: MutableMap<String, Any?>, model: String, params: InferenceParams) {
+        if (claudeSupportsSamplingParams(model)) {
+            payload["temperature"] = params.temperature
+        }
+    }
+
+    private data class ClaudeVersion(val major: Int, val minor: Int) : Comparable<ClaudeVersion> {
+        override fun compareTo(other: ClaudeVersion) = compareValuesBy(this, other, { it.major }, { it.minor })
+    }
+
+    // claude-sonnet-4-6, claude-opus-4.8, claude-sonnet-5, claude-3-7-sonnet-20250219
+    private val CLAUDE_VERSION = Regex(
+        """claude-(?:opus-|sonnet-|haiku-|fable-|mythos-)?(\d+)(?:[.\-](\d+))?""",
+    )
+
+    private fun claudeModelVersion(id: String): ClaudeVersion? {
+        val match = CLAUDE_VERSION.find(id) ?: return null
+        val major = match.groupValues[1].toIntOrNull() ?: return null
+        val minor = match.groupValues[2].toIntOrNull() ?: 0
+        return ClaudeVersion(major, minor)
+    }
 }
 
 data class ProviderValidationResult(
@@ -226,13 +261,13 @@ class CustomProviderService(private val context: Context? = null) {
         val messages = history.filter { it.role != "system" }.map {
             mapOf("role" to if (it.role == "assistant") "assistant" else "user", "content" to it.content)
         }
-        val payload = mutableMapOf<String, Any>(
+        val payload = mutableMapOf<String, Any?>(
             "model" to model.trim(),
             "messages" to messages,
             "stream" to true,
             "max_tokens" to params.maxTokens.coerceAtLeast(256),
-            "temperature" to params.temperature,
         )
+        CustomProviderCapabilities.putClaudeSampling(payload, model, params)
         if (systemPrompt.isNotBlank()) payload["system"] = systemPrompt
         val request = Request.Builder()
             .url("https://api.anthropic.com/v1/messages")

--- a/app/src/main/java/com/echoflow/data/CustomProviderToolStreamer.kt
+++ b/app/src/main/java/com/echoflow/data/CustomProviderToolStreamer.kt
@@ -432,8 +432,8 @@ internal class CustomProviderToolStreamer(
                 "messages" to messages,
                 "stream" to true,
                 "max_tokens" to params.maxTokens.coerceAtLeast(1024),
-                "temperature" to params.temperature,
             )
+            CustomProviderCapabilities.putClaudeSampling(payload, model, params)
             if (searchCount < maxToolSearches) payload["tools"] = listOf(webSearchToolClaude)
             if (systemPrompt.isNotBlank()) payload["system"] = systemPrompt
             val request = Request.Builder()

--- a/app/src/test/java/com/echoflow/data/CustomProviderCapabilitiesTest.kt
+++ b/app/src/test/java/com/echoflow/data/CustomProviderCapabilitiesTest.kt
@@ -20,4 +20,38 @@ class CustomProviderCapabilitiesTest {
         assertFalse(CustomProviderCapabilities.xAiSupportsImages("future-model"))
         assertFalse(CustomProviderCapabilities.xAiSupportsImages(""))
     }
+
+    @Test
+    fun `Claude sampling stays on models that still accept temperature`() {
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-sonnet-4-6"))
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-sonnet-4-5"))
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-opus-4-6"))
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-haiku-4-5-20251001"))
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-3-7-sonnet-20250219"))
+        assertTrue(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-3-5-sonnet-20241022"))
+    }
+
+    @Test
+    fun `Claude sampling is omitted on 4_7 and later`() {
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-opus-4-7"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-opus-4.8"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-opus-4-8"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-opus-5"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-sonnet-5"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-fable-5"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("claude-mythos-preview"))
+        assertFalse(CustomProviderCapabilities.claudeSupportsSamplingParams("anthropic/claude-opus-4-8"))
+    }
+
+    @Test
+    fun `Claude payload omits temperature only when sampling is unsupported`() {
+        val params = InferenceParams(temperature = 0.7f, topK = 0, topP = 1f, maxTokens = 256)
+        val withTemp = mutableMapOf<String, Any?>()
+        CustomProviderCapabilities.putClaudeSampling(withTemp, "claude-sonnet-4-6", params)
+        assertTrue(withTemp.containsKey("temperature"))
+
+        val withoutTemp = mutableMapOf<String, Any?>()
+        CustomProviderCapabilities.putClaudeSampling(withoutTemp, "claude-opus-4-8", params)
+        assertFalse(withoutTemp.containsKey("temperature"))
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Direct Claude custom API always sent `temperature` from the global cloud sampler. Anthropic now returns HTTP 400 (`temperature is deprecated for this model`) for Claude Opus 4.7 and later (including Sonnet 5, Fable 5, and Mythos), which the app surfaces as “Connection lost”.

This omits `temperature` on those model IDs for both the plain Messages stream and the web-search tool loop, while still sending it on Claude 4.6 / 4.5 / 3.x IDs that accept sampling params.

## Testing
- `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.CustomProviderCapabilitiesTest` — BUILD SUCCESSFUL (5 tests, 0 failures). Cloud VMs cannot run the arm64 emulator, so this is validated with Robolectric/JUnit rather than on-device chat.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d652aee7-e794-4a37-b04e-9a2175de60e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d652aee7-e794-4a37-b04e-9a2175de60e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude model compatibility by applying sampling parameters only where supported.
  * Prevented unsupported `temperature` settings from being sent to newer or unrecognized Claude models.
  * Applied the same behavior consistently during standard responses and tool interactions.

* **Tests**
  * Added coverage for supported Claude model families and conditional sampling-parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->