### PR TITLE
Copy assistant output as plain text, without reasoning

### DIFF
--- a/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
+++ b/app/src/main/java/com/echoflow/data/ChatStreamModels.kt
@@ -1,5 +1,6 @@
 package com.echoflow.data
 
+import com.echoflow.ui.components.markdownToPlainText
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -419,10 +420,12 @@ object ReplyVersions {
         )
     }
 
-    fun copyText(message: ChatMessage, index: Int): String {
-        val shown = display(message, index)
-        val fromSegments = textFromSegments(shown.segmentsJson)
-        return fromSegments.ifBlank { shown.content }
+    fun copyText(message: ChatMessage, index: Int): String = copyText(display(message, index))
+
+    /** Plain-text answer body for the clipboard — no reasoning, no markdown syntax. */
+    fun copyText(message: ChatMessage): String {
+        val fromSegments = textFromSegments(message.segmentsJson)
+        return markdownToPlainText(fromSegments.ifBlank { message.content })
     }
 
     fun textFromSegments(segmentsJson: String?): String {
@@ -431,7 +434,6 @@ object ReplyVersions {
         return segments.mapNotNull { segment ->
             when (segment.type) {
                 "text", "report", "data" -> segment.text
-                "reasoning" -> segment.text?.let { "Reasoning:\n$it" }
                 else -> null
             }
         }.filter { !it.isNullOrBlank() }.joinToString("\n\n")

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
@@ -305,7 +305,8 @@ private fun tidyInlinePlainText(text: String): String =
 private fun isMarkdownImageOpener(text: String): Boolean {
     if (!text.endsWith("!")) return false
     val before = text.getOrNull(text.lastIndex - 1)
-    return before == null || before.isWhitespace()
+    // `Look![docs](url)` keeps the bang; `See:![diagram](url)` and ` ![img]` drop it.
+    return before == null || !before.isLetterOrDigit()
 }
 
 /** Per CommonMark a single newline inside a paragraph is a soft break (rendered as a space). */
@@ -408,6 +409,26 @@ internal fun isEscaped(text: String, index: Int): Boolean {
         i--
     }
     return slashCount % 2 == 1
+}
+
+/** Index of the `)` that closes a markdown link destination that starts at [openParen]. */
+internal fun findLinkDestinationClose(source: String, openParen: Int, end: Int): Int? {
+    if (openParen >= end || source[openParen] != '(') return null
+    var depth = 0
+    var i = openParen
+    while (i < end) {
+        if (!isEscaped(source, i)) {
+            when (source[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return i
+                }
+            }
+        }
+        i++
+    }
+    return null
 }
 
 internal fun looksLikeMath(content: String, before: Char?, after: Char?): Boolean {
@@ -555,7 +576,11 @@ internal class InlineParser(private val source: String) {
                 "link" -> {
                     val labelEnd = source.indexOf("]", nextIdx + 1).takeIf { it in 0 until end }
                     val parenOpen = labelEnd?.let { source.getOrNull(it + 1) }
-                    val parenClose = if (parenOpen == '(') source.indexOf(")", labelEnd + 2).takeIf { it in 0 until end } else null
+                    val parenClose = if (parenOpen == '(') {
+                        findLinkDestinationClose(source, labelEnd + 1, end)
+                    } else {
+                        null
+                    }
                     if (labelEnd != null && parenClose != null) {
                         val labelText = source.substring(nextIdx + 1, labelEnd)
                         val url = source.substring(labelEnd + 2, parenClose)

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
@@ -261,12 +261,18 @@ private fun flattenInline(nodes: List<InlineNode>): String = buildString {
         }
     }
     nodes.forEachIndexed { index, node ->
-        val imageBang = node is InlineNode.Link &&
-            index > 0 &&
-            (nodes[index - 1] as? InlineNode.Text)?.text?.endsWith("!") == true
+        val prefix = (nodes.getOrNull(index - 1) as? InlineNode.Text)?.text
+        val imageBang = node is InlineNode.Link && prefix != null && isMarkdownImageOpener(prefix)
         if (imageBang && isNotEmpty() && this[lastIndex] == '!') deleteCharAt(lastIndex)
         walk(node)
     }
+}
+
+/** True when [text] ends with the `!` of `![alt](url)`, not a sentence `!` jammed against a link. */
+private fun isMarkdownImageOpener(text: String): Boolean {
+    if (!text.endsWith("!")) return false
+    val before = text.getOrNull(text.lastIndex - 1)
+    return before == null || before.isWhitespace()
 }
 
 /** Per CommonMark a single newline inside a paragraph is a soft break (rendered as a space). */

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
@@ -199,6 +199,76 @@ fun parseMarkdownBlocks(text: String): List<MarkdownBlock> {
     return blocks
 }
 
+/**
+ * Visible text of [markdown] with CommonMark/GFM markers removed, for clipboard paste.
+ * Matches the renderer: headers and emphasis drop their syntax, links keep the label,
+ * fenced code keeps the code, math keeps the LaTeX.
+ */
+fun markdownToPlainText(markdown: String): String {
+    if (markdown.isBlank()) return markdown
+    val blocks = parseMarkdownBlocks(markdown)
+    val out = StringBuilder()
+    var prevList = false
+    fun appendBlock(text: String, list: Boolean = false) {
+        if (text.isBlank()) {
+            prevList = list
+            return
+        }
+        if (out.isNotEmpty()) out.append(if (list && prevList) '\n' else "\n\n")
+        out.append(text)
+        prevList = list
+    }
+    for (block in blocks) {
+        when (block) {
+            is MarkdownBlock.Header -> appendBlock(stripInlineMarkdown(block.text))
+            is MarkdownBlock.Paragraph -> appendBlock(stripInlineMarkdown(block.text))
+            is MarkdownBlock.Quote -> appendBlock(stripInlineMarkdown(block.text))
+            is MarkdownBlock.BulletItem -> {
+                val marker = block.ordinal?.let { "$it." } ?: "•"
+                val indent = "  ".repeat(block.indent)
+                appendBlock("$indent$marker ${stripInlineMarkdown(block.text)}", list = true)
+            }
+            is MarkdownBlock.CodeBlock -> appendBlock(block.code)
+            is MarkdownBlock.MathBlock -> appendBlock(
+                block.latex.ifBlank { stripInlineMarkdown(block.raw) },
+            )
+            is MarkdownBlock.Table -> appendBlock(
+                buildString {
+                    append(block.headers.joinToString("\t") { stripInlineMarkdown(it) })
+                    block.rows.forEach { row ->
+                        append('\n')
+                        append(row.joinToString("\t") { stripInlineMarkdown(it) })
+                    }
+                },
+            )
+            MarkdownBlock.Divider -> prevList = false
+        }
+    }
+    return out.toString()
+}
+
+internal fun stripInlineMarkdown(text: String): String = flattenInline(InlineParser(text).parse())
+
+private fun flattenInline(nodes: List<InlineNode>): String = buildString {
+    fun walk(node: InlineNode) {
+        when (node) {
+            is InlineNode.Text -> append(node.text)
+            is InlineNode.Math -> append(node.latex)
+            is InlineNode.Code -> append(node.text)
+            is InlineNode.Span -> node.children.forEach(::walk)
+            is InlineNode.Link -> node.label.forEach(::walk)
+            is InlineNode.Citation -> append(node.label)
+        }
+    }
+    nodes.forEachIndexed { index, node ->
+        val imageBang = node is InlineNode.Link &&
+            index > 0 &&
+            (nodes[index - 1] as? InlineNode.Text)?.text?.endsWith("!") == true
+        if (imageBang && isNotEmpty() && this[lastIndex] == '!') deleteCharAt(lastIndex)
+        walk(node)
+    }
+}
+
 /** Per CommonMark a single newline inside a paragraph is a soft break (rendered as a space). */
 internal fun appendParagraphLine(sb: StringBuilder, line: String) {
     if (sb.isNotEmpty()) sb.append(' ')

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
@@ -247,7 +247,8 @@ fun markdownToPlainText(markdown: String): String {
     return out.toString()
 }
 
-internal fun stripInlineMarkdown(text: String): String = flattenInline(InlineParser(text).parse())
+internal fun stripInlineMarkdown(text: String): String =
+    tidyInlinePlainText(flattenInline(InlineParser(text).parse()))
 
 private fun flattenInline(nodes: List<InlineNode>): String = buildString {
     fun walk(node: InlineNode) {
@@ -257,16 +258,48 @@ private fun flattenInline(nodes: List<InlineNode>): String = buildString {
             is InlineNode.Code -> append(node.text)
             is InlineNode.Span -> node.children.forEach(::walk)
             is InlineNode.Link -> node.label.forEach(::walk)
-            is InlineNode.Citation -> append(node.label)
+            is InlineNode.Citation -> Unit
         }
     }
-    nodes.forEachIndexed { index, node ->
-        val prefix = (nodes.getOrNull(index - 1) as? InlineNode.Text)?.text
+    var i = 0
+    while (i < nodes.size) {
+        val skipped = skipCopiedCitation(this, nodes, i)
+        if (skipped != null) {
+            i = skipped
+            continue
+        }
+        val node = nodes[i]
+        val prefix = (nodes.getOrNull(i - 1) as? InlineNode.Text)?.text
         val imageBang = node is InlineNode.Link && prefix != null && isMarkdownImageOpener(prefix)
         if (imageBang && isNotEmpty() && this[lastIndex] == '!') deleteCharAt(lastIndex)
         walk(node)
+        i++
     }
 }
+
+/**
+ * Drops numbered pills (`[1](url)`) and parenthetical source links (`([Reuters](url))`)
+ * so copy matches the prose, not the citation chrome the app already shows separately.
+ * Returns the next index, or null if [i] is not a citation to skip.
+ */
+private fun skipCopiedCitation(out: StringBuilder, nodes: List<InlineNode>, i: Int): Int? {
+    val node = nodes[i]
+    if (node is InlineNode.Citation) return i + 1
+    val prefix = node as? InlineNode.Text ?: return null
+    val cite = nodes.getOrNull(i + 1) ?: return null
+    if (cite !is InlineNode.Link && cite !is InlineNode.Citation) return null
+    val suffix = nodes.getOrNull(i + 2) as? InlineNode.Text ?: return null
+    if (!prefix.text.endsWith("(") || !suffix.text.startsWith(")")) return null
+    out.append(prefix.text.replace(Regex("""[ \t]*\($"""), ""))
+    val rest = suffix.text.substring(1)
+    if (rest.isNotEmpty()) out.append(rest)
+    return i + 3
+}
+
+private fun tidyInlinePlainText(text: String): String =
+    text.replace(Regex("""[ \t]{2,}"""), " ")
+        .replace(Regex(""" +([,.;:!?])"""), "$1")
+        .trim()
 
 /** True when [text] ends with the `!` of `![alt](url)`, not a sentence `!` jammed against a link. */
 private fun isMarkdownImageOpener(text: String): Boolean {

--- a/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
+++ b/app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt
@@ -251,13 +251,17 @@ internal fun stripInlineMarkdown(text: String): String =
     tidyInlinePlainText(flattenInline(InlineParser(text).parse()))
 
 private fun flattenInline(nodes: List<InlineNode>): String = buildString {
+    appendFlattened(nodes)
+}
+
+private fun StringBuilder.appendFlattened(nodes: List<InlineNode>) {
     fun walk(node: InlineNode) {
         when (node) {
             is InlineNode.Text -> append(node.text)
             is InlineNode.Math -> append(node.latex)
             is InlineNode.Code -> append(node.text)
-            is InlineNode.Span -> node.children.forEach(::walk)
-            is InlineNode.Link -> node.label.forEach(::walk)
+            is InlineNode.Span -> appendFlattened(node.children)
+            is InlineNode.Link -> appendFlattened(node.label)
             is InlineNode.Citation -> Unit
         }
     }
@@ -305,8 +309,9 @@ private fun tidyInlinePlainText(text: String): String =
 private fun isMarkdownImageOpener(text: String): Boolean {
     if (!text.endsWith("!")) return false
     val before = text.getOrNull(text.lastIndex - 1)
-    // `Look![docs](url)` keeps the bang; `See:![diagram](url)` and ` ![img]` drop it.
-    return before == null || !before.isLetterOrDigit()
+    // Standalone `![img]`, `see ![img]`, and `See:![img]` drop the bang.
+    // `Look![docs]`, `Wow!![docs]`, and `(see here)![docs]` keep sentence punctuation.
+    return before == null || before.isWhitespace() || before == ':'
 }
 
 /** Per CommonMark a single newline inside a paragraph is a soft break (rendered as a space). */

--- a/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt
@@ -589,8 +589,7 @@ private fun AssistantAnswerBody(
     // [message] is already the selected snapshot. Reading its body directly keeps embedded
     // report/data copy actions aligned with the version currently on screen.
     val copyAction: () -> Unit = {
-        val timelineText = ReplyVersions.textFromSegments(message.segmentsJson)
-        onCopy(timelineText.ifBlank { message.content })
+        onCopy(ReplyVersions.copyText(message))
     }
 
     message.attachments.forEach { att ->

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -90,4 +90,22 @@ class MarkdownTextTest {
             plain,
         )
     }
+
+    @Test
+    fun markdownToPlainTextKeepsExclamationBeforeALink() {
+        assertEquals(
+            "Look! docs",
+            markdownToPlainText("Look![docs](https://example.com)"),
+        )
+        assertEquals(
+            "Look! docs",
+            markdownToPlainText("Look! [docs](https://example.com)"),
+        )
+    }
+
+    @Test
+    fun markdownToPlainTextStripsImageBangButKeepsAltText() {
+        assertEquals("diagram", markdownToPlainText("![diagram](https://example.com/a.png)"))
+        assertEquals("See diagram", markdownToPlainText("See ![diagram](https://example.com/a.png)"))
+    }
 }

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -108,6 +108,19 @@ class MarkdownTextTest {
         assertEquals("diagram", markdownToPlainText("![diagram](https://example.com/a.png)"))
         assertEquals("See diagram", markdownToPlainText("See ![diagram](https://example.com/a.png)"))
         assertEquals("See:diagram", markdownToPlainText("See:![diagram](https://example.com/a.png)"))
+        assertEquals("diagram", markdownToPlainText("**![diagram](https://example.com/a.png)**"))
+    }
+
+    @Test
+    fun markdownToPlainTextKeepsBangAfterClosingPunctuation() {
+        assertEquals(
+            "Wow!!docs",
+            markdownToPlainText("Wow!![docs](https://example.com)"),
+        )
+        assertEquals(
+            "(see here)!docs",
+            markdownToPlainText("(see here)![docs](https://example.com)"),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -1,6 +1,7 @@
 package com.echoflow
 
 import com.echoflow.ui.components.MarkdownBlock
+import com.echoflow.ui.components.markdownToPlainText
 import com.echoflow.ui.components.parseMarkdownBlocks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -57,5 +58,36 @@ class MarkdownTextTest {
         val math = blocks.single() as MarkdownBlock.MathBlock
         assertFalse(math.complete)
         assertEquals("$$\n\\frac{x}{y}", math.raw)
+    }
+
+    @Test
+    fun markdownToPlainTextStripsSyntaxAndKeepsVisibleText() {
+        val plain = markdownToPlainText(
+            """
+            ## Heading
+
+            A **bold** word, *italic*, `code`, and a [label](https://example.com).
+
+            - first
+            - second
+
+            ```kotlin
+            val x = 1
+            ```
+            """.trimIndent()
+        )
+        assertEquals(
+            """
+            Heading
+
+            A bold word, italic, code, and a label.
+
+            • first
+            • second
+
+            val x = 1
+            """.trimIndent(),
+            plain,
+        )
     }
 }

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -108,4 +108,24 @@ class MarkdownTextTest {
         assertEquals("diagram", markdownToPlainText("![diagram](https://example.com/a.png)"))
         assertEquals("See diagram", markdownToPlainText("See ![diagram](https://example.com/a.png)"))
     }
+
+    @Test
+    fun markdownToPlainTextOmitsCitationHyperlinks() {
+        assertEquals(
+            "The sky is blue.",
+            markdownToPlainText("The sky is blue [1](https://example.com)."),
+        )
+        assertEquals(
+            "Revenue grew last quarter.",
+            markdownToPlainText("Revenue grew last quarter. ([Reuters](https://reuters.com))"),
+        )
+        assertEquals(
+            "Two sources agree.",
+            markdownToPlainText("Two sources agree [1](https://a.example) [2](https://b.example)."),
+        )
+        assertEquals(
+            "See the docs for more.",
+            markdownToPlainText("See [the docs](https://example.com/guide) for more."),
+        )
+    }
 }

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -94,7 +94,7 @@ class MarkdownTextTest {
     @Test
     fun markdownToPlainTextKeepsExclamationBeforeALink() {
         assertEquals(
-            "Look! docs",
+            "Look!docs",
             markdownToPlainText("Look![docs](https://example.com)"),
         )
         assertEquals(

--- a/app/src/test/java/com/echoflow/MarkdownTextTest.kt
+++ b/app/src/test/java/com/echoflow/MarkdownTextTest.kt
@@ -107,6 +107,15 @@ class MarkdownTextTest {
     fun markdownToPlainTextStripsImageBangButKeepsAltText() {
         assertEquals("diagram", markdownToPlainText("![diagram](https://example.com/a.png)"))
         assertEquals("See diagram", markdownToPlainText("See ![diagram](https://example.com/a.png)"))
+        assertEquals("See:diagram", markdownToPlainText("See:![diagram](https://example.com/a.png)"))
+    }
+
+    @Test
+    fun markdownToPlainTextHandlesNestedParensInLinkUrls() {
+        assertEquals(
+            "docs",
+            markdownToPlainText("[docs](https://example.com/Foo_(bar))"),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
@@ -72,6 +72,19 @@ class ReplyVersionsTest {
     }
 
     @Test
+    fun `copyText omits numbered citation hyperlinks`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "",
+            createdAt = 1L,
+            segmentsJson = """[{"type":"text","text":"The sky is blue [1](https://example.com)."}]""",
+        )
+        assertEquals("The sky is blue.", ReplyVersions.copyText(message, 0))
+    }
+
+    @Test
     fun `copyText falls back to plain content when there are no text segments`() {
         val message = ChatMessage(
             id = "a1",

--- a/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
+++ b/app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt
@@ -58,6 +58,34 @@ class ReplyVersionsTest {
     }
 
     @Test
+    fun `copyText is plain answer without reasoning or markdown`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "",
+            createdAt = 1L,
+            reasoning = "should not be copied",
+            segmentsJson = """[{"type":"reasoning","text":"Hidden chain of thought"},{"type":"text","text":"## Title\n\n**Bold** answer with a [link](https://example.com)."}]""",
+        )
+        assertEquals("Title\n\nBold answer with a link.", ReplyVersions.copyText(message, 0))
+    }
+
+    @Test
+    fun `copyText falls back to plain content when there are no text segments`() {
+        val message = ChatMessage(
+            id = "a1",
+            chatId = "c1",
+            role = "assistant",
+            content = "Just **markdown** content",
+            createdAt = 1L,
+            reasoning = "think",
+            segmentsJson = """[{"type":"reasoning","text":"only thoughts"}]""",
+        )
+        assertEquals("Just markdown content", ReplyVersions.copyText(message, 0))
+    }
+
+    @Test
     fun `snapshot captures the live assistant fields`() {
         val message = ChatMessage(
             id = "a1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Copying an assistant reply now puts the **visible answer** on the clipboard as **plain text**.

- Reasoning / thinking segments are omitted.
- Markdown syntax (`**bold**`, headings, list markers, link URLs, fences) is stripped so paste matches what you read on screen.
- Citation hyperlinks are omitted: numbered pills (`[1](url)`) and parenthetical sources (`([Reuters](url))`). Ordinary in-prose link labels stay.
- User-message copy is unchanged.
- Sentence `!` before a link is kept (`Look![docs]`, `Wow!![docs]`, `(see here)![docs]`); `![alt](url)` image syntax is dropped, including after a colon, after a space, and inside emphasis (`**![diagram]**`).
- Link destinations with nested parentheses (`Foo_(bar)`) no longer leak a stray `)`.

## Why
The Copy action concatenated every timeline segment, including `Reasoning: …`, and wrote the stored markdown source. Citation chrome is already shown separately in the app.

## How
`ReplyVersions.copyText` now takes only `text` / `report` / `data` segments, then runs `markdownToPlainText()` (same block parser as the renderer).

## Test plan
- `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.ReplyVersionsTest --tests com.echoflow.MarkdownTextTest`
- Cloud agents cannot run the arm64 emulator; on-device check: copy a reply that has a reasoning block, markdown, and `[1](url)` citations — paste should be the answer only, unformatted, without citation pills.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-750b8b88-6227-4bcb-849f-2068e24ad73c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-750b8b88-6227-4bcb-849f-2068e24ad73c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Copying assistant replies now produces clean plain text without Markdown formatting.
  - Copied text preserves readable lists, links, code, and other visible content.
- **Bug Fixes**
  - Reasoning content is no longer included when copying replies.
  - Replies without text segments now correctly fall back to available content.
  - Exclamation marks before regular links are preserved, while image syntax is cleaned up.
- **Tests**
  - Added coverage for Markdown removal, content fallback, reasoning exclusion, and visible reply text preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

I like the product direction: copying only the visible answer as plain text makes assistant output substantially easier to reuse while respecting the separation between answers and reasoning. A parser-level representation that distinguishes images from ordinary links would be a cleaner long-term implementation than inferring image syntax from preceding punctuation.
- Routes assistant copy actions through a shared plain-text conversion path.
- Excludes reasoning segments and citation chrome while preserving visible answer content.
- Adds Markdown flattening and regression coverage for links, images, nested destinations, lists, code, and reply versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/components/MarkdownParsing.kt | Adds block-aware Markdown-to-plain-text conversion and resolves the previously reported punctuation and image-marker cases. |
| app/src/main/java/com/echoflow/data/ChatStreamModels.kt | Centralizes assistant clipboard text generation, excludes reasoning segments, and applies plain-text conversion. |
| app/src/main/java/com/echoflow/ui/screens/ChatMessages.kt | Routes the assistant reply copy action through the new shared conversion path. |
| app/src/test/java/com/echoflow/MarkdownTextTest.kt | Adds focused regression coverage for Markdown flattening, citations, links, images, punctuation, and nested link destinations. |
| app/src/test/java/com/echoflow/data/ReplyVersionsTest.kt | Verifies reasoning exclusion, plain-text output, citation removal, and content fallback behavior. |

<sub>Reviews (5): Last reviewed commit: ["Keep bangs after closing punctuation; st..."](https://github.com/adityavardhansharma/echoflow/commit/1a8c51b951a96a0a47b04092ba9027301d4f6eb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58818806)</sub>

**Context used:**

- Knowledge Base — [Conversational experience](https://app.greptile.com/adityavardhansharma/-/custom-context/knowledge-base/adityavardhansharma/echoflow/-/docs/chat-experience.md)

<!-- /greptile_comment -->