### PR TITLE
Restyle the OpenRouter sign-in return page

### DIFF
--- a/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
+++ b/app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt
@@ -98,17 +98,16 @@ internal class OpenRouterAuthService(
     }
 
     private fun respond(socket: Socket, accepted: Boolean, declined: Boolean) {
-        val message = if (declined) "Sign-in was cancelled. Your saved connection has not changed."
-            else "Your authorization was received. Return to EchoFlow to finish connecting."
-        val body = if (accepted) {
-            """<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Return to EchoFlow</title><body style="font:18px system-ui;padding:32px;max-width:440px;margin:auto"><h1>Continue in EchoFlow</h1><p>$message</p><a href="$RETURN_TO_APP_URI" style="display:inline-block;padding:16px 24px;background:#222;color:white;border-radius:32px;text-decoration:none">Return to EchoFlow</a><p>If your browser cannot open this button, switch back to EchoFlow manually.</p></body></html>"""
-        } else "Invalid callback. Continue sign-in from EchoFlow."
+        val body = callbackHtml(accepted, declined)
         val bytes = body.toByteArray(Charsets.UTF_8)
         val status = if (accepted) "200 OK" else "400 Bad Request"
+        val csp = "default-src 'none'; style-src 'unsafe-inline'; " +
+            (if (accepted && !declined) "script-src 'unsafe-inline'; " else "") +
+            "frame-ancestors 'none'"
         socket.getOutputStream().apply {
             write(("HTTP/1.1 $status\r\nContent-Type: text/html; charset=utf-8\r\n" +
                 "Cache-Control: no-store\r\nReferrer-Policy: no-referrer\r\n" +
-                "Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'\r\n" +
+                "Content-Security-Policy: $csp\r\n" +
                 "Connection: close\r\nContent-Length: ${bytes.size}\r\n\r\n").toByteArray(Charsets.US_ASCII))
             write(bytes)
             flush()
@@ -127,6 +126,67 @@ internal class OpenRouterAuthService(
             MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII)),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
+
+        internal fun callbackHtml(accepted: Boolean, declined: Boolean): String = when {
+            !accepted -> page(
+                heading = "Couldn’t finish sign-in",
+                status = "Try again in the app",
+                message = "This return link isn’t valid. Continue sign-in from EchoFlow.",
+                autoOpen = false,
+            )
+            declined -> page(
+                heading = "Sign-in cancelled",
+                status = "Nothing was changed",
+                message = "OpenRouter authorization was declined. Your saved connection has not changed.",
+                autoOpen = false,
+            )
+            else -> page(
+                heading = "Continue in EchoFlow",
+                status = "OpenRouter approved",
+                message = "Your authorization was received. Return to EchoFlow to finish connecting.",
+                autoOpen = true,
+            )
+        }
+
+        private fun page(heading: String, status: String, message: String, autoOpen: Boolean): String {
+            val href = RETURN_TO_APP_URI
+            val script = if (autoOpen) {
+                """<script>setTimeout(function(){location.href=${JSONObject.quote(href)};},400);</script>"""
+            } else ""
+            return """
+                <!doctype html><html lang="en"><head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width,initial-scale=1">
+                <meta name="color-scheme" content="light dark">
+                <title>Return to EchoFlow</title>
+                <style>
+                :root{--bg:#f4f4f5;--card:#fff;--text:#18181b;--muted:#52525b;--btn:#18181b;--on-btn:#fafafa;--ring:#e4e4e7;--accent:#3f3f46}
+                @media (prefers-color-scheme:dark){:root{--bg:#09090b;--card:#18181b;--text:#fafafa;--muted:#a1a1aa;--btn:#fafafa;--on-btn:#18181b;--ring:#3f3f46;--accent:#d4d4d8}}
+                *{box-sizing:border-box}html,body{height:100%;margin:0}
+                body{font:16px/1.45 system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+                main{width:min(100%,400px);background:var(--card);border:1px solid var(--ring);border-radius:28px;padding:28px 24px 24px;text-align:center}
+                .mark{width:56px;height:56px;margin:0 auto 18px;border-radius:16px;background:var(--bg);color:var(--text);display:grid;place-items:center}
+                .status{margin:0 0 8px;color:var(--accent);font-size:.75rem;font-weight:650;letter-spacing:.06em;text-transform:uppercase}
+                h1{margin:0 0 10px;font-size:1.35rem;letter-spacing:-.02em;font-weight:650}
+                p{margin:0;color:var(--muted)}
+                a.btn{display:flex;align-items:center;justify-content:center;min-height:52px;margin:22px 0 14px;padding:14px 24px;border-radius:999px;background:var(--btn);color:var(--on-btn);text-decoration:none;font-weight:650}
+                a.btn:focus-visible{outline:3px solid var(--accent);outline-offset:3px}
+                .hint{font-size:.875rem}
+                .local{margin-top:16px;font-size:.75rem}
+                </style></head><body><main>
+                <div class="mark" aria-hidden="true"><svg viewBox="0 0 48 48" width="36" height="36">
+                <path d="M16 31c6.2-7.4 9.8-7.4 16 0" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round"/>
+                <path d="M12 25c9-11.5 15-11.5 24 0" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round"/>
+                <circle cx="24" cy="35.5" r="2.3" fill="currentColor"/></svg></div>
+                <p class="status">$status</p>
+                <h1>$heading</h1>
+                <p>$message</p>
+                <a class="btn" href="$href">Return to EchoFlow</a>
+                <p class="hint">If the button doesn’t open the app, switch to EchoFlow from Recents.</p>
+                <p class="local">This page is from EchoFlow on this phone. It never shows your key.</p>
+                </main>$script</body></html>
+            """.trimIndent()
+        }
 
         internal fun authorizationUrl(callback: String, verifier: String): String =
             "https://openrouter.ai/auth".toHttpUrl().newBuilder()

--- a/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
+++ b/app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt
@@ -74,6 +74,10 @@ class OpenRouterAuthServiceTest {
             socket.getOutputStream().write("GET ${requestUrl.encodedPath}?${requestUrl.encodedQuery} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".toByteArray())
             val page = socket.getInputStream().bufferedReader().readText()
             assertTrue(page.contains("Return to EchoFlow"))
+            assertTrue(page.contains("OpenRouter approved"))
+            assertTrue(page.contains("prefers-color-scheme:dark"))
+            assertTrue(page.contains("This page is from EchoFlow on this phone"))
+            assertTrue(page.contains("location.href="))
             assertTrue(page.contains(OpenRouterAuthService.RETURN_TO_APP_URI))
             assertFalse(page.contains("href=\"com.echoflow.openrouter:"))
             assertFalse(page.contains("authorization-code"))
@@ -81,6 +85,23 @@ class OpenRouterAuthServiceTest {
         }
         assertEquals("sk-or-v1-returned-user-key", signIn.await())
         assertTrue(exchanged)
+    }
+
+    @Test fun `callback pages cover success cancel and invalid without leaking secrets`() {
+        val success = OpenRouterAuthService.callbackHtml(accepted = true, declined = false)
+        val cancelled = OpenRouterAuthService.callbackHtml(accepted = true, declined = true)
+        val invalid = OpenRouterAuthService.callbackHtml(accepted = false, declined = false)
+        assertTrue(success.contains("Return to EchoFlow"))
+        assertTrue(success.contains("location.href="))
+        assertFalse(cancelled.contains("<script>"))
+        assertTrue(cancelled.contains("Sign-in cancelled"))
+        assertFalse(invalid.contains("<script>"))
+        assertTrue(invalid.contains("Couldn’t finish sign-in"))
+        listOf(success, cancelled, invalid).forEach { page ->
+            assertTrue(page.contains(OpenRouterAuthService.RETURN_TO_APP_URI))
+            assertTrue(page.contains("color-scheme"))
+            assertFalse(page.contains("sk-or-"))
+        }
     }
 
     @Test fun `cancel closes listener without exchanging a key`() = runBlocking {

--- a/docs/openrouter-sign-in.md
+++ b/docs/openrouter-sign-in.md
@@ -27,12 +27,15 @@ documented authorization URL. The local callback accepts a single code only for
 the expected path and exchanges it directly with OpenRouter over HTTPS. The
 exchange client has no credential/logging interceptors and follows no redirects.
 
-The callback response includes a **Return to EchoFlow** Android intent URI bound
-to the installed EchoFlow application ID. Registering the same custom scheme in
-another app cannot capture this return. Browsers without intent-URI support show
-instructions to return manually. This link carries no code or credential and only
-returns focus; the local listener handles authorization. The response never echoes
-the authorization code and disables caching/referrer transmission.
+The callback response is a self-contained success, cancel, or invalid page with a
+**Return to EchoFlow** Android intent URI bound to the installed EchoFlow
+application ID. Registering the same custom scheme in another app cannot capture
+this return. The success page also tries to reopen EchoFlow after a short delay;
+browsers that block that still show the button and a Recents fallback. This link
+carries no code or credential and only returns focus; the local listener handles
+authorization. The HTML uses inline CSS only (including a dark-mode palette) and
+never loads remote assets. The response never echoes the authorization code and
+disables caching/referrer transmission.
 
 The Settings ViewModel owns sign-in through rotation. Cancelling or clearing the
 ViewModel closes the listener; it otherwise expires after ten minutes. A process
@@ -52,7 +55,8 @@ Reference: https://openrouter.ai/docs/guides/overview/auth/oauth
 Repository tests cover both existing-key migration paths, restart, account
 switching, restoring a saved manual key, manual replacement and disconnect.
 Authentication tests cover PKCE format and randomness, callback rejection,
-a real local socket callback with a mocked HTTPS exchange, and cancellation.
+success/cancel/invalid return pages, a real local socket callback with a mocked
+HTTPS exchange, and cancellation.
 Compose tests cover the primary sign-in action, replacement confirmation, manual
 entry and connection states, with light/dark and narrow-screen render captures.
 Manual-entry behavioral coverage is separate from native screenshot tests and


### PR DESCRIPTION
## Summary
- Replace the loopback `127.0.0.1` stub with a self-contained EchoFlow card for success, cancel, and invalid OpenRouter callbacks (inline CSS, system dark mode, no remote assets).
- Success still uses the package-bound **Return to EchoFlow** intent and now also tries to reopen the app after a short delay; cancel/invalid keep the button without auto-open.
- Cover the three pages in unit tests and keep the existing socket exchange assertions (no code or key in the HTML).

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest --tests com.echoflow.data.OpenRouterAuthServiceTest`
- [ ] On a device, sign in with OpenRouter and confirm the browser page looks finished in light and dark, then **Return to EchoFlow** (or Recents) finishes connecting
- [ ] Decline/cancel authorization and confirm the cancel copy; no key is saved
- [ ] Confirm the page never shows the authorization code or API key


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the minimal OpenRouter callback response with polished, state-specific success, cancellation, and invalid-return cards, adds an optional success auto-return, and expands unit tests and documentation.

What I liked about the product direction:
- The self-contained design, dark-mode palette, clear state-specific copy, and absence of remote assets make the authentication handoff feel like a deliberate part of EchoFlow rather than a browser stub.
- Keeping callback credentials out of the HTML while retaining a package-bound return intent and manual fallback preserves the existing security model.
- Cancellation and invalid callbacks now give users substantially clearer recovery guidance.

What could be implemented better:
- Make vertical centering scroll-safe for short landscape viewports and browser zoom so the callback status and heading cannot be clipped.
- A small real-browser render matrix covering light/dark, short landscape, and zoomed text would complement the current substring tests and protect this UI direction.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking callback-page accessibility issue on short or heavily zoomed browser viewports.

The authentication exchange, package-bound return path, cancellation handling, and secret-exclusion behavior remain intact; the only accepted concern is that fixed-height vertical centering can make the callback status and heading unreachable under constrained viewport conditions.

**Files Needing Attention:** app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/echoflow/data/OpenRouterAuthService.kt | Adds self-contained callback cards, state-specific content, conditional CSP scripting, and delayed app return; the vertically centered layout can clip top content on short or zoomed viewports. |
| app/src/test/java/com/echoflow/data/OpenRouterAuthServiceTest.kt | Extends callback coverage across success, cancellation, and invalid HTML while retaining checks that callback secrets are absent. |
| docs/openrouter-sign-in.md | Accurately documents the redesigned callback pages, delayed success return, local assets, dark mode, and expanded tests. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant B as Browser
  participant L as Loopback callback
  participant O as OpenRouter
  participant E as EchoFlow
  B->>L: "GET /callback/{state}"
  alt Valid authorization code
    L-->>B: Success card + delayed app intent
    L->>O: Exchange code over HTTPS
    B-->>E: Package-bound return intent
    O-->>L: API key
    L-->>E: Save connection and update state
  else Authorization declined
    L-->>B: Cancellation card + manual return
  else Invalid callback
    L-->>B: HTTP 400 invalid card + manual return
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: restyle the OpenRouter sign-in ret..."](https://github.com/adityavardhansharma/echoflow/commit/e4934a2202cfa087ed50789c7dfdd465478db154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61557847)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->