### PR TITLE
Compact OpenRouter connection card on Models

### DIFF
--- a/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt
@@ -146,7 +146,7 @@ internal fun CloudModelsPage(viewModel: SettingsViewModel, onBack: () -> Unit, e
             onDisconnect = { viewModel.saveApiKey("") },
         )
 
-        Spacer(Modifier.height(Spacing.xl))
+        Spacer(Modifier.height(Spacing.l))
         PageSection("Your models", "Live pricing and context windows from the directory")
         Button(
             onClick = {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsComponents.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsComponents.kt
@@ -436,13 +436,16 @@ internal fun ParamValueDialog(
 }
 
 @Composable
-internal fun FormCard(content: @Composable ColumnScope.() -> Unit) {
+internal fun FormCard(
+    contentPadding: Dp = Spacing.l,
+    content: @Composable ColumnScope.() -> Unit,
+) {
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surfaceContainer,
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Column(Modifier.padding(Spacing.l), content = content)
+        Column(Modifier.padding(contentPadding), content = content)
     }
 }
 

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
 package com.echoflow.ui.screens
 
 import androidx.compose.foundation.layout.*
@@ -37,48 +39,46 @@ internal fun OpenRouterConnectionCard(
 ) {
     var showManual by rememberSaveable { mutableStateOf(false) }
     var confirmation by rememberSaveable { mutableStateOf<String?>(null) }
-    FormCard {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.m)) {
-            Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.secondaryContainer) {
-                Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
-                    Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 28.dp, height = 20.dp),
+    val compactTextPadding = PaddingValues(horizontal = Spacing.s, vertical = Spacing.xs)
+    FormCard(contentPadding = Spacing.base) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
+            Surface(shape = MaterialTheme.shapes.medium, color = MaterialTheme.colorScheme.secondaryContainer) {
+                Box(Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                    Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 24.dp, height = 16.dp),
                         tint = MaterialTheme.colorScheme.onSecondaryContainer)
                 }
             }
