### PR TITLE
Show Muse and other Image API models in Imagine

### DIFF
--- a/app/src/main/java/com/echoflow/data/ImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/ImageGenerationEngine.kt
@@ -12,6 +12,8 @@ data class ImageGenerationRequest(
     val history: List<ChatMessage> = emptyList(),
     val systemPrompt: String = "",
     val editImageDataUrl: String? = null,
+    val referenceImageDataUrls: List<String> = emptyList(),
+    val aspectRatio: String? = null,
     val params: InferenceParams? = null,
 )
 

--- a/app/src/main/java/com/echoflow/data/Models.kt
+++ b/app/src/main/java/com/echoflow/data/Models.kt
@@ -227,7 +227,8 @@ data class AgentProfile(
 /**
  * A cloud model the user has whitelisted for image generation. Kept separate from
  * [CustomModel] (chat models) because image output only works on the few directory models
- * whose `output_modalities` include "image", so it has its own add-model flow and search.
+ * whose `output_modalities` include "image" (chat-native or dedicated Image API), so it
+ * has its own add-model flow and search against OpenRouter's image listing.
  */
 @Entity(tableName = "image_models")
 data class ImageModel(

--- a/app/src/main/java/com/echoflow/data/OpenRouterImageGenerationEngine.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterImageGenerationEngine.kt
@@ -4,26 +4,37 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /**
- * Cloud image generation, unchanged in behaviour: one streaming chat completion with
- * `modalities: ["image","text"]` through [OpenRouterService.sendImageGeneration]
- * (conversational editing included via [ImageGenerationRequest.editImageDataUrl]). The
- * base64 payload is persisted through [GeneratedImageStore] here so raw multi-MB data
- * URLs never travel further up than this class.
+ * Cloud image generation. Chat-native image models (Gemini Flash Image, GPT-5 Image) still
+ * stream a chat completion with `modalities: ["image","text"]`. Dedicated Image API models
+ * (Muse, Flux, Seedream, gpt-image-*) POST `/api/v1/images` instead — they are not in the
+ * chat catalog and do not speak that protocol.
  */
 class OpenRouterImageGenerationEngine(
     private val service: OpenRouterService,
     private val store: GeneratedImageStore,
+    private val directory: OpenRouterModelDirectory = OpenRouterModelDirectory(),
 ) : ImageGenerationEngine {
 
     override fun generate(request: ImageGenerationRequest): Flow<ImageGenerationEvent> = flow {
-        service.sendImageGeneration(
-            apiKey = request.apiKey,
-            model = request.modelId,
-            history = request.history,
-            systemPrompt = request.systemPrompt,
-            editImageDataUrl = request.editImageDataUrl,
-            params = request.params,
-        ).collect { chunk ->
+        val chunks = if (usesDedicatedImageApi(request.modelId)) {
+            service.sendDedicatedImageGeneration(
+                apiKey = request.apiKey,
+                model = request.modelId,
+                prompt = request.prompt,
+                aspectRatio = request.aspectRatio,
+                referenceImageDataUrls = listOfNotNull(request.editImageDataUrl) + request.referenceImageDataUrls,
+            )
+        } else {
+            service.sendImageGeneration(
+                apiKey = request.apiKey,
+                model = request.modelId,
+                history = request.history,
+                systemPrompt = request.systemPrompt,
+                editImageDataUrl = request.editImageDataUrl,
+                params = request.params,
+            )
+        }
+        chunks.collect { chunk ->
             when (chunk) {
                 is StreamChunk.Content -> emit(ImageGenerationEvent.Text(chunk.text))
                 is StreamChunk.ImageGenerated -> {
@@ -35,9 +46,16 @@ class OpenRouterImageGenerationEngine(
                     )
                     emit(ImageGenerationEvent.ImageFile(saved))
                 }
-                else -> Unit // reasoning/search chunks don't occur on the image path
+                else -> Unit
             }
         }
+    }
+
+    private suspend fun usesDedicatedImageApi(modelId: String): Boolean {
+        val listed = runCatching { directory.imageModels() }.getOrNull()
+            ?.firstOrNull { it.id == modelId }
+        return listed?.usesDedicatedImageApi
+            ?: OpenRouterModelDirectory.fallbackUsesDedicatedImageApi(modelId)
     }
 
     /** The one-shot HTTP call is cancelled by cancelling the collecting coroutine. */

--- a/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterModelDirectory.kt
@@ -17,14 +17,30 @@ data class OpenRouterModelInfo(
     val promptPricePerM: Double?, // USD per 1M prompt tokens
     val completionPricePerM: Double?, // USD per 1M completion tokens
     val outputsImage: Boolean = false, // architecture.output_modalities contains "image"
+    val outputsText: Boolean = true, // architecture.output_modalities contains "text"
+    /** True when OpenRouter bills image output separately from prompt/completion tokens. */
+    val hasImageOutputPrice: Boolean = false,
 ) {
-    val isFree: Boolean get() = (promptPricePerM ?: 0.0) == 0.0 && (completionPricePerM ?: 0.0) == 0.0
+    val isFree: Boolean
+        get() = (promptPricePerM ?: 0.0) == 0.0 &&
+            (completionPricePerM ?: 0.0) == 0.0 &&
+            !hasImageOutputPrice
+
+    /**
+     * Dedicated Image API models (Muse, Flux, Seedream, gpt-image-*) output image only.
+     * Gemini/GPT-5 image models still speak chat completions with `modalities: ["image","text"]`.
+     */
+    val usesDedicatedImageApi: Boolean get() = outputsImage && !outputsText
 }
 
 /**
- * Fetches OpenRouter's public model directory (https://openrouter.ai/api/v1/models — no
- * auth needed) once per process and serves it from memory, so the add-model search can
- * filter the full list instantly as the user types.
+ * Fetches OpenRouter's public model directory once per process and serves it from memory,
+ * so the add-model search can filter the full list instantly as the user types.
+ *
+ * Chat and Imagine use different listings: unfiltered `/api/v1/models` is the chat catalog
+ * and omits dedicated image-only models. Imagine loads
+ * `/api/v1/models?output_modalities=image`, which is where Meta Muse Image and other
+ * Image-API models appear.
  */
 class OpenRouterModelDirectory {
     private val client = OkHttpClient.Builder()
@@ -32,45 +48,92 @@ class OpenRouterModelDirectory {
         .readTimeout(20, TimeUnit.SECONDS)
         .build()
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-
-    private val adapter = moshi.adapter(DirectoryResponse::class.java)
+    @Volatile
+    private var chatCache: List<OpenRouterModelInfo>? = null
 
     @Volatile
-    private var cache: List<OpenRouterModelInfo>? = null
+    private var imageCache: List<OpenRouterModelInfo>? = null
 
-    suspend fun allModels(): List<OpenRouterModelInfo> = withContext(Dispatchers.IO) {
+    suspend fun allModels(): List<OpenRouterModelInfo> = fetchInto(chatCache) { chatCache = it }
+
+    /**
+     * Every model OpenRouter will generate an image with, including dedicated Image API
+     * models that are missing from the chat catalog.
+     */
+    suspend fun imageModels(): List<OpenRouterModelInfo> = fetchInto(
+        imageCache,
+        url = IMAGE_DIRECTORY_URL,
+        keep = { it.outputsImage && !isRouterAuto(it.id) },
+    ) { imageCache = it }
+
+    private suspend fun fetchInto(
+        cache: List<OpenRouterModelInfo>?,
+        url: String = CHAT_DIRECTORY_URL,
+        keep: (OpenRouterModelInfo) -> Boolean = { true },
+        store: (List<OpenRouterModelInfo>) -> Unit,
+    ): List<OpenRouterModelInfo> = withContext(Dispatchers.IO) {
         cache?.let { return@withContext it }
 
-        val request = Request.Builder().url("https://openrouter.ai/api/v1/models").build()
+        val request = Request.Builder().url(url).build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 throw Exception("Could not load the model directory (HTTP ${response.code}).")
             }
             val body = response.body?.string().orEmpty()
-            val parsed = adapter.fromJson(body)?.data.orEmpty()
-            val models = parsed.mapNotNull { raw ->
+            val models = parseDirectory(body).filter(keep)
+            store(models)
+            models
+        }
+    }
+
+    companion object {
+        const val CHAT_DIRECTORY_URL = "https://openrouter.ai/api/v1/models"
+        const val IMAGE_DIRECTORY_URL = "https://openrouter.ai/api/v1/models?output_modalities=image"
+
+        fun parseDirectory(body: String): List<OpenRouterModelInfo> {
+            val parsed = directoryAdapter().fromJson(body)?.data.orEmpty()
+            return parsed.mapNotNull { raw ->
                 val id = raw.id ?: return@mapNotNull null
+                val outputs = raw.architecture?.outputModalities.orEmpty()
                 OpenRouterModelInfo(
                     id = id,
                     name = raw.name ?: id,
                     contextLength = raw.contextLength,
                     promptPricePerM = raw.pricing?.prompt?.toDoubleOrNull()?.times(1_000_000),
                     completionPricePerM = raw.pricing?.completion?.toDoubleOrNull()?.times(1_000_000),
-                    outputsImage = raw.architecture?.outputModalities.orEmpty().any { it.equals("image", ignoreCase = true) },
+                    outputsImage = outputs.any { it.equals("image", ignoreCase = true) },
+                    outputsText = outputs.any { it.equals("text", ignoreCase = true) } || outputs.isEmpty(),
+                    hasImageOutputPrice = raw.pricing?.imageOutput
+                        ?.toDoubleOrNull()
+                        ?.let { it > 0.0 } == true,
                 )
             }.sortedBy { it.name.lowercase() }
-            cache = models
-            models
         }
+
+        fun isRouterAuto(id: String): Boolean = id.startsWith("openrouter/auto")
+
+        /**
+         * When the live directory is unavailable, send Gemini/GPT-5 image models through
+         * chat completions and everything else (Muse, Flux, gpt-image-1) through `/images`.
+         */
+        fun fallbackUsesDedicatedImageApi(modelId: String): Boolean {
+            val id = modelId.lowercase()
+            if (isRouterAuto(id)) return false
+            if (id.contains("gpt-image")) return true
+            if ((id.contains("gemini") || id.contains("gpt-5")) && id.contains("image")) return false
+            return true
+        }
+
+        private fun directoryAdapter() = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+            .adapter(DirectoryResponse::class.java)
     }
 }
 
-private data class DirectoryResponse(val data: List<RawModel>? = null)
+internal data class DirectoryResponse(val data: List<RawModel>? = null)
 
-private data class RawModel(
+internal data class RawModel(
     val id: String? = null,
     val name: String? = null,
     @Json(name = "context_length") val contextLength: Int? = null,
@@ -78,11 +141,12 @@ private data class RawModel(
     val architecture: RawArchitecture? = null,
 )
 
-private data class RawArchitecture(
+internal data class RawArchitecture(
     @Json(name = "output_modalities") val outputModalities: List<String>? = null,
 )
 
-private data class RawPricing(
+internal data class RawPricing(
     val prompt: String? = null,
     val completion: String? = null,
+    @Json(name = "image_output") val imageOutput: String? = null,
 )

--- a/app/src/main/java/com/echoflow/data/OpenRouterService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterService.kt
@@ -458,6 +458,56 @@ class OpenRouterService(private val context: Context) {
         ) { emit(it) }
     }.flowOn(Dispatchers.IO)
 
+    /**
+     * Dedicated Image API (`POST /api/v1/images`). Used for image-only models that are not
+     * chat completions — Meta Muse Image, Flux, Seedream, `gpt-image-*`. Prompt plus optional
+     * reference images; the response is base64, not a token stream.
+     */
+    fun sendDedicatedImageGeneration(
+        apiKey: String,
+        model: String,
+        prompt: String,
+        aspectRatio: String? = null,
+        referenceImageDataUrls: List<String> = emptyList(),
+    ): Flow<StreamChunk> = flow {
+        if (apiKey.isBlank()) {
+            throw Exception("API key is missing! Please configure it in your Settings.")
+        }
+        val payload = buildMap<String, Any> {
+            put("model", model)
+            put("prompt", framedImagePrompt(prompt, aspectRatio))
+            val refs = referenceImageDataUrls.mapNotNull { url ->
+                url.takeIf { it.isNotBlank() }?.let {
+                    mapOf(
+                        "type" to "image_url",
+                        "image_url" to mapOf("url" to it),
+                    )
+                }
+            }
+            if (refs.isNotEmpty()) put("input_references", refs)
+        }
+        val request = Request.Builder()
+            .url("https://openrouter.ai/api/v1/images")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .addHeader("HTTP-Referer", "https://localhost")
+            .addHeader("X-Title", "EchoFlow")
+            .post(dynamicAdapter.toJson(payload).toRequestBody("application/json".toMediaType()))
+            .build()
+        echoClient.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw Exception(
+                    parseErrorMessage(body)
+                        ?: ProviderHttpSupport.errorMessage("OpenRouter", response.code, body)
+                )
+            }
+            val dataUrl = firstImageDataUrl(dynamicAdapter.fromJson(body))
+                ?: throw Exception("OpenRouter did not return an image.")
+            emit(StreamChunk.ImageGenerated(dataUrl))
+        }
+    }.flowOn(Dispatchers.IO)
+
     /** Config for one Echo Agent turn: the worker (subagent) model and its tool-call budget. */
     data class AgentRequest(val workerModel: String, val workerModelName: String, val maxToolCalls: Int)
 
@@ -1088,6 +1138,25 @@ class OpenRouterService(private val context: Context) {
         } catch (e: Exception) {
             // Fallback: derive a title from the user's message (row clips overflow itself).
             fallbackThreadTitle(firstUserMessage).ifBlank { "New Conversation" }
+        }
+    }
+
+    companion object {
+        fun framedImagePrompt(prompt: String, aspectRatio: String?): String {
+            val framing = aspectRatio?.takeIf { it.isNotBlank() }?.let { "Aspect ratio: $it. " }.orEmpty()
+            return framing + prompt
+        }
+
+        fun firstImageDataUrl(parsed: Any?): String? {
+            val root = parsed as? Map<*, *> ?: return null
+            val images = root["data"] as? List<*> ?: return null
+            for (item in images) {
+                val map = item as? Map<*, *> ?: continue
+                val b64 = (map["b64_json"] as? String)?.takeIf { it.isNotBlank() } ?: continue
+                val media = (map["media_type"] as? String)?.takeIf { it.isNotBlank() } ?: "image/png"
+                return "data:$media;base64,$b64"
+            }
+            return null
         }
     }
 }

--- a/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/ChatViewModel.kt
@@ -2009,6 +2009,10 @@ class ChatViewModel(
                                 aspectRatio = settingsRepository.getImageAspectRatioDirect(),
                             ),
                             editImageDataUrl = imageEditUrl,
+                            referenceImageDataUrls = listOfNotNull(
+                                if (attachmentUri != null && !pendingIsPdf) attachmentAsDataUrl(attachmentUri) else null,
+                            ),
+                            aspectRatio = settingsRepository.getImageAspectRatioDirect(),
                             params = inferenceParams,
                         )
                         val relay: suspend (ImageGenerationEvent) -> Unit = { event ->

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -214,13 +214,22 @@ class SettingsViewModel(
             initialValue = emptyList()
         )
 
-    /** Same directory, restricted to models whose output modalities include images. */
+    // Imagine's directory is a different OpenRouter listing (`output_modalities=image`).
+    // Dedicated Image API models such as meta/muse-image are absent from the chat catalog.
+    private val _orImageModels = MutableStateFlow<List<OpenRouterModelInfo>>(emptyList())
+
+    private val _orImageDirectoryLoading = MutableStateFlow(false)
+    val orImageDirectoryLoading: StateFlow<Boolean> = _orImageDirectoryLoading.asStateFlow()
+
+    private val _orImageDirectoryError = MutableStateFlow<String?>(null)
+    val orImageDirectoryError: StateFlow<String?> = _orImageDirectoryError.asStateFlow()
+
+    /** OpenRouter image-output models, including dedicated Image API entries. */
     val orImageModelResults: StateFlow<List<OpenRouterModelInfo>> =
-        combine(_orAllModels, _orModelQuery) { all, query ->
-            val imageCapable = all.filter { it.outputsImage }
+        combine(_orImageModels, _orModelQuery) { all, query ->
             val q = query.trim()
-            if (q.isEmpty()) imageCapable.take(40)
-            else imageCapable.filter { it.id.contains(q, true) || it.name.contains(q, true) }.take(60)
+            if (q.isEmpty()) all.take(40)
+            else all.filter { it.id.contains(q, true) || it.name.contains(q, true) }.take(60)
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
@@ -578,6 +587,22 @@ class SettingsViewModel(
                 _orDirectoryError.value = e.message ?: "Could not load the model directory."
             } finally {
                 _orDirectoryLoading.value = false
+            }
+        }
+    }
+
+    /** Loads OpenRouter's image-output listing (chat catalog + dedicated Image API models). */
+    fun loadOpenRouterImageDirectory() {
+        if (_orImageModels.value.isNotEmpty() || _orImageDirectoryLoading.value) return
+        viewModelScope.launch {
+            _orImageDirectoryLoading.value = true
+            _orImageDirectoryError.value = null
+            try {
+                _orImageModels.value = orDirectory.imageModels()
+            } catch (e: Exception) {
+                _orImageDirectoryError.value = e.message ?: "Could not load the image model directory."
+            } finally {
+                _orImageDirectoryLoading.value = false
             }
         }
     }

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -461,6 +461,12 @@ internal fun formatContext(tokens: Int): String = when {
 
 internal fun formatPricing(info: OpenRouterModelInfo): String {
     if (info.isFree) return "Free"
+    if ((info.promptPricePerM ?: 0.0) == 0.0 &&
+        (info.completionPricePerM ?: 0.0) == 0.0 &&
+        info.hasImageOutputPrice
+    ) {
+        return "Priced per image"
+    }
     fun fmt(v: Double?): String? = v?.let {
         when {
             it >= 10 -> "$%.0f".format(it)

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsImageGen.kt
@@ -53,8 +53,8 @@ internal fun ImageGenSection(viewModel: SettingsViewModel) {
     val selectedId by viewModel.imageGenModelId.collectAsState()
     val orQuery by viewModel.orModelQuery.collectAsState()
     val orImageResults by viewModel.orImageModelResults.collectAsState()
-    val orLoading by viewModel.orDirectoryLoading.collectAsState()
-    val orError by viewModel.orDirectoryError.collectAsState()
+    val orLoading by viewModel.orImageDirectoryLoading.collectAsState()
+    val orError by viewModel.orImageDirectoryError.collectAsState()
 
     var showDirectory by remember { mutableStateOf(false) }
 
@@ -140,7 +140,7 @@ internal fun ImageGenSection(viewModel: SettingsViewModel) {
         Button(
             onClick = {
                 showDirectory = true
-                viewModel.loadOpenRouterDirectory()
+                viewModel.loadOpenRouterImageDirectory()
             },
             shape = CircleShape,
             modifier = Modifier.fillMaxWidth().height(52.dp),
@@ -151,7 +151,7 @@ internal fun ImageGenSection(viewModel: SettingsViewModel) {
         }
         Spacer(Modifier.height(Spacing.s))
         Text(
-            "Only models that can output images appear in this search.",
+            "Live from OpenRouter’s image listing — dedicated generators such as Muse show up here even when they are not in the chat catalog.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -165,7 +165,7 @@ internal fun ImageGenSection(viewModel: SettingsViewModel) {
             error = orError,
             addedIds = imageModels.map { it.id }.toSet() + SettingsRepository.DEFAULT_IMAGE_MODEL_ID,
             onQueryChange = viewModel::updateOrModelQuery,
-            onRetry = viewModel::loadOpenRouterDirectory,
+            onRetry = viewModel::loadOpenRouterImageDirectory,
             onAdd = { info -> viewModel.addImageModel(info.id, info.name.substringAfter(": ")) },
             onRemove = viewModel::deleteImageModel,
             onDismiss = { showDirectory = false },

--- a/app/src/test/java/com/echoflow/data/OpenRouterImageDirectoryTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterImageDirectoryTest.kt
@@ -1,0 +1,85 @@
+package com.echoflow.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OpenRouterImageDirectoryTest {
+
+    @Test
+    fun `unfiltered chat catalog omits dedicated image-only models`() {
+        val models = OpenRouterModelDirectory.parseDirectory(CHAT_CATALOG)
+        assertNull(models.firstOrNull { it.id == "meta/muse-image" })
+        val gemini = models.first { it.id == "google/gemini-2.5-flash-image" }
+        assertTrue(gemini.outputsImage)
+        assertTrue(gemini.outputsText)
+        assertFalse(gemini.usesDedicatedImageApi)
+    }
+
+    @Test
+    fun `image listing includes muse and does not treat it as free`() {
+        val models = OpenRouterModelDirectory.parseDirectory(IMAGE_LISTING)
+            .filter { it.outputsImage && !OpenRouterModelDirectory.isRouterAuto(it.id) }
+        val muse = models.first { it.id == "meta/muse-image" }
+        assertEquals("Meta: Muse Image", muse.name)
+        assertTrue(muse.outputsImage)
+        assertFalse(muse.outputsText)
+        assertTrue(muse.usesDedicatedImageApi)
+        assertTrue(muse.hasImageOutputPrice)
+        assertFalse(muse.isFree)
+        assertNotNull(models.firstOrNull { it.id == "google/gemini-2.5-flash-image" })
+    }
+
+    @Test
+    fun `fallback routing sends muse to the image api and gemini through chat`() {
+        assertTrue(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("meta/muse-image"))
+        assertTrue(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("black-forest-labs/flux.2-pro"))
+        assertTrue(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("openai/gpt-image-1"))
+        assertFalse(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("google/gemini-2.5-flash-image"))
+        assertFalse(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("openai/gpt-5-image"))
+        assertFalse(OpenRouterModelDirectory.fallbackUsesDedicatedImageApi("openrouter/auto"))
+    }
+
+    @Test
+    fun `image api response unwraps the first base64 image`() {
+        val url = OpenRouterService.firstImageDataUrl(
+            mapOf(
+                "data" to listOf(
+                    mapOf("b64_json" to "QUJD", "media_type" to "image/jpeg"),
+                ),
+            ),
+        )
+        assertEquals("data:image/jpeg;base64,QUJD", url)
+        assertNull(OpenRouterService.firstImageDataUrl(mapOf("data" to emptyList<Any>())))
+    }
+
+    companion object {
+        private const val CHAT_CATALOG = """
+        {"data":[
+          {"id":"google/gemini-2.5-flash-image","name":"Google: Gemini 2.5 Flash Image",
+           "architecture":{"output_modalities":["image","text"]},
+           "pricing":{"prompt":"0.0000003","completion":"0.0000025","image_output":"0.00003"}},
+          {"id":"meta/muse-spark-1.2","name":"Meta: Muse Spark 1.2",
+           "architecture":{"output_modalities":["text"]},
+           "pricing":{"prompt":"0.1","completion":"0.1"}}
+        ]}
+        """
+
+        private const val IMAGE_LISTING = """
+        {"data":[
+          {"id":"meta/muse-image","name":"Meta: Muse Image",
+           "architecture":{"output_modalities":["image"]},
+           "pricing":{"prompt":"0","completion":"0","image_output":"0.000002395"}},
+          {"id":"google/gemini-2.5-flash-image","name":"Google: Gemini 2.5 Flash Image",
+           "architecture":{"output_modalities":["image","text"]},
+           "pricing":{"prompt":"0.0000003","completion":"0.0000025","image_output":"0.00003"}},
+          {"id":"openrouter/auto","name":"Auto",
+           "architecture":{"output_modalities":["text","image"]},
+           "pricing":{"prompt":"0","completion":"0"}}
+        ]}
+        """
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/screens/UiFormattingCharacterizationTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/UiFormattingCharacterizationTest.kt
@@ -1,5 +1,6 @@
 package com.echoflow.ui.screens
 
+import com.echoflow.data.OpenRouterModelInfo
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -31,5 +32,20 @@ class UiFormattingCharacterizationTest {
         assertEquals("1M ctx", formatContext(1_000_000))
         assertEquals("Off", endpointSubtitle(false, "Connected"))
         assertEquals("Connected", endpointSubtitle(true, "Connected"))
+        assertEquals(
+            "Priced per image",
+            formatPricing(
+                OpenRouterModelInfo(
+                    id = "meta/muse-image",
+                    name = "Meta: Muse Image",
+                    contextLength = null,
+                    promptPricePerM = 0.0,
+                    completionPricePerM = 0.0,
+                    outputsImage = true,
+                    outputsText = false,
+                    hasImageOutputPrice = true,
+                ),
+            ),
+        )
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Imagine’s “Browse image models” search was filtering OpenRouter’s **chat** catalog (`/api/v1/models`) for `output_modalities: image`. Dedicated image generators such as **Meta Muse Image** (`meta/muse-image`) are not on that list — they live on OpenRouter’s image listing (`/api/v1/models?output_modalities=image` / `/api/v1/images/models`). Chat model search looked fine because new chat models still appear in the unfiltered catalog.

## Fix
- Imagine settings now loads the image-output listing, so Muse, Flux, Seedream, `gpt-image-*`, etc. show up when searching.
- Image-only models generate via `POST /api/v1/images`. Gemini / GPT-5 image models still use chat completions with `modalities: ["image","text"]`.
- Per-image priced models are no longer labeled “Free” (prompt/completion tokens are $0).

## Testing
Unit tests cover directory parsing (Muse present on the image listing, absent from the chat catalog), generation routing, and the “Priced per image” label. This environment cannot run the Android emulator.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01d3ba6f-8751-4d69-ace4-dc9466a50b2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01d3ba6f-8751-4d69-ace4-dc9466a50b2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multiple reference images and optional aspect ratios during image generation.
  - Added dedicated image-generation API support for compatible models.
  - Added live image-model listings, routing, loading states, and retry handling in settings.
  - Added “Priced per image” pricing display.

- **Bug Fixes**
  - Improved selection between chat-based and dedicated image-generation services.
  - Preserved reference-image editing support while generating images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->