### PR TITLE
feat: Add Muse Voice Transcribe

### DIFF
--- a/app/src/main/java/com/echoflow/data/SttCatalog.kt
+++ b/app/src/main/java/com/echoflow/data/SttCatalog.kt
@@ -19,8 +19,8 @@ enum class SttMode(val storageKey: String) {
  * OpenRouter per-minute price mapped onto the $ / $$ / $$$ tags on the STT picker.
  *
  * Cheap is one red dollar; moderate is two green dollars; expensive is three green dollars.
- * Cutoffs sit in the gaps of the current catalog (Grok ~$0.0017, GPT Transcribe $0.0045,
- * Chirp $0.016) so a listing can move without retuning the UI by hand.
+ * Cutoffs sit in the gaps of the current catalog (Grok ~$0.0017, Muse Transcribe $0.003,
+ * GPT Transcribe $0.0045, Chirp $0.016) so a listing can move without retuning the UI by hand.
  */
 enum class SttCostTier(val dollars: Int) {
     Cheap(1),
@@ -47,10 +47,8 @@ enum class SttCostTier(val dollars: Int) {
  * [usdPerMinute] is the same OpenRouter rate, normalized to dollars per minute of audio so the
  * dollar-tag cutoffs can compare models billed per second, minute, or hour.
  *
- * [isBest] is true for exactly one model: the lowest Artificial Analysis word-error rate
- * (AA-WER, non-streaming) among catalog entries that have a published score. As of 2026-08:
- * GPT Transcribe 3.3%, Grok STT 4.0%. Chirp 3 is charted on the streaming leaderboard only;
- * Nemotron 3.5 ASR has no AA-WER yet.
+ * [isBest] is true for exactly one model: the recommended dictation pick. Muse Transcribe
+ * is first in the list. GPT Transcribe remains available below it.
  */
 data class SttModel(
     val id: String,
@@ -91,6 +89,16 @@ object SttCatalog {
     /** Cloud options offered on the STT settings page, in display order. */
     val CLOUD_MODELS = listOf(
         SttModel(
+            id = "meta/muse-voice-transcribe-1.0",
+            name = "Muse Transcribe",
+            provider = "Meta",
+            // OpenRouter lists $0.18/hour → $0.003/min.
+            pricing = "~\$0.003 / min",
+            blurb = "Push-to-talk dictation with speaker awareness and keyword biasing.",
+            usdPerMinute = 0.18 / 60.0,
+            isBest = true,
+        ),
+        SttModel(
             id = "openai/gpt-transcribe",
             name = "GPT Transcribe",
             provider = "OpenAI",
@@ -98,7 +106,6 @@ object SttCatalog {
             pricing = "~\$0.0045 / min",
             blurb = "High-accuracy dictation, strong on mixed or quiet speech.",
             usdPerMinute = 0.0045,
-            isBest = true,
         ),
         SttModel(
             id = "x-ai/grok-stt-1.0",
@@ -129,7 +136,7 @@ object SttCatalog {
         ),
     )
 
-    const val DEFAULT_MODEL_ID = "openai/gpt-transcribe"
+    const val DEFAULT_MODEL_ID = "meta/muse-voice-transcribe-1.0"
 
     fun byId(id: String): SttModel? = (CLOUD_MODELS + SARVAM_MODEL).firstOrNull { it.id == id }
 

--- a/app/src/main/java/com/echoflow/ui/screens/SettingsSpeechToText.kt
+++ b/app/src/main/java/com/echoflow/ui/screens/SettingsSpeechToText.kt
@@ -136,7 +136,7 @@ private fun SttCloudSection(viewModel: SettingsViewModel, onOpenCloudModels: () 
         Text(
             "OpenRouter prices are per minute of audio; Saaras is billed directly to your Sarvam key. " +
                 "One red \$ is cheap; two or three green \$ cost more. " +
-                "Best is the lowest word-error rate on Artificial Analysis evals.",
+                "Best is the recommended dictation model.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/test/java/com/echoflow/data/SttCatalogTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttCatalogTest.kt
@@ -1,6 +1,7 @@
 package com.echoflow.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -9,19 +10,19 @@ import org.junit.Test
  * Curated STT catalog prices are user-facing and must stay in sync with OpenRouter listings.
  * Update both the catalog strings and these expectations when OpenRouter changes STT pricing.
  *
- * Reference (as of 2026-08):
+ * Reference (as of 2026-09):
+ * - meta/muse-voice-transcribe-1.0 = $0.18/hour = $0.003/min
  * - openai/gpt-transcribe = $0.0045/min
  * - x-ai/grok-stt-1.0 = $0.10/hour ≈ $0.0017/min
  * - nvidia/nemotron-3.5-asr-streaming-multilingual-0.6b = $0.000003/sec = $0.00018/min
  * - google/chirp-3 = $0.016/min
- *
- * Artificial Analysis AA-WER (non-streaming): GPT Transcribe 3.3%, Grok STT 4.0%.
  */
 class SttCatalogTest {
 
     @Test fun `catalog lists the curated cloud models`() {
         assertEquals(
             listOf(
+                "meta/muse-voice-transcribe-1.0",
                 "openai/gpt-transcribe",
                 "x-ai/grok-stt-1.0",
                 "nvidia/nemotron-3.5-asr-streaming-multilingual-0.6b",
@@ -32,6 +33,7 @@ class SttCatalogTest {
     }
 
     @Test fun `user-facing prices match current OpenRouter STT listings`() {
+        assertEquals("~\$0.003 / min", SttCatalog.byId("meta/muse-voice-transcribe-1.0")!!.pricing)
         assertEquals("~\$0.0045 / min", SttCatalog.byId("openai/gpt-transcribe")!!.pricing)
         assertEquals("~\$0.0017 / min", SttCatalog.byId("x-ai/grok-stt-1.0")!!.pricing)
         assertEquals(
@@ -42,6 +44,7 @@ class SttCatalogTest {
     }
 
     @Test fun `dollar tags follow OpenRouter per-minute price`() {
+        assertEquals(SttCostTier.Moderate, SttCatalog.byId("meta/muse-voice-transcribe-1.0")!!.costTier)
         assertEquals(SttCostTier.Moderate, SttCatalog.byId("openai/gpt-transcribe")!!.costTier)
         assertEquals(SttCostTier.Cheap, SttCatalog.byId("x-ai/grok-stt-1.0")!!.costTier)
         assertEquals(
@@ -54,21 +57,24 @@ class SttCatalogTest {
         assertEquals(3, SttCostTier.Expensive.dollars)
     }
 
-    @Test fun `exactly one model carries the Best eval badge and it is GPT Transcribe`() {
+    @Test fun `exactly one model carries the Best badge and it is Muse Transcribe`() {
         val best = SttCatalog.CLOUD_MODELS.filter { it.isBest }
         assertEquals(1, best.size)
-        assertEquals("openai/gpt-transcribe", best.single().id)
+        assertEquals("meta/muse-voice-transcribe-1.0", best.single().id)
+        assertEquals("Muse Transcribe", best.single().name)
+        assertFalse(best.single().name.contains("1.0"))
     }
 
     @Test fun `cost-tier cutoffs sit between the catalog prices`() {
         assertEquals(SttCostTier.Cheap, SttCostTier.fromUsdPerMinute(0.00018))
         assertEquals(SttCostTier.Cheap, SttCostTier.fromUsdPerMinute(0.0017))
+        assertEquals(SttCostTier.Moderate, SttCostTier.fromUsdPerMinute(0.003))
         assertEquals(SttCostTier.Moderate, SttCostTier.fromUsdPerMinute(0.0045))
         assertEquals(SttCostTier.Expensive, SttCostTier.fromUsdPerMinute(0.016))
     }
 
-    @Test fun `default is GPT Transcribe and sits first so unknown ids fall through to it`() {
-        assertEquals("openai/gpt-transcribe", SttCatalog.DEFAULT_MODEL_ID)
+    @Test fun `default is Muse Transcribe and sits first so unknown ids fall through to it`() {
+        assertEquals("meta/muse-voice-transcribe-1.0", SttCatalog.DEFAULT_MODEL_ID)
         assertEquals(SttCatalog.DEFAULT_MODEL_ID, SttCatalog.CLOUD_MODELS.first().id)
         assertNotNull(SttCatalog.byId(SttCatalog.DEFAULT_MODEL_ID))
         assertTrue(SttCatalog.CLOUD_MODELS.first().isBest)

--- a/app/src/test/java/com/echoflow/data/SttRequestTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttRequestTest.kt
@@ -7,26 +7,26 @@ import org.junit.Test
 
 /**
  * Request-level coverage for the curated STT default. [SttCatalogTest] only sees the catalog;
- * a swapped default that never reaches `/audio/transcriptions`, or a GPT Transcribe body we
+ * a swapped default that never reaches `/audio/transcriptions`, or a Muse Transcribe body we
  * fail to parse, would pass that suite and break only on a real dictation.
  */
 class SttRequestTest {
 
     @Test fun `the catalog default is the model id posted on the transcription request`() {
         val body = SttPayloads.requestBody(SttCatalog.DEFAULT_MODEL_ID, "dGVzdA==")
-        assertEquals("openai/gpt-transcribe", body["model"])
+        assertEquals("meta/muse-voice-transcribe-1.0", body["model"])
         assertEquals(SttCatalog.DEFAULT_MODEL_ID, body["model"])
         val audio = body["input_audio"] as Map<*, *>
         assertEquals("wav", audio["format"])
         assertEquals("dGVzdA==", audio["data"])
     }
 
-    @Test fun `encoded body still carries the GPT Transcribe model id`() {
+    @Test fun `encoded body still carries the Muse Transcribe model id`() {
         val json = SttPayloads.encode(SttPayloads.requestBody(SttCatalog.DEFAULT_MODEL_ID, "dGVzdA=="))
-        assertTrue(json.contains("\"model\":\"openai/gpt-transcribe\""))
+        assertTrue(json.contains("\"model\":\"meta/muse-voice-transcribe-1.0\""))
     }
 
-    @Test fun `parses the OpenRouter text field GPT Transcribe returns`() {
+    @Test fun `parses the OpenRouter text field Muse Transcribe returns`() {
         assertEquals("hello there", SttPayloads.parseTranscript("""{"text":"hello there"}"""))
         assertEquals("trimmed", SttPayloads.parseTranscript("""{"text":"  trimmed  "}"""))
     }

--- a/app/src/test/java/com/echoflow/data/SttSettingsTest.kt
+++ b/app/src/test/java/com/echoflow/data/SttSettingsTest.kt
@@ -18,19 +18,19 @@ class SttSettingsTest {
         SettingsPreferenceStorage.secureOrNull(context)?.edit()?.clear()?.commit()
     }
 
-    @Test fun `a fresh install dictates with GPT Transcribe`() {
+    @Test fun `a fresh install dictates with Muse Transcribe`() {
         val repository = SettingsRepository(context)
-        assertEquals("openai/gpt-transcribe", repository.getSttCloudModelDirect())
+        assertEquals("meta/muse-voice-transcribe-1.0", repository.getSttCloudModelDirect())
         assertEquals(SttCatalog.DEFAULT_MODEL_ID, repository.sttCloudModel.value)
     }
 
-    @Test fun `a leftover Fish id is resolved to GPT Transcribe before it can be sent`() {
+    @Test fun `a leftover Fish id is resolved to Muse Transcribe before it can be sent`() {
         val stored = SettingsPreferenceStorage.secureOrNull(context)
             ?: SettingsPreferenceStorage.legacy(context)
         stored.edit().putString("stt_cloud_model", "fish-audio/transcribe-1").commit()
 
         val repository = SettingsRepository(context)
-        assertEquals("openai/gpt-transcribe", repository.getSttCloudModelDirect())
+        assertEquals("meta/muse-voice-transcribe-1.0", repository.getSttCloudModelDirect())
     }
 
     @Test fun `Nemotron ASR is a selectable cloud model`() {


### PR DESCRIPTION
## Summary
- Add `meta/muse-voice-transcribe-1.0` to the cloud dictation catalog at the top of Settings → Dictation.
- Show it as **Muse Transcribe** (title case, no `1.0` in the chip) with Meta as the provider and OpenRouter’s `$0.18/hour` rate (`~$0.003 / min`).
- Move the **Best** badge and the fresh-install default off GPT Transcribe onto Muse Transcribe. GPT Transcribe stays selectable.

## Test plan
- [ ] Open Settings → Dictation and confirm Muse Transcribe is first, labeled without `1.0`, and has the Best badge.
- [ ] Confirm GPT Transcribe is still listed and selectable.
- [ ] On a fresh install (or cleared STT preference), dictation uses `meta/muse-voice-transcribe-1.0`.
- [ ] With an OpenRouter key, a short mic capture transcribes through the selected model.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Meta Muse Transcribe as the recommended cloud speech-to-text model.
  * New installations now use Muse Transcribe by default.
  * Updated model details, including pricing and cost tier information.

* **Updates**
  * The “Best” label now identifies the recommended dictation model.
  * Existing speech-to-text settings and requests now resolve to Muse Transcribe where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63532351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge; the only concern is a non-blocking opportunity to make the Best badge’s recommendation rationale clearer.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Recommendation Rationale Is Missing** <a href="https://github.com/adityavardhansharma/EchoFlow/pull/160#discussion_r3998298825">▶</a>

<h3>Summary</h3>

- I like the product direction: promoting a lower-priced model with speaker-awareness and keyword-biasing capabilities makes the default dictation experience more differentiated while retaining GPT Transcribe as an option.
- The catalog, persistence fallback, credential routing, request model ID, and user-facing pricing are updated consistently.
- The UI presentation would be stronger if the Best badge explained why Muse is recommended rather than making the recommendation self-referential.
- Test coverage verifies catalog order, display name, pricing tier, unique badge ownership, default persistence, stale-ID fallback, and request serialization.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Fresh install or invalid stored STT ID] --> B[SettingsRepository resolves default]
    B --> C[Muse Transcribe]
    D[Existing valid GPT selection] --> E[Selection preserved]
    C --> F[OpenRouter key and endpoint]
    E --> F
    F --> G[Audio transcription request]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat: make Muse Transcribe the default d..."](https://github.com/adityavardhansharma/echoflow/commit/56c2690709f66cc14ac1ab3d91b52de0c7f57f42)</sub>

<!-- /greptile_comment -->