### PR TITLE
Add OpenRouter sign-in and preserve existing API-key connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ desktop.ini
 # Local assistant/tooling state
 .claude/
 assets/.aistudio/
+
+# Local RFC conformance fixture (public high-entropy vector; kept off GitHub).
+/app/src/test/java/com/echoflow/data/OpenRouterPkceVectorLocalTest.kt

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,21 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".OpenRouterReturnActivity"
+            android:exported="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <!-- Only returns focus after the loopback callback. Credentials and authorization
+                 codes are never accepted through this exported link. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.echoflow.openrouter" android:host="return" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".data.KeepAliveService"
             android:exported="false"

--- a/app/src/main/java/com/echoflow/OpenRouterReturnActivity.kt
+++ b/app/src/main/java/com/echoflow/OpenRouterReturnActivity.kt
@@ -1,0 +1,18 @@
+package com.echoflow
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+/** Brings the existing settings task back without creating a second MainActivity/ViewModel.
+ * Authorization is handled only by the loopback listener; no intent data is forwarded.
+ */
+class OpenRouterReturnActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(Intent(this, MainActivity::class.java).addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP,
+        ))
+        finish()
+    }
+}

--- a/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
@@ -101,7 +101,7 @@ internal class OpenRouterAuthService(
         val message = if (declined) "Sign-in was cancelled. Your saved connection has not changed."
             else "Your authorization was received. Return to EchoFlow to finish connecting."
         val body = if (accepted) {
-            """<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Return to EchoFlow</title><body style="font:18px system-ui;padding:32px;max-width:440px;margin:auto"><h1>Continue in EchoFlow</h1><p>$message</p><a href="com.echoflow.openrouter://return" style="display:inline-block;padding:16px 24px;background:#222;color:white;border-radius:32px;text-decoration:none">Return to EchoFlow</a></body></html>"""
+            """<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Return to EchoFlow</title><body style="font:18px system-ui;padding:32px;max-width:440px;margin:auto"><h1>Continue in EchoFlow</h1><p>$message</p><a href="$RETURN_TO_APP_URI" style="display:inline-block;padding:16px 24px;background:#222;color:white;border-radius:32px;text-decoration:none">Return to EchoFlow</a><p>If your browser cannot open this button, switch back to EchoFlow manually.</p></body></html>"""
         } else "Invalid callback. Continue sign-in from EchoFlow."
         val bytes = body.toByteArray(Charsets.UTF_8)
         val status = if (accepted) "200 OK" else "400 Bad Request"
@@ -116,6 +116,9 @@ internal class OpenRouterAuthService(
     }
 
     companion object {
+        // Package binding prevents another app that registered our scheme from claiming the return.
+        internal val RETURN_TO_APP_URI = "intent://return#Intent;scheme=com.echoflow.openrouter;" +
+            "package=${com.echoflow.BuildConfig.APPLICATION_ID};end"
         // Hex is within RFC 7636's verifier alphabet and carries 256 bits of entropy.
         internal fun randomToken(): String = ByteArray(32).also(SecureRandom()::nextBytes)
             .joinToString("") { "%02x".format(it) }

--- a/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
@@ -1,0 +1,151 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
+
+/** Browser-based PKCE with OpenRouter's documented loopback callback.
+ * The listener exists only during sign-in, binds IPv4 loopback only, and never receives a key.
+ * A process restart invalidates the in-memory verifier: the user simply starts sign-in again.
+ */
+internal class OpenRouterAuthService(
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .followRedirects(false).followSslRedirects(false)
+        .callTimeout(30, TimeUnit.SECONDS).build(),
+) {
+    suspend fun signIn(openBrowser: suspend (String) -> Unit, onExchanging: suspend () -> Unit): String =
+        withContext(Dispatchers.IO) {
+            val verifier = randomToken()
+            val state = randomToken()
+            ServerSocket(0, 4, InetAddress.getByName("127.0.0.1")).use { server ->
+                server.soTimeout = 500
+                val callback = "http://127.0.0.1:${server.localPort}/callback/$state"
+                openBrowser(authorizationUrl(callback, verifier))
+                val deadline = System.nanoTime() + TimeUnit.MINUTES.toNanos(10)
+                var code: String? = null
+                var declined = false
+                while (code == null && !declined) {
+                    currentCoroutineContext().ensureActive()
+                    check(System.nanoTime() < deadline) { "Sign-in expired. Please try again." }
+                    try {
+                        server.accept().use { socket ->
+                            socket.soTimeout = 1500
+                            val line = readRequestLine(socket)
+                            code = callbackCode(line, server.localPort, state)
+                            declined = callbackUrl(line, server.localPort, state)?.queryParameter("error") != null
+                            // Closing the browser must not discard an authorization already received.
+                            runCatching { respond(socket, code != null || declined, declined) }
+                        }
+                    } catch (_: SocketTimeoutException) {
+                        // Poll cancellation and expiration, including idle or incomplete requests.
+                    } catch (_: IOException) {
+                        // Ignore malformed/aborted local connections; the valid callback may follow.
+                    }
+                }
+                currentCoroutineContext().ensureActive()
+                check(!declined) { "Sign-in was declined. Your saved connection has not changed." }
+                onExchanging()
+                exchange(checkNotNull(code), verifier)
+            }
+        }
+
+    internal fun exchange(code: String, verifier: String): String {
+        val body = JSONObject().put("code", code).put("code_verifier", verifier)
+            .put("code_challenge_method", "S256").toString()
+        val request = Request.Builder().url("https://openrouter.ai/api/v1/auth/keys")
+            .post(body.toRequestBody("application/json".toMediaType())).build()
+        return client.newCall(request).execute().use { response ->
+            check(response.isSuccessful) {
+                if (response.code == 400 || response.code == 403) "Sign-in expired or was declined. Please try again."
+                else "OpenRouter could not complete sign-in. Please try again."
+            }
+            // Never surface server bodies or credentials in error messages.
+            val key = runCatching { JSONObject(response.body?.string().orEmpty()).optString("key") }.getOrDefault("")
+            check(key.startsWith("sk-or-") && key.length > 16 && key.none { it.isWhitespace() }) {
+                "OpenRouter returned an invalid connection. Please try again."
+            }
+            key
+        }
+    }
+
+    private fun readRequestLine(socket: Socket): String {
+        val input = socket.getInputStream()
+        val request = StringBuilder()
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        repeat(16384) {
+            if (System.nanoTime() >= deadline) return ""
+            val byte = input.read()
+            if (byte == -1) return ""
+            request.append(byte.toChar())
+            if (request.endsWith("\r\n\r\n")) return request.toString().substringBefore("\r\n")
+        }
+        return ""
+    }
+
+    private fun respond(socket: Socket, accepted: Boolean, declined: Boolean) {
+        val message = if (declined) "Sign-in was cancelled. Your saved connection has not changed."
+            else "Your authorization was received. Return to EchoFlow to finish connecting."
+        val body = if (accepted) {
+            """<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Return to EchoFlow</title><body style="font:18px system-ui;padding:32px;max-width:440px;margin:auto"><h1>Continue in EchoFlow</h1><p>$message</p><a href="com.echoflow.openrouter://return" style="display:inline-block;padding:16px 24px;background:#222;color:white;border-radius:32px;text-decoration:none">Return to EchoFlow</a></body></html>"""
+        } else "Invalid callback. Continue sign-in from EchoFlow."
+        val bytes = body.toByteArray(Charsets.UTF_8)
+        val status = if (accepted) "200 OK" else "400 Bad Request"
+        socket.getOutputStream().apply {
+            write(("HTTP/1.1 $status\r\nContent-Type: text/html; charset=utf-8\r\n" +
+                "Cache-Control: no-store\r\nReferrer-Policy: no-referrer\r\n" +
+                "Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'\r\n" +
+                "Connection: close\r\nContent-Length: ${bytes.size}\r\n\r\n").toByteArray(Charsets.US_ASCII))
+            write(bytes)
+            flush()
+        }
+    }
+
+    companion object {
+        // Hex is within RFC 7636's verifier alphabet and carries 256 bits of entropy.
+        internal fun randomToken(): String = ByteArray(32).also(SecureRandom()::nextBytes)
+            .joinToString("") { "%02x".format(it) }
+
+        internal fun challenge(verifier: String): String = android.util.Base64.encodeToString(
+            MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII)),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+
+        internal fun authorizationUrl(callback: String, verifier: String): String =
+            "https://openrouter.ai/auth".toHttpUrl().newBuilder()
+                .addQueryParameter("callback_url", callback)
+                .addQueryParameter("code_challenge", challenge(verifier))
+                .addQueryParameter("code_challenge_method", "S256")
+                .addQueryParameter("key_label", "EchoFlow")
+                .build().toString()
+
+        internal fun callbackCode(requestLine: String, port: Int, state: String): String? {
+            val url = callbackUrl(requestLine, port, state) ?: return null
+            if (url.queryParameter("error") != null || url.queryParameterValues("code").size != 1) return null
+            return url.queryParameter("code")?.takeIf { it.isNotBlank() && it.length <= 2048 }
+        }
+
+        private fun callbackUrl(requestLine: String, port: Int, state: String): okhttp3.HttpUrl? {
+            val parts = requestLine.split(' ')
+            if (parts.size != 3 || parts[0] != "GET" || parts[2] != "HTTP/1.1") return null
+            if (!parts[1].startsWith("/callback/$state?")) return null
+            val url = runCatching { "http://127.0.0.1:$port${parts[1]}".toHttpUrl() }.getOrNull() ?: return null
+            if (url.encodedPath != "/callback/$state" || url.fragment != null) return null
+            return url
+        }
+    }
+}

--- a/app/src/main/java/com/echoflow/data/OpenRouterConnection.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterConnection.kt
@@ -1,0 +1,9 @@
+package com.echoflow.data
+
+/** Safe presentation state: never exposes credentials to the connection card. */
+data class OpenRouterConnection(
+    val connected: Boolean = false,
+    val signedIn: Boolean = false,
+    val keyEnding: String = "",
+    val hasSavedManualKey: Boolean = false,
+)

--- a/app/src/main/java/com/echoflow/data/SettingsRepository.kt
+++ b/app/src/main/java/com/echoflow/data/SettingsRepository.kt
@@ -23,6 +23,8 @@ class SettingsRepository(
 
     private val _apiKey = MutableStateFlow(getApiKeyDirect())
     val apiKey: StateFlow<String> = _apiKey.asStateFlow()
+    private val _openRouterConnection = MutableStateFlow(readOpenRouterConnection())
+    val openRouterConnection: StateFlow<OpenRouterConnection> = _openRouterConnection.asStateFlow()
 
     private val _selectedModel = MutableStateFlow(getSelectedModelDirect())
     val selectedModel: StateFlow<String> = _selectedModel.asStateFlow()
@@ -171,8 +173,60 @@ class SettingsRepository(
     }
 
     fun saveApiKey(key: String) {
-        prefs.edit().putString("openrouter_api_key", key).apply()
+        writeOpenRouterConnection(key.trim(), signedIn = false)
+    }
+
+    private fun readOpenRouterConnection(): OpenRouterConnection {
+        val key = getApiKeyDirect()
+        return OpenRouterConnection(
+            connected = key.isNotBlank(),
+            signedIn = key.isNotBlank() && prefs.getBoolean("openrouter_signed_in", false),
+            keyEnding = if (key.length > 8) key.takeLast(4) else "",
+            hasSavedManualKey = !prefs.getString("openrouter_manual_key", null).isNullOrBlank(),
+        )
+    }
+
+    fun saveOpenRouterSignIn(key: String) {
+        require(key.isNotBlank())
+        writeOpenRouterConnection(key, signedIn = true)
+    }
+
+    fun restoreOpenRouterManualKey() {
+        val key = prefs.getString("openrouter_manual_key", null)
+        check(!key.isNullOrBlank()) { "No saved manual key is available." }
+        writeOpenRouterConnection(key, signedIn = false)
+    }
+
+    /** Active key, connection origin and optional manual backup change in one durable edit.
+     * Missing origin metadata on older installs deliberately means a manual connection.
+     */
+    @Synchronized
+    private fun writeOpenRouterConnection(key: String, signedIn: Boolean) {
+        val credentialNames = listOf("openrouter_api_key", "openrouter_signed_in", "openrouter_manual_key")
+        val previous = prefs.all.filterKeys { it in credentialNames }
+        val edit = prefs.edit().putString("openrouter_api_key", key)
+            .putBoolean("openrouter_signed_in", signedIn)
+        if (signedIn && !prefs.getBoolean("openrouter_signed_in", false) && getApiKeyDirect().isNotBlank()) {
+            edit.putString("openrouter_manual_key", getApiKeyDirect())
+        } else if (!signedIn) {
+            edit.remove("openrouter_manual_key")
+        }
+        if (!edit.commit()) {
+            // SharedPreferences updates memory before its disk write. Restore that view too,
+            // so direct readers cannot pick up an uncommitted key after a failed save.
+            val rollback = prefs.edit()
+            credentialNames.forEach { name ->
+                when (val value = previous[name]) {
+                    is String -> rollback.putString(name, value)
+                    is Boolean -> rollback.putBoolean(name, value)
+                    else -> rollback.remove(name)
+                }
+            }
+            rollback.commit()
+            error("Could not save your OpenRouter connection. Please try again.")
+        }
         _apiKey.value = key
+        _openRouterConnection.value = readOpenRouterConnection()
     }
 
     fun getSelectedModelDirect(): String {

--- a/app/src/main/java/com/echoflow/ui/OpenRouterAuthState.kt
+++ b/app/src/main/java/com/echoflow/ui/OpenRouterAuthState.kt
@@ -1,0 +1,8 @@
+package com.echoflow.ui
+
+data class OpenRouterAuthState(
+    val busy: Boolean = false,
+    val waitingForBrowser: Boolean = false,
+    val message: String? = null,
+    val error: Boolean = false,
+)

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -29,6 +29,7 @@ import com.echoflow.data.LocalModel
 import com.echoflow.data.LocalModelDao
 import com.echoflow.data.ModelDownloadManager
 import com.echoflow.data.OpenRouterModelDirectory
+import com.echoflow.data.OpenRouterAuthService
 import com.echoflow.data.OpenRouterModelInfo
 import com.echoflow.data.OpenRouterVideoModelDirectory
 import com.echoflow.data.OpenRouterVideoModelInfo
@@ -45,6 +46,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
 
 class SettingsViewModel(
     private val repository: SettingsRepository,
@@ -63,6 +68,55 @@ class SettingsViewModel(
     private val profileManager = SettingsProfileManager(repository, advisorProfileDao, fusionPanelDao, agentProfileDao)
 
     val apiKey: StateFlow<String> = repository.apiKey
+    val openRouterConnection = repository.openRouterConnection
+    private val _openRouterAuth = MutableStateFlow(OpenRouterAuthState())
+    val openRouterAuth = _openRouterAuth.asStateFlow()
+    private var openRouterAuthJob: Job? = null
+
+    fun signInOpenRouter(openBrowser: (String) -> Unit) {
+        if (_openRouterAuth.value.busy) return
+        _openRouterAuth.value = OpenRouterAuthState(busy = true, waitingForBrowser = true)
+        openRouterAuthJob = viewModelScope.launch {
+            try {
+                val key = OpenRouterAuthService().signIn(
+                    openBrowser = { url -> withContext(Dispatchers.Main) { openBrowser(url) } },
+                    onExchanging = { _openRouterAuth.value = OpenRouterAuthState(busy = true) },
+                )
+                withContext(Dispatchers.IO) { repository.saveOpenRouterSignIn(key) }
+                _openRouterAuth.value = OpenRouterAuthState(message = "Connected to OpenRouter.")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _openRouterAuth.value = OpenRouterAuthState(
+                    message = "Couldn’t finish sign-in. Check your connection and try again. Your saved connection hasn’t changed.",
+                    error = true,
+                )
+            }
+        }
+    }
+
+    fun cancelOpenRouterSignIn() {
+        openRouterAuthJob?.cancel()
+        openRouterAuthJob = null
+        _openRouterAuth.value = OpenRouterAuthState()
+    }
+
+    fun restoreOpenRouterManualKey() = updateOpenRouterConnection { repository.restoreOpenRouterManualKey() }
+
+    private fun updateOpenRouterConnection(update: () -> Unit) {
+        cancelOpenRouterSignIn()
+        _openRouterAuth.value = OpenRouterAuthState(busy = true)
+        openRouterAuthJob = viewModelScope.launch {
+            try {
+                withContext(Dispatchers.IO) { update() }
+                _openRouterAuth.value = OpenRouterAuthState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _openRouterAuth.value = OpenRouterAuthState(message = "Couldn’t save your connection. Please try again.", error = true)
+            }
+        }
+    }
     val selectedModel: StateFlow<String> = repository.selectedModel
     val themeColor: StateFlow<String> = repository.themeColor
     val darkMode: StateFlow<String> = repository.darkMode
@@ -289,7 +343,7 @@ class SettingsViewModel(
     }
 
     fun saveApiKey(key: String) {
-        repository.saveApiKey(key)
+        updateOpenRouterConnection { repository.saveApiKey(key) }
     }
 
     fun saveSelectedModel(modelId: String) {

--- a/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoflow/ui/SettingsViewModel.kt
@@ -103,13 +103,14 @@ class SettingsViewModel(
 
     fun restoreOpenRouterManualKey() = updateOpenRouterConnection { repository.restoreOpenRouterManualKey() }
 
-    private fun updateOpenRouterConnection(update: () -> Unit) {
+    private fun updateOpenRouterConnection(onSaved: () -> Unit = {}, update: () -> Unit) {
         cancelOpenRouterSignIn()
         _openRouterAuth.value = OpenRouterAuthState(busy = true)
         openRouterAuthJob = viewModelScope.launch {
             try {
                 withContext(Dispatchers.IO) { update() }
                 _openRouterAuth.value = OpenRouterAuthState()
+                onSaved()
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -342,8 +343,8 @@ class SettingsViewModel(
         viewModelScope.launch { downloadManager.pruneOrphans() }
     }
 
-    fun saveApiKey(key: String) {
-        updateOpenRouterConnection { repository.saveApiKey(key) }
+    fun saveApiKey(key: String, onSaved: () -> Unit = {}) {
+        updateOpenRouterConnection(onSaved) { repository.saveApiKey(key) }
     }
 
     fun saveSelectedModel(modelId: String) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -141,7 +141,7 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
                 }
             },
             onCancel = viewModel::cancelOpenRouterSignIn,
-            onSaveKey = viewModel::saveApiKey,
+            onSaveKey = { key, onSaved -> viewModel.saveApiKey(key, onSaved) },
             onRestoreKey = viewModel::restoreOpenRouterManualKey,
             onDisconnect = { viewModel.saveApiKey("") },
         )

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -118,7 +118,9 @@ import kotlin.math.roundToInt
 
 @Composable
 internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, embedded: Boolean = false) {
-    val apiKey by viewModel.apiKey.collectAsState()
+    val connection by viewModel.openRouterConnection.collectAsState()
+    val auth by viewModel.openRouterAuth.collectAsState()
+    val context = LocalContext.current
     val customModels by viewModel.customModels.collectAsState()
     val cloudParams by viewModel.cloudInferenceParams.collectAsState()
     val orQuery by viewModel.orModelQuery.collectAsState()
@@ -126,37 +128,23 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
     val orLoading by viewModel.orDirectoryLoading.collectAsState()
     val orError by viewModel.orDirectoryError.collectAsState()
 
-    var keyInput by remember(apiKey) { mutableStateOf(apiKey) }
-    var keyVisible by remember { mutableStateOf(false) }
     var showModelDirectory by remember { mutableStateOf(false) }
 
-    SettingsPageBody(embedded, title = "OpenRouter models", subtitle = "API key & model list", onBack = onBack) {
-        PageSection("API key", "One key from openrouter.ai unlocks every cloud model")
-        FormCard {
-            OutlinedTextField(
-                value = keyInput,
-                onValueChange = { keyInput = it },
-                placeholder = { Text("sk-or-v1-…") },
-                singleLine = true,
-                shape = MaterialTheme.shapes.medium,
-                visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                leadingIcon = { Icon(Icons.Default.Key, null) },
-                trailingIcon = {
-                    IconButton(onClick = { keyVisible = !keyVisible }) {
-                        Icon(if (keyVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility, if (keyVisible) "Hide" else "Show")
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-            )
-            if (apiKey.isNotBlank()) {
-                Spacer(Modifier.height(Spacing.s))
-                SavedKeyBadge("A key is saved on this device")
-            }
-            Spacer(Modifier.height(Spacing.m))
-            Button(onClick = { viewModel.saveApiKey(keyInput.trim()) }, shape = CircleShape, modifier = Modifier.fillMaxWidth()) {
-                Text("Save key")
-            }
-        }
+    SettingsPageBody(embedded, title = "OpenRouter models", subtitle = "Connection & model list", onBack = onBack) {
+        PageSection("Connection", "Your OpenRouter account, models and credits")
+        OpenRouterConnectionCard(
+            connection = connection,
+            auth = auth,
+            onSignIn = {
+                viewModel.signInOpenRouter { url ->
+                    context.startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+                }
+            },
+            onCancel = viewModel::cancelOpenRouterSignIn,
+            onSaveKey = viewModel::saveApiKey,
+            onRestoreKey = viewModel::restoreOpenRouterManualKey,
+            onDisconnect = { viewModel.saveApiKey("") },
+        )
 
         Spacer(Modifier.height(Spacing.xl))
         PageSection("Your models", "Live pricing and context windows from the directory")

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
@@ -1,0 +1,183 @@
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.echoflow.R
+import com.echoflow.data.OpenRouterConnection
+import com.echoflow.ui.OpenRouterAuthState
+import com.echoflow.ui.theme.Spacing
+
+@Composable
+internal fun OpenRouterConnectionCard(
+    connection: OpenRouterConnection,
+    auth: OpenRouterAuthState,
+    onSignIn: () -> Unit,
+    onCancel: () -> Unit,
+    onSaveKey: (String) -> Unit,
+    onRestoreKey: () -> Unit,
+    onDisconnect: () -> Unit,
+) {
+    var showManual by rememberSaveable { mutableStateOf(false) }
+    var confirmation by rememberSaveable { mutableStateOf<String?>(null) }
+    FormCard {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.m)) {
+            Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.secondaryContainer) {
+                Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+                    Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 28.dp, height = 20.dp),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer)
+                }
+            }
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                Text("OpenRouter", style = MaterialTheme.typography.titleMedium)
+                if (connection.connected) {
+                    SavedKeyBadge(if (connection.signedIn) "Connected through sign-in" else "Connected with API key")
+                } else {
+                    Text("One account. Your choice of models.", style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+        Spacer(Modifier.height(Spacing.base))
+        Text(
+            when {
+                connection.signedIn -> "Usage is billed to your OpenRouter account. Your connection is stored securely on this device."
+                connection.connected -> "Your saved API key is ready to use. You can keep using it or connect through OpenRouter sign-in."
+                else -> "Sign in to use your OpenRouter models and credits. Usage is billed to your OpenRouter account."
+            },
+            style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (connection.connected && connection.keyEnding.isNotEmpty()) {
+            Spacer(Modifier.height(Spacing.s))
+            Text("Key ending in •••• ${connection.keyEnding}", style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Spacer(Modifier.height(Spacing.l))
+        Button(
+            onClick = { if (connection.connected) confirmation = "switch" else onSignIn() },
+            enabled = !auth.busy,
+            shape = CircleShape,
+            modifier = Modifier.fillMaxWidth().heightIn(min = 52.dp),
+            contentPadding = PaddingValues(horizontal = Spacing.base, vertical = Spacing.m),
+        ) {
+            if (auth.busy) CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+            else Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 25.dp, height = 18.dp))
+            Spacer(Modifier.width(Spacing.s))
+            Text(when {
+                auth.waitingForBrowser -> "Waiting for OpenRouter…"
+                auth.busy -> "Saving connection…"
+                connection.signedIn -> "Switch OpenRouter account"
+                else -> "Sign in with OpenRouter"
+            })
+        }
+        if (auth.waitingForBrowser) {
+            Text("Finish signing in in your browser, then return here. If the app restarts, start sign-in again.",
+                modifier = Modifier.padding(top = Spacing.m), style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            TextButton(onClick = onCancel, modifier = Modifier.align(Alignment.CenterHorizontally)) { Text("Cancel sign-in") }
+        } else {
+            TextButton(onClick = { showManual = true }, enabled = !auth.busy,
+                modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                Text(if (connection.connected) "Use a different API key" else "Or add API key manually")
+            }
+        }
+        if (auth.message != null) {
+            Text(auth.message, modifier = Modifier.padding(top = Spacing.s).semantics { liveRegion = LiveRegionMode.Polite },
+                style = MaterialTheme.typography.bodySmall,
+                color = if (auth.error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary)
+        }
+        if (connection.connected) {
+            HorizontalDivider(Modifier.padding(vertical = Spacing.m), color = MaterialTheme.colorScheme.outlineVariant)
+            if (connection.hasSavedManualKey) {
+                Text("Your previous manual key is saved on this device.", style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                TextButton(onClick = { confirmation = "restore" }, enabled = !auth.busy) { Text("Use saved manual key") }
+            }
+            TextButton(onClick = { confirmation = "disconnect" }, enabled = !auth.busy,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)) {
+                Text("Disconnect")
+            }
+        }
+    }
+    if (showManual) {
+        OpenRouterManualKeyDialog(
+            replacing = connection.connected,
+            onDismiss = { showManual = false },
+            onSave = { showManual = false; onSaveKey(it) },
+        )
+    }
+    if (confirmation != null) {
+        val action = confirmation
+        AlertDialog(
+            onDismissRequest = { confirmation = null },
+            title = { Text(when (action) {
+                "disconnect" -> "Disconnect OpenRouter?"
+                "restore" -> "Use your saved manual key?"
+                else -> "Switch OpenRouter connection?"
+            }) },
+            text = { Text(when (action) {
+                "disconnect" -> "This removes your OpenRouter connection and any saved manual key from this device. Your models and chats stay here. To revoke a key on OpenRouter, visit openrouter.ai/keys."
+                "restore" -> "Your saved manual key will become the active connection. The sign-in key will be removed from this device."
+                else -> if (connection.signedIn) "Your current connection stays active until the new sign-in succeeds."
+                    else "Your current API key stays active until sign-in succeeds. It will remain saved so you can switch back later."
+            }) },
+            confirmButton = { TextButton(onClick = {
+                confirmation = null
+                when (action) { "disconnect" -> onDisconnect(); "restore" -> onRestoreKey(); else -> onSignIn() }
+            }) { Text(if (action == "disconnect") "Disconnect" else "Continue") } },
+            dismissButton = { TextButton(onClick = { confirmation = null }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun OpenRouterManualKeyDialog(replacing: Boolean, onDismiss: () -> Unit, onSave: (String) -> Unit) {
+    // Do not save credentials in Compose saved-instance state or prefill an existing secret.
+    var key by remember { mutableStateOf("") }
+    var visible by remember { mutableStateOf(false) }
+    val trimmed = key.trim()
+    val valid = trimmed.startsWith("sk-or-") && trimmed.length > 16 && trimmed.none { it.isWhitespace() }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Key, null) },
+        title = { Text(if (replacing) "Replace API key" else "Add API key") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.m)) {
+                Text(if (replacing) "Saving replaces the active connection and any saved manual key on this device."
+                    else "Paste a key from openrouter.ai/keys. It will be stored securely on this device.")
+                OutlinedTextField(
+                    value = key, onValueChange = { key = it }, label = { Text("OpenRouter API key") },
+                    placeholder = { Text("sk-or-v1-…") }, singleLine = true,
+                    modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.medium,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
+                    visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+                    isError = trimmed.isNotEmpty() && !valid,
+                    supportingText = { if (trimmed.isNotEmpty() && !valid) Text("Enter a complete OpenRouter API key.") },
+                    trailingIcon = { IconButton(onClick = { visible = !visible }) {
+                        Icon(if (visible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            if (visible) "Hide API key" else "Show API key")
+                    } },
+                )
+            }
+        },
+        confirmButton = { TextButton(onClick = { onSave(trimmed) }, enabled = valid) { Text("Save key") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
@@ -31,7 +31,7 @@ internal fun OpenRouterConnectionCard(
     auth: OpenRouterAuthState,
     onSignIn: () -> Unit,
     onCancel: () -> Unit,
-    onSaveKey: (String) -> Unit,
+    onSaveKey: (String, () -> Unit) -> Unit,
     onRestoreKey: () -> Unit,
     onDisconnect: () -> Unit,
 ) {
@@ -119,8 +119,10 @@ internal fun OpenRouterConnectionCard(
     if (showManual) {
         OpenRouterManualKeyDialog(
             replacing = connection.connected,
+            saving = auth.busy,
+            error = auth.message.takeIf { auth.error },
             onDismiss = { showManual = false },
-            onSave = { showManual = false; onSaveKey(it) },
+            onSave = { key -> onSaveKey(key) { showManual = false } },
         )
     }
     if (confirmation != null) {
@@ -148,14 +150,21 @@ internal fun OpenRouterConnectionCard(
 }
 
 @Composable
-private fun OpenRouterManualKeyDialog(replacing: Boolean, onDismiss: () -> Unit, onSave: (String) -> Unit) {
+internal fun OpenRouterManualKeyDialog(
+    replacing: Boolean,
+    saving: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
     // Do not save credentials in Compose saved-instance state or prefill an existing secret.
     var key by remember { mutableStateOf("") }
     var visible by remember { mutableStateOf(false) }
+    var attempted by remember { mutableStateOf(false) }
     val trimmed = key.trim()
     val valid = trimmed.startsWith("sk-or-") && trimmed.length > 16 && trimmed.none { it.isWhitespace() }
     AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (!saving) onDismiss() },
         icon = { Icon(Icons.Default.Key, null) },
         title = { Text(if (replacing) "Replace API key" else "Add API key") },
         text = {
@@ -164,20 +173,27 @@ private fun OpenRouterManualKeyDialog(replacing: Boolean, onDismiss: () -> Unit,
                     else "Paste a key from openrouter.ai/keys. It will be stored securely on this device.")
                 OutlinedTextField(
                     value = key, onValueChange = { key = it }, label = { Text("OpenRouter API key") },
+                    enabled = !saving,
                     placeholder = { Text("sk-or-v1-…") }, singleLine = true,
                     modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.medium,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
                     visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
                     isError = trimmed.isNotEmpty() && !valid,
                     supportingText = { if (trimmed.isNotEmpty() && !valid) Text("Enter a complete OpenRouter API key.") },
-                    trailingIcon = { IconButton(onClick = { visible = !visible }) {
+                    trailingIcon = { IconButton(onClick = { visible = !visible }, enabled = !saving) {
                         Icon(if (visible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                             if (visible) "Hide API key" else "Show API key")
                     } },
                 )
+                if (attempted && error != null) {
+                    Text(error, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite })
+                }
             }
         },
-        confirmButton = { TextButton(onClick = { onSave(trimmed) }, enabled = valid) { Text("Save key") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        confirmButton = { TextButton(onClick = { attempted = true; onSave(trimmed) }, enabled = valid && !saving) {
+            Text(if (saving) "Saving…" else "Save key")
+        } },
+        dismissButton = { TextButton(onClick = onDismiss, enabled = !saving) { Text("Cancel") } },
     )
 }

--- a/app/src/main/res/drawable/logo_openrouter.xml
+++ b/app/src/main/res/drawable/logo_openrouter.xml
@@ -1,0 +1,10 @@
+<!-- OpenRouter's July 2026 brand mark, from https://openrouter.ai/.
+     Original SVG viewBox: 19.82 17.199 365.556 258.298. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28.3dp" android:height="20dp"
+    android:viewportWidth="365.556" android:viewportHeight="258.298">
+    <group android:translateX="-19.82" android:translateY="-17.199">
+        <path android:fillColor="#000000"
+            android:pathData="M303.9475,17.19926c42.79734,0,77.48933,34.69327,77.48933,77.48933s-34.69199,77.48933,-77.48933,77.48933l76.86166,76.86244c9.76367,9.76313,2.84903,26.45667,-10.95697,26.45667h-220.88335c-71.32686,0,-129.14889,-57.82202,-129.14889,-129.14889S77.64197,17.19926,148.96884,17.19926h154.97866ZM148.96884,68.85881c-42.79607,0,-77.48933,34.69327,-77.48933,77.48933s34.69327,77.48933,77.48933,77.48933,77.48933,-34.69327,77.48933,-77.48933,-34.69327,-77.48933,-77.48933,-77.48933Z" />
+    </group>
+</vector>

--- a/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
@@ -18,6 +18,12 @@ import java.net.Socket
 
 @RunWith(RobolectricTestRunner::class)
 class OpenRouterAuthServiceTest {
+    @Test fun `browser return is restricted to EchoFlow package`() {
+        val intent = android.content.Intent.parseUri(OpenRouterAuthService.RETURN_TO_APP_URI, android.content.Intent.URI_INTENT_SCHEME)
+        assertEquals(com.echoflow.BuildConfig.APPLICATION_ID, intent.`package`)
+        assertEquals("com.echoflow.openrouter://return", intent.dataString)
+        assertNull(intent.selector)
+    }
     @Test fun `PKCE uses fresh verifiers and unpadded base64url challenges`() {
         val verifier = OpenRouterAuthService.randomToken()
         assertEquals(64, verifier.length)
@@ -68,6 +74,8 @@ class OpenRouterAuthServiceTest {
             socket.getOutputStream().write("GET ${requestUrl.encodedPath}?${requestUrl.encodedQuery} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".toByteArray())
             val page = socket.getInputStream().bufferedReader().readText()
             assertTrue(page.contains("Return to EchoFlow"))
+            assertTrue(page.contains(OpenRouterAuthService.RETURN_TO_APP_URI))
+            assertFalse(page.contains("href=\"com.echoflow.openrouter:"))
             assertFalse(page.contains("authorization-code"))
             assertFalse(page.contains("sk-or-"))
         }

--- a/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
@@ -1,0 +1,86 @@
+package com.echoflow.data
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.Socket
+
+@RunWith(RobolectricTestRunner::class)
+class OpenRouterAuthServiceTest {
+    @Test fun `PKCE uses fresh verifiers and unpadded base64url challenges`() {
+        val verifier = OpenRouterAuthService.randomToken()
+        assertEquals(64, verifier.length)
+        assertTrue(OpenRouterAuthService.challenge(verifier).matches(Regex("[A-Za-z0-9_-]{43}")))
+        assertNotEquals(OpenRouterAuthService.randomToken(), OpenRouterAuthService.randomToken())
+    }
+
+    @Test fun `callback rejects foreign state duplicate code and non GET requests`() {
+        fun code(line: String) = OpenRouterAuthService.callbackCode(line, 1234, "expected-state")
+        assertEquals("abc", code("GET /callback/expected-state?code=abc HTTP/1.1"))
+        assertNull(code("GET /callback/wrong-state?code=abc HTTP/1.1"))
+        assertNull(code("GET /callback/expected-state?code=abc&code=def HTTP/1.1"))
+        assertNull(code("POST /callback/expected-state?code=abc HTTP/1.1"))
+        assertNull(code("GET /callback/expected-state?code= HTTP/1.1"))
+        assertNull(code("GET /callback/expected-state?error=access_denied HTTP/1.1"))
+        assertNull(code("GET http://evil.test/callback/expected-state?code=abc HTTP/1.1"))
+    }
+
+    @Test fun `browser callback exchanges authorization with original verifier`() = runBlocking {
+        var exchanged = false
+        var expectedChallenge = ""
+        val browser = CompletableDeferred<String>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            val request = chain.request()
+            assertEquals("https://openrouter.ai/api/v1/auth/keys", request.url.toString())
+            assertEquals("POST", request.method)
+            assertNull(request.header("Authorization"))
+            val buffer = okio.Buffer()
+            request.body!!.writeTo(buffer)
+            val body = org.json.JSONObject(buffer.readUtf8())
+            assertEquals("authorization-code", body.getString("code"))
+            assertEquals("S256", body.getString("code_challenge_method"))
+            assertEquals(expectedChallenge,
+                OpenRouterAuthService.challenge(body.getString("code_verifier")))
+            exchanged = true
+            Response.Builder().request(request).protocol(Protocol.HTTP_1_1).code(200).message("OK")
+                .body("{\"key\":\"sk-or-v1-returned-user-key\"}".toResponseBody("application/json".toMediaType())).build()
+        }.build()
+        val signIn = async { OpenRouterAuthService(client).signIn({
+            expectedChallenge = it.toHttpUrl().queryParameter("code_challenge").orEmpty()
+            browser.complete(it)
+        }, {}) }
+        val callback = browser.await().toHttpUrl().queryParameter("callback_url")!!.toHttpUrl()
+        val requestUrl = callback.newBuilder().addQueryParameter("code", "authorization-code").build()
+        // Synchronous socket request uses a real loopback listener; no external account required.
+        Socket("127.0.0.1", callback.port).use { socket ->
+            socket.soTimeout = 5000
+            socket.getOutputStream().write("GET ${requestUrl.encodedPath}?${requestUrl.encodedQuery} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".toByteArray())
+            val page = socket.getInputStream().bufferedReader().readText()
+            assertTrue(page.contains("Return to EchoFlow"))
+            assertFalse(page.contains("authorization-code"))
+            assertFalse(page.contains("sk-or-"))
+        }
+        assertEquals("sk-or-v1-returned-user-key", signIn.await())
+        assertTrue(exchanged)
+    }
+
+    @Test fun `cancel closes listener without exchanging a key`() = runBlocking {
+        val browser = CompletableDeferred<String>()
+        val signIn = async { OpenRouterAuthService().signIn({ browser.complete(it) }, { fail("Must not exchange") }) }
+        val callback = browser.await().toHttpUrl().queryParameter("callback_url")!!.toHttpUrl()
+        signIn.cancelAndJoin()
+        assertThrows(java.net.ConnectException::class.java) { Socket("127.0.0.1", callback.port).close() }
+        Unit
+    }
+}

--- a/app/src/test/java/com/echoflow/data/OpenRouterConnectionTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterConnectionTest.kt
@@ -1,0 +1,118 @@
+package com.echoflow.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OpenRouterConnectionTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = context.getSharedPreferences("openrouter-connection-test", Context.MODE_PRIVATE)
+    private val legacy = SettingsPreferenceStorage.legacy(context)
+    @Before fun reset() { prefs.edit().clear().commit(); legacy.edit().clear().commit() }
+    private fun repository() = SettingsRepository(context, prefs)
+
+    @Test fun `existing encrypted key is recognized as manual without rewriting it`() {
+        prefs.edit().putString("openrouter_api_key", "existing-user-key").commit()
+        val settings = repository()
+        assertEquals("existing-user-key", settings.apiKey.value)
+        assertTrue(settings.openRouterConnection.value.connected)
+        assertFalse(settings.openRouterConnection.value.signedIn)
+        assertFalse(prefs.contains("openrouter_signed_in"))
+    }
+
+    @Test fun `legacy plaintext key migrates before connection state is read`() {
+        legacy.edit().putString("openrouter_api_key", "legacy-key").commit()
+        val settings = repository()
+        assertEquals("legacy-key", settings.apiKey.value)
+        assertTrue(settings.openRouterConnection.value.connected)
+        assertFalse(settings.openRouterConnection.value.signedIn)
+        assertTrue(legacy.all.isEmpty())
+    }
+
+    @Test fun `successful sign in retains manual key across restart and account switch`() {
+        val settings = repository()
+        settings.saveApiKey("manual-secret")
+        settings.saveOpenRouterSignIn("oauth-secret-one")
+        settings.saveOpenRouterSignIn("oauth-secret-two")
+        val restarted = repository()
+        assertTrue(restarted.openRouterConnection.value.signedIn)
+        assertTrue(restarted.openRouterConnection.value.hasSavedManualKey)
+        assertEquals("oauth-secret-two", restarted.apiKey.value)
+        restarted.restoreOpenRouterManualKey()
+        assertEquals("manual-secret", restarted.apiKey.value)
+        assertFalse(restarted.openRouterConnection.value.signedIn)
+        assertFalse(restarted.openRouterConnection.value.hasSavedManualKey)
+    }
+
+    @Test fun `manual replacement becomes the only credential`() {
+        val settings = repository()
+        settings.saveApiKey("original-manual")
+        settings.saveOpenRouterSignIn("signed-in-secret")
+        settings.saveApiKey("  replacement-manual  ")
+        assertEquals("replacement-manual", repository().apiKey.value)
+        assertFalse(settings.openRouterConnection.value.hasSavedManualKey)
+        assertFalse(settings.openRouterConnection.value.signedIn)
+    }
+
+    @Test fun `disconnect removes active and saved keys and survives restart`() {
+        val settings = repository()
+        settings.saveApiKey("original-manual")
+        settings.saveOpenRouterSignIn("signed-in-secret")
+        settings.saveApiKey("")
+        assertEquals(OpenRouterConnection(), repository().openRouterConnection.value)
+        assertEquals("", repository().apiKey.value)
+        assertFalse(prefs.contains("openrouter_manual_key"))
+    }
+
+    @Test fun `empty sign in result cannot replace existing connection`() {
+        val settings = repository()
+        settings.saveApiKey("existing-key")
+        assertThrows(IllegalArgumentException::class.java) { settings.saveOpenRouterSignIn("") }
+        assertEquals("existing-key", repository().apiKey.value)
+    }
+
+    @Test fun `missing manual backup does not erase active key`() {
+        val settings = repository()
+        settings.saveOpenRouterSignIn("signed-in-secret")
+        assertThrows(IllegalStateException::class.java) { settings.restoreOpenRouterManualKey() }
+        assertEquals("signed-in-secret", settings.apiKey.value)
+    }
+
+    @Test fun `failed durable save restores direct readers and leaves flows unchanged`() {
+        prefs.edit().putString("openrouter_api_key", "existing-key").commit()
+        var failNext = true
+        val failing = object : SharedPreferences by prefs {
+            override fun edit(): SharedPreferences.Editor {
+                val delegate = prefs.edit()
+                return object : SharedPreferences.Editor by delegate {
+                    override fun putString(key: String?, value: String?): SharedPreferences.Editor {
+                        delegate.putString(key, value); return this
+                    }
+                    override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor {
+                        delegate.putBoolean(key, value); return this
+                    }
+                    override fun remove(key: String?): SharedPreferences.Editor {
+                        delegate.remove(key); return this
+                    }
+                    override fun commit(): Boolean {
+                        val result = delegate.commit()
+                        if (failNext) { failNext = false; return false }
+                        return result
+                    }
+                }
+            }
+        }
+        val settings = SettingsRepository(context, failing)
+        assertThrows(IllegalStateException::class.java) { settings.saveOpenRouterSignIn("new-sign-in-key") }
+        assertEquals("existing-key", settings.getApiKeyDirect())
+        assertEquals("existing-key", settings.apiKey.value)
+        assertFalse(settings.openRouterConnection.value.signedIn)
+        assertFalse(repository().openRouterConnection.value.hasSavedManualKey)
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
@@ -72,18 +72,10 @@ class OpenRouterConnectionCardTest {
         composeRule.onRoot().captureRoboImage("build/outputs/openrouter/signed-in-light.png")
     }
 
-    @Test fun manual_entry_is_secondary_and_validates_before_save() {
-        var saved = ""
-        show(onSave = { saved = it })
-        // Drive the text-field/IME animation explicitly under Robolectric.
-        composeRule.mainClock.autoAdvance = false
-        composeRule.onNodeWithText("Or add API key manually").performClick()
-        composeRule.mainClock.advanceTimeBy(500)
-        composeRule.onNodeWithText("Save key").assertIsNotEnabled()
-        composeRule.onNodeWithText("OpenRouter API key").performTextInput("sk-or-v1-manual-test-key")
-        composeRule.mainClock.advanceTimeBy(500)
-        composeRule.onNodeWithText("Save key").performClick()
-        assertEquals("sk-or-v1-manual-test-key", saved)
+    @Test fun manual_entry_is_secondary() {
+        show()
+        composeRule.onNodeWithText("Or add API key manually").assertIsDisplayed()
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/manual-entry-secondary.png")
     }
 
     @Test fun failed_sign_in_keeps_existing_connection_visible() {

--- a/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
@@ -39,7 +39,7 @@ class OpenRouterConnectionCardTest {
                 Surface {
                     Column(Modifier.verticalScroll(rememberScrollState()).padding(Spacing.base)) {
                         PageSection("Connection", "Your OpenRouter account, models and credits")
-                        OpenRouterConnectionCard(connection, auth, onSignIn, {}, onSave, {}, {})
+                        OpenRouterConnectionCard(connection, auth, onSignIn, {}, { key, done -> onSave(key); done() }, {}, {})
                     }
                 }
             }

--- a/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
@@ -1,0 +1,102 @@
+package com.echoflow.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.echoflow.data.OpenRouterConnection
+import com.echoflow.ui.OpenRouterAuthState
+import com.echoflow.ui.theme.EchoFlowTheme
+import com.echoflow.ui.theme.Spacing
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp-xhdpi", sdk = [36])
+class OpenRouterConnectionCardTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    private fun show(connection: OpenRouterConnection = OpenRouterConnection(), dark: Boolean = false,
+        auth: OpenRouterAuthState = OpenRouterAuthState(), onSignIn: () -> Unit = {}, onSave: (String) -> Unit = {},
+        fontScale: Float = 1f) {
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(LocalDensity.current.density, fontScale)) {
+            EchoFlowTheme(darkTheme = dark) {
+                Surface {
+                    Column(Modifier.verticalScroll(rememberScrollState()).padding(Spacing.base)) {
+                        PageSection("Connection", "Your OpenRouter account, models and credits")
+                        OpenRouterConnectionCard(connection, auth, onSignIn, {}, onSave, {}, {})
+                    }
+                }
+            }
+            }
+        }
+    }
+
+    @Test fun new_user_light() {
+        var signIns = 0
+        show(onSignIn = { signIns++ })
+        composeRule.onNodeWithText("Sign in with OpenRouter").performClick()
+        assertEquals(1, signIns)
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/new-user-light.png")
+    }
+
+    @Test fun existing_key_dark_requires_confirmation() {
+        var signIns = 0
+        show(OpenRouterConnection(connected = true, keyEnding = "a1b2"), dark = true, onSignIn = { signIns++ })
+        composeRule.onNodeWithText("Connected with API key").assertIsDisplayed()
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/existing-key-dark.png")
+        composeRule.onNodeWithText("Sign in with OpenRouter").performClick()
+        assertEquals(0, signIns)
+        composeRule.onNodeWithText("Continue").performClick()
+        assertEquals(1, signIns)
+    }
+
+    @Test fun signed_in_with_restore_option() {
+        show(OpenRouterConnection(true, true, "c3d4", true))
+        composeRule.onNodeWithText("Use saved manual key").assertIsDisplayed()
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/signed-in-light.png")
+    }
+
+    @Test fun manual_entry_is_secondary_and_validates_before_save() {
+        var saved = ""
+        show(onSave = { saved = it })
+        // Drive the text-field/IME animation explicitly under Robolectric.
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onNodeWithText("Or add API key manually").performClick()
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.onNodeWithText("Save key").assertIsNotEnabled()
+        composeRule.onNodeWithText("OpenRouter API key").performTextInput("sk-or-v1-manual-test-key")
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.onNodeWithText("Save key").performClick()
+        assertEquals("sk-or-v1-manual-test-key", saved)
+    }
+
+    @Test fun failed_sign_in_keeps_existing_connection_visible() {
+        show(OpenRouterConnection(true, false, "a1b2"), auth = OpenRouterAuthState(
+            message = "Couldn’t finish sign-in. Your saved connection hasn’t changed.", error = true))
+        composeRule.onNodeWithText("Connected with API key").assertIsDisplayed()
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/sign-in-error.png")
+    }
+
+    @Test @Config(qualifiers = "w320dp-h800dp-xhdpi", sdk = [36])
+    fun narrow_screen_large_text() {
+        show(OpenRouterConnection(true, true, "c3d4", true), dark = true, fontScale = 1.5f)
+        composeRule.onNodeWithText("Switch OpenRouter account").assertIsDisplayed()
+        composeRule.onRoot().captureRoboImage("build/outputs/openrouter/large-text-dark.png")
+    }
+}

--- a/app/src/test/java/com/echoflow/ui/screens/OpenRouterManualEntryTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/OpenRouterManualEntryTest.kt
@@ -1,0 +1,57 @@
+package com.echoflow.ui.screens
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import com.echoflow.data.OpenRouterConnection
+import com.echoflow.ui.OpenRouterAuthState
+import com.echoflow.ui.theme.EchoFlowTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Behavioral tests run independently from native screenshot rendering. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class OpenRouterManualEntryTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test fun `manual key validates retains draft on failure and closes only after success`() {
+        val auth = mutableStateOf(OpenRouterAuthState())
+        var saved = ""
+        var completeSave: () -> Unit = {}
+        var attempts = 0
+        composeRule.setContent {
+            EchoFlowTheme {
+                OpenRouterConnectionCard(OpenRouterConnection(), auth.value, {}, {}, { key, done ->
+                    attempts++
+                    saved = key
+                    completeSave = done
+                    auth.value = OpenRouterAuthState(busy = true)
+                }, {}, {})
+            }
+        }
+        composeRule.onNodeWithText("Or add API key manually").performClick()
+        composeRule.onNodeWithText("Save key").assertIsNotEnabled()
+        composeRule.onNodeWithText("OpenRouter API key").performTextInput("invalid")
+        composeRule.onNodeWithText("Save key").assertIsNotEnabled()
+        val draft = "sk-or-v1-manual-test-key"
+        composeRule.onNodeWithText("OpenRouter API key").performTextReplacement(draft)
+        composeRule.onNodeWithText("Save key").assertIsEnabled().performClick()
+        assertEquals(draft, saved)
+        composeRule.onNodeWithText("Saving…").assertIsNotEnabled()
+        composeRule.onNodeWithText("Cancel").assertIsNotEnabled()
+        assertEquals(1, attempts)
+
+        composeRule.runOnIdle { auth.value = OpenRouterAuthState(message = "Couldn’t save. Please retry.", error = true) }
+        composeRule.onNodeWithText("OpenRouter API key").assertExists()
+        composeRule.onNodeWithText("Save key").assertIsEnabled().performClick()
+        assertEquals(draft, saved)
+        assertEquals(2, attempts)
+        composeRule.runOnIdle { auth.value = OpenRouterAuthState(); completeSave() }
+        composeRule.onNodeWithText("OpenRouter API key").assertDoesNotExist()
+    }
+}

--- a/docs/openrouter-sign-in.md
+++ b/docs/openrouter-sign-in.md
@@ -1,0 +1,59 @@
+# OpenRouter connection
+
+The OpenRouter settings card offers browser sign-in first and manual API-key entry
+as a secondary dialog. Both methods feed the existing `SettingsRepository.apiKey`
+flow and `getApiKeyDirect()` accessor, so chat, search, image and video consumers
+continue to use the same active credential.
+
+## Storage and migration
+
+`openrouter_api_key` remains the active key in the existing encrypted preferences.
+Missing `openrouter_signed_in` metadata means a manual connection; no existing key
+is rewritten or invalidated on upgrade. The existing plaintext-to-encrypted
+migration still runs before the connection state is read.
+
+Successful sign-in atomically writes the active key and its origin. When switching
+from a manual key, that key is retained as `openrouter_manual_key` in the same
+encrypted store. Signing in again preserves this backup. Restoring it makes it
+active and removes the backup entry. Explicit manual replacement or disconnect
+removes the backup. Disconnect only removes local credentials; it does not revoke
+keys on OpenRouter. Android backup rules already exclude all shared preferences.
+
+## Browser flow
+
+`OpenRouterAuthService` uses S256 PKCE and a random callback-path nonce. It opens
+an ephemeral listener on **127.0.0.1 only**, then sends the browser to OpenRouter's
+documented authorization URL. The local callback accepts a single code only for
+the expected path and exchanges it directly with OpenRouter over HTTPS. The
+exchange client has no credential/logging interceptors and follows no redirects.
+
+The callback response includes a **Return to EchoFlow** link that brings the app
+to the foreground. This Android link carries no code or credential and only
+returns focus; the local listener handles authorization. The response never echoes
+the authorization code and disables caching/referrer transmission.
+
+The Settings ViewModel owns sign-in through rotation. Cancelling or clearing the
+ViewModel closes the listener; it otherwise expires after ten minutes. A process
+restart deliberately loses the in-memory verifier, requiring a fresh sign-in.
+The prior active credential is retained throughout authorization and exchange.
+
+No hosted callback service or OAuth client secret is required. OpenRouter labels
+localhost integrations by host/port rather than giving them public marketplace
+attribution. A future branded public callback would require a controlled HTTPS
+domain and verified Android App Links; a custom scheme alone is not a documented
+OpenRouter callback option.
+
+Reference: https://openrouter.ai/docs/guides/overview/auth/oauth
+
+## Validation
+
+Repository tests cover both existing-key migration paths, restart, account
+switching, restoring a saved manual key, manual replacement and disconnect.
+Authentication tests cover the RFC 7636 challenge vector, callback rejection,
+a real local socket callback with a mocked HTTPS exchange, and cancellation.
+Compose tests cover the primary sign-in action, replacement confirmation, manual
+entry and connection states, with light/dark and narrow-screen render captures.
+
+A real OpenRouter account/browser authorization still needs a device smoke test:
+sign in, return to EchoFlow, run a request, restore a manual key, then cancel and
+retry sign-in. Also exercise process termination during browser authorization.

--- a/docs/openrouter-sign-in.md
+++ b/docs/openrouter-sign-in.md
@@ -27,8 +27,10 @@ documented authorization URL. The local callback accepts a single code only for
 the expected path and exchanges it directly with OpenRouter over HTTPS. The
 exchange client has no credential/logging interceptors and follows no redirects.
 
-The callback response includes a **Return to EchoFlow** link that brings the app
-to the foreground. This Android link carries no code or credential and only
+The callback response includes a **Return to EchoFlow** Android intent URI bound
+to the installed EchoFlow application ID. Registering the same custom scheme in
+another app cannot capture this return. Browsers without intent-URI support show
+instructions to return manually. This link carries no code or credential and only
 returns focus; the local listener handles authorization. The response never echoes
 the authorization code and disables caching/referrer transmission.
 
@@ -49,10 +51,17 @@ Reference: https://openrouter.ai/docs/guides/overview/auth/oauth
 
 Repository tests cover both existing-key migration paths, restart, account
 switching, restoring a saved manual key, manual replacement and disconnect.
-Authentication tests cover the RFC 7636 challenge vector, callback rejection,
+Authentication tests cover PKCE format and randomness, callback rejection,
 a real local socket callback with a mocked HTTPS exchange, and cancellation.
 Compose tests cover the primary sign-in action, replacement confirmation, manual
 entry and connection states, with light/dark and narrow-screen render captures.
+Manual-entry behavioral coverage is separate from native screenshot tests and
+checks input validation, duplicate-submit prevention, retaining the transient
+draft after a failed write, retry, and dismissal only after persistence succeeds.
+
+The public RFC 7636 vector test is retained only in the locally ignored
+`OpenRouterPkceVectorLocalTest.kt`, per the maintainer's preference. No secret
+detectors are disabled.
 
 A real OpenRouter account/browser authorization still needs a device smoke test:
 sign in, return to EchoFlow, run a request, restore a manual key, then cancel and


### PR DESCRIPTION
Replace the always-visible OpenRouter API-key form with a primary **Sign in with OpenRouter** button using the refreshed official logo and EchoFlow's existing Material components. Manual key entry remains a secondary dialog; connected users get masked key details, connection switching, restoration of their previous manual key, and disconnect actions.

### Authentication and migration

- Use S256 PKCE with an ephemeral IPv4 loopback callback and nonce validation. Exchange codes directly over HTTPS; credentials never pass through the exported return link.
- Preserve the existing encrypted `openrouter_api_key` storage and all downstream consumers. Existing installations default to a manual connection without rewriting their key.
- Keep the current credential active until sign-in succeeds. Retain a previous manual key in encrypted storage so users can restore it, and atomically update connection metadata with the active key.
- Return to the existing app task after browser authorization. Cancellation closes the listener; process death requires a fresh sign-in without deleting the saved connection.
- Add repository, authentication, and Compose tests plus architecture and smoke-test documentation in `docs/openrouter-sign-in.md`.

### Validation status

Publishing now at the author's request; further testing is deferred to reviewers/the author.

- An intermediate revision passed `:app:assembleDebug`.
- The first unit-test run completed 469 tests with 3 failures in the new test harness: a non-Unit JUnit method, an unsupported font-scale qualifier, and Compose text-field idling. Fixes have been applied but **not rerun**.
- Later changes, including the dedicated return activity and failed-write rollback, have **not received a final build/test pass**. UI render captures have not yet been visually reviewed. No claim of a green final test suite or final lint pass.
- `git diff --check` passed.

### Review / device smoke-test notes

The documented localhost OAuth flow avoids a hosted callback service. OpenRouter may label authorization with the local host/port rather than EchoFlow's public app attribution. A branded HTTPS callback would require a controlled domain and Android App Links.

Real-account authorization has not been exercised on a device. Please verify browser authorization and return, a model request afterward, cancellation/retry, rotation/process termination, manual-key restoration, and disconnect. Disconnect removes local credentials only; OpenRouter-side revocation is separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser-based OpenRouter sign-in with secure callback handling.
  - Added an OpenRouter connection panel showing connection status and key details.
  - Added manual API-key entry, validation, restore, account switching, and disconnect options.
  - Added progress, cancellation, and error feedback during sign-in.
  - Added support for retaining and restoring a manually saved key.

- **Documentation**
  - Added documentation covering browser sign-in, manual keys, storage, migration, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a browser-first OpenRouter connection experience using S256 PKCE and an IPv4 loopback callback while preserving the existing encrypted API-key integration and manual-key fallback.

- I like the product direction: making account sign-in the primary path substantially improves onboarding without abandoning existing users or advanced manual-key workflows.
- The UI clearly distinguishes signed-in, manual-key, waiting, failure, restoration, and disconnection states, with confirmations around destructive or connection-switching actions.
- Credential migration and switching are thoughtfully designed: the active credential remains unchanged until sign-in and durable persistence succeed, and a prior manual key can be restored.
- The dedicated behavioral test added since the previous review now exercises manual-key validation, retry behavior, draft retention, and dismissal after successful persistence.
- The package-bound intent URI addresses the earlier return-link interception concern while keeping authorization codes and credentials out of the exported activity.
- What could be better implemented is final validation: the product-facing flow would benefit from a complete build/test pass and a real-device browser smoke test covering authorization, return-to-task behavior, cancellation, process death, and a subsequent model request.

<h3>Confidence Score: 5/5</h3>

The reviewed code appears safe to merge, with no outstanding findings; completing the deferred final build, test run, and device smoke test remains advisable.

Both previous findings are fully addressed: the browser return now uses a package-bound intent URI, and a dedicated Compose test covers the manual-entry behavior that was previously missing. The only change since the previous review removes obsolete incident-specific wording from documentation and introduces no new defect.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt | Implements nonce-bound loopback OAuth, S256 PKCE, direct HTTPS key exchange, cancellation, and a package-bound return URI. |
| app/src/main/java/com/echoflow/data/SettingsRepository.kt | Preserves legacy credentials while atomically managing active sign-in keys, manual-key backups, restoration, disconnection, and failed-write rollback. |
| app/src/main/java/com/echoflow/ui/SettingsViewModel.kt | Coordinates the sign-in lifecycle and asynchronous credential updates while retaining the current connection on failure. |
| app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt | Adds the browser-first connection card, manual-key dialog, progress and error states, and confirmations for switching, restoration, and disconnection. |
| app/src/test/java/com/echoflow/ui/screens/OpenRouterManualEntryTest.kt | Restores behavioral coverage for validation, save invocation, retry, draft retention, and success-only dialog dismissal. |
| docs/openrouter-sign-in.md | Documents credential migration, browser authorization, lifecycle behavior, security boundaries, and remaining device validation. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant UI as Settings UI
    participant VM as SettingsViewModel
    participant Auth as OpenRouterAuthService
    participant Browser
    participant OR as OpenRouter
    participant Repo as SettingsRepository

    User->>UI: Sign in with OpenRouter
    UI->>VM: signInOpenRouter()
    VM->>Auth: signIn()
    Auth->>Auth: Create verifier, challenge, nonce, loopback listener
    Auth->>Browser: Open authorization URL
    Browser->>OR: Authorize account
    OR->>Auth: Redirect code to 127.0.0.1 callback
    Auth->>OR: Exchange code and verifier over HTTPS
    OR-->>Auth: API key
    Auth-->>VM: Validated key
    VM->>Repo: Atomically save key and connection metadata
    Repo-->>UI: Updated connection state
    Auth-->>Browser: Package-bound return link
    Browser->>UI: Restore EchoFlow task
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: bind OpenRouter return to EchoFlow ..."](https://github.com/adityavardhansharma/echoflow/commit/8666f232056f4d464c425ae8a3626dfd3dd89fc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61299660)</sub>

<!-- /greptile_comment -->