-            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-                Text("OpenRouter", style = MaterialTheme.typography.titleMedium)
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text("OpenRouter", style = MaterialTheme.typography.titleSmall)
                 if (connection.connected) {
                     SavedKeyBadge(if (connection.signedIn) "Connected through sign-in" else "Connected with API key")
+                    if (connection.keyEnding.isNotEmpty()) {
+                        Text("Key ending in •••• ${connection.keyEnding}", style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
                 } else {
                     Text("One account. Your choice of models.", style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
-        Spacer(Modifier.height(Spacing.base))
-        Text(
-            when {
-                connection.signedIn -> "Usage is billed to your OpenRouter account. Your connection is stored securely on this device."
-                connection.connected -> "Your saved API key is ready to use. You can keep using it or connect through OpenRouter sign-in."
-                else -> "Sign in to use your OpenRouter models and credits. Usage is billed to your OpenRouter account."
-            },
-            style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        if (connection.connected && connection.keyEnding.isNotEmpty()) {
+        if (!connection.connected) {
             Spacer(Modifier.height(Spacing.s))
-            Text("Key ending in •••• ${connection.keyEnding}", style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(
+                "Sign in to use your OpenRouter models and credits. Usage is billed to your OpenRouter account.",
+                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
-        Spacer(Modifier.height(Spacing.l))
+        Spacer(Modifier.height(Spacing.m))
         Button(
             onClick = { if (connection.connected) confirmation = "switch" else onSignIn() },
             enabled = !auth.busy,
             shape = CircleShape,
-            modifier = Modifier.fillMaxWidth().heightIn(min = 52.dp),
-            contentPadding = PaddingValues(horizontal = Spacing.base, vertical = Spacing.m),
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = Spacing.base, vertical = Spacing.s),
         ) {
-            if (auth.busy) CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
-            else Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 25.dp, height = 18.dp))
+            if (auth.busy) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+            else Icon(painterResource(R.drawable.logo_openrouter), null, Modifier.size(width = 22.dp, height = 16.dp))
             Spacer(Modifier.width(Spacing.s))
             Text(when {
                 auth.waitingForBrowser -> "Waiting for OpenRouter…"
@@ -89,31 +89,41 @@ internal fun OpenRouterConnectionCard(
         }
         if (auth.waitingForBrowser) {
             Text("Finish signing in in your browser, then return here. If the app restarts, start sign-in again.",
-                modifier = Modifier.padding(top = Spacing.m), style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = Spacing.s), style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)
-            TextButton(onClick = onCancel, modifier = Modifier.align(Alignment.CenterHorizontally)) { Text("Cancel sign-in") }
-        } else {
-            TextButton(onClick = { showManual = true }, enabled = !auth.busy,
-                modifier = Modifier.align(Alignment.CenterHorizontally)) {
-                Text(if (connection.connected) "Use a different API key" else "Or add API key manually")
-            }
         }
         if (auth.message != null) {
             Text(auth.message, modifier = Modifier.padding(top = Spacing.s).semantics { liveRegion = LiveRegionMode.Polite },
                 style = MaterialTheme.typography.bodySmall,
                 color = if (auth.error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary)
         }
-        if (connection.connected) {
-            HorizontalDivider(Modifier.padding(vertical = Spacing.m), color = MaterialTheme.colorScheme.outlineVariant)
-            if (connection.hasSavedManualKey) {
-                Text("Your previous manual key is saved on this device.", style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                TextButton(onClick = { confirmation = "restore" }, enabled = !auth.busy) { Text("Use saved manual key") }
+        FlowRow(
+            Modifier.fillMaxWidth().padding(top = Spacing.xs),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (auth.waitingForBrowser) {
+                TextButton(onClick = onCancel, contentPadding = compactTextPadding) { Text("Cancel sign-in") }
+            } else {
+                TextButton(onClick = { showManual = true }, enabled = !auth.busy, contentPadding = compactTextPadding) {
+                    Text(if (connection.connected) "Use a different API key" else "Or add API key manually")
+                }
             }
-            TextButton(onClick = { confirmation = "disconnect" }, enabled = !auth.busy,
-                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)) {
-                Text("Disconnect")
+            if (connection.connected) {
+                TextButton(
+                    onClick = { confirmation = "disconnect" },
+                    enabled = !auth.busy,
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                    contentPadding = compactTextPadding,
+                ) { Text("Disconnect") }
             }
+        }
+        if (connection.connected && connection.hasSavedManualKey) {
+            TextButton(
+                onClick = { confirmation = "restore" },
+                enabled = !auth.busy,
+                contentPadding = compactTextPadding,
+            ) { Text("Use saved manual key") }
         }
     }
     if (showManual) {

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt
@@ -40,7 +40,7 @@ internal fun OpenRouterConnectionCard(
     var showManual by rememberSaveable { mutableStateOf(false) }
     var confirmation by rememberSaveable { mutableStateOf<String?>(null) }
     val compactTextPadding = PaddingValues(horizontal = Spacing.s, vertical = Spacing.xs)
-    FormCard(contentPadding = Spacing.base) {
+    FormCard(contentPadding = Spacing.m) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.s)) {
             Surface(shape = MaterialTheme.shapes.medium, color = MaterialTheme.colorScheme.secondaryContainer) {
                 Box(Modifier.size(40.dp), contentAlignment = Alignment.Center) {
@@ -69,7 +69,7 @@ internal fun OpenRouterConnectionCard(
                 style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        Spacer(Modifier.height(Spacing.m))
+        Spacer(Modifier.height(Spacing.s))
         Button(
             onClick = { if (connection.connected) confirmation = "switch" else onSignIn() },
             enabled = !auth.busy,
@@ -97,33 +97,35 @@ internal fun OpenRouterConnectionCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = if (auth.error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary)
         }
-        FlowRow(
-            Modifier.fillMaxWidth().padding(top = Spacing.xs),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            if (auth.waitingForBrowser) {
-                TextButton(onClick = onCancel, contentPadding = compactTextPadding) { Text("Cancel sign-in") }
-            } else {
-                TextButton(onClick = { showManual = true }, enabled = !auth.busy, contentPadding = compactTextPadding) {
-                    Text(if (connection.connected) "Use a different API key" else "Or add API key manually")
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 36.dp) {
+            FlowRow(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                if (auth.waitingForBrowser) {
+                    TextButton(onClick = onCancel, contentPadding = compactTextPadding) { Text("Cancel sign-in") }
+                } else {
+                    TextButton(onClick = { showManual = true }, enabled = !auth.busy, contentPadding = compactTextPadding) {
+                        Text(if (connection.connected) "Use a different API key" else "Or add API key manually")
+                    }
+                }
+                if (connection.connected) {
+                    TextButton(
+                        onClick = { confirmation = "disconnect" },
+                        enabled = !auth.busy,
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                        contentPadding = compactTextPadding,
+                    ) { Text("Disconnect") }
                 }
             }
-            if (connection.connected) {
+            if (connection.connected && connection.hasSavedManualKey) {
                 TextButton(
-                    onClick = { confirmation = "disconnect" },
+                    onClick = { confirmation = "restore" },
                     enabled = !auth.busy,
-                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
                     contentPadding = compactTextPadding,
-                ) { Text("Disconnect") }
+                ) { Text("Use saved manual key") }
             }
-        }
-        if (connection.connected && connection.hasSavedManualKey) {
-            TextButton(
-                onClick = { confirmation = "restore" },
-                enabled = !auth.busy,
-                contentPadding = compactTextPadding,
-            ) { Text("Use saved manual key") }
         }
     }
     if (showManual) {

--- a/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
+++ b/app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt
@@ -32,14 +32,14 @@ class OpenRouterConnectionCardTest {
 
     private fun show(connection: OpenRouterConnection = OpenRouterConnection(), dark: Boolean = false,
         auth: OpenRouterAuthState = OpenRouterAuthState(), onSignIn: () -> Unit = {}, onSave: (String) -> Unit = {},
-        fontScale: Float = 1f) {
+        onDisconnect: () -> Unit = {}, fontScale: Float = 1f) {
         composeRule.setContent {
             CompositionLocalProvider(LocalDensity provides Density(LocalDensity.current.density, fontScale)) {
             EchoFlowTheme(darkTheme = dark) {
                 Surface {
                     Column(Modifier.verticalScroll(rememberScrollState()).padding(Spacing.base)) {
                         PageSection("Connection", "Your OpenRouter account, models and credits")
-                        OpenRouterConnectionCard(connection, auth, onSignIn, {}, { key, done -> onSave(key); done() }, {}, {})
+                        OpenRouterConnectionCard(connection, auth, onSignIn, {}, { key, done -> onSave(key); done() }, {}, onDisconnect)
                     }
                 }
             }
@@ -69,7 +69,19 @@ class OpenRouterConnectionCardTest {
     @Test fun signed_in_with_restore_option() {
         show(OpenRouterConnection(true, true, "c3d4", true))
         composeRule.onNodeWithText("Use saved manual key").assertIsDisplayed()
+        composeRule.onNodeWithText("Use a different API key").assertIsDisplayed()
+        composeRule.onNodeWithText("Disconnect").assertIsDisplayed()
         composeRule.onRoot().captureRoboImage("build/outputs/openrouter/signed-in-light.png")
+    }
+
+    @Test fun disconnect_confirms_before_removing_connection() {
+        var disconnects = 0
+        show(OpenRouterConnection(true, true, "c3d4"), onDisconnect = { disconnects++ })
+        composeRule.onNodeWithText("Disconnect").performClick()
+        composeRule.onNodeWithText("Disconnect OpenRouter?").assertIsDisplayed()
+        assertEquals(0, disconnects)
+        composeRule.onAllNodesWithText("Disconnect")[1].performClick()
+        assertEquals(1, disconnects)
     }
 
     @Test fun manual_entry_is_secondary() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Models → OpenRouter connection card was taking too much vertical space: a large padded container, a long connected-state explanation, a divider, and Disconnect sitting in its own empty row.

This tightens that card only:

- Smaller inner padding and header logo
- Connected state keeps badge + key ending in the header, without the extra billing paragraph
- Primary action uses default button height instead of a 52dp min
- Disconnect sits beside “Use a different API key” (or Cancel during sign-in)
- Restore-saved-key stays as a compact extra action
- Existing confirmations and manual-key dialog are unchanged

Compose unit tests for the card (including disconnect confirmation) pass. Recorded renders:

[Signed-in connection card](https://cursor.com/agents/bc-1ef75f16-3133-4656-b09a-d7dbd2e9ca73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodels_connection_signed_in.png)
[New-user connection card](https://cursor.com/agents/bc-1ef75f16-3133-4656-b09a-d7dbd2e9ca73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodels_connection_new_user.png)
[Existing API key connection card (dark)](https://cursor.com/agents/bc-1ef75f16-3133-4656-b09a-d7dbd2e9ca73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodels_connection_existing_key_dark.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ef75f16-3133-4656-b09a-d7dbd2e9ca73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ef75f16-3133-4656-b09a-d7dbd2e9ca73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR successfully makes the OpenRouter card feel more focused by preserving connection status and key information while removing explanatory bulk and consolidating related actions.

- I like the product direction: the connected state is easier to scan, the card consumes less Models-page space, and Disconnect remains visible while retaining confirmation.
- The latest revision improves the padding balance and keeps the saved-key action with the other compact controls.
- The compact appearance would be better implemented by retaining standard 48dp touch bounds around the visually smaller text buttons.
- Waiting-browser layout coverage requested in the previous review is still absent, so that rearranged state remains unguarded.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with non-blocking accessibility and waiting-state test improvements remaining.

The compact secondary actions now expose only 36dp touch targets, which reduces accessibility but does not break the connection flow. The previous request for waiting-browser layout coverage also remains outstanding because no waiting-state test was added.

**Files Needing Attention:** app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/ui/screens/SettingsOpenRouterConnection.kt | Compacts connection status and actions effectively, but explicitly shrinks secondary-action touch targets to 36dp. |
| app/src/test/java/com/echoflow/ui/screens/OpenRouterConnectionCardTest.kt | Adds useful disconnect-confirmation and connected-action coverage, while still omitting the waiting-browser arrangement identified previously. |
| app/src/main/java/com/echoflow/ui/screens/SettingsComponents.kt | Adds a backward-compatible configurable padding parameter to FormCard. |
| app/src/main/java/com/echoflow/ui/screens/SettingsCloudModels.kt | Reduces spacing after the compact connection card to maintain the denser Models-page layout. |

<sub>Reviews (2): Last reviewed commit: ["Tighten OpenRouter connection footer spa..."](https://github.com/adityavardhansharma/echoflow/commit/e3f5ec460c374b997be50e01812450b588934fd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61316633)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined the OpenRouter connection card with a more compact layout, tighter spacing, and clearer organization of connection details and actions.
  * Connection information is now shown more selectively based on connection status.
  * Updated action buttons to use a flexible layout that better accommodates different screen sizes.
  * Disconnecting an OpenRouter connection now requires confirmation before the connection is removed.
  * Adjusted spacing between the connection card and the models section for a more streamlined settings experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->